### PR TITLE
Fix docs broken link to containers page

### DIFF
--- a/packages/docs/pages/docs/README.md
+++ b/packages/docs/pages/docs/README.md
@@ -24,7 +24,7 @@
 
 ## Advanced
 
-- [Containers](advanced/container.mdx)
+- [Containers](advanced/containers.mdx)
 - [Optimizer](advanced/optimizer.mdx)
 - [QRL](advanced/qrl.mdx)
 - [Qwikloader](advanced/qwikloader.mdx)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This is a simple fix for a broken link in the Docs navigation to the "Containers" page.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

N/A

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
