### PR TITLE
Update Qwik City getting started docs

### DIFF
--- a/starters/apps/qwik-city/src/routes/docs/getting-started.mdx
+++ b/starters/apps/qwik-city/src/routes/docs/getting-started.mdx
@@ -6,21 +6,27 @@ import { Counter } from '~/components/counter/counter';
 
 # Welcome
 
-Welcome to the fabolous Qwik City. QwikCity is our official kit to build amazing sites:
+Welcome to the fabulous Qwik City. QwikCity is our official kit to build amazing sites:
 
 - 🐎 Powered by Qwik. Zero hydration and instant interactivity.
 - 🗃 File based routing (like Nextjs)
-- 🌏 Deploy easily to edge: Netlify, Cloudflare, Vercel, Deno...
+- 🌏 Deploy easily to the edge: Netlify, Cloudflare, Vercel, Deno...
 - 📖 Author content directly in Markdown or MDX. MDX brings the best of markdown and JSX, allowing you to render Qwik components directly in markdown, like this one:
 
 <Counter />
 
 ## Next steps
 
-Open your editor and check the following:
+Open your editor and check out the following:
 
-- **The `pages` folder**: This is where the main content lives. Adding you files (`.md`, `.mdx`, or `.tsx`) will automatically create new URLs.
-- **The `src/layout` folder**: This is what bring form to your content. Different kinds of pages, might need to be rendered by a different layout.
-  This way you can reuse easily the layout across different content. By default, the `src/layout/default` is used.
-- **The `src/components` folder**: QwikCity is still a normal Qwik app. Any custom component, design systems, or funcionality should live here. Notice the `header`, `footer` and `content-nav` components. They are used by the `default` layout!
-- **The `src/utils` folder**: Place here business logic, or functions that are not components.
+**The `src/routes` folder**
+
+This is where the main content lives. Adding folders and / or files (`.md`, `.mdx`, or `.tsx`) will automatically create new URLs. For example, code saved at `routes/dashboard/settings/index.tsx` will be accessible via the URL path `/dashboard/settings`.
+
+**The `src/routes/_layout` files and folders**
+
+These bring form to your content. Since different pages may need to be rendered by different layouts, QwikCity provides the ability to scope layouts to specific routes, while still allowing for easy reuse across different content. For any page without its own layout defined, the `src/routes/_layout.tsx` is used by default.
+
+**The `src/components` folder**
+
+QwikCity is still a normal Qwik app. Any custom component, design systems, or functionality should live here. Notice the `header`, `footer` and `content-nav` components. They are used by the `default` layout!


### PR DESCRIPTION
# What is it?

- [X] Docs / tests

# Description

This PR makes some minor adjustments to the current Qwik City `getting-started.md` docs, adjusting the folder and file names listed to better reflect the current structure that's generated when starting a new project.

I first raised the issue in Discord [here](https://discord.com/channels/842438759945601056/991805589623668758/993554808017526826) as I thought maybe I was just missing the noted files / folders. There it was determined that these docs are probably just a bit out of date and I was prompted to submit a PR.

Note, I just saw that there's another docs related PR going on [here](https://github.com/BuilderIO/qwik/pull/720). It may be worth waiting for that to get merged and then linking to specific docs pages from here (e.g. adding something like `Learn more about QwikCity layouts <a href="/docs/layouts>here</a>.`). That's assuming of course that y'all even plan to keep this doc around!