### PR TITLE
fix(build): Bazel should produce prod build.

### DIFF
--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -8,7 +8,8 @@ nodejs_binary(
     entry_point = ":index.js",
     templated_args = [
         "--build",
-        "--dev",
+        # Adding dev seems to break the output in a way where a CJS output still has `import()`
+        # "--dev",
         "--tsc",
         "--api",
         # Dissable these flags, as we don't need them for now.

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -45,7 +45,10 @@ export async function build(config: BuildConfig) {
       await setDevVersion(config);
     }
 
-    console.log(`🌎 Qwik v${config.distVersion}`);
+    console.log(
+      `🌎 Qwik v${config.distVersion}`,
+      `[node:  ${process.version}, platform: ${process.platform}, arch: ${process.arch}]`
+    );
 
     if (config.tsc) {
       tsc(config);

--- a/scripts/package-json.ts
+++ b/scripts/package-json.ts
@@ -28,6 +28,8 @@ export async function generatePackageJson(config: BuildConfig) {
         import: './core.mjs',
         require: './core.cjs',
       },
+      './core.cjs': './core.cjs',
+      './core.mjs': './core.mjs',
       './jsx-runtime': {
         import: './jsx-runtime.mjs',
         require: './jsx-runtime.cjs',
@@ -36,6 +38,7 @@ export async function generatePackageJson(config: BuildConfig) {
         import: './optimizer.mjs',
         require: './optimizer.cjs',
       },
+      './server/index.cjs': './server/index.cjs',
       './server': {
         import: './server/index.mjs',
         require: './server/index.cjs',
@@ -44,6 +47,7 @@ export async function generatePackageJson(config: BuildConfig) {
         import: './testing/index.mjs',
         require: './testing/index.cjs',
       },
+      './qwikloader.js': './qwikloader.js',
       './package.json': './package.json',
     },
     files: Array.from(new Set(rootPkg.files)).sort((a, b) => {


### PR DESCRIPTION
The dev build of bazel creates a 'import()' inside `.cjs` files.