### PR TITLE
fix: qwik-city dev server client-only

### DIFF
--- a/packages/qwik-city/buildtime/runtime-generation/generate-runtime.ts
+++ b/packages/qwik-city/buildtime/runtime-generation/generate-runtime.ts
@@ -27,7 +27,7 @@ export function generateQwikCityPlan(ctx: BuildContext) {
     c.push(`  trailingSlash: true,`);
   }
 
-  if (ctx.isDevServerBuild) {
+  if (ctx.isDevServer) {
     c.push(`  cacheModules: false,`);
   }
 

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -8,7 +8,8 @@ export interface BuildContext {
   frontmatter: Map<string, string[]>;
   diagnostics: Diagnostic[];
   target: 'ssr' | 'client';
-  isDevServerBuild: boolean;
+  isDevServer: boolean;
+  isDevServerClientOnly: boolean;
 }
 
 export interface Diagnostic {

--- a/packages/qwik-city/buildtime/utils/context.ts
+++ b/packages/qwik-city/buildtime/utils/context.ts
@@ -17,7 +17,8 @@ export function createBuildContext(
     diagnostics: [],
     frontmatter: new Map(),
     target: target || 'ssr',
-    isDevServerBuild: false,
+    isDevServer: false,
+    isDevServerClientOnly: false,
   };
   return ctx;
 }

--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -54,6 +54,9 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions) {
 
       ctx = createBuildContext(rootDir!, userOpts, target);
 
+      ctx.isDevServer = config.command === 'serve';
+      ctx.isDevServerClientOnly = ctx.isDevServer && config.mode !== 'ssr';
+
       await validatePlugin(ctx.opts);
 
       mdxTransform = await createMdxTransformer(ctx);
@@ -61,7 +64,6 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions) {
 
     configureServer(server) {
       if (ctx) {
-        ctx.isDevServerBuild = true;
         configureDevServer(ctx, server);
       }
     },
@@ -81,7 +83,7 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions) {
       if (ctx) {
         if (id.endsWith(QWIK_CITY_PLAN_ID)) {
           // @qwik-city-plan
-          if (!ctx.isDevServerBuild) {
+          if (!ctx.isDevServer) {
             await build(ctx);
             ctx.diagnostics.forEach((d) => {
               this.warn(d.message);


### PR DESCRIPTION
This fixes the scenario when the dev server is client-side only (no ssr) and the qwikCity userContext has an issue both serializing the json data to string, and then being injected into the dev server's generated html. Since client-side only will always do a new fetch anyways with useEndpoint(), this PR avoids the serialization issue.