### PR TITLE
Reference to doGet should be onGet

### DIFF
--- a/packages/docs/src/pages/qwikcity/endpoint/data.mdx
+++ b/packages/docs/src/pages/qwikcity/endpoint/data.mdx
@@ -20,9 +20,9 @@ The first step is to layout out the files so that we can accept `https://example
 
 ## Implement Endpoint
 
-An endpoint is a `doGet` function that retrieves data (typically from a database, or other stores.) The retrieved data can be returned directly as JSON or used as an input to the component to render HTML. The `doGet` function receives the `params` to extract the parameters used to do data lookup.
+An endpoint is a `onGet` function that retrieves data (typically from a database, or other stores.) The retrieved data can be returned directly as JSON or used as an input to the component to render HTML. The `onGet` function receives the `params` to extract the parameters used to do data lookup.
 
-The `doGet` function returns an object that contains:
+The `onGet` function returns an object that contains:
 - `status`: HTTP status code
 - `headers`: HTTP headers to control caches etc...
 - `body`: The body of the response to be returned as JSON or to be used as input to the HTML.
@@ -56,7 +56,7 @@ export const onGet: EndpointHandler<EndpointData> = async ({ params }) => {
 
 ## Using Endpoint in Component
 
-An endpoint `doGet` function retrieves data and makes it available as JSON. The next step is to convert the JSON to HTML. This is done with a standard component as described [Components](/qwikcity/content/component). What is new is `useEndpoint()` to retrieve the data from the `doGet` function.
+An endpoint `onGet` function retrieves data and makes it available as JSON. The next step is to convert the JSON to HTML. This is done with a standard component as described [Components](/qwikcity/content/component). What is new is `useEndpoint()` to retrieve the data from the `onGet` function.
   
 ```typescript
 import { Resource, component$, Host, useStore } from '@builder.io/qwik';
@@ -85,9 +85,9 @@ export default component$(() => {
 });
 ```
 
-1. Notice that the data endpoint and the component are defined in the same file. The data endpoint is serviced by the `doGet` function and the component is by the modules default export.
-2. The component uses `useEndpoint()` function to retrieve the data. The `useEndpoint()` function invokes `doGet` function directly on the server but using `fetch()` on the client. Your component does not need to think about server/client differences when using data. The `useEndpoint()` function returns an object of type `Resource`. `Resource`s are promise-like objects that can be serialized by Qwik. 
-3. The `doGet` function is invoked before the component. This allows the `doGet` to return 404 or redirect in case the data is not available. 
+1. Notice that the data endpoint and the component are defined in the same file. The data endpoint is serviced by the `onGet` function and the component is by the modules default export.
+2. The component uses `useEndpoint()` function to retrieve the data. The `useEndpoint()` function invokes `onGet` function directly on the server but using `fetch()` on the client. Your component does not need to think about server/client differences when using data. The `useEndpoint()` function returns an object of type `Resource`. `Resource`s are promise-like objects that can be serialized by Qwik. 
+3. The `onGet` function is invoked before the component. This allows the `onGet` to return 404 or redirect in case the data is not available. 
 4. Notice the use of `<Resource>` JSX element. The purpose of `Resource` is to allow the client to render different states of the `useEndpoint()` resource. 
 5. On the server the `<Resource>` element will pause rendering until the `Resource` is resolved or rejected. This is because we don't want the server to render `loading...`. (The server needs to know when the component is ready for serialization into HTML.)
 

--- a/packages/docs/src/pages/qwikcity/head/title.mdx
+++ b/packages/docs/src/pages/qwikcity/head/title.mdx
@@ -57,4 +57,4 @@ export const head: DocumentHead = (props: DocumentHeadProps<EndpointData>): Reso
 };
 ```
 
-The second case is a bit more complicated but it showcases how we can set the title of the page with the value that is retrieved from the `doGet` endpoint. (See [endpoint documentation](/qwikcity/endpoint/data) for retrieving data.) The Qwik City invokes `doGet` to retrieve the data for the route and then passes the data to the `head` function allowing it to create a custom title.
+The second case is a bit more complicated but it showcases how we can set the title of the page with the value that is retrieved from the `onGet` endpoint. (See [endpoint documentation](/qwikcity/endpoint/data) for retrieving data.) The Qwik City invokes `onGet` to retrieve the data for the route and then passes the data to the `head` function allowing it to create a custom title.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The docs make references to an endpoint function called `doGet`. It should be `onGet`. :+1: 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
