### PR TITLE
Fix: Missing @rollup/plugin-typescript in generated projects, and a wrong path in the document

### DIFF
--- a/starters/README.md
+++ b/starters/README.md
@@ -15,7 +15,7 @@ Here are steps to try out the CLI in local environment.
 1. Run CLI:
 
    ```
-   # node ./dist-dev/cli/index.js
+   # node ./dist-dev/create-qwik/index.js
    💫 Let's create a Qwik project 💫
 
    ✔ Project name … todo-express

--- a/starters/apps/starter-builder/package.json
+++ b/starters/apps/starter-builder/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@builder.io/qwik": "0.0.16-1",
     "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-typescript": "^8.3.0",
     "concurrently": "^6.4.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.59.0",

--- a/starters/apps/starter-builder/rollup.config.js
+++ b/starters/apps/starter-builder/rollup.config.js
@@ -1,4 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 import { qwikRollup } from '@builder.io/qwik/optimizer';
 import { writeFile, mkdir } from "fs/promises";
 import { dirname } from "path";
@@ -15,7 +16,8 @@ export default async function () {
         symbolsOutput: (data) => {
           outputJSON('./server/build/q-symbols.json', data);
         },
-      })
+      }),
+      typescript(),
     ],
     output: [
       {

--- a/starters/apps/starter-partytown/package.json
+++ b/starters/apps/starter-partytown/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@builder.io/qwik": "0.0.16-1",
     "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-typescript": "^8.3.0",
     "concurrently": "^6.4.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.59.0",

--- a/starters/apps/starter-partytown/rollup.config.js
+++ b/starters/apps/starter-partytown/rollup.config.js
@@ -1,4 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 import { qwikRollup } from '@builder.io/qwik/optimizer';
 import { writeFile, mkdir } from "fs/promises";
 import { dirname } from "path";
@@ -15,7 +16,8 @@ export default async function () {
         symbolsOutput: (data) => {
           outputJSON('./server/build/q-symbols.json', data);
         },
-      })
+      }),
+      typescript(),
     ],
     output: [
       {

--- a/starters/apps/starter/package.json
+++ b/starters/apps/starter/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@builder.io/qwik": "0.0.16-1",
     "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-typescript": "^8.3.0",
     "concurrently": "^6.4.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.59.0",

--- a/starters/apps/starter/rollup.config.js
+++ b/starters/apps/starter/rollup.config.js
@@ -1,4 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 import { qwikRollup } from '@builder.io/qwik/optimizer';
 import { writeFile, mkdir } from "fs/promises";
 import { dirname } from "path";
@@ -15,7 +16,8 @@ export default async function () {
         symbolsOutput: (data) => {
           outputJSON('./server/build/q-symbols.json', data);
         },
-      })
+      }),
+      typescript(),
     ],
     output: [
       {

--- a/starters/apps/todo/package.json
+++ b/starters/apps/todo/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@builder.io/qwik": "0.0.16-1",
     "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-typescript": "^8.3.0",
     "concurrently": "^6.4.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.59.0",

--- a/starters/apps/todo/rollup.config.js
+++ b/starters/apps/todo/rollup.config.js
@@ -1,4 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 import { qwikRollup } from '@builder.io/qwik/optimizer';
 import { terser } from "rollup-plugin-terser";
 import { writeFile, mkdir } from "fs/promises";
@@ -17,6 +18,7 @@ export default async function () {
           outputJSON('./server/build/q-symbols.json', data);
         },
       }),
+      typescript(),
       terser(),
     ],
     output: [


### PR DESCRIPTION
Fix the following error I encountered when running `npm run build` in a project generated by `npm init qwik`:

```
> npm run build

> qwik-app@0.0.1 build
> npm run clean && rollup -c

> qwik-app@0.0.1 clean
> rimraf */build/

src/index.server.tsx, src/my-app.tsx → public/build, server/build...
[!] Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
src\my-app.tsx (4:52)
2: import { qComponent, qHook, useEvent } from '@builder.io/qwik';
3:
4: export const MyApp = qComponent<{}, { name: string }>({
                                                       ^
5:   tagName: 'my-app', // optional
6:   onMount: qHook(() => ({ name: 'World' })),
Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
    at error (C:\Users\igrep\Downloads\t\qwik-app\node_modules\rollup\dist\shared\rollup.js:158:30)
    at Module.error (C:\Users\igrep\Downloads\t\qwik-app\node_modules\rollup\dist\shared\rollup.js:12420:16)
    at Module.tryParse (C:\Users\igrep\Downloads\t\qwik-app\node_modules\rollup\dist\shared\rollup.js:12823:25)
    at Module.setSource (C:\Users\igrep\Downloads\t\qwik-app\node_modules\rollup\dist\shared\rollup.js:12726:24)
    at ModuleLoader.addModuleSource (C:\Users\igrep\Downloads\t\qwik-app\node_modules\rollup\dist\shared\rollup.js:22197:20)
```

# My Environment

OS: Windows 10
Node: v16.13.1