### PR TITLE
fix: support --extensions flag in optimizer CLI

### DIFF
--- a/packages/qwik/src/optimizer/cli/src/main.rs
+++ b/packages/qwik/src/optimizer/cli/src/main.rs
@@ -70,7 +70,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .about("transpile TS and JSX into JS").takes_value(false)
                  )
                 .arg(Arg::new("minify").long("minify").possible_values(["minify", "simplify", "none"]).takes_value(true).about("outputs minified source code"))
-                .arg(Arg::new("sourcemaps").long("sourcemaps").about("generates sourcemaps").takes_value(false)),
+                .arg(Arg::new("sourcemaps").long("sourcemaps").about("generates sourcemaps").takes_value(false))
+                .arg(Arg::new("extensions").long("extensions").about("keep explicit extensions on imports").takes_value(false)),
         )
         .get_matches();
 


### PR DESCRIPTION
Was already supported by the code that creates the `OptimizerInput`, you just can't pass it because clap does not know about it.
