### PR TITLE
chore(optimizer): Use Rust's stable channel

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,11 +42,11 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-09-30
+          toolchain: nightly
           override: true
 
       - name: Run benchmark
-        run: cargo +nightly-2021-09-30 bench --workspace | tee output.txt
+        run: cargo +nightly bench --workspace | tee output.txt
 
       - name: Download previous benchmark results
         run: mkdir raw-data && curl -o raw-data/benchmark-data.json https://raw.githubusercontent.com/BuilderIO/qwik-raw-data/gh-pages/benchmark-data.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,10 @@ jobs:
     name: Build WASM
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        rust_version: ['1.59.0', '1.60.0', 'stable']
+
     needs: changes
 
     steps:
@@ -141,7 +145,7 @@ jobs:
         with:
           profile: minimal
           override: true
-          toolchain: 1.59.0
+          toolchain: ${{ matrix.rust_version }}
           target: wasm32-unknown-unknown
 
       - name: Checkout
@@ -194,6 +198,7 @@ jobs:
   build-bindings:
     strategy:
       matrix:
+        rust_version: ['1.59.0', '1.60.0', 'stable']
         settings:
           - host: macos-latest
             target: x86_64-apple-darwin
@@ -210,7 +215,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             build: yarn build.platform
 
-    name: Build ${{ matrix.settings.target }}
+    name: Build ${{ matrix.settings.target }} (${{ matrix.rust_version }})
     runs-on: ${{ matrix.settings.host }}
 
     needs: changes
@@ -237,7 +242,7 @@ jobs:
         with:
           profile: minimal
           override: true
-          toolchain: 1.59.0
+          toolchain: ${{ matrix.rust_version }}
           target: ${{ matrix.settings.target }}
 
       - name: Cache NPM Dependencies
@@ -296,6 +301,10 @@ jobs:
   build-distribution:
     name: Build Distribution
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust_version: ['1.59.0', '1.60.0', 'stable']
 
     needs:
       - build-package
@@ -538,7 +547,7 @@ jobs:
         if: ${{ needs.changes.outputs.fullbuild == 'true' }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.59.0
+          toolchain: ${{ matrix.rust_version }}
           profile: default
           override: true
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2022-02-23
+stable

--- a/src/napi/Cargo.toml
+++ b/src/napi/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Manu Mtz.-Almeida <manu@builder.io>"]
 name = "qwik-napi"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.59"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/optimizer/cli/Cargo.toml
+++ b/src/optimizer/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qwik"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.59"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/optimizer/core/Cargo.toml
+++ b/src/optimizer/core/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 description = "Qwik optimizer compiler"
 keywords = ["qwik", "swc", "javascript", "optimizer", "compiler"]
 categories = ["development-tools", "development-tools::cargo-plugins"]
+rust-version = "1.59"
 
 [lib]
 crate-type = ["rlib"]

--- a/src/optimizer/core/README.md
+++ b/src/optimizer/core/README.md
@@ -1,6 +1,6 @@
 # qwik-core
 
-## 1. Install rust
+## 1. Install Rust
 
 https://www.rust-lang.org/tools/install
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

The optimizer is currently running a (rather old) version of Rust's nightly channel. This PR switches it to Rust stable.

- [x] Check what runs and what fails on stable
- [x] Keep on the latest nightly the necessary CI jobs (like `cargo bench`)
- [x] Establish a Minimum Rust Version

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
