### PR TITLE
chore: add type imports, set importsNotUsedAsValues "error" in tsconfig

### DIFF
--- a/client/component/component.ts
+++ b/client/component/component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { QRL } from '../import/qrl.js';
+import type { QRL } from '../import/qrl.js';
 import { QError, qError } from '../error/error.js';
 import '../util/qDev.js';
 import { AttributeMarker } from '../util/markers.js';

--- a/client/entity/entity.ts
+++ b/client/entity/entity.ts
@@ -10,7 +10,7 @@ import { AttributeMarker } from '../util/markers.js';
 import { getConfig, QConfig } from '../config/qGlobal.js';
 import { qError, QError } from '../error/error.js';
 import { qImport } from '../import/qImport.js';
-import { QRL } from '../import/qrl.js';
+import type { QRL } from '../import/qrl.js';
 import { keyToEntityAttribute, EntityKey, keyToProps, propsToKey } from './entity_key.js';
 import { getFilePathFromFrame } from '../util/base_uri.js';
 import { fromCamelToKebabCase } from '../util/case.js';

--- a/client/error/error.ts
+++ b/client/error/error.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { AttributeMarker } from 'client/util/markers.js';
+import { AttributeMarker } from '../util/markers.js';
 import { stringifyDebug } from './stringify.js';
 
 export const enum QError {

--- a/client/event/emit_event.ts
+++ b/client/event/emit_event.ts
@@ -10,8 +10,8 @@ import { qImport, qParams, toBaseURI, toUrl } from '../import/qImport.js';
 import { QError, qError } from '../error/error.js';
 import { findAttribute } from '../util/dom_attrs.js';
 import { AttributeMarker } from '../util/markers.js';
-import { EventHandler } from './types.js';
-import { QRL } from '../import/qrl.js';
+import type { EventHandler } from './types.js';
+import type { QRL } from '../import/qrl.js';
 import { fromCamelToKebabCase } from '../util/case.js';
 
 /**

--- a/client/event/event_entity.ts
+++ b/client/event/event_entity.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { EntityKey } from '../entity/entity_key.js';
+import type { EntityKey } from '../entity/entity_key.js';
 import { Entity } from '../entity/entity.js';
-import { Props } from '../injector/types.js';
-import { QRL } from '../import/qrl.js';
+import type { Props } from '../injector/types.js';
+import type { QRL } from '../import/qrl.js';
 
 /**
  * `EventEntity` is only visible during event processing and can be used to retrieve `Event`

--- a/client/event/event_injector.ts
+++ b/client/event/event_injector.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { EntityKey } from '../entity/entity_key.js';
+import type { EntityKey } from '../entity/entity_key.js';
 import type { Component, ComponentConstructor } from '../component/component.js';
 import { BaseInjector } from '../injector/base_injector.js';
 import { ElementInjector, getClosestInjector } from '../injector/element_injector.js';
-import { Injector, Props } from '../injector/types.js';
-import {
+import type { Injector, Props } from '../injector/types.js';
+import type {
   Entity,
   EntityConstructor,
   EntityPromise,

--- a/client/event/inject_event_handler.ts
+++ b/client/event/inject_event_handler.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { QRL } from '../import/qrl.js';
-import { InjectedFunction, ProviderReturns } from '../injector/types.js';
+import type { QRL } from '../import/qrl.js';
+import type { InjectedFunction, ProviderReturns } from '../injector/types.js';
 import '../util/qDev.js';
 import { EventInjector } from './event_injector.js';
-import { EventHandler } from './types.js';
+import type { EventHandler } from './types.js';
 
 /**
  * Create an event handler with injected values.

--- a/client/event/provide_element.ts
+++ b/client/event/provide_element.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Injector, Provider } from '../injector/types.js';
+import type { Injector, Provider } from '../injector/types.js';
 
 /**
  * Provide the event Element.

--- a/client/event/provide_event.ts
+++ b/client/event/provide_event.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Injector, Provider } from '../injector/types.js';
+import type { Injector, Provider } from '../injector/types.js';
 import { EventEntity } from './event_entity.js';
 
 /**

--- a/client/event/provide_qrl_exp.ts
+++ b/client/event/provide_qrl_exp.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Injector, Provider } from '../injector/types.js';
+import type { Injector, Provider } from '../injector/types.js';
 import { assertDefined } from '../assert/index.js';
 import { QError, qError } from '../error/error.js';
 import { EventEntity } from '../event/event_entity.js';

--- a/client/event/provide_url.ts
+++ b/client/event/provide_url.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Injector, Provider } from '../injector/types.js';
+import type { Injector, Provider } from '../injector/types.js';
 import { EventEntity } from './event_entity.js';
 
 /**

--- a/client/event/types.ts
+++ b/client/event/types.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { InjectedFunction } from '../injector/types.js';
+import type { InjectedFunction } from '../injector/types.js';
 
 /**
  * @public

--- a/client/import/qImport.ts
+++ b/client/import/qImport.ts
@@ -7,8 +7,8 @@
  */
 
 import { getConfig } from '../config/qGlobal.js';
-import { QRL } from './qrl.js';
-import { QConfig } from '../config/qGlobal.js';
+import type { QRL } from './qrl.js';
+import type { QConfig } from '../config/qGlobal.js';
 import { QError, qError } from '../error/error.js';
 
 let importCache: Map<string, unknown | Promise<unknown>>;

--- a/client/injector/base_injector.ts
+++ b/client/injector/base_injector.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { EntityKey } from '../entity/entity_key.js';
+import type { EntityKey } from '../entity/entity_key.js';
 import type { Component, ComponentConstructor } from '../component/component.js';
 import { qError, QError } from '../error/error.js';
-import {
+import type {
   Entity,
   EntityConstructor,
   EntityPromise,
@@ -19,7 +19,7 @@ import {
 import { extractPropsFromElement } from '../util/attributes.js';
 import '../util/qDev.js';
 import { resolveArgs } from './resolve_args.js';
-import { InjectedFunction, Injector, Props } from './types.js';
+import type { InjectedFunction, Injector, Props } from './types.js';
 
 export abstract class BaseInjector implements Injector {
   element: Element;

--- a/client/injector/element_injector.ts
+++ b/client/injector/element_injector.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import {
+import type {
   ComponentPropsOf,
   ComponentStateOf,
   Component,
@@ -14,9 +14,9 @@ import {
 } from '../component/component.js';
 import { qError, QError } from '../error/error.js';
 import { qImport } from '../import/qImport.js';
-import { QRL } from '../import/qrl.js';
+import type { QRL } from '../import/qrl.js';
 import { keyToEntityAttribute, EntityKey } from '../entity/entity_key.js';
-import {
+import type {
   Entity,
   EntityConstructor,
   EntityPromise,
@@ -28,7 +28,7 @@ import { AttributeMarker } from '../util/markers.js';
 import '../util/qDev.js';
 import { isHtmlElement } from '../util/types.js';
 import { BaseInjector } from './base_injector.js';
-import { Injector } from './types.js';
+import type { Injector } from './types.js';
 
 interface EntityValue {
   promise: EntityPromise<Entity<any, any>>;

--- a/client/injector/inject.ts
+++ b/client/injector/inject.ts
@@ -7,7 +7,7 @@
  */
 
 import '../util/qDev.js';
-import { ConcreteType, InjectedFunction, ProviderReturns } from './types.js';
+import type { ConcreteType, InjectedFunction, ProviderReturns } from './types.js';
 
 /**
  * Decorate a function for injection by associating providers.

--- a/client/injector/provide_injector.ts
+++ b/client/injector/provide_injector.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Injector, Provider } from './types.js';
+import type { Injector, Provider } from './types.js';
 
 /**
  * Provide `Injector`.

--- a/client/injector/provide_provider_of.ts
+++ b/client/injector/provide_provider_of.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Injector, Provider } from './types.js';
+import type { Injector, Provider } from './types.js';
 
 /**
  * Provide a function for lazy retrieving the provider.

--- a/client/injector/resolve_args.ts
+++ b/client/injector/resolve_args.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Injector, Provider, ValueOrProviderReturns } from './types.js';
+import type { Injector, Provider, ValueOrProviderReturns } from './types.js';
 
 /**
  *

--- a/client/injector/types.ts
+++ b/client/injector/types.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { EntityKey } from '../entity/entity_key.js';
+import type { EntityKey } from '../entity/entity_key.js';
 import type { Component, ComponentConstructor } from '../component/component.js';
 import type {
   Entity,

--- a/client/provider/provide_component_prop.ts
+++ b/client/provider/provide_component_prop.ts
@@ -8,7 +8,7 @@
 
 import { qError, QError } from '../error/error.js';
 import { getClosestInjector } from '../injector/element_injector.js';
-import { Provider, Injector } from '../injector/types.js';
+import type { Provider, Injector } from '../injector/types.js';
 
 /**
  * Provides the Component Property.

--- a/client/provider/provide_component_props.ts
+++ b/client/provider/provide_component_props.ts
@@ -7,7 +7,7 @@
  */
 
 import { assertDefined } from '../assert/index.js';
-import { Provider, Injector } from '../injector/types.js';
+import type { Provider, Injector } from '../injector/types.js';
 
 /**
  * Returns `Props` of component.

--- a/client/provider/provide_component_state.ts
+++ b/client/provider/provide_component_state.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Provider, Injector } from '../injector/types.js';
+import type { Provider, Injector } from '../injector/types.js';
 import { QError, qError } from '../error/error.js';
 
 /**

--- a/client/provider/provide_entity.ts
+++ b/client/provider/provide_entity.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { EntityKey } from '../entity/entity_key.js';
+import type { EntityKey } from '../entity/entity_key.js';
 import { getClosestInjector } from '../injector/element_injector.js';
 import { resolveArgs } from '../injector/resolve_args.js';
-import { Injector, Provider } from '../injector/types.js';
-import { Entity } from '../entity/entity.js';
+import type { Injector, Provider } from '../injector/types.js';
+import type { Entity } from '../entity/entity.js';
 
 /**
  * Provide a entity for a given key.

--- a/client/provider/provide_entity_state.ts
+++ b/client/provider/provide_entity_state.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { EntityKey } from '../entity/entity_key.js';
+import type { EntityKey } from '../entity/entity_key.js';
 import { getClosestInjector } from '../injector/element_injector.js';
 import { resolveArgs } from '../injector/resolve_args.js';
-import { Injector, Provider } from '../injector/types.js';
-import { Entity, EntityStateOf } from '../entity/entity.js';
+import type { Injector, Provider } from '../injector/types.js';
+import type { Entity, EntityStateOf } from '../entity/entity.js';
 
 /**
  * Provide the entity state for a given entity key.

--- a/client/render/jsx/attributes.ts
+++ b/client/render/jsx/attributes.ts
@@ -9,8 +9,8 @@ import { fromCamelToKebabCase } from '../../util/case.js';
 import { stringify } from '../../util/stringify.js';
 import { assertValidDataKey } from '../../error/data.js';
 import { AttributeMarker } from '../../util/markers.js';
-import { EntityConstructor } from '../../entity/entity.js';
-import { QRL } from '../../import/qrl.js';
+import type { EntityConstructor } from '../../entity/entity.js';
+import type { QRL } from '../../import/qrl.js';
 import { QError, qError } from '../../error/error.js';
 import type { JSXBase } from './html_base.js';
 

--- a/client/render/jsx/factory.ts
+++ b/client/render/jsx/factory.ts
@@ -7,11 +7,11 @@
  */
 
 import { EMPTY_OBJ } from '../../util/flyweight.js';
-import { QRL } from '../../import/qrl.js';
-import { Props } from '../../injector/types.js';
-import { JSXFactory, JSXNode } from './types.js';
+import type { QRL } from '../../import/qrl.js';
+import type { Props } from '../../injector/types.js';
+import type { JSXFactory, JSXNode } from './types.js';
 import { AttributeMarker } from '../../util/markers.js';
-import { JSXBase } from './html_base.js';
+import type { JSXBase } from './html_base.js';
 import { flattenArray } from '../../util/array.js';
 
 class JSXNode_<T extends string | null | JSXFactory | unknown> {

--- a/client/render/jsx/html_base.ts
+++ b/client/render/jsx/html_base.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { QRL } from 'client/import/qrl.js';
-import { EntityConstructor } from '../../entity/entity.js';
+import type { QRL } from '../../import/qrl.js';
+import type { EntityConstructor } from '../../entity/entity.js';
 
 /**
  * Base JSX type containing universal properties.

--- a/client/render/jsx/mark_dirty.ts
+++ b/client/render/jsx/mark_dirty.ts
@@ -10,13 +10,13 @@ import { isElement } from '../../util/element.js';
 import { assertString } from '../../assert/index.js';
 import { Component, isComponent } from '../../component/component.js';
 import { QError, qError } from '../../error/error.js';
-import { QRL } from '../../import/qrl.js';
-import { Props } from '../../injector/types.js';
+import type { QRL } from '../../import/qrl.js';
+import type { Props } from '../../injector/types.js';
 import { isEntity, Entity } from '../../entity/entity.js';
 import { extractPropsFromElement } from '../../util/attributes.js';
 import { AttributeMarker } from '../../util/markers.js';
 import { flattenPromiseTree, isPromise } from '../../util/promises.js';
-import { HostElements } from '../types.js';
+import type { HostElements } from '../types.js';
 import { jsxRenderComponent } from './render.js';
 
 /**

--- a/client/render/jsx/render.ts
+++ b/client/render/jsx/render.ts
@@ -6,22 +6,22 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { AttributeMarker } from 'client/util/markers.js';
+import { AttributeMarker } from '../../util/markers.js';
 import { QError, qError } from '../../error/error.js';
 import { qImport } from '../../import/index.js';
-import { QRL } from '../../import/qrl.js';
+import type { QRL } from '../../import/qrl.js';
 import { getInjector } from '../../injector/element_injector.js';
-import { InjectedFunction, Injector, Props } from '../../injector/types.js';
+import type { InjectedFunction, Injector, Props } from '../../injector/types.js';
 import { removeNode, replaceNode } from '../../util/dom.js';
 import { EMPTY_OBJ } from '../../util/flyweight.js';
 import { flattenPromiseTree, isPromise } from '../../util/promises.js';
 import '../../util/qDev.js';
 import { isDomElementWithTagName, isTextNode, NodeType } from '../../util/types.js';
-import { AsyncHostElementPromises, HostElements } from '../types.js';
+import type { AsyncHostElementPromises, HostElements } from '../types.js';
 import { applyAttributes } from './attributes.js';
 import { isJSXNode } from './factory.js';
 import { Host } from './host.js';
-import { JSXFactory, JSXNode } from './types.js';
+import type { JSXFactory, JSXNode } from './types.js';
 
 /**
  * Render JSX into a host element reusing DOM nodes when possible.

--- a/client/render/jsx/types.ts
+++ b/client/render/jsx/types.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Props } from '../../injector/types.js';
+import type { Props } from '../../injector/types.js';
 
 /**
  * @public

--- a/integration/hello_server/Greeter_component.ts
+++ b/integration/hello_server/Greeter_component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { GreeterProps } from './Greeter.js';
+import type { GreeterProps } from './Greeter.js';
 import { Component, QRL } from './qwik.js';
 
 /**

--- a/integration/todo/ui/Footer.ts
+++ b/integration/todo/ui/Footer.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { TodoEntity } from '../data/Todo.js';
+import type { TodoEntity } from '../data/Todo.js';
 import { jsxDeclareComponent, QRL, EntityKey } from '../qwik.js';
 
 /**

--- a/integration/todo/ui/Footer_template.tsx
+++ b/integration/todo/ui/Footer_template.tsx
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Todo, TodoEntity } from '../data/Todo.js';
+import type { Todo, TodoEntity } from '../data/Todo.js';
 import {
   QRL,
   injectFunction,

--- a/integration/todo/ui/Header_component.ts
+++ b/integration/todo/ui/Header_component.ts
@@ -7,7 +7,7 @@
  */
 
 import { Component, QRL } from '../qwik.js';
-import { HeaderProps } from './Header.js';
+import type { HeaderProps } from './Header.js';
 
 interface HeaderState {
   text: string;

--- a/integration/todo/ui/Item_component.ts
+++ b/integration/todo/ui/Item_component.ts
@@ -7,7 +7,7 @@
  */
 
 import { Component, QRL } from '../qwik.js';
-import { ItemProps } from './Item.js';
+import type { ItemProps } from './Item.js';
 
 interface ItemState {}
 

--- a/integration/todo/ui/Item_edit.ts
+++ b/integration/todo/ui/Item_edit.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { ItemEntity } from '../data/Item.js';
-import { Provider, EntityKey } from '../qwik.js';
+import type { ItemEntity } from '../data/Item.js';
+import type { Provider, EntityKey } from '../qwik.js';
 import {
   injectEventHandler,
   markDirty,

--- a/integration/todo/ui/Item_remove.ts
+++ b/integration/todo/ui/Item_remove.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { ItemEntity } from '../data/Item.js';
+import type { ItemEntity } from '../data/Item.js';
 import { TodoEntity } from '../data/Todo.js';
 import { injectEventHandler, provideEntity, provideUrlProp, EntityKey, Provider } from '../qwik.js';
 

--- a/integration/todo/ui/Item_template.tsx
+++ b/integration/todo/ui/Item_template.tsx
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { Item, ItemEntity } from '../data/Item.js';
+import type { Item, ItemEntity } from '../data/Item.js';
 import {
   injectMethod,
   jsxFactory,

--- a/integration/todo/ui/Item_toggle.ts
+++ b/integration/todo/ui/Item_toggle.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://github.com/BuilderIO/qwik/blob/main/LICENSE
  */
 
-import { EntityKey, Provider } from '../qwik.js';
-import { ItemEntity } from '../data/Item.js';
+import type { EntityKey, Provider } from '../qwik.js';
+import type { ItemEntity } from '../data/Item.js';
 import { injectEventHandler, provideComponentProp, provideQrlExp, provideEntity } from '../qwik.js';
 
 export default injectEventHandler(

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -39,6 +39,7 @@
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
+    "importsNotUsedAsValues": "error",
     /* Module Resolution Options */
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     "baseUrl": "." /* Base directory to resolve non-absolute module names. */,


### PR DESCRIPTION
Add `type` to type only imports to ensure output JS files only reference actual JS files. "This flag works because you can use import type to explicitly create an import statement which should never be emitted into JavaScript."
https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues

Helpful for client source code, but adding to the examples too since they're sharing the tsconfig.