### PR TITLE
fix: high order components

### DIFF
--- a/src/core/api.md
+++ b/src/core/api.md
@@ -12,10 +12,10 @@ export function $<T>(expression: T): QRL<T>;
 // @public
 export function Async<T>(props: AsyncProps<T>): JSXNode<any>;
 
-// Warning: (ae-forgotten-export) The symbol "PublicProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "Component" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function component$<PROPS extends {}>(onMount: OnMountFn<PROPS>, options?: ComponentOptions): (props: PublicProps<PROPS>) => JSXNode<PROPS>;
+export function component$<PROPS extends {}>(onMount: OnMountFn<PROPS>, options?: ComponentOptions): Component<PROPS>;
 
 // @public (undocumented)
 export type ComponentChild = JSXNode<any> | object | string | number | bigint | boolean | null | undefined;
@@ -30,7 +30,7 @@ export interface ComponentOptions {
 }
 
 // @public
-export function componentQrl<PROPS extends {}>(onMount: QRL<OnMountFn<PROPS>>, options?: ComponentOptions): (props: PublicProps<PROPS>) => JSXNode<PROPS>;
+export function componentQrl<PROPS extends {}>(onMount: QRL<OnMountFn<PROPS>>, options?: ComponentOptions): Component<PROPS>;
 
 // @public (undocumented)
 export interface CorePlatform {
@@ -208,7 +208,7 @@ export type PromiseValue<T> = {
 export type Props<T extends {} = {}> = Record<string, any> & T;
 
 // @public
-export type PropsOf<COMP extends (props: any) => JSXNode> = COMP extends (props: infer PROPS) => JSXNode<any> ? PROPS : never;
+export type PropsOf<COMP extends (props: any) => (JSXNode<any> | null)> = COMP extends (props: infer PROPS) => (JSXNode<any> | null) ? NonNullable<PROPS> : never;
 
 // @public
 export interface QRL<TYPE = any> {

--- a/src/core/api.md
+++ b/src/core/api.md
@@ -208,7 +208,7 @@ export type PromiseValue<T> = {
 export type Props<T extends {} = {}> = Record<string, any> & T;
 
 // @public
-export type PropsOf<COMP extends (props: any) => (JSXNode<any> | null)> = COMP extends (props: infer PROPS) => (JSXNode<any> | null) ? NonNullable<PROPS> : never;
+export type PropsOf<COMP extends (props: any) => JSXNode<any> | null> = COMP extends (props: infer PROPS) => JSXNode<any> | null ? NonNullable<PROPS> : never;
 
 // @public
 export interface QRL<TYPE = any> {

--- a/src/core/component/component-ctx.ts
+++ b/src/core/component/component-ctx.ts
@@ -27,6 +27,7 @@ export const renderComponent = (rctx: RenderContext, ctx: QContext) => {
   const hostElement = ctx.element as HTMLElement;
   const onRenderQRL = ctx.renderQrl!;
   assertDefined(onRenderQRL);
+  onRenderQRL.setContainer(rctx.containerEl);
   const onRenderFn = onRenderQRL.invokeFn();
 
   // Component is not dirty any more

--- a/src/core/import/qrl.ts
+++ b/src/core/import/qrl.ts
@@ -17,6 +17,7 @@ import { logError } from '../util/log';
 import { then } from '../util/promises';
 import { getPlatform } from '../platform/platform';
 import { unwrapSubscriber } from '../use/use-subscriber';
+import { tryGetInvokeContext } from '../use/use-core';
 
 let runtimeSymbolId = 0;
 const RUNTIME_QRL = '/runtimeQRL';
@@ -123,7 +124,12 @@ export function qrl<T = any>(
       lexicalScopeCapture[i] = unwrapSubscriber(lexicalScopeCapture[i]);
     }
   }
-  return new QRLInternal<T>(chunk, symbol, null, symbolFn, null, lexicalScopeCapture);
+  const qrl = new QRLInternal<T>(chunk, symbol, null, symbolFn, null, lexicalScopeCapture);
+  const ctx = tryGetInvokeContext();
+  if (ctx && ctx.element) {
+    qrl.setContainer(ctx.element);
+  }
+  return qrl;
 }
 
 export function runtimeQrl<T>(symbol: T, lexicalScopeCapture: any[] = EMPTY_ARRAY): QRL<T> {

--- a/starters/apps/e2e/src/components/factory/factory.tsx
+++ b/starters/apps/e2e/src/components/factory/factory.tsx
@@ -1,0 +1,28 @@
+import { $, component$, Host } from '@builder.io/qwik';
+import { factory$ } from './utils';
+
+export const A = factory$(() => {
+  return <div>A</div>;
+});
+
+export const B = factory$(() => {
+  return <div>B</div>;
+});
+
+export function Light(props: { prop: string }) {
+  return <div>Light: {props.prop}</div>;
+}
+
+export const C = factory$(Light);
+
+export const Factory = component$(() => {
+  return $(() => {
+    return (
+      <Host>
+        <A />
+        <B />
+        <C prop="wow!" />
+      </Host>
+    );
+  });
+});

--- a/starters/apps/e2e/src/components/factory/utils.tsx
+++ b/starters/apps/e2e/src/components/factory/utils.tsx
@@ -1,0 +1,16 @@
+import { $, component$, implicit$FirstArg, QRL, useHostElement } from '@builder.io/qwik';
+
+export function factoryQrl<P>(componentQRL: QRL<(props: P) => any>) {
+  return component$((props: P) => {
+    return $(async () => {
+      const hostElement = useHostElement();
+      const Component = await componentQRL.resolve(hostElement);
+      return (
+        <div>
+          <Component {...props} />
+        </div>
+      );
+    });
+  });
+}
+export const factory$ = implicit$FirstArg(factoryQrl);

--- a/starters/apps/e2e/src/entry.server.tsx
+++ b/starters/apps/e2e/src/entry.server.tsx
@@ -16,6 +16,7 @@ import { Render } from './components/render/render';
 import { Events } from './components/events/events';
 import { Async } from './components/async/async';
 import { Containers } from './components/containers/container';
+import { Factory } from './components/factory/factory';
 
 /**
  * Entry point for server-side pre-rendering.
@@ -34,6 +35,7 @@ export function render(opts: RenderToStringOptions) {
     '/e2e/events': () => <Events />,
     '/e2e/async': () => <Async />,
     '/e2e/container': () => <Containers />,
+    '/e2e/factory': () => <Factory />,
   };
   const Test = tests[url.pathname];
 

--- a/starters/apps/e2e/src/main.tsx
+++ b/starters/apps/e2e/src/main.tsx
@@ -27,6 +27,9 @@ export const Main = component$(() => {
         <p>
           <a href="/e2e/container">Container</a>
         </p>
+        <p>
+          <a href="/e2e/factory">Factory</a>
+        </p>
       </section>
     );
   });

--- a/starters/e2e/e2e.spec.ts
+++ b/starters/e2e/e2e.spec.ts
@@ -230,4 +230,16 @@ test.describe('e2e', () => {
       expect((await content3.innerText()).trim()).toEqual('Placeholder Start\nINSIDE THING 1');
     });
   });
+
+  test.describe('factory', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/e2e/factory');
+    });
+
+    test('should render correctly', async ({ page }) => {
+      const body = await page.locator('body');
+
+      expect((await body.innerText()).trim()).toEqual('A\nB\nLight: wow!');
+    });
+  });
 });


### PR DESCRIPTION
This works now:

utils.ts
```tsx
import { $, component$, implicit$FirstArg, QRL, useHostElement } from '@builder.io/qwik';

export function factoryQrl<P>(componentQRL: QRL<(props: P) => any>) {
  return component$((props: P) => {
    return $(async () => {
      const hostElement = useHostElement();
      const Component = await componentQRL.resolve(hostElement);
      return (
        <div>
          <Component {...props} />
        </div>
      );
    });
  });
}
export const factory$ = implicit$FirstArg(factoryQrl);
```

```app.tsx
import { $, component$, Host } from '@builder.io/qwik';
import { factory$ } from './utils';

export const A = factory$(() => {
  return <div>A</div>;
});

export const B = factory$(() => {
  return <div>B</div>;
});

export function Light(props: { prop: string }) {
  return <div>Light: {props.prop}</div>;
}

export const C = factory$(Light);

export const Factory = component$(() => {
  return $(() => {
    return (
      <Host>
        <A />
        <B />
        <C prop="wow!" />
      </Host>
    );
  });
});
```