### PR TITLE
Fix: Qwik City Html Component attributes

### DIFF
--- a/packages/qwik-city/runtime/src/library/html.tsx
+++ b/packages/qwik-city/runtime/src/library/html.tsx
@@ -108,7 +108,11 @@ export const Html = component$<HtmlProps>(
       }
     });
 
-    return <Host {...props}><SkipRerender /></Host>;
+    return (
+      <Host {...props}>
+        <SkipRerender />
+      </Host>
+    );
   },
   { tagName: 'html' }
 );

--- a/packages/qwik-city/runtime/src/library/html.tsx
+++ b/packages/qwik-city/runtime/src/library/html.tsx
@@ -1,5 +1,6 @@
 import {
   component$,
+  Host,
   noSerialize,
   QwikIntrinsicElements,
   SkipRerender,
@@ -32,7 +33,7 @@ import { clientNavigate, normalizePath } from './client-history';
  * @public
  */
 export const Html = component$<HtmlProps>(
-  () => {
+  (props) => {
     const ctx = useQwikCityContext();
 
     const routeLocation = useStore<MutableRouteLocation>(() => {
@@ -107,7 +108,7 @@ export const Html = component$<HtmlProps>(
       }
     });
 
-    return <SkipRerender />;
+    return <Host {...props}><SkipRerender /></Host>;
   },
   { tagName: 'html' }
 );

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -194,7 +194,7 @@ export interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
     // (undocumented)
     datatype?: string | undefined;
     // (undocumented)
-    dir?: string | undefined;
+    dir?: 'ltr' | 'rtl' | 'auto' | undefined;
     // (undocumented)
     draggable?: Booleanish | undefined;
     // (undocumented)

--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -306,7 +306,7 @@ export interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
   className?: string | undefined;
   contentEditable?: Booleanish | 'inherit' | undefined;
   contextMenu?: string | undefined;
-  dir?: string | undefined;
+  dir?: "ltr" | "rtl" | "auto" | undefined;
   draggable?: Booleanish | undefined;
   hidden?: boolean | undefined;
   id?: string | undefined;

--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -306,7 +306,7 @@ export interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
   className?: string | undefined;
   contentEditable?: Booleanish | 'inherit' | undefined;
   contextMenu?: string | undefined;
-  dir?: "ltr" | "rtl" | "auto" | undefined;
+  dir?: 'ltr' | 'rtl' | 'auto' | undefined;
   draggable?: Booleanish | undefined;
   hidden?: boolean | undefined;
   id?: string | undefined;

--- a/starters/apps/qwik-city/src/root.tsx
+++ b/starters/apps/qwik-city/src/root.tsx
@@ -6,7 +6,7 @@ import './global.css';
 
 export default () => {
   return (
-    <Html lang="en">
+    <Html lang="en" dir="ltr">
       <Head />
       <Body />
     </Html>

--- a/starters/e2e/qwik-city.spec.ts
+++ b/starters/e2e/qwik-city.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('renderered', () => {
-  test.beforeEach(async ({page}) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto('/qwik-city');
     page.on('pageerror', (err) => expect(err).toEqual(undefined));
   });
-  test('html tag has attributes', async ({page}) => {
+  test('html tag has attributes', async ({ page }) => {
     const lang = await page.getAttribute('html', 'lang');
     const dir = await page.getAttribute('html', 'dir');
-    expect(lang === 'en' && dir === 'ltr')
+    expect(lang === 'en' && dir === 'ltr');
   });
 });
 

--- a/starters/e2e/qwik-city.spec.ts
+++ b/starters/e2e/qwik-city.spec.ts
@@ -1,4 +1,16 @@
-// import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+
+test.describe('renderered', () => {
+  test.beforeEach(async ({page}) => {
+    await page.goto('/qwik-city');
+    page.on('pageerror', (err) => expect(err).toEqual(undefined));
+  });
+  test('html tag has attributes', async ({page}) => {
+    const lang = await page.getAttribute('html', 'lang');
+    const dir = await page.getAttribute('html', 'dir');
+    expect(lang === 'en' && dir === 'ltr')
+  });
+});
 
 // test.describe('API Route Form Submssion', () => {
 //   test.beforeEach(async ({ page }) => {
@@ -34,4 +46,4 @@
 //   });
 // });
 
-export {};
+// export {};


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently, Qwik City's Html tag accepts props but it does not pass those props to the Host tag.

Also adds the correct values to for the `dir` attribute:

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir

Fixes: #863 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
