### PR TITLE
docs: Improve clarity of Lite Component declaration

### DIFF
--- a/packages/docs/src/pages/docs/components/lite-components.mdx
+++ b/packages/docs/src/pages/docs/components/lite-components.mdx
@@ -8,10 +8,12 @@ fetch: https://hackmd.io/@mhevery/HkDvV6yb5
 In addition to standard Qwik components that have all of its lazy-loaded properties, Qwik also supports lite components that act more like traditional frameworks.
 
 ```tsx
+// Lite component: declared using a standard function.
 function MyButton(props: { text: string }) {
   return <button>{props.text}</button>;
 }
 
+// Component: declared using `component$()`.
 const MyApp = component$(() => {
   return (
     <div>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Adds an inline comment in the code example for lite components to explicitly callout the difference between how components and lite components are declared.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
