### PR TITLE
docs: use correct signature of jsxDeclareComponent

### DIFF
--- a/src/core/component/README.md
+++ b/src/core/component/README.md
@@ -78,11 +78,11 @@ Create a public file: `<COMPONENT>.ts` (`greeter.ts`): A facade to be included b
 
   ```typescript
   export const <COMPONENT> = jsxDeclareComponent<<COMPONENT>Props>(
-    // Name of the DOM host element which will be created for this component.
-    '<COMPONENT>',
     /// non-symbolic pointer to the implementation used for lazy loading.
     /// (As a convention, the template file ends with `_template`.)
-    QRL`./<COMPONENT>_template`);
+    QRL`./<COMPONENT>_template`,
+    // Name of the DOM host element which will be created for this component.
+    '<COMPONENT>');
   ```
 
   Example:

--- a/src/core/event/README.md
+++ b/src/core/event/README.md
@@ -78,11 +78,11 @@ Create a public file: `<COMPONENT>.ts` (`greeter.ts`): A facade to be included b
 
   ```typescript
   export const <COMPONENT> = jsxDeclareComponent<<COMPONENT>Props>(
-    // Name of the DOM host element which will be created for this component.
-    '<COMPONENT>',
     /// non-symbolic pointer to the implementation used for lazy loading.
     /// (As a convention, the template file ends with `_template`.)
     QRL`./<COMPONENT>_template`);
+    // Name of the DOM host element which will be created for this component.
+    '<COMPONENT>',
   ```
 
   Example:


### PR DESCRIPTION
The order of the arguments is inverted in one of the examples using the `jsxDeclareComponent()` facade.