### PR TITLE
Docs: Fix broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # The HTML-first framework
 
-Qwik is designed for the fastest possible page load time, by delivering pure HTML with near 0 javascript for your pages to become interactive, regardless of how complex your site or app is. It achieves this via [resumability](https://github.com/BuilderIO/qwik/blob/main/docs/RESUMABLE.md) of HTML and [ultra fine-grained lazy-loading](https://github.com/BuilderIO/qwik/blob/main/docs/LAZY_LOADING.md) of code.
+Qwik is designed for the fastest possible page load time, by delivering pure HTML with near 0 javascript for your pages to become interactive, regardless of how complex your site or app is. It achieves this via [resumability](https://github.com/BuilderIO/qwik/blob/main/docs/pages/guide/resumable-vs-replayable.mdx) of HTML and [ultra fine-grained lazy-loading](https://github.com/BuilderIO/qwik/blob/main/docs/pages/guide/lazy-loading.mdx) of code.
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Try out our starter:
 npm init qwik@latest
 ```
 
-- Understand the difference between [resumable and replayable](https://github.com/BuilderIO/qwik/blob/main/docs/RESUMABLE.md) applications.
-- Learn about Qwik's high level [mental model](https://github.com/BuilderIO/qwik/blob/main/docs/LAZY_LOADING.md).
+- Understand the difference between [resumable and replayable](https://github.com/BuilderIO/qwik/blob/main/docs/pages/guide/resumable-vs-replayable.mdx) applications.
+- Learn about Qwik's high level [mental model](https://github.com/BuilderIO/qwik/blob/main/docs/pages/guide/mental-model.mdx).
 
 ## Blog Posts
 


### PR DESCRIPTION
This commit fixes broken links in the README file for links to resumable-vs-replayable, mental-model, and lazy-loading files.