### PR TITLE
fix(core): allow invoking base injector when using cjs

### DIFF
--- a/src/core/injector/base_injector.ts
+++ b/src/core/injector/base_injector.ts
@@ -33,6 +33,10 @@ export abstract class BaseInjector implements Injector {
     self?: SELF | null,
     ...rest: REST
   ): Promise<RET> {
+    if ((fn as any).default) {
+      fn = (fn as any).default;
+    }
+
     if (isInjectedFunction(fn)) {
       try {
         const selfType = fn.$thisType;
@@ -52,7 +56,7 @@ export abstract class BaseInjector implements Injector {
           (values: any[]) => {
             return (fn as any).apply(values.shift(), values.concat(rest));
           },
-          (error) => Promise.reject(addDeclaredInfo(fn, error))
+          (error) => Promise.reject(addDeclaredInfo(fn as any, error))
         );
       } catch (e) {
         throw addDeclaredInfo(fn, e);

--- a/src/core/injector/base_injector.unit.ts
+++ b/src/core/injector/base_injector.unit.ts
@@ -66,6 +66,22 @@ describe('BaseInjector', () => {
       expect(log).to.eql([null, 'self', 'arg0', 'extra']);
     });
 
+    it('should call injected function (as default)', async () => {
+      const log: (string | null)[] = [];
+      const injectedFn = injectFunction(
+        provideConst('self'), //
+        provideConst('arg0'),
+        function (this: null, arg0: string, arg1: string, arg2: string) {
+          log.push(this, arg0, arg1, arg2);
+          return 'ret';
+        }
+      );
+      expect(await hostInjector.invoke({ default: injectedFn } as any, null, 'extra')).to.eql(
+        'ret'
+      );
+      expect(log).to.eql([null, 'self', 'arg0', 'extra']);
+    });
+
     it('should call injected method', async () => {
       const log: (string | MyComponent)[] = [];
       fixture.host.setAttribute(AttributeMarker.ComponentTemplate, MyComponent.$templateQRL as any);
@@ -81,6 +97,23 @@ describe('BaseInjector', () => {
       expect(await hostInjector.invoke(injectedFn, null, 'arg2')).to.eql('ret');
       expect(log).to.eql([{ $host: fixture.host, $props: {}, $state: {} }, 'arg0', 'arg1', 'arg2']);
     });
+
+    it('should call injected method (as default)', async () => {
+      const log: (string | MyComponent)[] = [];
+      fixture.host.setAttribute(AttributeMarker.ComponentTemplate, MyComponent.$templateQRL as any);
+      const injectedFn = injectMethod(
+        MyComponent,
+        provideConst('arg0'), //
+        provideConst('arg1'),
+        function (this: MyComponent, arg0: string, arg1: string, arg2: string) {
+          log.push(this, arg0, arg1, arg2);
+          return 'ret';
+        }
+      );
+      expect(await hostInjector.invoke({ default: injectedFn } as any, null, 'arg2')).to.eql('ret');
+      expect(log).to.eql([{ $host: fixture.host, $props: {}, $state: {} }, 'arg0', 'arg1', 'arg2']);
+    });
+
     describe('error', async () => {
       it('should include declare context when throwing error', async () => {
         fixture.host.setAttribute(


### PR DESCRIPTION
When the user's app is built using CommonJS, Qwik cannot invoke the base injector function because it's exported as `default`. This change fixes that issue.