### PR TITLE
Fix typo in Why Qwik docs page

### DIFF
--- a/docs/pages/guide/why-qwik.mdx
+++ b/docs/pages/guide/why-qwik.mdx
@@ -22,7 +22,7 @@ To make matters worse, JavaScript is single-threaded; therefore, our complex sit
 ## Why is the problem worth solving?
 
 Because there is a lot of evidence that says that site startup performance affects the bottom line. Slow sites:
-- Frustrat users
+- Frustrate users
 - Lower conversion rates
 - Decrease profits
 


### PR DESCRIPTION
# What is it?

- [x] Docs / tests

# Description

Teeny tiny typo fix:
* Frustrat -> Frustrate (users)

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
