### PR TITLE
fix: prefetching

### DIFF
--- a/packages/qwik/src/server/prefetch-implementation.ts
+++ b/packages/qwik/src/server/prefetch-implementation.ts
@@ -13,7 +13,7 @@ export function applyPrefetchImplementation(
 ) {
   const prefetchStrategy = opts.prefetchStrategy;
   if (prefetchStrategy !== null) {
-    const prefetchImpl = prefetchStrategy?.implementation || 'link-prefetch';
+    const prefetchImpl = prefetchStrategy?.implementation || 'worker-fetch';
 
     if (
       prefetchImpl === 'link-prefetch-html' ||


### PR DESCRIPTION
Turns out that many browsers ignore pre-fetching even if they claim to
support it. For now we are going to make web-workers the default
prefetching strategy.

Closes #736

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
