### PR TITLE
Bump Clap to the latest version (3.1.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,33 +131,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.5"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
  "indexmap",
- "lazy_static",
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
  "textwrap",
- "unicase",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.0.0-beta.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -415,15 +399,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -703,9 +678,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_str_bytes"
-version = "4.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
@@ -882,30 +857,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1740,12 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tinyvec"
@@ -1807,15 +1755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,12 +1774,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"

--- a/src/optimizer/cli/Cargo.toml
+++ b/src/optimizer/cli/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0.0-beta.5"
+clap = "3.1.8"
 qwik-core = { path = "../core", features = ["fs", "parallel"] }
 path-absolutize = "3.0.11"

--- a/src/optimizer/cli/src/main.rs
+++ b/src/optimizer/cli/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use clap::{App, AppSettings, Arg};
+use clap::{Arg, Command};
 use path_absolutize::Absolutize;
 use qwik_core::{transform_fs, EntryStrategy, MinifyMode, TransformFsOptions};
 
@@ -20,27 +20,29 @@ struct OptimizerInput {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let matches = App::new("qwik")
+    let matches = Command::new("qwik")
         .version("1.0")
-        .setting(
-            AppSettings::ArgRequiredElseHelp
-                | AppSettings::SubcommandRequiredElseHelp
-                | AppSettings::InferSubcommands
-                | AppSettings::DisableHelpSubcommand,
+        // .setting(
+        //     AppSettings::ArgRequiredElseHelp
+        //         | AppSettings::SubcommandRequiredElseHelp
+        //         | AppSettings::InferSubcommands
+        //         | AppSettings::DisableHelpSubcommand,
 
-        )
+        // )
+        .subcommand_required(true).arg_required_else_help(true)
         .about("Qwik CLI allows to optimize qwik projects before bundling")
         .subcommand(
-            App::new("optimize")
+            Command::new("optimize")
                 .about("takes a source directory of qwik code and outputs an optimized version that lazy loads")
-                .setting(AppSettings::ArgRequiredElseHelp)
+                // .setting(AppSettings::ArgRequiredElseHelp)
+                .arg_required_else_help(true)
                 .arg(
                     Arg::new("src")
                         .short('s')
                         .long("src")
                         .default_value(".")
                         .takes_value(true)
-                        .about("relative path to the source directory"),
+                        .help("relative path to the source directory"),
                 )
                 .arg(
                     Arg::new("dest")
@@ -48,29 +50,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .long("dest")
                         .required(true)
                         .takes_value(true)
-                        .about("relative path to the output directory"),
+                        .help("relative path to the output directory"),
                 )
                 .arg(
                     Arg::new("glob")
                         .short('g')
                         .long("glob")
                         .takes_value(true)
-                        .about("glob used to match files within the source directory"),
+                        .help("glob used to match files within the source directory"),
                 )
                 .arg(
                     Arg::new("strategy")
                     .long("strategy")
                         .possible_values(["single", "hook", "smart", "component"])
                         .takes_value(true)
-                        .about("entry strategy used to group hooks"),
+                        .help("entry strategy used to group hooks"),
                 )
                 .arg(
                     Arg::new("no-transpile")
                     .long("no-transpile")
-                    .about("transpile TS and JSX into JS").takes_value(false)
+                    .help("transpile TS and JSX into JS").takes_value(false)
                  )
-                .arg(Arg::new("minify").long("minify").possible_values(["minify", "simplify", "none"]).takes_value(true).about("outputs minified source code"))
-                .arg(Arg::new("sourcemaps").long("sourcemaps").about("generates sourcemaps").takes_value(false)),
+                .arg(Arg::new("minify").long("minify").possible_values(["minify", "simplify", "none"]).takes_value(true).help("outputs minified source code"))
+                .arg(Arg::new("sourcemaps").long("sourcemaps").help("generates sourcemaps").takes_value(false)),
         )
         .get_matches();
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Bump Clap to the [latest version](https://crates.io/crates/clap/3.1.8). The latest stable version changed and deprecated some of the API. This PR bumps the version and fixes all the deprecation warnings. 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
