### PR TITLE
Vendor yarn executable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.json  linguist-language=JSON-with-Comments
+.yarn/releases/** binary
+.yarn/plugins/** binary

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ target
 *.node
 todo-express/
 qwik-app/
+
+# Yarn
+.yarn/*
+!.yarn/releases

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@
 *.
 .vscode/settings.json
 .history
+.yarn
 bazel-*
 bazel-bin
 bazel-out

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.23.0-20211220.1904.cjs

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ install-rust-deps:
 	cargo install wasm-pack
 	rustup component add clippy
 
+add-target:
+	rustup target add wasm32-unknown-unknown
+
 install-all: install-rust install-rust-deps
 
 install-cli:


### PR DESCRIPTION
## Description

Adds a vendored copy of the yarn executable to version control as well as a 
config file (.yarnrc.yml) to instruct clients which version to use.

Purpose of this is to ensure that everyone uses the same version, leading to
reproducible builds - and ensures that the project builds properly when mounted
as a submodule of a directory that also has a yarn lock file. In effect this
ensures that this project is built with yarn 1 and treated as it's own root.

## Changelog
- chore: vendor yarn version
- chore: change git ignore for yarn files
- chore: "add-target" make target
