### PR TITLE
Add an inline comment to callout lazy-loaded behavior

### DIFF
--- a/packages/docs/src/pages/docs/concepts/progressive.mdx
+++ b/packages/docs/src/pages/docs/concepts/progressive.mdx
@@ -62,9 +62,13 @@ Lazy-loading is a core property of the framework and not an afterthought.
 Let's look at our example again:
 
 ```tsx
+// the `$` suffix for `component` indicates that the component should be 
+// lazy-loaded.
 const Counter = component$(() => {
   const store = useStore({ count: 0 });
 
+  // the `$` suffix for `onClick` indicates that the implementation for 
+  // the handler should be lazy-loaded. 
   return <button onClick$={() => store.count++}>{store.count}</button>;
 });
 ```


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Adding inline comments to the code examples so that the lazy-loading sigils are easy to find.

# Use cases and why
In reading through the examples, it's easy to miss the `$` to indicate that a part of the functionality is being lazy-loaded.  Since this example is used to teach lazy-loading, let's explicitly annotate the code.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
