### PR TITLE
fix(docs): fix typo, useStore instead of useStore$

### DIFF
--- a/packages/docs/src/pages/tutorial/understanding/capturing/index.mdx
+++ b/packages/docs/src/pages/tutorial/understanding/capturing/index.mdx
@@ -3,7 +3,7 @@ title: Understanding Qwik Difference - Capturing the lexical scope
 layout: tutorial
 ---
 
-In this example, we will explore how Qwik serializes the component state. A naive approach would be for Qwik to simply save all of the state associated with the `useStore$()`. Qwik is more intelligent about the approach and tries to tree shake the stores that are not needed by the client. 
+In this example, we will explore how Qwik serializes the component state. A naive approach would be for Qwik to simply save all of the state associated with the `useStore()`. Qwik is more intelligent about the approach and tries to tree shake the stores that are not needed by the client. 
 
 The example consists of:
 - `<App/>`: which creates a store.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
