### PR TITLE
fix(todo): make blur event always working in editing

### DIFF
--- a/cypress/integration/todo_spec.ts
+++ b/cypress/integration/todo_spec.ts
@@ -42,10 +42,24 @@ describe('todo', () => {
       it('should edit an item', function () {
         cy.get('.todo-list>li:first-child label').dblclick();
         cy.wait(50);
-        cy.get('.todo-list>li:first-child input.edit').type('123{enter}');
+        cy.get('.todo-list>li:first-child input.edit').focused().type('123{enter}');
         cy.get('.todo-list>li:first-child').should((item: any) =>
           expect(item).to.have.text('Read Qwik docs123')
         );
+      });
+
+      it('should blur input.edit element', function () {
+        cy.get('.todo-list>li:first-child label').dblclick();
+        cy.wait(50);
+
+        // Focused input.edit element with a proper cursor position after dblclick event
+        cy.get('.todo-list>li:first-child input.edit')
+          .focused()
+          .should('have.prop', 'selectionStart', 14)
+          .and('have.prop', 'selectionEnd', 14);
+
+        // Blur input.edit element
+        cy.get('.todo-list>li:first-child input.edit').blur().should('have.length', 0);
       });
 
       it('should clear completed', () => {

--- a/integration/todo/ui/Item_edit.ts
+++ b/integration/todo/ui/Item_edit.ts
@@ -20,9 +20,15 @@ import { ItemComponent } from './Item_component';
 
 export const begin = injectEventHandler(
   ItemComponent, //
-  async function (this: ItemComponent) {
+  provideEntity<ItemEntity>(provideUrlProp('itemKey') as any as Provider<EntityKey<ItemEntity>>), // TODO fix cast
+  async function (this: ItemComponent, itemEntity: ItemEntity) {
     this.editing = true;
-    markDirty(this);
+    await markDirty(this);
+    // focus input element
+    const inputEl = this.$host.querySelector('input.edit') as HTMLInputElement;
+    inputEl.focus();
+    // move cursor to the end
+    inputEl.selectionStart = inputEl.selectionEnd = itemEntity.$state.title.length;
   }
 );
 

--- a/integration/todo/ui/Item_template.tsx
+++ b/integration/todo/ui/Item_template.tsx
@@ -35,14 +35,14 @@ export default injectMethod(
             checked={item.completed}
             on:click={QRL`ui:/Item_toggle#?toggleState=.target.checked`}
           />
-          <label on:dblclick={QRL`ui:/Item_edit#begin`}>{item.title}</label>
+          <label on:dblclick={QRL`ui:/Item_edit#begin?itemKey=${itemKey}`}>{item.title}</label>
           <button class="destroy" on:click={QRL`ui:/Item_remove#?itemKey=${itemKey}`}></button>
         </div>
         {this.editing ? (
           <input
             class="edit"
             value={item.title}
-            on:blur={QRL`ui:/Item_edit#end`} // TODO: investigate why this sometimes does not fire
+            on:blur={QRL`ui:/Item_edit#end`}
             on:keyup={QRL`ui:/Item_edit#change?value=.target.value&code=.code&itemKey=${itemKey}`}
           />
         ) : null}


### PR DESCRIPTION
**Existing flow**
- dblclick an item
- **input.edit element is not focused without a user click**
- blur element (it's not working on a non-focused element)


**Changed flow in the PR**
- dblclick an item
- focus input.edit element
- properly set cursor position once the item is focused
- blur element