### PR TITLE
add fastify starter server

### DIFF
--- a/starters/servers/fastify/README.md
+++ b/starters/servers/fastify/README.md
@@ -1,0 +1,9 @@
+## Fastify Server
+
+This app has a minimal [Fastify server](https://fastify.io/) implementation. After running a full build, you can preview the build using the command:
+
+```
+npm run serve
+```
+
+Then visit [http://localhost:8080/](http://localhost:8080/)

--- a/starters/servers/fastify/package.json
+++ b/starters/servers/fastify/package.json
@@ -1,0 +1,11 @@
+{
+  "description": "Fastify server.",
+  "scripts": {
+    "build.ssr": "vite build --ssr src/entry.fastify.tsx",
+    "serve": "node server/entry.fastify.js"
+  },
+  "devDependencies": {
+    "@fastify/static": "^6.4.0",
+    "fastify": "^4.0.0"
+  }
+}

--- a/starters/servers/fastify/src/entry.fastify.tsx
+++ b/starters/servers/fastify/src/entry.fastify.tsx
@@ -1,0 +1,62 @@
+import Fastify from 'fastify';
+import staticPlugin from '@fastify/static';
+import { join } from 'path';
+import { render } from './entry.ssr';
+
+/**
+ * Create a fastify server
+ * https://fastify.io/
+ */
+const app = Fastify();
+
+/**
+ * Serve static client build files,
+ * hashed filenames, immutable cache-control
+ */
+app.register(staticPlugin, {
+  prefix: '/build/',
+  root: join(__dirname, '..', 'dist', 'build'),
+  immutable: true,
+  maxAge: '1y',
+});
+
+/**
+ * Serve static public files at the root
+ */
+app.register(staticPlugin, {
+  root: join(__dirname, '..', 'dist'),
+  index: false,
+  decorateReply: false,
+  wildcard: false,
+});
+
+/**
+ * Server-Side Render Qwik application
+ */
+app.get('/*', async (request, reply) => {
+  try {
+    // Render the Root component to a string
+    const result = await render({
+      url: request.url,
+    });
+
+    // respond with SSR'd HTML
+    reply.type('text/html').send(result.html);
+  } catch (e) {
+    // Error while server-side rendering
+    app.log.error(e);
+    throw e;
+  }
+});
+
+/**
+ * Start the fastify server
+ */
+app.listen({ port: 8080 }, (e) => {
+  if (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+
+  console.log(`http://localhost:8080/`);
+});

--- a/starters/servers/fastify/src/entry.fastify.tsx
+++ b/starters/servers/fastify/src/entry.fastify.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import Fastify from 'fastify';
 import staticPlugin from '@fastify/static';
 import { join } from 'path';


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement

# Description

This is a copy of starters/servers/express for Fastify.
I have replaced Express by it in the Todo starter as a test.
I have also run `build.cli`, `cli` and `cli.validate` successfully.

It's probably missing something to be usable right away, though.

# Use cases and why

- 1. I wanted to use Qwik on an existing project
- 2. the cli should offer more choices

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality