### PR TITLE
DX: Refine useEndpoint generic

### DIFF
--- a/packages/docs/src/pages/qwikcity/endpoint/data.mdx
+++ b/packages/docs/src/pages/qwikcity/endpoint/data.mdx
@@ -67,7 +67,7 @@ interface ProductData { ... }
 export const onGet: EndpointHandler<EndpointData> = async ({ params }) => { ... };
 
 export default component$(() => {
-  const resource = useEndpoint<EndpointData>();
+  const resource = useEndpoint<typeof onGet>(); // equivalent to useEndpoint<EndpointData>
   return (
     <Resource 
       resource={resource}
@@ -90,5 +90,6 @@ export default component$(() => {
 3. The `onGet` function is invoked before the component. This allows the `onGet` to return 404 or redirect in case the data is not available. 
 4. Notice the use of `<Resource>` JSX element. The purpose of `Resource` is to allow the client to render different states of the `useEndpoint()` resource. 
 5. On the server the `<Resource>` element will pause rendering until the `Resource` is resolved or rejected. This is because we don't want the server to render `loading...`. (The server needs to know when the component is ready for serialization into HTML.)
+6. You may use `typeof onGet` to keep your `onGet` function and `useEndpoint()` types in sync. Qwik City is smart enough to determine the types for you. 
 
 All of the above is done to abstract the data access from the component in a way that results in correct behavior on both the server and the client.

--- a/packages/docs/src/pages/qwikcity/endpoint/non-200.mdx
+++ b/packages/docs/src/pages/qwikcity/endpoint/non-200.mdx
@@ -45,7 +45,7 @@ export const onGet: EndpointHandler<EndpointData> = async ({ params }) => {
 };
 
 export default component$(() => {
-  const resource = useEndpoint<EndpointData>();
+  const resource = useEndpoint<typeof onGet>(); //equivalent to useEndpoint<EndpointData>
   // Early return for 404
   if (resource.state=='resolved' && !resource.resolved) {
     return <div>404: Product not found!!!</div>

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -166,8 +166,10 @@ export const useContent: () => ContentState;
 // @public (undocumented)
 export const useDocumentHead: () => Required<ResolvedDocumentHead>;
 
+// Warning: (ae-forgotten-export) The symbol "GetEndpointData" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export const useEndpoint: <T = unknown>() => ResourceReturn<T>;
+export const useEndpoint: <T = unknown, _R = GetEndpointData<T>>() => ResourceReturn<_R>;
 
 // @public (undocumented)
 export const useLocation: () => RouteLocation;

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -169,7 +169,7 @@ export const useDocumentHead: () => Required<ResolvedDocumentHead>;
 // Warning: (ae-forgotten-export) The symbol "GetEndpointData" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const useEndpoint: <T = unknown, _R = GetEndpointData<T>>() => ResourceReturn<_R>;
+export const useEndpoint: <T = unknown>() => ResourceReturn<GetEndpointData<T>>;
 
 // @public (undocumented)
 export const useLocation: () => RouteLocation;

--- a/packages/qwik-city/runtime/src/app/routes/blog/[...slug].tsx
+++ b/packages/qwik-city/runtime/src/app/routes/blog/[...slug].tsx
@@ -2,7 +2,7 @@ import { component$, Host, Resource } from '@builder.io/qwik';
 import { useEndpoint, DocumentHead, EndpointHandler } from '~qwik-city-runtime';
 
 export default component$(() => {
-  const resource = useEndpoint<EndpointData>();
+  const resource = useEndpoint<typeof onGet>();
 
   return (
     <Host>

--- a/packages/qwik-city/runtime/src/app/routes/products/[id].tsx
+++ b/packages/qwik-city/runtime/src/app/routes/products/[id].tsx
@@ -6,7 +6,7 @@ export default component$(() => {
   const { params, pathname } = useLocation();
   const store = useStore({ productFetchData: '' });
 
-  const resource = useEndpoint<EndpointData>();
+  const resource = useEndpoint<typeof onGet>();
 
   return (
     <Host>

--- a/packages/qwik-city/runtime/src/library/use-endpoint.ts
+++ b/packages/qwik-city/runtime/src/library/use-endpoint.ts
@@ -1,14 +1,17 @@
 import { useResource$ } from '@builder.io/qwik';
 import { useLocation, useQwikCityContext } from './use-functions';
 import { isServer } from '@builder.io/qwik/build';
+import type { EndpointHandler } from './types';
+
+type GetEndpointData<T> = T extends EndpointHandler<infer U> ? U : T;
 
 /**
  * @public
  */
-export const useEndpoint = <T = unknown>() => {
+export const useEndpoint = <T = unknown, _R = GetEndpointData<T>>() => {
   const loc = useLocation();
   const ctx = useQwikCityContext();
-  return useResource$<T>(async ({ track, cleanup }) => {
+  return useResource$<_R>(async ({ track, cleanup }) => {
     const pathname = track(loc, 'pathname');
 
     if (isServer) {

--- a/packages/qwik-city/runtime/src/library/use-endpoint.ts
+++ b/packages/qwik-city/runtime/src/library/use-endpoint.ts
@@ -8,10 +8,10 @@ type GetEndpointData<T> = T extends EndpointHandler<infer U> ? U : T;
 /**
  * @public
  */
-export const useEndpoint = <T = unknown, _R = GetEndpointData<T>>() => {
+export const useEndpoint = <T = unknown>() => {
   const loc = useLocation();
   const ctx = useQwikCityContext();
-  return useResource$<_R>(async ({ track, cleanup }) => {
+  return useResource$<GetEndpointData<T>>(async ({ track, cleanup }) => {
     const pathname = track(loc, 'pathname');
 
     if (isServer) {

--- a/starters/apps/qwik-city/src/routes/blog/[...slug].tsx
+++ b/starters/apps/qwik-city/src/routes/blog/[...slug].tsx
@@ -2,7 +2,7 @@ import { component$, Host, Resource } from '@builder.io/qwik';
 import { useEndpoint, DocumentHead, EndpointHandler } from '@builder.io/qwik-city';
 
 export default component$(() => {
-  const resource = useEndpoint<EndpointData>();
+  const resource = useEndpoint<typeof onGet>();
 
   return (
     <Host>

--- a/starters/apps/qwik-city/src/routes/products/[id].tsx
+++ b/starters/apps/qwik-city/src/routes/products/[id].tsx
@@ -6,7 +6,7 @@ export default component$(() => {
   const { params, pathname } = useLocation();
   const store = useStore({ productFetchData: '' });
 
-  const resource = useEndpoint<EndpointData>();
+  const resource = useEndpoint<typeof onGet>();
 
   return (
     <Host>


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Currently it is hard to type your useEndpoint call to your endpoint function.

Consider we have an `onGet` defined as an `EndpointHandler<string>`

Current behavior:
```ts
const onGet: EndpointHandler<string> = () => {
  return "Oh Qwik..."
}
const resource = useEndpoint(); // ResourceReturn<unknown>
const resource = useEndpoint<typeof onGet>(); // ResourceReturn<EndpointHandler<string>
const resource = useEndpoint<ReturnType<typeof onGet>>(); // ResouceReturn<string|void|null|undefined|Promise<string|void|null|undefined>>
```

Of course, you could type it yourself, ie `useEndpoint<string>`, but any changes to the return type of `onGet` do not trigger a type error for `useEndpoint`, making it a brittle solution. Also, you have the option of incorrectly type your `useEndpoint` call and not receiving an error until runtime. :grimacing: 

By adding a little helper type to the useEndpoint<T> definition, we can check the generic, and if T extends EndpointHandler, extract the EndpointHandler type, otherwise use the original T type.

This allows developers to pass the relatively terse `useEndpoint<typeof onGet>()` and receive proper typing.

This gives the following behavior:

```ts
const onGet: EndpointHandler<string> = () => {
  return "Yay Qwik!"
}
const resource = useEndpoint(); // ResourceReturn<unknown>
const resource = useEndpoint<boolean>(); // ResourceReturn<boolean>
const resource = useEndpoint<null>(); // ResourceReturn<null>
//...etc
const resource = useEndpoint<typeof onGet>(); // ResourceReturn<string>
``` 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
