### PR TITLE
fix: use WeakSet for noSerialize()

### DIFF
--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -141,7 +141,7 @@ export interface JSXNode<T = any> {
 
 // @alpha (undocumented)
 export type NoSerialize<T> = (T & {
-    [NOSERIALIZE]: true;
+    __no_serialize__: true;
 }) | undefined;
 
 // @alpha (undocumented)

--- a/packages/qwik/src/core/object/q-object.ts
+++ b/packages/qwik/src/core/object/q-object.ts
@@ -303,12 +303,11 @@ function verifySerializable<T>(value: T) {
   }
 }
 
-const NOSERIALIZE = Symbol('NoSerialize');
+const noSerializeSet = /*#__PURE__*/ new WeakSet<any>();
 
 export function shouldSerialize(obj: any): boolean {
   if (obj !== null && (typeof obj == 'object' || typeof obj === 'function')) {
-    const noSerialize = (obj as any)[NOSERIALIZE] === true;
-    return !noSerialize;
+    return !noSerializeSet.has(obj);
   }
   return true;
 }
@@ -316,12 +315,12 @@ export function shouldSerialize(obj: any): boolean {
 /**
  * @alpha
  */
-export type NoSerialize<T> = (T & { [NOSERIALIZE]: true }) | undefined;
+export type NoSerialize<T> = (T & { __no_serialize__: true }) | undefined;
 
 /**
  * @alpha
  */
 export function noSerialize<T extends {}>(input: T): NoSerialize<T> {
-  (input as any)[NOSERIALIZE] = true;
+  noSerializeSet.add(input);
   return input as any;
 }


### PR DESCRIPTION
# Description

Previously the noSerialize() would add a  Symbol() to the object to identify later on the object shouldn't be serialized. However, some objects, like an iframe window on a different domain, can not be assigned a property to it.