### PR TITLE
fix(server-platform): logError instead throw in raf()

### DIFF
--- a/packages/qwik/src/server/platform.ts
+++ b/packages/qwik/src/server/platform.ts
@@ -49,7 +49,8 @@ function createPlatform(
       return symbol;
     },
     raf: () => {
-      return Promise.reject('server can not rerender');
+      logError('server can not rerender');
+      return Promise.resolve();
     },
     nextTick: (fn) => {
       return new Promise((resolve) => {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

See message on Discord: https://discord.com/channels/842438759945601056/842438761287254019/988537861114564618

What does the error `Server can not rerender` mean? 
See: https://github.com/BuilderIO/qwik/blob/91a566f15605928eaf242a0df591a63f7e8caf6b/packages/qwik/src/server/platform.ts#L38-L40

My understanding is that the server cannot render a component multiple times. Is that correct? Does that mean that the code is triggering mulitple renders?
What pattern should we be looking for to identify the culprit?

With recent node versions (16+), the node process crashes when an unhandled exception is thrown. This makes it tough to track the root cause.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
