### PR TITLE
docs: Fix code typo in `lite-components.mdx`

### DIFF
--- a/docs/pages/guide/components/lite-components.mdx
+++ b/docs/pages/guide/components/lite-components.mdx
@@ -9,7 +9,7 @@ In addition to standard Qwik components that have all of the lazy-loaded propert
 
 ```tsx
 function MyButton(props: { text: string }) {
-  return <button>{text}</button>;
+  return <button>{props.text}</button>;
 }
 
 const MyApp = component$(() => {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fix code typo in `lite-components.mdx`; a prop wasn't destructured in the arguments list, but referenced directly anyway.