### PR TITLE
refactor: new syntax for JSX events

### DIFF
--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -108,9 +108,6 @@ export interface DOMAttributes<T> extends QwikProps, QwikEvents {
 }
 
 // @public (undocumented)
-export type EventHandler<T> = QRL<(value: T) => any>;
-
-// @public (undocumented)
 export const Fragment: FunctionComponent<{
     children?: any;
 }>;
@@ -296,16 +293,14 @@ export type NoSerialize<T> = (T & {
 // @alpha
 export const noSerialize: <T extends {}>(input: T) => NoSerialize<T>;
 
-// @public
-export type On$Props<T extends {}> = {
-    [K in keyof T as K extends `${infer A}Qrl` ? NonNullable<T[K]> extends QRL ? `${A}$` : never : never]?: NonNullable<T[K]> extends QRL<infer B> ? B : never;
-};
-
 // @public (undocumented)
 export type OnRenderFn<PROPS> = (props: PROPS) => JSXNode<any> | null | (() => JSXNode<any>);
 
 // @alpha
 export const pauseContainer: (elmOrDoc: Element | Document) => Promise<SnapshotResult>;
+
+// @public (undocumented)
+export type PropFunction<T extends Function> = T extends (...args: infer ARGS) => infer RET ? (...args: ARGS) => Promise<RET> : never;
 
 // @public (undocumented)
 export type Props<T extends {} = {}> = Record<string, any> & T;
@@ -317,12 +312,16 @@ export type PropsOf<COMP extends Component<any>> = COMP extends Component<infer 
 // Warning: (ae-forgotten-export) The symbol "ComponentBaseProps" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type PublicProps<PROPS extends {}> = MutableProps<PROPS> & On$Props<PROPS> & ComponentBaseProps;
+export type PublicProps<PROPS extends {}> = MutableProps<PROPS> & ComponentBaseProps;
 
 // @public
 export interface QRL<TYPE = any> {
-    invoke(...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<TYPE extends (...args: any[]) => infer RETURN ? RETURN : never>;
-    resolve(): Promise<TYPE>;
+    (...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<TYPE extends (...args: any[]) => infer RETURN ? RETURN : never>;
+    // (undocumented)
+    getHash(): string;
+    // (undocumented)
+    getSymbol(): string;
+    resolve(el?: Element): Promise<TYPE>;
 }
 
 // @alpha

--- a/packages/qwik/src/core/component/component.public.ts
+++ b/packages/qwik/src/core/component/component.public.ts
@@ -5,7 +5,6 @@ import type { ComponentBaseProps } from '../render/jsx/types/jsx-qwik-attributes
 import type { FunctionComponent } from '../render/jsx/types/jsx-node';
 import { jsx } from '../render/jsx/jsx-runtime';
 import type { MutableWrapper } from '../object/q-object';
-import type { QRLInternal } from '../import/qrl-class';
 
 /**
  * Infers `Props` from the component.
@@ -67,67 +66,13 @@ export type Component<PROPS extends {}> = FunctionComponent<PublicProps<PROPS>>;
 /**
  * @public
  */
-export type PublicProps<PROPS extends {}> = MutableProps<PROPS> &
-  On$Props<PROPS> &
-  ComponentBaseProps;
+export type PublicProps<PROPS extends {}> = MutableProps<PROPS> & ComponentBaseProps;
 
 /**
  * @public
  */
 export type MutableProps<PROPS extends {}> = {
   [K in keyof PROPS]: PROPS[K] | MutableWrapper<PROPS[K]>;
-};
-
-// <docs markdown="../readme.md#On$Props">
-// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#On$Props instead)
-/**
- * The type used to autogenerate the `$` suffixed properties on the component props.
- *
- * When declaring component props, it is not possible to pass in closures. Instead, the closures
- * need to be passed in as QRLs. This is usually done automatically by the Optimizer by suffixing
- * the property with `$`. This type automatically generates the `$`-suffixed properties from
- * `Qrl`-suffixed properties.
- *
- * ```tsx
- * export const App = component$(() => {
- *   const goodbyeQrl = $(() => alert('Good Bye!'));
- *
- *   // This is not-canonical usage of On$Props. It is here only as an example.
- *   const myComponentProps: On$Props<MyComponentProps> & MyComponentProps = {
- *     goodbyeQrl: goodbyeQrl,
- *     hello$: (name) => alert('Hello ' + name),
- *   };
- *   return (
- *     <div>
- *       <MyComponent {...myComponentProps} />
- *     </div>
- *   );
- * });
- *
- * interface MyComponentProps {
- *   goodbyeQrl?: QRL<() => void>;
- *   helloQrl?: QRL<(name: string) => void>;
- * }
- * export const MyComponent = component$((props: MyComponentProps) => {
- *   return (
- *     <div>
- *       <button onClickQrl={props.goodbyeQrl}>hello</button>
- *       <button onClick$={async () => await props.helloQrl?.invoke('World')}>good bye</button>
- *     </div>
- *   );
- * });
- * ```
- *
- * @public
- */
-// </docs>
-export type On$Props<T extends {}> = {
-  [K in keyof T as K extends `${infer A}Qrl`
-    ? NonNullable<T[K]> extends QRL
-      ? `${A}$`
-      : never
-    : never]?: NonNullable<T[K]> extends QRL<infer B> ? B : never;
 };
 
 /**
@@ -200,9 +145,7 @@ export const componentQrl = <PROPS extends {}>(
 
   // Return a QComponent Factory function.
   return function QSimpleComponent(props, key): JSXNode<PROPS> {
-    const finalKey = skipKey
-      ? undefined
-      : (onRenderQrl as QRLInternal).getHash() + ':' + (key ? key : '');
+    const finalKey = skipKey ? undefined : onRenderQrl.getHash() + ':' + (key ? key : '');
     return jsx(tagName, { [OnRenderProp]: onRenderQrl, ...props }, finalKey) as any;
   };
 };

--- a/packages/qwik/src/core/component/component.unit.tsx
+++ b/packages/qwik/src/core/component/component.unit.tsx
@@ -123,14 +123,14 @@ export const MyCounter = component$(
       <div>
         <button
           class="decrement"
-          onClickQrl={runtimeQrl(MyCounter_update, [props, state, { dir: -1 }])}
+          onClick$={runtimeQrl(MyCounter_update, [props, state, { dir: -1 }])}
         >
           -
         </button>
         <span>{state.count}</span>
         <button
           class="increment"
-          onClickQrl={runtimeQrl(MyCounter_update, [props, state, { dir: -1 }])}
+          onClick$={runtimeQrl(MyCounter_update, [props, state, { dir: -1 }])}
         >
           +
         </button>

--- a/packages/qwik/src/core/component/qrl-styles.ts
+++ b/packages/qwik/src/core/component/qrl-styles.ts
@@ -1,11 +1,11 @@
-import type { QRLInternal } from '../import/qrl-class';
 import { ComponentStylesPrefixContent, ComponentStylesPrefixHost } from '../util/markers';
 import { hashCode } from '../util/hash_code';
+import type { QRL } from '../import/qrl.public';
 
 /**
  * @public
  */
-export const styleKey = (qStyles: QRLInternal<string>, index: number): string => {
+export const styleKey = (qStyles: QRL<string>, index: number): string => {
   return `${hashCode(qStyles.getHash())}-${index}`;
 };
 

--- a/packages/qwik/src/core/examples.tsx
+++ b/packages/qwik/src/core/examples.tsx
@@ -6,7 +6,7 @@
 // it to the desired comment location
 //
 
-import { component$, On$Props } from './component/component.public';
+import { component$ } from './component/component.public';
 import { qrl } from './import/qrl';
 import { $, QRL } from './import/qrl.public';
 import { Host } from './render/jsx/host.public';
@@ -280,38 +280,6 @@ export const CmpInline = component$(() => {
   // </docs>
   return Cmp;
 };
-
-//
-// <docs anchor="On$Props">
-export const App = component$(() => {
-  const goodbyeQrl = $(() => alert('Good Bye!'));
-
-  // This is not-canonical usage of On$Props. It is here only as an example.
-  const myComponentProps: On$Props<MyComponentProps> & MyComponentProps = {
-    goodbyeQrl: goodbyeQrl,
-    hello$: (name) => alert('Hello ' + name),
-  };
-  return (
-    <div>
-      <MyComponent {...myComponentProps} />
-    </div>
-  );
-});
-
-interface MyComponentProps {
-  goodbyeQrl?: QRL<() => void>;
-  helloQrl?: QRL<(name: string) => void>;
-}
-export const MyComponent = component$((props: MyComponentProps) => {
-  return (
-    <div>
-      <button onClickQrl={props.goodbyeQrl}>hello</button>
-      <button onClick$={async () => await props.helloQrl?.invoke('World')}>good bye</button>
-    </div>
-  );
-});
-// </docs>
-//
 
 () => {
   // <docs anchor="use-client-mount">

--- a/packages/qwik/src/core/import/qrl-class.ts
+++ b/packages/qwik/src/core/import/qrl-class.ts
@@ -1,69 +1,93 @@
 import { qError, QError_qrlIsNotFunction } from '../error/error';
 import { verifySerializable } from '../object/q-object';
+import { getPlatform } from '../platform/platform';
 import { InvokeContext, newInvokeContext, useInvoke } from '../use/use-core';
 import { then } from '../util/promises';
 import { qDev } from '../util/qdev';
 import { isFunction, ValueOrPromise } from '../util/types';
-import { qrlImport, QRLSerializeOptions, stringifyQRL } from './qrl';
-import type { QRL as IQRL } from './qrl.public';
+import { QRLSerializeOptions, stringifyQRL } from './qrl';
+import type { QRL } from './qrl.public';
 
-export const isQrl = (value: any): value is QRL => {
-  return value instanceof QRL;
+export const isQrl = (value: any): value is QRLInternal => {
+  return typeof value === 'function';
 };
 
-class QRL<TYPE = any> implements IQRL<TYPE> {
-  __brand__QRL__!: TYPE;
-  $refSymbol$?: string;
+export interface QRLInternalMethods<TYPE> {
+  readonly $chunk$: string;
+  readonly $symbol$: string;
+  readonly $refSymbol$: string | null;
+  $capture$: string[] | null;
+  $captureRef$: any[] | null;
 
-  private $el$: Element | undefined;
+  resolve(el?: Element): Promise<TYPE>;
+  getSymbol(): string;
+  getHash(): string;
 
-  constructor(
-    public $chunk$: string,
-    public $symbol$: string,
-    public $symbolRef$: null | ValueOrPromise<TYPE>,
-    public $symbolFn$: null | (() => Promise<Record<string, any>>),
-    public $capture$: null | string[],
-    public $captureRef$: any[] | null
-  ) {
-    if (qDev) {
-      verifySerializable($captureRef$);
+  $setContainer$(el: Element): void;
+  $resolveLazy$(el: Element): void;
+  $invokeFn$(el?: Element, currentCtx?: InvokeContext, beforeFn?: () => void): any;
+  $copy$(): QRLInternal<TYPE>;
+  $serialize$(options?: QRLSerializeOptions): string;
+}
+
+export interface QRLInternal<TYPE = any> extends QRL<TYPE>, QRLInternalMethods<TYPE> {}
+
+export const createQrl = <TYPE>(
+  chunk: string,
+  symbol: string,
+  symbolRef: null | ValueOrPromise<TYPE>,
+  symbolFn: null | (() => Promise<Record<string, any>>),
+  capture: null | string[],
+  captureRef: any[] | null,
+  refSymbol: string | null
+) => {
+  if (qDev) {
+    verifySerializable(captureRef);
+  }
+
+  let cachedEl: Element | undefined;
+
+  const setContainer = (el: Element) => {
+    if (!cachedEl) {
+      cachedEl = el;
     }
-  }
+  };
 
-  setContainer(el: Element) {
-    if (!this.$el$) {
-      this.$el$ = el;
-    }
-  }
-
-  getSymbol(): string {
-    return this.$refSymbol$ ?? this.$symbol$;
-  }
-
-  getHash(): string {
-    return getSymbolHash(this.$refSymbol$ ?? this.$symbol$);
-  }
-
-  async resolve(el?: Element): Promise<TYPE> {
+  const resolve = async (el?: Element): Promise<TYPE> => {
     if (el) {
-      this.setContainer(el);
+      setContainer(el);
     }
-    return qrlImport(this.$el$, this as any);
-  }
+    if (symbolRef) {
+      return symbolRef;
+    }
+    if (symbolFn) {
+      return (symbolRef = symbolFn().then((module) => (symbolRef = module[symbol])));
+    } else {
+      if (!cachedEl) {
+        throw new Error(
+          `QRL '${chunk}#${symbol || 'default'}' does not have an attached container`
+        );
+      }
+      const symbol2 = getPlatform(cachedEl).importSymbol(cachedEl, chunk, symbol);
+      return (symbolRef = then(symbol2, (ref) => {
+        return (symbolRef = ref);
+      }));
+    }
+  };
 
-  resolveLazy(el?: Element): ValueOrPromise<TYPE> {
-    return isFunction(this.$symbolRef$) ? this.$symbolRef$ : this.resolve(el);
-  }
+  const resolveLazy = (el?: Element): ValueOrPromise<TYPE> => {
+    return isFunction(symbolRef) ? symbolRef : resolve(el);
+  };
 
-  invokeFn(el?: Element, currentCtx?: InvokeContext, beforeFn?: () => void): any {
+  const invokeFn = (el?: Element, currentCtx?: InvokeContext, beforeFn?: () => void) => {
     return ((...args: any[]): any => {
-      const fn = this.resolveLazy(el) as TYPE;
+      const fn = resolveLazy(el) as TYPE;
       return then(fn, (fn) => {
         if (isFunction(fn)) {
           const baseContext = currentCtx ?? newInvokeContext();
           const context: InvokeContext = {
             ...baseContext,
-            $qrl$: this,
+            $qrl$: QRL as QRLInternal<any>,
           };
           if (beforeFn) {
             beforeFn();
@@ -73,31 +97,46 @@ class QRL<TYPE = any> implements IQRL<TYPE> {
         throw qError(QError_qrlIsNotFunction);
       });
     }) as any;
-  }
+  };
 
-  copy(): QRL<TYPE> {
-    const copy = new QRL(
-      this.$chunk$,
-      this.$symbol$,
-      this.$symbolRef$,
-      this.$symbolFn$,
-      null,
-      this.$captureRef$
-    );
-    copy.$refSymbol$ = this.$refSymbol$;
-    return copy;
-  }
-
-  async invoke(...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never) {
-    const fn = this.invokeFn();
+  const invoke = async function (...args: any) {
+    const fn = invokeFn();
     const result = await fn(...args);
     return result;
-  }
+  };
 
-  serialize(options?: QRLSerializeOptions) {
-    return stringifyQRL(this, options);
-  }
-}
+  const QRL: QRLInternal<TYPE> = invoke as any;
+  const methods: QRLInternalMethods<TYPE> = {
+    getSymbol: () => refSymbol ?? symbol,
+    getHash: () => getSymbolHash(refSymbol ?? symbol),
+    resolve,
+    $resolveLazy$: resolveLazy,
+    $setContainer$: setContainer,
+    $chunk$: chunk,
+    $symbol$: symbol,
+    $refSymbol$: refSymbol,
+    get $capture$() {
+      return capture;
+    },
+    set $capture$(v) {
+      capture = v;
+    },
+    get $captureRef$() {
+      return captureRef;
+    },
+    set $captureRef$(v) {
+      captureRef = v;
+    },
+    $invokeFn$: invokeFn,
+    $copy$(): QRLInternal<TYPE> {
+      return createQrl<TYPE>(chunk, symbol, symbolRef, symbolFn, null, captureRef, refSymbol);
+    },
+    $serialize$(options?: QRLSerializeOptions) {
+      return stringifyQRL(QRL, options);
+    },
+  };
+  return Object.assign(invoke, methods);
+};
 
 export const getSymbolHash = (symbolName: string) => {
   const index = symbolName.lastIndexOf('_');
@@ -107,8 +146,12 @@ export const getSymbolHash = (symbolName: string) => {
   return symbolName;
 };
 
-export const isSameQRL = (a: QRL<any>, b: QRL<any>): boolean => {
+export const isSameQRL = (a: QRLInternal<any>, b: QRLInternal<any>): boolean => {
   return a.getHash() === b.getHash();
 };
 
-export { QRL as QRLInternal };
+export function assertQrl<T>(qrl: QRL<T>): asserts qrl is QRLInternal<T> {
+  if (!isQrl(qrl)) {
+    throw new Error('Not a QRL');
+  }
+}

--- a/packages/qwik/src/core/import/qrl-class.ts
+++ b/packages/qwik/src/core/import/qrl-class.ts
@@ -9,7 +9,7 @@ import { QRLSerializeOptions, stringifyQRL } from './qrl';
 import type { QRL } from './qrl.public';
 
 export const isQrl = (value: any): value is QRLInternal => {
-  return typeof value === 'function';
+  return typeof value === 'function' && typeof value.getSymbol === 'function';
 };
 
 export interface QRLInternalMethods<TYPE> {

--- a/packages/qwik/src/core/import/qrl.public.ts
+++ b/packages/qwik/src/core/import/qrl.public.ts
@@ -127,23 +127,29 @@ import { runtimeQrl } from './qrl';
 // </docs>
 export interface QRL<TYPE = any> {
   /**
-   * Resolve the QRL and return the actual value.
-   */
-  resolve(): Promise<TYPE>;
-  /**
    * Resolve the QRL of closure and invoke it.
    * @param args - Clousure arguments.
    * @returns A promise of the return value of the closure.
    */
-  invoke(
-    ...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never
-  ): Promise<TYPE extends (...args: any[]) => infer RETURN ? RETURN : never>;
+  (...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<
+    TYPE extends (...args: any[]) => infer RETURN ? RETURN : never
+  >;
+
+  /**
+   * Resolve the QRL and return the actual value.
+   */
+  resolve(el?: Element): Promise<TYPE>;
+
+  getSymbol(): string;
+  getHash(): string;
 }
 
 /**
  * @public
  */
-export type EventHandler<T> = QRL<(value: T) => any>;
+export type PropFunction<T extends Function> = T extends (...args: infer ARGS) => infer RET
+  ? (...args: ARGS) => Promise<RET>
+  : never;
 
 // <docs markdown="../readme.md#$">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!

--- a/packages/qwik/src/core/import/qrl.unit.ts
+++ b/packages/qwik/src/core/import/qrl.unit.ts
@@ -5,40 +5,40 @@ import { qrl } from './qrl';
 describe('QRL', () => {
   describe('serialization', () => {
     it('should parse', () => {
-      expect(parseQRL('./chunk')).toMatchObject({ $chunk$: './chunk', $symbol$: 'default' });
-      expect(parseQRL('./chunk#mySymbol')).toMatchObject({
+      matchProps(parseQRL('./chunk'), { $chunk$: './chunk', $symbol$: 'default' });
+      matchProps(parseQRL('./chunk#mySymbol'), {
         $chunk$: './chunk',
         $symbol$: 'mySymbol',
       });
-      expect(parseQRL('./chunk#mySymbol')).toMatchObject({
+      matchProps(parseQRL('./chunk#mySymbol'), {
         $chunk$: './chunk',
         $symbol$: 'mySymbol',
       });
-      expect(parseQRL('./chunk#s1')).toMatchObject({
+      matchProps(parseQRL('./chunk#s1'), {
         $chunk$: './chunk',
         $symbol$: 's1',
         $capture$: [],
       });
-      expect(parseQRL('./chunk#s1[1 b]')).toMatchObject({
+      matchProps(parseQRL('./chunk#s1[1 b]'), {
         $chunk$: './chunk',
         $symbol$: 's1',
         $capture$: ['1', 'b'],
       });
-      expect(parseQRL('./chunk#s1[1 b]')).toMatchObject({
+      matchProps(parseQRL('./chunk#s1[1 b]'), {
         $chunk$: './chunk',
         $symbol$: 's1',
         $capture$: ['1', 'b'],
       });
-      expect(parseQRL('./chunk#s1[1 b]')).toMatchObject({
+      matchProps(parseQRL('./chunk#s1[1 b]'), {
         $chunk$: './chunk',
         $symbol$: 's1',
         $capture$: ['1', 'b'],
       });
-      expect(parseQRL('./chunk[1 b]')).toMatchObject({
+      matchProps(parseQRL('./chunk[1 b]'), {
         $chunk$: './chunk',
         $capture$: ['1', 'b'],
       });
-      expect(parseQRL('./path#symbol[2]')).toMatchObject({
+      matchProps(parseQRL('./path#symbol[2]'), {
         $chunk$: './path',
         $symbol$: 'symbol',
         $capture$: ['2'],
@@ -62,19 +62,26 @@ describe('QRL', () => {
 
   describe('qrl', () => {
     it('should parse reference', () => {
-      expect(
+      matchProps(
         qrl(
           () =>
             Promise.resolve().then(function () {
               return require('./h_my-app_myapp_init-73253fd4.js');
             }),
           'MyApp_init'
-        )
-      ).toMatchObject({
-        $chunk$: './h_my-app_myapp_init-73253fd4.js',
-        $symbol$: 'MyApp_init',
-      });
+        ),
+        {
+          $chunk$: './h_my-app_myapp_init-73253fd4.js',
+          $symbol$: 'MyApp_init',
+        }
+      );
     });
     it('should parse self-reference', () => {});
   });
 });
+
+function matchProps(obj: any, properties: Record<string, any>) {
+  for (const [key, value] of Object.entries(properties)) {
+    expect(obj[key]).toEqual(value);
+  }
+}

--- a/packages/qwik/src/core/import/qrl.unit.ts
+++ b/packages/qwik/src/core/import/qrl.unit.ts
@@ -1,5 +1,5 @@
 import { parseQRL, stringifyQRL } from './qrl';
-import { QRLInternal } from './qrl-class';
+import { createQrl } from './qrl-class';
 import { qrl } from './qrl';
 
 describe('QRL', () => {
@@ -46,15 +46,15 @@ describe('QRL', () => {
     });
 
     it('should stringify', () => {
-      expect(stringifyQRL(new QRLInternal('./chunk', '', null, null, null, null))).toEqual(
+      expect(stringifyQRL(createQrl('./chunk', '', null, null, null, null, null))).toEqual(
         './chunk'
       );
-      expect(stringifyQRL(new QRLInternal('./c', 's1', null, null, null, null))).toEqual('./c#s1');
-      expect(stringifyQRL(new QRLInternal('./c', 's1', null, null, [], null))).toEqual('./c#s1');
-      expect(stringifyQRL(new QRLInternal('./c', 's1', null, null, [1, '2'] as any, null))).toEqual(
+      expect(stringifyQRL(createQrl('./c', 's1', null, null, null, null, null))).toEqual('./c#s1');
+      expect(stringifyQRL(createQrl('./c', 's1', null, null, [], null, null))).toEqual('./c#s1');
+      expect(stringifyQRL(createQrl('./c', 's1', null, null, [1, '2'] as any, null, null))).toEqual(
         './c#s1[1 2]'
       );
-      expect(stringifyQRL(new QRLInternal('./c', 's1', null, null, [1 as any, '2'], null))).toEqual(
+      expect(stringifyQRL(createQrl('./c', 's1', null, null, [1 as any, '2'], null, null))).toEqual(
         './c#s1[1 2]'
       );
     });

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -9,7 +9,6 @@ export type {
   OnRenderFn,
   Component,
   PublicProps,
-  On$Props,
 } from './component/component.public';
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -23,7 +22,7 @@ export type { SnapshotState, SnapshotResult } from './object/store';
 //////////////////////////////////////////////////////////////////////////////////////////
 export { $ } from './import/qrl.public';
 export { qrl, inlinedQrl } from './import/qrl';
-export type { QRL, EventHandler } from './import/qrl.public';
+export type { QRL, PropFunction } from './import/qrl.public';
 export type { Props } from './props/props.public';
 export { implicit$FirstArg } from './util/implicit_dollar';
 

--- a/packages/qwik/src/core/object/q-object.ts
+++ b/packages/qwik/src/core/object/q-object.ts
@@ -253,10 +253,10 @@ class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
 }
 
 const wrap = <T>(value: T, containerState: ContainerState): T => {
+  if (isQrl(value)) {
+    return value;
+  }
   if (isObject(value)) {
-    if (isQrl(value)) {
-      return value;
-    }
     if (Object.isFrozen(value)) {
       return value;
     }
@@ -296,6 +296,9 @@ const _verifySerializable = <T>(value: T, seen: Set<any>): T => {
       return value;
     }
     seen.add(unwrapped);
+    if (isQrl(unwrapped)) {
+      return value;
+    }
     switch (typeof unwrapped) {
       case 'object':
         if (isArray(unwrapped)) {
@@ -311,7 +314,6 @@ const _verifySerializable = <T>(value: T, seen: Set<any>): T => {
           return value;
         }
         if (isPromise(unwrapped)) return value;
-        if (isQrl(unwrapped)) return value;
         if (isElement(unwrapped)) return value;
         if (isDocument(unwrapped)) return value;
         break;

--- a/packages/qwik/src/core/object/store.ts
+++ b/packages/qwik/src/core/object/store.ts
@@ -352,12 +352,12 @@ export const pauseState = async (containerEl: Element): Promise<SnapshotResult> 
   };
 
   const convertedObjs = objs.map((obj) => {
+    if (isQrl(obj)) {
+      return QRL_PREFIX + stringifyQRL(obj, qrlSerializeOptions);
+    }
     if (isObject(obj)) {
       if (isArray(obj)) {
         return obj.map(serialize);
-      }
-      if (isQrl(obj)) {
-        return QRL_PREFIX + stringifyQRL(obj, qrlSerializeOptions);
       }
       const output: Record<string, any> = {};
       Object.entries(obj).forEach(([key, value]) => {
@@ -570,14 +570,15 @@ const reviveValues = (
 };
 
 const reviveNestedObjects = (obj: any, getObject: GetObject) => {
+  if (isQrl(obj)) {
+    if (obj.$capture$ && obj.$capture$.length > 0) {
+      obj.$captureRef$ = obj.$capture$.map(getObject);
+      obj.$capture$ = null;
+    }
+    return;
+  }
   if (obj && typeof obj == 'object') {
-    if (isQrl(obj)) {
-      if (obj.$capture$ && obj.$capture$.length > 0) {
-        obj.$captureRef$ = obj.$capture$.map(getObject);
-        obj.$capture$ = null;
-      }
-      return;
-    } else if (isArray(obj)) {
+    if (isArray(obj)) {
       for (let i = 0; i < obj.length; i++) {
         const value = obj[i];
         if (typeof value == 'string') {
@@ -769,6 +770,10 @@ const getPromiseValue = (promise: Promise<any>) => {
 const collectQObjects = async (input: any, collector: Collector) => {
   let obj = input;
   if (obj != null) {
+    if (isQrl(obj)) {
+      await collectQrl(obj, collector);
+      return true;
+    }
     if (typeof obj === 'object') {
       if (isPromise(obj)) {
         if (collector.$seen$.has(obj)) {
@@ -785,10 +790,6 @@ const collectQObjects = async (input: any, collector: Collector) => {
           return true;
         }
         return false;
-      }
-      if (isQrl(obj)) {
-        await collectQrl(obj, collector);
-        return true;
       }
       const subs = collector.$containerState$.$subsManager$.$tryGetLocal$(target)?.$subs$;
       if (subs) {

--- a/packages/qwik/src/core/object/store.ts
+++ b/packages/qwik/src/core/object/store.ts
@@ -212,7 +212,7 @@ export const pauseState = async (containerEl: Element): Promise<SnapshotResult> 
     if (ctx.$listeners$) {
       for (const listeners of ctx.$listeners$.values()) {
         for (const l of listeners) {
-          const captured = (l as QRLInternal).$captureRef$;
+          const captured = l.$captureRef$;
           if (captured) {
             for (const obj of captured) {
               await collectValue(obj, collector);

--- a/packages/qwik/src/core/object/store.unit.tsx
+++ b/packages/qwik/src/core/object/store.unit.tsx
@@ -93,5 +93,5 @@ export const LexicalScope = component$(() => {
     el,
     doc,
   ]);
-  return <div onClickQrl={thing}></div>;
+  return <div onClick$={thing}></div>;
 });

--- a/packages/qwik/src/core/props/props-on.ts
+++ b/packages/qwik/src/core/props/props-on.ts
@@ -5,11 +5,10 @@ import { fromCamelToKebabCase } from '../util/case';
 import { EMPTY_ARRAY } from '../util/flyweight';
 import type { QContext } from './props';
 import { RenderContext, setAttribute } from '../render/cursor';
-import type { QRL } from '../import/qrl.public';
 import { directGetAttribute } from '../render/fast-calls';
 import { isArray } from '../util/types';
 
-const ON_PROP_REGEX = /^(window:|document:|)on([A-Z]|-.).*(Qrl|\$)$/;
+const ON_PROP_REGEX = /^(window:|document:|)on([A-Z]|-.).*\$$/;
 
 export const isOnProp = (prop: string): boolean => {
   return ON_PROP_REGEX.test(prop);
@@ -19,7 +18,7 @@ export const qPropWriteQRL = (
   rctx: RenderContext,
   ctx: QContext,
   prop: string,
-  value: QRL<any>[] | QRL<any>
+  value: QRLInternal<any>[] | QRLInternal<any>
 ) => {
   if (!value) {
     return;
@@ -33,8 +32,8 @@ export const qPropWriteQRL = (
 
   const newQRLs = isArray(value) ? value : [value];
   for (const value of newQRLs) {
-    const cp = (value as QRLInternal).copy();
-    cp.setContainer(ctx.$element$);
+    const cp = value.$copy$();
+    cp.$setContainer$(ctx.$element$);
 
     const capture = cp.$capture$;
     if (capture == null) {
@@ -83,7 +82,7 @@ export const getDomListeners = (el: Element): Map<string, QRLInternal[]> => {
   return listeners;
 };
 
-const serializeQRLs = (existingQRLs: QRL<any>[], ctx: QContext): string => {
+const serializeQRLs = (existingQRLs: QRLInternal<any>[], ctx: QContext): string => {
   const opts: QRLSerializeOptions = {
     $platform$: getPlatform(ctx.$element$),
     $element$: ctx.$element$,

--- a/packages/qwik/src/core/props/props.ts
+++ b/packages/qwik/src/core/props/props.ts
@@ -20,7 +20,7 @@ import { qDev } from '../util/qdev';
 import { logError } from '../util/log';
 import { isQrl, QRLInternal } from '../import/qrl-class';
 import { directGetAttribute } from '../render/fast-calls';
-import { assertDefined } from '../assert/assert';
+import { assertDefined, assertEqual } from '../assert/assert';
 import { codeToText, QError_immutableJsxProps } from '../error/error';
 
 const Q_CTX = '__ctx__';
@@ -130,12 +130,12 @@ export const normalizeOnProp = (prop: string) => {
 };
 
 export const setEvent = (rctx: RenderContext, ctx: QContext, prop: string, value: any) => {
-  const dollar = qDev && prop.endsWith('$');
+  assertEqual(prop.endsWith('$'), true);
   qPropWriteQRL(
     rctx,
     ctx,
-    normalizeOnProp(prop.slice(0, dollar ? -1 : -3)),
-    dollar ? $(value) : value
+    normalizeOnProp(prop.slice(0, -1)),
+    isQrl(value) ? value : ($(value) as QRLInternal)
   );
 };
 

--- a/packages/qwik/src/core/props/props.ts
+++ b/packages/qwik/src/core/props/props.ts
@@ -22,6 +22,7 @@ import { isQrl, QRLInternal } from '../import/qrl-class';
 import { directGetAttribute } from '../render/fast-calls';
 import { assertDefined, assertEqual } from '../assert/assert';
 import { codeToText, QError_immutableJsxProps } from '../error/error';
+import { isArray } from '../util/types';
 
 const Q_CTX = '__ctx__';
 
@@ -131,12 +132,12 @@ export const normalizeOnProp = (prop: string) => {
 
 export const setEvent = (rctx: RenderContext, ctx: QContext, prop: string, value: any) => {
   assertEqual(prop.endsWith('$'), true);
-  qPropWriteQRL(
-    rctx,
-    ctx,
-    normalizeOnProp(prop.slice(0, -1)),
-    isQrl(value) ? value : ($(value) as QRLInternal)
-  );
+  const qrl = isArray(value) ? value.map(ensureQrl) : ensureQrl(value);
+  qPropWriteQRL(rctx, ctx, normalizeOnProp(prop.slice(0, -1)), qrl);
+};
+
+const ensureQrl = (value: any) => {
+  return isQrl(value) ? value : ($(value) as QRLInternal);
 };
 
 export const createProps = (target: any, containerState: ContainerState) => {

--- a/packages/qwik/src/core/readme.md
+++ b/packages/qwik/src/core/readme.md
@@ -30,16 +30,6 @@ See also: `component`, `useCleanup`, `onResume`, `onPause`, `useOn`, `useOnDocum
 
 @public
 
-# `On$Props`
-
-The type used to autogenerate the `$` suffixed properties on the component props.
-
-When declaring component props, it is not possible to pass in closures. Instead, the closures need to be passed in as QRLs. This is usually done automatically by the Optimizer by suffixing the property with `$`. This type automatically generates the `$`-suffixed properties from `Qrl`-suffixed properties.
-
-<docs code="./examples.tsx#On$Props"/>
-
-@public
-
 # `useStore`
 
 Creates an object that Qwik can track across serializations.

--- a/packages/qwik/src/core/render/cursor.ts
+++ b/packages/qwik/src/core/render/cursor.ts
@@ -34,7 +34,7 @@ import type { SubscriptionManager } from '../object/q-object';
 import { getDocument } from '../util/dom';
 import { directGetAttribute, directSetAttribute } from './fast-calls';
 import { HOST_TYPE, SKIP_RENDER_TYPE } from './jsx/jsx-runtime';
-import type { QRLInternal } from '../import/qrl-class';
+import { assertQrl } from '../import/qrl-class';
 
 export const SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -310,7 +310,8 @@ export const patchVnode = (
   if (isComponent) {
     if (!dirty && !ctx.$renderQrl$ && !ctx.$element$.hasAttribute(QHostAttr)) {
       setAttribute(rctx, ctx.$element$, QHostAttr, '');
-      ctx.$renderQrl$ = props![OnRenderProp]! as QRLInternal<OnRenderFn<any>>;
+      ctx.$renderQrl$ = props![OnRenderProp];
+      assertQrl(ctx.$renderQrl$ as any);
       dirty = true;
     }
     const promise = dirty ? renderComponent(rctx, ctx) : undefined;
@@ -538,7 +539,8 @@ const createElm = (
   let wait: ValueOrPromise<void>;
   if (isComponent) {
     // Run mount hook
-    const renderQRL = props![OnRenderProp]! as QRLInternal<OnRenderFn<any>>;
+    const renderQRL = props![OnRenderProp];
+    assertQrl<OnRenderFn<any>>(renderQRL);
     ctx.$renderQrl$ = renderQRL;
     directSetAttribute(ctx.$element$, QHostAttr, '');
     wait = renderComponent(rctx, ctx);

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -29,133 +29,135 @@ export interface QwikProps {
 /**
  * @public
  */
-export type EventHandler<Type = Event> = (event: Type, element: Element) => any;
+export type NativeEventHandler<T = Event> =
+  | ((ev: T, element: Element) => any)
+  | ((ev: T, element: Element) => any)[];
 
 /**
  * @public
  */
-export type QrlEvent<Type = Event> = QRL<EventHandler<Type>>;
+export type QrlEvent<Type = Event> = QRL<NativeEventHandler<Type>>;
 
 /**
  * @public
  */
 export interface QwikEvents {
   // Clipboard Events
-  onCopy$?: (event: ClipboardEvent, el: Element) => void;
-  onCopyCapture$?: (event: ClipboardEvent, el: Element) => void;
-  onCut$?: (event: ClipboardEvent, el: Element) => void;
-  onCutCapture$?: (event: ClipboardEvent, el: Element) => void;
-  onPaste$?: (event: ClipboardEvent, el: Element) => void;
-  onPasteCapture$?: (event: ClipboardEvent, el: Element) => void;
-  onCompositionEnd$?: (event: CompositionEvent, el: Element) => void;
-  onCompositionEndCapture$?: (event: CompositionEvent, el: Element) => void;
-  onCompositionStart$?: (event: CompositionEvent, el: Element) => void;
-  onCompositionStartCapture$?: (event: CompositionEvent, el: Element) => void;
-  onCompositionUpdate$?: (event: CompositionEvent, el: Element) => void;
-  onCompositionUpdateCapture$?: (event: CompositionEvent, el: Element) => void;
-  onFocus$?: (event: FocusEvent, el: Element) => void;
-  onFocusCapture$?: (event: FocusEvent, el: Element) => void;
-  onFocusin$?: (event: FocusEvent, el: Element) => void;
-  onFocusinCapture$?: (event: FocusEvent, el: Element) => void;
-  onFocusout$?: (event: FocusEvent, el: Element) => void;
-  onFocusoutCapture$?: (event: FocusEvent, el: Element) => void;
-  onBlur$?: (event: FocusEvent, el: Element) => void;
-  onBlurCapture$?: (event: FocusEvent, el: Element) => void;
-  onChange$?: (event: Event, el: Element) => void;
-  onChangeCapture$?: (event: Event, el: Element) => void;
-  onInput$?: (event: Event, el: Element) => void;
-  onInputCapture$?: (event: Event, el: Element) => void;
-  onReset$?: (event: Event, el: Element) => void;
-  onResetCapture$?: (event: Event, el: Element) => void;
-  onSubmit$?: (event: Event, el: Element) => void;
-  onSubmitCapture$?: (event: Event, el: Element) => void;
-  onInvalid$?: (event: Event, el: Element) => void;
-  onInvalidCapture$?: (event: Event, el: Element) => void;
-  onLoad$?: (event: Event, el: Element) => void;
-  onLoadCapture$?: (event: Event, el: Element) => void;
-  onError$?: (event: Event, el: Element) => void; // also a Media Event
-  onErrorCapture$?: (event: Event, el: Element) => void; // also a Media Event
-  onKeyDown$?: (event: KeyboardEvent, el: Element) => void;
-  onKeyDownCapture$?: (event: KeyboardEvent, el: Element) => void;
-  onKeyPress$?: (event: KeyboardEvent, el: Element) => void;
-  onKeyPressCapture$?: (event: KeyboardEvent, el: Element) => void;
-  onKeyUp$?: (event: KeyboardEvent, el: Element) => void;
-  onKeyUpCapture$?: (event: KeyboardEvent, el: Element) => void;
-  onAuxClick$?: (event: MouseEvent, el: Element) => void;
-  onClick$?: (event: MouseEvent, el: Element) => void;
-  onClickCapture$?: (event: MouseEvent, el: Element) => void;
-  onContextMenu$?: (event: MouseEvent, el: Element) => void;
-  onContextMenuCapture$?: (event: MouseEvent, el: Element) => void;
-  onDblClick$?: (event: MouseEvent, el: Element) => void;
-  onDblClickCapture$?: (event: MouseEvent, el: Element) => void;
-  onDrag$?: (event: DragEvent, el: Element) => void;
-  onDragCapture$?: (event: DragEvent, el: Element) => void;
-  onDragEnd$?: (event: DragEvent, el: Element) => void;
-  onDragEndCapture$?: (event: DragEvent, el: Element) => void;
-  onDragEnter$?: (event: DragEvent, el: Element) => void;
-  onDragEnterCapture$?: (event: DragEvent, el: Element) => void;
-  onDragExit$?: (event: DragEvent, el: Element) => void;
-  onDragExitCapture$?: (event: DragEvent, el: Element) => void;
-  onDragLeave$?: (event: DragEvent, el: Element) => void;
-  onDragLeaveCapture$?: (event: DragEvent, el: Element) => void;
-  onDragOver$?: (event: DragEvent, el: Element) => void;
-  onDragOverCapture$?: (event: DragEvent, el: Element) => void;
-  onDragStart$?: (event: DragEvent, el: Element) => void;
-  onDragStartCapture$?: (event: DragEvent, el: Element) => void;
-  onDrop$?: (event: DragEvent, el: Element) => void;
-  onDropCapture$?: (event: DragEvent, el: Element) => void;
-  onMouseDown$?: (event: MouseEvent, el: Element) => void;
-  onMouseDownCapture$?: (event: MouseEvent, el: Element) => void;
-  onMouseEnter$?: (event: MouseEvent, el: Element) => void;
-  onMouseLeave$?: (event: MouseEvent, el: Element) => void;
-  onMouseMove$?: (event: MouseEvent, el: Element) => void;
-  onMouseMoveCapture$?: (event: MouseEvent, el: Element) => void;
-  onMouseOut$?: (event: MouseEvent, el: Element) => void;
-  onMouseOutCapture$?: (event: MouseEvent, el: Element) => void;
-  onMouseOver$?: (event: MouseEvent, el: Element) => void;
-  onMouseOverCapture$?: (event: MouseEvent, el: Element) => void;
-  onMouseUp$?: (event: MouseEvent, el: Element) => void;
-  onMouseUpCapture$?: (event: MouseEvent, el: Element) => void;
-  onTouchCancel$?: (event: TouchEvent, el: Element) => void;
-  onTouchCancelCapture$?: (event: TouchEvent, el: Element) => void;
-  onTouchEnd$?: (event: TouchEvent, el: Element) => void;
-  onTouchEndCapture$?: (event: TouchEvent, el: Element) => void;
-  onTouchMove$?: (event: TouchEvent, el: Element) => void;
-  onTouchMoveCapture$?: (event: TouchEvent, el: Element) => void;
-  onTouchStart$?: (event: TouchEvent, el: Element) => void;
-  onTouchStartCapture$?: (event: TouchEvent, el: Element) => void;
-  onPointerDown$?: (event: PointerEvent, el: Element) => void;
-  onPointerDownCapture$?: (event: PointerEvent, el: Element) => void;
-  onPointerMove$?: (event: PointerEvent, el: Element) => void;
-  onPointerMoveCapture$?: (event: PointerEvent, el: Element) => void;
-  onPointerUp$?: (event: PointerEvent, el: Element) => void;
-  onPointerUpCapture$?: (event: PointerEvent, el: Element) => void;
-  onPointerCancel$?: (event: PointerEvent, el: Element) => void;
-  onPointerCancelCapture$?: (event: PointerEvent, el: Element) => void;
-  onPointerEnter$?: (event: PointerEvent, el: Element) => void;
-  onPointerEnterCapture$?: (event: PointerEvent, el: Element) => void;
-  onPointerLeave$?: (event: PointerEvent, el: Element) => void;
-  onPointerLeaveCapture$?: (event: PointerEvent, el: Element) => void;
-  onPointerOver$?: (event: PointerEvent, el: Element) => void;
-  onPointerOverCapture$?: (event: PointerEvent, el: Element) => void;
-  onPointerOut$?: (event: PointerEvent, el: Element) => void;
-  onPointerOutCapture$?: (event: PointerEvent, el: Element) => void;
-  onGotPointerCapture$?: (event: PointerEvent, el: Element) => void;
-  onGotPointerCaptureCapture$?: (event: PointerEvent, el: Element) => void;
-  onLostPointerCapture$?: (event: PointerEvent, el: Element) => void;
-  onLostPointerCaptureCapture$?: (event: PointerEvent, el: Element) => void;
-  onScroll$?: (event: UIEvent, el: Element) => void;
-  onScrollCapture$?: (event: UIEvent, el: Element) => void;
-  onWheel$?: (event: WheelEvent, el: Element) => void;
-  onWheelCapture$?: (event: WheelEvent, el: Element) => void;
-  onAnimationStart$?: (event: AnimationEvent, el: Element) => void;
-  onAnimationStartCapture$?: (event: AnimationEvent, el: Element) => void;
-  onAnimationEnd$?: (event: AnimationEvent, el: Element) => void;
-  onAnimationEndCapture$?: (event: AnimationEvent, el: Element) => void;
-  onAnimationIteration$?: (event: AnimationEvent, el: Element) => void;
-  onAnimationIterationCapture$?: (event: AnimationEvent, el: Element) => void;
-  onTransitionEnd$?: (event: TransitionEvent, el: Element) => void;
-  onTransitionEndCapture$?: (event: TransitionEvent, el: Element) => void;
+  onCopy$?: NativeEventHandler<ClipboardEvent>;
+  onCopyCapture$?: NativeEventHandler<ClipboardEvent>;
+  onCut$?: NativeEventHandler<ClipboardEvent>;
+  onCutCapture$?: NativeEventHandler<ClipboardEvent>;
+  onPaste$?: NativeEventHandler<ClipboardEvent>;
+  onPasteCapture$?: NativeEventHandler<ClipboardEvent>;
+  onCompositionEnd$?: NativeEventHandler<CompositionEvent>;
+  onCompositionEndCapture$?: NativeEventHandler<CompositionEvent>;
+  onCompositionStart$?: NativeEventHandler<CompositionEvent>;
+  onCompositionStartCapture$?: NativeEventHandler<CompositionEvent>;
+  onCompositionUpdate$?: NativeEventHandler<CompositionEvent>;
+  onCompositionUpdateCapture$?: NativeEventHandler<CompositionEvent>;
+  onFocus$?: NativeEventHandler<FocusEvent>;
+  onFocusCapture$?: NativeEventHandler<FocusEvent>;
+  onFocusin$?: NativeEventHandler<FocusEvent>;
+  onFocusinCapture$?: NativeEventHandler<FocusEvent>;
+  onFocusout$?: NativeEventHandler<FocusEvent>;
+  onFocusoutCapture$?: NativeEventHandler<FocusEvent>;
+  onBlur$?: NativeEventHandler<FocusEvent>;
+  onBlurCapture$?: NativeEventHandler<FocusEvent>;
+  onChange$?: NativeEventHandler<Event>;
+  onChangeCapture$?: NativeEventHandler<Event>;
+  onInput$?: NativeEventHandler<Event>;
+  onInputCapture$?: NativeEventHandler<Event>;
+  onReset$?: NativeEventHandler<Event>;
+  onResetCapture$?: NativeEventHandler<Event>;
+  onSubmit$?: NativeEventHandler<Event>;
+  onSubmitCapture$?: NativeEventHandler<Event>;
+  onInvalid$?: NativeEventHandler<Event>;
+  onInvalidCapture$?: NativeEventHandler<Event>;
+  onLoad$?: NativeEventHandler<Event>;
+  onLoadCapture$?: NativeEventHandler<Event>;
+  onError$?: NativeEventHandler<Event>; // also a Media Event
+  onErrorCapture$?: NativeEventHandler<Event>; // also a Media Event
+  onKeyDown$?: NativeEventHandler<KeyboardEvent>;
+  onKeyDownCapture$?: NativeEventHandler<KeyboardEvent>;
+  onKeyPress$?: NativeEventHandler<KeyboardEvent>;
+  onKeyPressCapture$?: NativeEventHandler<KeyboardEvent>;
+  onKeyUp$?: NativeEventHandler<KeyboardEvent>;
+  onKeyUpCapture$?: NativeEventHandler<KeyboardEvent>;
+  onAuxClick$?: NativeEventHandler<MouseEvent>;
+  onClick$?: NativeEventHandler<MouseEvent>;
+  onClickCapture$?: NativeEventHandler<MouseEvent>;
+  onContextMenu$?: NativeEventHandler<MouseEvent>;
+  onContextMenuCapture$?: NativeEventHandler<MouseEvent>;
+  onDblClick$?: NativeEventHandler<MouseEvent>;
+  onDblClickCapture$?: NativeEventHandler<MouseEvent>;
+  onDrag$?: NativeEventHandler<DragEvent>;
+  onDragCapture$?: NativeEventHandler<DragEvent>;
+  onDragEnd$?: NativeEventHandler<DragEvent>;
+  onDragEndCapture$?: NativeEventHandler<DragEvent>;
+  onDragEnter$?: NativeEventHandler<DragEvent>;
+  onDragEnterCapture$?: NativeEventHandler<DragEvent>;
+  onDragExit$?: NativeEventHandler<DragEvent>;
+  onDragExitCapture$?: NativeEventHandler<DragEvent>;
+  onDragLeave$?: NativeEventHandler<DragEvent>;
+  onDragLeaveCapture$?: NativeEventHandler<DragEvent>;
+  onDragOver$?: NativeEventHandler<DragEvent>;
+  onDragOverCapture$?: NativeEventHandler<DragEvent>;
+  onDragStart$?: NativeEventHandler<DragEvent>;
+  onDragStartCapture$?: NativeEventHandler<DragEvent>;
+  onDrop$?: NativeEventHandler<DragEvent>;
+  onDropCapture$?: NativeEventHandler<DragEvent>;
+  onMouseDown$?: NativeEventHandler<MouseEvent>;
+  onMouseDownCapture$?: NativeEventHandler<MouseEvent>;
+  onMouseEnter$?: NativeEventHandler<MouseEvent>;
+  onMouseLeave$?: NativeEventHandler<MouseEvent>;
+  onMouseMove$?: NativeEventHandler<MouseEvent>;
+  onMouseMoveCapture$?: NativeEventHandler<MouseEvent>;
+  onMouseOut$?: NativeEventHandler<MouseEvent>;
+  onMouseOutCapture$?: NativeEventHandler<MouseEvent>;
+  onMouseOver$?: NativeEventHandler<MouseEvent>;
+  onMouseOverCapture$?: NativeEventHandler<MouseEvent>;
+  onMouseUp$?: NativeEventHandler<MouseEvent>;
+  onMouseUpCapture$?: NativeEventHandler<MouseEvent>;
+  onTouchCancel$?: NativeEventHandler<TouchEvent>;
+  onTouchCancelCapture$?: NativeEventHandler<TouchEvent>;
+  onTouchEnd$?: NativeEventHandler<TouchEvent>;
+  onTouchEndCapture$?: NativeEventHandler<TouchEvent>;
+  onTouchMove$?: NativeEventHandler<TouchEvent>;
+  onTouchMoveCapture$?: NativeEventHandler<TouchEvent>;
+  onTouchStart$?: NativeEventHandler<TouchEvent>;
+  onTouchStartCapture$?: NativeEventHandler<TouchEvent>;
+  onPointerDown$?: NativeEventHandler<PointerEvent>;
+  onPointerDownCapture$?: NativeEventHandler<PointerEvent>;
+  onPointerMove$?: NativeEventHandler<PointerEvent>;
+  onPointerMoveCapture$?: NativeEventHandler<PointerEvent>;
+  onPointerUp$?: NativeEventHandler<PointerEvent>;
+  onPointerUpCapture$?: NativeEventHandler<PointerEvent>;
+  onPointerCancel$?: NativeEventHandler<PointerEvent>;
+  onPointerCancelCapture$?: NativeEventHandler<PointerEvent>;
+  onPointerEnter$?: NativeEventHandler<PointerEvent>;
+  onPointerEnterCapture$?: NativeEventHandler<PointerEvent>;
+  onPointerLeave$?: NativeEventHandler<PointerEvent>;
+  onPointerLeaveCapture$?: NativeEventHandler<PointerEvent>;
+  onPointerOver$?: NativeEventHandler<PointerEvent>;
+  onPointerOverCapture$?: NativeEventHandler<PointerEvent>;
+  onPointerOut$?: NativeEventHandler<PointerEvent>;
+  onPointerOutCapture$?: NativeEventHandler<PointerEvent>;
+  onGotPointerCapture$?: NativeEventHandler<PointerEvent>;
+  onGotPointerCaptureCapture$?: NativeEventHandler<PointerEvent>;
+  onLostPointerCapture$?: NativeEventHandler<PointerEvent>;
+  onLostPointerCaptureCapture$?: NativeEventHandler<PointerEvent>;
+  onScroll$?: NativeEventHandler<UIEvent>;
+  onScrollCapture$?: NativeEventHandler<UIEvent>;
+  onWheel$?: NativeEventHandler<WheelEvent>;
+  onWheelCapture$?: NativeEventHandler<WheelEvent>;
+  onAnimationStart$?: NativeEventHandler<AnimationEvent>;
+  onAnimationStartCapture$?: NativeEventHandler<AnimationEvent>;
+  onAnimationEnd$?: NativeEventHandler<AnimationEvent>;
+  onAnimationEndCapture$?: NativeEventHandler<AnimationEvent>;
+  onAnimationIteration$?: NativeEventHandler<AnimationEvent>;
+  onAnimationIterationCapture$?: NativeEventHandler<AnimationEvent>;
+  onTransitionEnd$?: NativeEventHandler<TransitionEvent>;
+  onTransitionEndCapture$?: NativeEventHandler<TransitionEvent>;
 
   'document:onLoad$'?: (event: Event, el: Element) => any;
   'document:onLoadQrl'?: QRL<(event: Event, el: Element) => any>;
@@ -169,14 +171,9 @@ export interface QwikEvents {
   'document:onVisibilityChange$'?: (event: Event, el: Element) => any;
   'document:onVisibilityChangeQrl'?: QRL<(event: Event, el: Element) => any>;
 
-  [key: `on${string}$`]: EventHandler<any> | undefined;
-  [key: `on${string}Qrl`]: QrlEvent<any> | QrlEvent<any>[] | undefined;
-
-  [key: `document:on${string}$`]: EventHandler<any> | undefined;
-  [key: `document:on${string}Qrl`]: QrlEvent<any> | QrlEvent<any>[] | undefined;
-
-  [key: `window:on${string}$`]: EventHandler<any> | undefined;
-  [key: `window:on${string}Qrl`]: QrlEvent<any> | QrlEvent<any>[] | undefined;
+  [key: `on${string}$`]: NativeEventHandler<any> | undefined;
+  [key: `document:on${string}$`]: NativeEventHandler<any> | undefined;
+  [key: `window:on${string}$`]: NativeEventHandler<any> | undefined;
 }
 
 interface CSSProperties {
@@ -198,13 +195,13 @@ export interface ComponentBaseProps {
 
   [key: `host:${string}`]: any;
 
-  [key: `host:on${string}$`]: EventHandler;
+  [key: `host:on${string}$`]: NativeEventHandler;
   [key: `host:on${string}Qrl`]: QrlEvent | QrlEvent[];
 
-  [key: `document:on${string}$`]: EventHandler | undefined;
+  [key: `document:on${string}$`]: NativeEventHandler | undefined;
   [key: `document:on${string}Qrl`]: QrlEvent | QrlEvent[] | undefined;
 
-  [key: `window:on${string}$`]: EventHandler | undefined;
+  [key: `window:on${string}$`]: NativeEventHandler | undefined;
   [key: `window:on${string}Qrl`]: QrlEvent | QrlEvent[] | undefined;
 
   [key: `preventDefault:${string}`]: boolean;

--- a/packages/qwik/src/core/render/notify-render.ts
+++ b/packages/qwik/src/core/render/notify-render.ts
@@ -253,7 +253,7 @@ const executeWatches = async (
 
   containerState.$watchNext$.forEach((watch) => {
     if (watchPred(watch, false)) {
-      watchPromises.push(then(watch.qrl.resolveLazy(watch.el), () => watch));
+      watchPromises.push(then(watch.qrl.$resolveLazy$(watch.el), () => watch));
       containerState.$watchNext$.delete(watch);
     }
   });
@@ -261,7 +261,7 @@ const executeWatches = async (
     // Run staging effected
     containerState.$watchStaging$.forEach((watch) => {
       if (watchPred(watch, true)) {
-        watchPromises.push(then(watch.qrl.resolveLazy(watch.el), () => watch));
+        watchPromises.push(then(watch.qrl.$resolveLazy$(watch.el), () => watch));
       } else {
         containerState.$watchNext$.add(watch);
       }

--- a/packages/qwik/src/core/render/render-component.ts
+++ b/packages/qwik/src/core/render/render-component.ts
@@ -36,7 +36,7 @@ export const renderComponent = (rctx: RenderContext, ctx: QContext): ValueOrProm
   rctx.$containerState$.$subsManager$.$clearSub$(hostElement);
 
   // Resolve render function
-  const onRenderFn = onRenderQRL.invokeFn(rctx.$containerEl$, invocatinContext);
+  const onRenderFn = onRenderQRL.$invokeFn$(rctx.$containerEl$, invocatinContext);
 
   try {
     // Execution of the render function

--- a/packages/qwik/src/core/render/render.unit.tsx
+++ b/packages/qwik/src/core/render/render.unit.tsx
@@ -687,11 +687,11 @@ export const Counter = component$((props: { step?: number }) => {
   const step = Number(props.step || 1);
   return (
     <>
-      <button class="decrement" onClickQrl={runtimeQrl(Counter_add, [state, { value: -step }])}>
+      <button class="decrement" onClick$={runtimeQrl(Counter_add, [state, { value: -step }])}>
         -
       </button>
       <span>{state.count}</span>
-      <button class="increment" onClickQrl={runtimeQrl(Counter_add, [state, { value: step }])}>
+      <button class="increment" onClick$={runtimeQrl(Counter_add, [state, { value: step }])}>
         +
       </button>
     </>

--- a/packages/qwik/src/core/use/use-lexical-scope.public.ts
+++ b/packages/qwik/src/core/use/use-lexical-scope.public.ts
@@ -2,7 +2,7 @@ import { assertDefined, assertEqual } from '../assert/assert';
 import { parseQRL } from '../import/qrl';
 import { getContext, QContext, resumeIfNeeded } from '../props/props';
 import { getContainer, getInvokeContext } from './use-core';
-import type { QRLInternal } from '../import/qrl-class';
+import { assertQrl } from '../import/qrl-class';
 
 // <docs markdown="../readme.md#useLexicalScope">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
@@ -21,8 +21,9 @@ import type { QRLInternal } from '../import/qrl-class';
 export const useLexicalScope = <VARS extends any[]>(): VARS => {
   const context = getInvokeContext();
   const hostElement = context.$hostElement$;
-  const qrl = (context.$qrl$ ??
-    parseQRL(decodeURIComponent(String(context.$url$)), hostElement)) as QRLInternal;
+  const qrl = context.$qrl$ ?? parseQRL(decodeURIComponent(String(context.$url$)), hostElement);
+  assertQrl(qrl);
+
   if (qrl.$captureRef$ == null) {
     const el = context.$element$!;
     assertDefined(el);

--- a/packages/qwik/src/core/use/use-on.ts
+++ b/packages/qwik/src/core/use/use-on.ts
@@ -1,4 +1,4 @@
-import type { QRLInternal } from '../import/qrl-class';
+import { assertQrl } from '../import/qrl-class';
 import type { QRL } from '../import/qrl.public';
 import { getContext } from '../props/props';
 import { qPropWriteQRL } from '../props/props-on';
@@ -35,9 +35,10 @@ import { WatchDescriptor, WatchFlagsIsCleanup } from './use-watch';
 export const useCleanupQrl = (unmountFn: QRL<() => void>): void => {
   const { get, set, i, ctx } = useSequentialScope<boolean>();
   if (!get) {
+    assertQrl(unmountFn);
     const el = ctx.$hostElement$;
     const watch: WatchDescriptor = {
-      qrl: unmountFn as QRLInternal,
+      qrl: unmountFn,
       el,
       f: WatchFlagsIsCleanup,
       i,
@@ -301,5 +302,6 @@ export const useOnWindow = (event: string, eventQrl: QRL<(ev: Event) => void>) =
 const _useOn = (eventName: string, eventQrl: QRL<(ev: Event) => void>) => {
   const invokeCtx = useInvokeContext();
   const ctx = getContext(invokeCtx.$hostElement$);
+  assertQrl(eventQrl);
   qPropWriteQRL(invokeCtx.$renderCtx$, ctx, eventName, eventQrl);
 };

--- a/packages/qwik/src/core/use/use-styles.ts
+++ b/packages/qwik/src/core/use/use-styles.ts
@@ -1,5 +1,4 @@
 import { styleKey } from '../component/qrl-styles';
-import { toQrlOrError } from '../import/qrl';
 import type { QRL } from '../import/qrl.public';
 import { appendStyle, hasStyle } from '../render/cursor';
 import { directSetAttribute } from '../render/fast-calls';
@@ -85,14 +84,13 @@ export const useScopedStylesQrl = (styles: QRL<string>): void => {
 // </docs>
 export const useScopedStyles$ = /*#__PURE__*/ implicit$FirstArg(useScopedStylesQrl);
 
-const _useStyles = (styles: QRL<string>, scoped: boolean) => {
+const _useStyles = (styleQrl: QRL<string>, scoped: boolean) => {
   const { get, set, ctx, i } = useSequentialScope<boolean>();
   if (get === true) {
     return;
   }
   set(true);
   const renderCtx = ctx.$renderCtx$;
-  const styleQrl = toQrlOrError(styles);
   const styleId = styleKey(styleQrl, i);
   const hostElement = ctx.$hostElement$;
   if (scoped) {

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export.snap
@@ -54,7 +54,7 @@ import { jsx as _jsx } from "@builder.io/qwik/jsx-runtime";
 import { qrl } from "@builder.io/qwik";
 export const _____slug___component_vgk6N3QaQd4 = ()=>{
     return /*#__PURE__*/ _jsx("div", {
-        onClickQrl: qrl(()=>import("./entry______slug__.js")
+        onClick$: qrl(()=>import("./entry______slug__.js")
         , "_____slug___component_div_onClick_OesyMV0SO3o")
     });
 };

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export_index.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export_index.snap
@@ -20,7 +20,7 @@ export default component$(() => {
 import { componentQrl } from "@builder.io/qwik";
 import { inlinedQrl } from "@builder.io/qwik";
 export default /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
-    return <div onClickQrl={inlinedQrl(()=>console.log(mongodb)
+    return <div onClick$={inlinedQrl(()=>console.log(mongodb)
     , "mongo_component_div_onClick_2EK0wZbP8qw")}>
 
         </div>;

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_2.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_2.snap
@@ -118,7 +118,7 @@ export const App_component_ckEPmXZlub0 = (props)=>{
     const STEP_2 = 2;
     const count2 = state.count * 2;
     return /*#__PURE__*/ _jsxs("div", {
-        onClickQrl: qrl(()=>import("./app_component_div_onclick_1cgetmfzx0g")
+        onClick$: qrl(()=>import("./app_component_div_onclick_1cgetmfzx0g")
         , "App_component_div_onClick_1CGetmFZx0g", [
             count2,
             state
@@ -128,7 +128,7 @@ export const App_component_ckEPmXZlub0 = (props)=>{
                 children: state.count
             }),
             buttons.map((btn)=>/*#__PURE__*/ _jsx("button", {
-                    onClickQrl: qrl(()=>import("./app_component_div_button_onclick_f5nww9e63a4")
+                    onClick$: qrl(()=>import("./app_component_div_button_onclick_f5nww9e63a4")
                     , "App_component_div_button_onClick_f5NwW9e63a4", [
                         STEP_2,
                         btn,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_capture_props.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_capture_props.snap
@@ -112,7 +112,7 @@ import { qrl } from "@builder.io/qwik";
 export const App_component_1_w0t0o3QMovU = ()=>{
     const [C2, C3, C4, C5, C6, C7, C8, I2, I3, I4, I5, I6, I7, I8, count, state] = useLexicalScope();
     return /*#__PURE__*/ _jsxs("div", {
-        onClickQrl: qrl(()=>import("./app_component_div_onclick_1cgetmfzx0g")
+        onClick$: qrl(()=>import("./app_component_div_onclick_1cgetmfzx0g")
         , "App_component_div_onClick_1CGetmFZx0g", [
             count,
             state

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_inlined_entry_strategy.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_inlined_entry_strategy.snap
@@ -50,7 +50,7 @@ export const Child = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
     }, "Child_component_useClientEffect_kYRT1iERt9g", [
         state
     ]));
-    return <div onClickQrl={inlinedQrl(()=>console.log(mongodb)
+    return <div onClick$={inlinedQrl(()=>console.log(mongodb)
     , "Child_component_div_onClick_elliVSnAiOQ")}>
 
         </div>;

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_listeners.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_listeners.snap
@@ -25,9 +25,9 @@ export const Foo = component$(() => {
                 host:onDocumentScroll$={()=>console.log('host:onDocument:scroll')}
                 host:onDocumentScroll$={()=>console.log('host:onWindow:scroll')}
 
-                onKeyup={handler}
-                onDocument:keyup={handler}
-                onWindow:keyup={handler}
+                onKeyup$={handler}
+                onDocument:keyup$={handler}
+                onWindow:keyup$={handler}
 
                 custom$={()=>console.log('custom')}
             />
@@ -93,7 +93,7 @@ export const Foo_component_HTDRsvUbLiE = ()=>{
   "captures": false,
   "loc": [
     83,
-    1042
+    1045
   ]
 }
 */
@@ -129,28 +129,28 @@ export const Foo_component_1_DvU6FitWglY = ()=>{
     const handler = qrl(()=>import("./foo_component_handler_h10xztd0e7w")
     , "Foo_component_handler_H10xZtD0e7w");
     return /*#__PURE__*/ _jsx("div", {
-        onClickQrl: qrl(()=>import("./foo_component_div_onclick_m48dyiidsjw")
+        onClick$: qrl(()=>import("./foo_component_div_onclick_m48dyiidsjw")
         , "Foo_component_div_onClick_M48DYiidSJw"),
-        onDocumentScrollQrl: qrl(()=>import("./foo_component_div_ondocumentscroll_rwfftfivukc")
+        onDocumentScroll$: qrl(()=>import("./foo_component_div_ondocumentscroll_rwfftfivukc")
         , "Foo_component_div_onDocumentScroll_rwFFtFiVuKc"),
-        onDocumentScrollQrl: qrl(()=>import("./foo_component_div_ondocumentscroll_1_cwneogpmtzi")
+        onDocumentScroll$: qrl(()=>import("./foo_component_div_ondocumentscroll_1_cwneogpmtzi")
         , "Foo_component_div_onDocumentScroll_1_CwneoGpmTZI"),
-        "on-cLickQrl": qrl(()=>import("./foo_component_div_on_click_ioasjw8vyjc")
+        "on-cLick$": qrl(()=>import("./foo_component_div_on_click_ioasjw8vyjc")
         , "Foo_component_div_on_cLick_IoAsJW8vYJc"),
-        "onDocument-sCrollQrl": qrl(()=>import("./foo_component_div_ondocument_scroll_5vnik61pzom")
+        "onDocument-sCroll$": qrl(()=>import("./foo_component_div_ondocument_scroll_5vnik61pzom")
         , "Foo_component_div_onDocument_sCroll_5VNik61PZOM"),
-        "onDocument-scroLLQrl": qrl(()=>import("./foo_component_div_ondocument_scroll_1q0sgr8te3g")
+        "onDocument-scroLL$": qrl(()=>import("./foo_component_div_ondocument_scroll_1q0sgr8te3g")
         , "Foo_component_div_onDocument_scroLL_1q0Sgr8te3g"),
-        "host:onClickQrl": qrl(()=>import("./foo_component_div_host_onclick_cpeh970jbey")
+        "host:onClick$": qrl(()=>import("./foo_component_div_host_onclick_cpeh970jbey")
         , "Foo_component_div_host_onClick_cPEH970JbEY"),
-        "host:onDocumentScrollQrl": qrl(()=>import("./foo_component_div_host_ondocumentscroll_zip7mifsjry")
+        "host:onDocumentScroll$": qrl(()=>import("./foo_component_div_host_ondocumentscroll_zip7mifsjry")
         , "Foo_component_div_host_onDocumentScroll_Zip7mifsjRY"),
-        "host:onDocumentScrollQrl": qrl(()=>import("./foo_component_div_host_ondocumentscroll_1_em1lspk7jvg")
+        "host:onDocumentScroll$": qrl(()=>import("./foo_component_div_host_ondocumentscroll_1_em1lspk7jvg")
         , "Foo_component_div_host_onDocumentScroll_1_Em1LspK7JVg"),
-        onKeyup: handler,
-        "onDocument:keyup": handler,
-        "onWindow:keyup": handler,
-        customQrl: qrl(()=>import("./foo_component_div_custom_pyhnxab17ms")
+        onKeyup$: handler,
+        "onDocument:keyup$": handler,
+        "onWindow:keyup$": handler,
+        custom$: qrl(()=>import("./foo_component_div_custom_pyhnxab17ms")
         , "Foo_component_div_custom_pyHnxab17ms")
     });
 };
@@ -173,7 +173,7 @@ export { hW as handleWatch };
   "captures": false,
   "loc": [
     105,
-    1038
+    1041
   ]
 }
 */
@@ -220,8 +220,8 @@ export const Foo_component_div_custom_pyHnxab17ms = ()=>console.log('custom')
   "ctxName": "custom$",
   "captures": false,
   "loc": [
-    981,
-    1006
+    984,
+    1009
   ]
 }
 */

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_lightweight_functional.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_lightweight_functional.snap
@@ -126,14 +126,14 @@ export const Foo = /*#__PURE__*/ componentQrl(qrl(()=>import("./foo_component_ht
     tagName: "my-foo"
 });
 export function Button({ text , color  }) {
-    return <button color={color} onClickQrl={qrl(()=>import("./button_button_onclick_nsm0jyv00jw")
+    return <button color={color} onClick$={qrl(()=>import("./button_button_onclick_nsm0jyv00jw")
     , "Button_button_onClick_NsM0JYV00Jw", [
         color,
         text
     ])}>{text}</button>;
 }
 export const ButtonArrow = ({ text , color  })=>{
-    return <button color={color} onClickQrl={qrl(()=>import("./buttonarrow_button_onclick_9npo43figik")
+    return <button color={color} onClick$={qrl(()=>import("./buttonarrow_button_onclick_9npo43figik")
     , "ButtonArrow_button_onClick_9npo43fIGik", [
         color,
         text

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_parsed_inlined_qrls.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_parsed_inlined_qrls.snap
@@ -21,7 +21,7 @@ export const App = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
             }),
             /*#__PURE__*/ jsx("p", {
                 children: /*#__PURE__*/ jsx("button", {
-                    onClickQrl: inlinedQrl(()=>{
+                    onClick$: inlinedQrl(()=>{
                         const [store] = useLexicalScope();
                         return store.count++;
                     }, "App_component_div_p_button_onClick_odz7eidI4GM", [
@@ -57,8 +57,8 @@ export const App_component_div_p_button_onClick_odz7eidI4GM = ()=>{
   "ctxName": "onClick$",
   "captures": true,
   "loc": [
-    577,
-    709
+    575,
+    707
   ]
 }
 */
@@ -82,7 +82,7 @@ export const App_component_Fh88JClhbC0 = ()=>{
             }),
             /*#__PURE__*/ jsx("p", {
                 children: /*#__PURE__*/ jsx("button", {
-                    onClickQrl: qrl(()=>import("./entry_hooks")
+                    onClick$: qrl(()=>import("./entry_hooks")
                     , "App_component_div_p_button_onClick_odz7eidI4GM", [
                         store
                     ]),
@@ -108,7 +108,7 @@ export const App_component_Fh88JClhbC0 = ()=>{
   "captures": false,
   "loc": [
     159,
-    908
+    906
   ]
 }
 */

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_prod_node.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_prod_node.snap
@@ -23,13 +23,13 @@ import { qrl } from "@builder.io/qwik";
 export const s_HTDRsvUbLiE = ()=>{
     return <div >
 
-            <div onClickQrl={qrl(()=>import("./s_9dcjc0ujddo")
+            <div onClick$={qrl(()=>import("./s_9dcjc0ujddo")
     , "s_9DcJc0uJDDo")}/>
 
-            <div onClickQrl={qrl(()=>import("./s_rjqdy8i0mxc")
+            <div onClick$={qrl(()=>import("./s_rjqdy8i0mxc")
     , "s_RjQdy8I0MXc")}/>
 
-            <div onClickQrl={qrl(()=>import("./s_w9ptfrbvk1e")
+            <div onClick$={qrl(()=>import("./s_w9ptfrbvk1e")
     , "s_w9ptFRBVK1E")}/>
 
         </div>;

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_conflict.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_conflict.snap
@@ -68,7 +68,7 @@ export const Foo_component_HTDRsvUbLiE = ()=>{
     console.log(qwik);
     const qrl1 = 23;
     return /*#__PURE__*/ _jsx("div", {
-        onClickQrl: qrl(()=>import("./foo_component_div_onclick_m48dyiidsjw")
+        onClick$: qrl(()=>import("./foo_component_div_onclick_m48dyiidsjw")
         , "Foo_component_div_onClick_M48DYiidSJw", [
             qrl1
         ])

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_server_mount.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_server_mount.snap
@@ -69,7 +69,7 @@ export const Parent_component_0TaiDayHrlo = ()=>{
         state
     ]));
     return /*#__PURE__*/ _jsx("div", {
-        onClickQrl: qrl(()=>import("./entry_Parent")
+        onClick$: qrl(()=>import("./entry_Parent")
         , "Parent_component_div_onClick_C5XE49Nqd3A"),
         children: state.text
     });
@@ -162,7 +162,7 @@ export const Child_component_9GyF01GDKqw = ()=>{
         state
     ]));
     return /*#__PURE__*/ _jsx("div", {
-        onClickQrl: qrl(()=>import("./entry_Child")
+        onClick$: qrl(()=>import("./entry_Child")
         , "Child_component_div_onClick_elliVSnAiOQ"),
         children: state.text
     });

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__relative_paths.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__relative_paths.snap
@@ -25,8 +25,8 @@ export const App_component_div_p_button_onClick_8dWUa0cJAr4 = ()=>{
   "ctxName": "onClick$",
   "captures": true,
   "loc": [
-    714,
-    846
+    712,
+    844
   ]
 }
 */
@@ -48,7 +48,7 @@ export const App_component_AkbU84a8zes = ()=>{
             }),
             /*#__PURE__*/ jsx("p", {
                 children: /*#__PURE__*/ jsx("button", {
-                    onClickQrl: qrl(()=>import("./app_component_div_p_button_onclick_8dwua0cjar4.js")
+                    onClick$: qrl(()=>import("./app_component_div_p_button_onclick_8dwua0cjar4.js")
                     , "App_component_div_p_button_onClick_8dWUa0cJAr4", [
                         store
                     ]),
@@ -74,7 +74,7 @@ export const App_component_AkbU84a8zes = ()=>{
   "captures": false,
   "loc": [
     321,
-    1045
+    1043
   ]
 }
 */

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -735,9 +735,9 @@ export const Foo = component$(() => {
                 host:onDocumentScroll$={()=>console.log('host:onDocument:scroll')}
                 host:onDocumentScroll$={()=>console.log('host:onWindow:scroll')}
 
-                onKeyup={handler}
-                onDocument:keyup={handler}
-                onWindow:keyup={handler}
+                onKeyup$={handler}
+                onDocument:keyup$={handler}
+                onWindow:keyup$={handler}
 
                 custom$={()=>console.log('custom')}
             />
@@ -1122,7 +1122,7 @@ export const App = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
             }),
             /*#__PURE__*/ jsx("p", {
                 children: /*#__PURE__*/ jsx("button", {
-                    onClickQrl: inlinedQrl(()=>{
+                    onClick$: inlinedQrl(()=>{
                         const [store] = useLexicalScope();
                         return store.count++;
                     }, "App_component_div_p_button_onClick_odz7eidI4GM", [
@@ -1391,7 +1391,7 @@ export const App = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
             }),
             /*#__PURE__*/ jsx("p", {
                 children: /*#__PURE__*/ jsx("button", {
-                    onClickQrl: inlinedQrl(()=>{
+                    onClick$: inlinedQrl(()=>{
                         const [store] = useLexicalScope();
                         return store.count++;
                     }, "App_component_div_p_button_onClick_8dWUa0cJAr4", [

--- a/packages/qwik/src/server/prefetch-strategy.ts
+++ b/packages/qwik/src/server/prefetch-strategy.ts
@@ -6,7 +6,7 @@ import type {
   RenderToStringOptions,
   SnapshotResult,
 } from './types';
-import { isQrl, QRLInternal } from '../core/import/qrl-class';
+import { isQrl } from '../core/import/qrl-class';
 import type { SymbolMapper } from '../optimizer/src/types';
 
 export function getPrefetchResources(
@@ -64,7 +64,7 @@ function getAutoPrefetch(
     // manifest already prioritized the symbols at build time
     for (const prioritizedSymbolName in mapper) {
       const hasSymbol = listeners.some((l) => {
-        return (l.qrl as QRLInternal).getHash() === prioritizedSymbolName;
+        return l.qrl.getHash() === prioritizedSymbolName;
       });
 
       if (hasSymbol) {

--- a/packages/qwik/src/testing/element-fixture.ts
+++ b/packages/qwik/src/testing/element-fixture.ts
@@ -104,7 +104,7 @@ export function qPropReadQRL(ctx: QContext, prop: string): ((event: Event) => vo
     const qrls = listeners.get(prop) || [];
     await Promise.all(
       qrls.map((qrl) => {
-        const fn = qrl.invokeFn(ctx.$element$);
+        const fn = qrl.$invokeFn$(ctx.$element$);
         return fn(event);
       })
     );

--- a/starters/apps/e2e/src/components/events/events.tsx
+++ b/starters/apps/e2e/src/components/events/events.tsx
@@ -1,4 +1,4 @@
-import { component$, useStore, Host, EventHandler } from '@builder.io/qwik';
+import { component$, useStore, Host, PropFunction } from '@builder.io/qwik';
 
 export const Events = component$(() => {
   const store = useStore({
@@ -10,10 +10,10 @@ export const Events = component$(() => {
   return (
     <Host>
       <Buttons
-        onTransparentClick$={() => {
+        onTransparentClick$={async () => {
           store.countTransparent++;
         }}
-        onWrappedClick$={() => {
+        onWrappedClick$={async () => {
           store.countWrapped++;
         }}
       ></Buttons>
@@ -41,8 +41,8 @@ export const Events = component$(() => {
 });
 
 interface ButtonProps {
-  onTransparentClickQrl?: EventHandler<Event>; // QRL<(Event)=>any>
-  onWrappedClickQrl?: EventHandler<number>;
+  onTransparentClick$?: PropFunction<(ev: Event) => any>;
+  onWrappedClick$?: PropFunction<(nu: number) => void>;
 }
 
 export const Buttons = component$((props: ButtonProps) => {
@@ -50,14 +50,14 @@ export const Buttons = component$((props: ButtonProps) => {
   return (
     <Host>
       <span>some</span>
-      <button id="btn-transparent" onClickQrl={props.onTransparentClickQrl}>
+      <button id="btn-transparent" onClick$={props.onTransparentClick$}>
         Transparent
       </button>
       <button
         id="btn-wrapped"
-        onClick$={() => {
+        onClick$={async () => {
           store.count++;
-          props.onWrappedClickQrl!.invoke(store.count);
+          await props.onWrappedClick$?.(store.count);
         }}
       >
         Wrapped {store.count}

--- a/starters/apps/e2e/src/components/lexical-scope/lexicalScope.tsx
+++ b/starters/apps/e2e/src/components/lexical-scope/lexicalScope.tsx
@@ -65,7 +65,7 @@ export const LexicalScopeChild = component$((props: LexicalScopeProps) => {
         <p>{props.message}</p>
         <p>{promise}</p>
       </div>
-      <button onClickQrl={onclick} id="rerender">
+      <button onClick$={onclick} id="rerender">
         Rerender {state.count}
       </button>
       <div id="result">{state.result}</div>

--- a/starters/apps/e2e/src/components/two-listeners/twolisteners.tsx
+++ b/starters/apps/e2e/src/components/two-listeners/twolisteners.tsx
@@ -8,7 +8,7 @@ export const TwoListeners = component$(() => {
       href="/"
       preventDefault:click
       class="two-listeners"
-      onClickQrl={[$(() => store1.count++), $(() => store2.count++)]}
+      onClick$={[$(() => store1.count++), $(() => store2.count++)]}
     >
       {store1.count} / {store2.count}
     </a>


### PR DESCRIPTION
- [x] Drop Qrl prefix
- [x] Custom events are much easier to author


```tsx
import { component$, useStore, Host, PropFunction } from '@builder.io/qwik';

export const Events = component$(() => {
  const store = useStore({
    countTransparent: 0,
    countWrapped: 0,
    countAnchor: 0,
  });

  return (
    <Host>
      <Buttons
        onTransparentClick$={async () => {
          store.countTransparent++;
        }}
        onWrappedClick$={async () => {
          store.countWrapped++;
        }}
      ></Buttons>

      <p id="count-transparent">countTransparent: {store.countTransparent}</p>
      <p id="count-wrapped">countWrapped: {store.countWrapped}</p>
    </Host>
  );
});

export interface ButtonsProps {
  onTransparentClick$?: PropFunction<(ev: Event) => any>;
  onWrappedClick$?: PropFunction<(nu: number) => void>;
}

export const Buttons = component$((props: ButtonsProps) => {
  const store = useStore({ count: 0 });
  return (
    <Host>
      <button onClick$={props.onTransparentClick$}>
        Transparent
      </button>
      <button
        onClick$={async () => {
          store.count++;
          await props.onWrappedClick$?.(store.count);
        }}
      >
        Wrapped {store.count}
      </button>
    </Host>
  );
});
```