### PR TITLE
Fix starters blank esm

### DIFF
--- a/starters/README.md
+++ b/starters/README.md
@@ -17,7 +17,7 @@ Here are steps to try out the CLI in local environment.
 1. Run CLI:
 
    ```
-   # node ./dist-dev/create-qwik/create-qwik
+   # node ./packages/create-qwik/dist/create-qwik
    💫 Let's create a Qwik project 💫
 
    ✔ Project name … todo-express

--- a/starters/apps/blank/src/entry.express.tsx
+++ b/starters/apps/blank/src/entry.express.tsx
@@ -1,6 +1,9 @@
 import express from 'express';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 import render from './entry.ssr';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * Create an express server


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

minor fix for current blank starters not able to running

```bash
$ yarn serve
ReferenceError: __dirname is not defined in ES module scope
```

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. `npm init qwik@latest` select blank, build then serve

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
