### PR TITLE
Fix typo in preventdefault example

### DIFF
--- a/packages/docs/src/pages/tutorial/events/preventdefault/index.mdx
+++ b/packages/docs/src/pages/tutorial/events/preventdefault/index.mdx
@@ -11,4 +11,4 @@ To solve this Qwik provides a declarative API to automatically call `preventDefa
 
 ## Example 
 
-Clicking on the link will cause a navigation event. We wish to prevent this and call our callback instead. Add `preventdeault:click` to the `<a href>` to achieve this.
+Clicking on the link will cause a navigation event. We wish to prevent this and call our callback instead. Add `preventdefault:click` to the `<a href>` to achieve this.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The `preventdefault` example had a typo

# Use cases and why

does not apply (I guess 🤷‍♂️)

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
