### PR TITLE
Remove npm suggestion from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # CONTRIBUTING
 
-To build Qwik for local development, first [npm](https://docs.npmjs.com/) (or [yarn](https://yarnpkg.com/)) install the dev dependencies:
+To build Qwik for local development, first install the dev dependencies using [yarn](https://yarnpkg.com/)):
 
 ```
 yarn install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 To build Qwik for local development, first install the dev dependencies using [yarn](https://yarnpkg.com/)):
 
 ```
-yarn install
+yarn
 ```
 
 Next the `start` command will:


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Qwik's contributing docs includes a recommendation to use npm or yarn but the repo itself uses a yarn lock file and if you install it locally using npm it will generate a package-lock.json incorrectly.

# Use cases and why

I checked the repo out during a worshop and noticed this when reading the docs.

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
