### PR TITLE
Replace references to router

### DIFF
--- a/packages/docs/src/pages/qwikcity/content/mdx.mdx
+++ b/packages/docs/src/pages/qwikcity/content/mdx.mdx
@@ -6,7 +6,7 @@ title: Qwik City - MDX
 
 An alternative way to author content is using `.mdx` files. (Markdown JSX.) These files are authored as Markdown, but they are compiled down to Qwik components. In addition to Markdown syntax, `.mdx` files can also refer to other components.
 
-Let's assume you have the router set up such as this:
+Let's assume you have your routes set up like this:
 ```
 - src/
   - routes/

--- a/packages/docs/src/pages/qwikcity/routing/overview.mdx
+++ b/packages/docs/src/pages/qwikcity/routing/overview.mdx
@@ -4,11 +4,11 @@ title: Qwik City - Routing
 
 # Qwik City - Routing
 
-Routing is a way to map public URLs for a site to specific components declared in your application. Qwik City uses a file-based router. This means that the directory/file structure drives the public-facing URLs that the user will see for your application.
+Routing is a way to map public URLs for a site to specific components declared in your application. Qwik City uses file-based routing. This means that the directory/file structure drives the public-facing URLs that the user will see for your application.
 
 ## Basic routing
 
-In the Qwik City router, folders map to paths. For example, if the user sees `https://example.com/some/path`, the component exported at `src/routes/some/path` (either `.mdx` or `.tsx`) will be shown. 
+In the Qwik City routes directory, folders map to paths. For example, if the user sees `https://example.com/some/path`, the component exported at `src/routes/some/path` (either `.mdx` or `.tsx`) will be shown. 
 
 ```
 - src/


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Changes references to `router` to refer to the `routes directory` and `file-base routing`. `router` is potentially too evocative of `client-side routing` and therefor may be confusing.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
