### PR TITLE
fix: change the build file to entry.ssr.tsx

### DIFF
--- a/starters/apps/base/package.json
+++ b/starters/apps/base/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "npm run typecheck && npm run build.client && npm run build.ssr",
     "build.client": "vite build",
-    "build.ssr": "vite build --ssr src/entry.server.tsx",
+    "build.ssr": "vite build --ssr src/entry.ssr.tsx",
     "dev": "vite",
     "dev.ssr": "node --inspect node_modules/vite/bin/vite.js --mode ssr",
     "dev.debug": "node --inspect-brk node_modules/vite/bin/vite.js --mode ssr",


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

after creating a qwik app with `npm create qwik` and building there is a build error as it searches for `entry.server.tsx` instead of `entry.ssr.tsx`

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
