### PR TITLE
Fix "TypeError: URL constructor: / is not a valid URL" in express starter

### DIFF
--- a/starters/servers/express/server/index.js
+++ b/starters/servers/express/server/index.js
@@ -9,7 +9,7 @@ async function startServer() {
   async function handleQwik(req, res) {
     const result = await renderApp({
       symbols,
-      url: new URL(req.url),
+      url: new URL(`${req.protocol}://${req.hostname}${req.url}`),
       debug: true,
     });
     res.send(result.html);


### PR DESCRIPTION
The express server in starter throws an error when trying to access it:

```
Uncaught TypeError: URL constructor: / is not a valid URL.
```

This is because `URL` requires a full URL when only passing one argument (and req.url only contains the path), [see docs here](https://nodejs.org/api/url.html#new-urlinput-base)...

Might be an issue for cloudflare starter as well but I don't have an account to try it out.