### PR TITLE
feat: Improve Event Map and Manifest

### DIFF
--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -5,81 +5,73 @@ import type { Ref } from '../../../use/use-ref';
 import type { JSXNode } from './jsx-node';
 
 export type PascalCaseEventNames =
-  | "Copy"
-  | "Cut"
-  | "Paste"
-  | "CompositionEnd"
-  | "CompositionStart"
-  | "CompositionUpdate"
-  | "Focus"
-  | "FocusIn"
-  | "FocusOut"
-  | "Blur"
-  | "Change"
-  | "Input"
-  | "Reset"
-  | "Submit"
-  | "Invalid"
-  | "Load"
-  | "Error"
-  | "KeyDown"
-  | "KeyPress"
-  | "KeyUp"
-  | "AuxClick"
-  | "Click"
-  | "ContextMenu"
-  | "DblClick"
-  | "Drag"
-  | "DragEnd"
-  | "DragEnter"
-  | "DragExit"
-  | "DragLeave"
-  | "DragOver"
-  | "DragStart"
-  | "Drop"
-  | "MouseDown"
-  | "MouseEnter"
-  | "MouseLeave"
-  | "MouseMove"
-  | "MouseOut"
-  | "MouseOver"
-  | "MouseUp"
-  | "TouchCancel"
-  | "TouchEnd"
-  | "TouchMove"
-  | "TouchStart"
-  | "PointerDown"
-  | "PointerMove"
-  | "PointerUp"
-  | "PointerCancel"
-  | "PointerEnter"
-  | "PointerLeave"
-  | "PointerOver"
-  | "PointerOut"
-  | "GotPointer"
-  | "LostPointer"
-  | "Scroll"
-  | "Wheel"
-  | "AnimationStart"
-  | "AnimationEnd"
-  | "AnimationIteration"
-  | "TransitionEnd"
+  | 'Copy'
+  | 'Cut'
+  | 'Paste'
+  | 'CompositionEnd'
+  | 'CompositionStart'
+  | 'CompositionUpdate'
+  | 'Focus'
+  | 'FocusIn'
+  | 'FocusOut'
+  | 'Blur'
+  | 'Change'
+  | 'Input'
+  | 'Reset'
+  | 'Submit'
+  | 'Invalid'
+  | 'Load'
+  | 'Error'
+  | 'KeyDown'
+  | 'KeyPress'
+  | 'KeyUp'
+  | 'AuxClick'
+  | 'Click'
+  | 'ContextMenu'
+  | 'DblClick'
+  | 'Drag'
+  | 'DragEnd'
+  | 'DragEnter'
+  | 'DragExit'
+  | 'DragLeave'
+  | 'DragOver'
+  | 'DragStart'
+  | 'Drop'
+  | 'MouseDown'
+  | 'MouseEnter'
+  | 'MouseLeave'
+  | 'MouseMove'
+  | 'MouseOut'
+  | 'MouseOver'
+  | 'MouseUp'
+  | 'TouchCancel'
+  | 'TouchEnd'
+  | 'TouchMove'
+  | 'TouchStart'
+  | 'PointerDown'
+  | 'PointerMove'
+  | 'PointerUp'
+  | 'PointerCancel'
+  | 'PointerEnter'
+  | 'PointerLeave'
+  | 'PointerOver'
+  | 'PointerOut'
+  | 'GotPointer'
+  | 'LostPointer'
+  | 'Scroll'
+  | 'Wheel'
+  | 'AnimationStart'
+  | 'AnimationEnd'
+  | 'AnimationIteration'
+  | 'TransitionEnd';
 
 export type GetEvent<K extends string> = Lowercase<K> extends keyof HTMLElementEventMap
   ? HTMLElementEventMap[Lowercase<K>]
-  : Event
+  : Event;
 
-export type QwikCaptureEventMap = {
-  [K in PascalCaseEventNames as `${K}Capture`]: GetEvent<K>
-}
-
-export type QwikDomEventMap = {
-  [K in PascalCaseEventNames]: Lowercase<K> extends keyof HTMLElementEventMap
-  ? HTMLElementEventMap[Lowercase<K>]
-  : Event
+type QwikEventMap = {
+  [K in PascalCaseEventNames as `${K}${'' | 'Capture'}`]: GetEvent<K>;
 };
-
-interface QwikEventMap extends QwikDomEventMap, QwikCaptureEventMap { }
 
 export type PreventDefault = {
   [K in keyof QwikEventMap as `prevent${'default' | 'Default'}:${Lowercase<K>}`]?: boolean;
@@ -161,8 +153,8 @@ export type ComponentKnownEvents = {
  */
 export interface ComponentBaseProps
   extends PreventDefault,
-  ComponentCustomEvents,
-  ComponentKnownEvents {
+    ComponentCustomEvents,
+    ComponentKnownEvents {
   class?: string | { [className: string]: boolean };
   className?: string | undefined;
   style?: Record<string, string | number> | string | undefined;
@@ -177,7 +169,7 @@ export interface ComponentBaseProps
   'host:tagName'?: JSXTagName;
   children?: JSXChildren;
 }
-export interface QwikAttributes extends QwikProps, QwikEvents { }
+export interface QwikAttributes extends QwikProps, QwikEvents {}
 
 /**
  * @public

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -4,123 +4,82 @@ import type { QRL } from '../../../import/qrl.public';
 import type { Ref } from '../../../use/use-ref';
 import type { JSXNode } from './jsx-node';
 
-export type QwikEventMap = {
-  Copy: ClipboardEvent;
-  CopyCapture: ClipboardEvent;
-  Cut: ClipboardEvent;
-  CutCapture: ClipboardEvent;
-  Paste: ClipboardEvent;
-  PasteCapture: ClipboardEvent;
-  CompositionEnd: CompositionEvent;
-  CompositionEndCapture: CompositionEvent;
-  CompositionStart: CompositionEvent;
-  CompositionStartCapture: CompositionEvent;
-  CompositionUpdate: CompositionEvent;
-  CompositionUpdateCapture: CompositionEvent;
-  Focus: FocusEvent;
-  FocusCapture: FocusEvent;
-  Focusin: FocusEvent;
-  FocusinCapture: FocusEvent;
-  Focusout: FocusEvent;
-  FocusoutCapture: FocusEvent;
-  Blur: FocusEvent;
-  BlurCapture: FocusEvent;
-  Change: Event;
-  ChangeCapture: Event;
-  Input: Event;
-  InputCapture: Event;
-  Reset: Event;
-  ResetCapture: Event;
-  Submit: Event;
-  SubmitCapture: Event;
-  Invalid: Event;
-  InvalidCapture: Event;
-  Load: Event;
-  LoadCapture: Event;
-  Error: Event; // also a Media Event
-  ErrorCapture: Event; // also a Media Event
-  KeyDown: KeyboardEvent;
-  KeyDownCapture: KeyboardEvent;
-  KeyPress: KeyboardEvent;
-  KeyPressCapture: KeyboardEvent;
-  KeyUp: KeyboardEvent;
-  KeyUpCapture: KeyboardEvent;
-  AuxClick: MouseEvent;
-  Click: MouseEvent;
-  ClickCapture: MouseEvent;
-  ContextMenu: MouseEvent;
-  ContextMenuCapture: MouseEvent;
-  DblClick: MouseEvent;
-  DblClickCapture: MouseEvent;
-  Drag: DragEvent;
-  DragCapture: DragEvent;
-  DragEnd: DragEvent;
-  DragEndCapture: DragEvent;
-  DragEnter: DragEvent;
-  DragEnterCapture: DragEvent;
-  DragExit: DragEvent;
-  DragExitCapture: DragEvent;
-  DragLeave: DragEvent;
-  DragLeaveCapture: DragEvent;
-  DragOver: DragEvent;
-  DragOverCapture: DragEvent;
-  DragStart: DragEvent;
-  DragStartCapture: DragEvent;
-  Drop: DragEvent;
-  DropCapture: DragEvent;
-  MouseDown: MouseEvent;
-  MouseDownCapture: MouseEvent;
-  MouseEnter: MouseEvent;
-  MouseLeave: MouseEvent;
-  MouseMove: MouseEvent;
-  MouseMoveCapture: MouseEvent;
-  MouseOut: MouseEvent;
-  MouseOutCapture: MouseEvent;
-  MouseOver: MouseEvent;
-  MouseOverCapture: MouseEvent;
-  MouseUp: MouseEvent;
-  MouseUpCapture: MouseEvent;
-  TouchCancel: TouchEvent;
-  TouchCancelCapture: TouchEvent;
-  TouchEnd: TouchEvent;
-  TouchEndCapture: TouchEvent;
-  TouchMove: TouchEvent;
-  TouchMoveCapture: TouchEvent;
-  TouchStart: TouchEvent;
-  TouchStartCapture: TouchEvent;
-  PointerDown: PointerEvent;
-  PointerDownCapture: PointerEvent;
-  PointerMove: PointerEvent;
-  PointerMoveCapture: PointerEvent;
-  PointerUp: PointerEvent;
-  PointerUpCapture: PointerEvent;
-  PointerCancel: PointerEvent;
-  PointerCancelCapture: PointerEvent;
-  PointerEnter: PointerEvent;
-  PointerEnterCapture: PointerEvent;
-  PointerLeave: PointerEvent;
-  PointerLeaveCapture: PointerEvent;
-  PointerOver: PointerEvent;
-  PointerOverCapture: PointerEvent;
-  PointerOut: PointerEvent;
-  PointerOutCapture: PointerEvent;
-  GotPointerCapture: PointerEvent;
-  GotPointerCaptureCapture: PointerEvent;
-  LostPointerCapture: PointerEvent;
-  LostPointerCaptureCapture: PointerEvent;
-  Scroll: UIEvent;
-  ScrollCapture: UIEvent;
-  Wheel: WheelEvent;
-  WheelCapture: WheelEvent;
-  AnimationStart: AnimationEvent;
-  AnimationStartCapture: AnimationEvent;
-  AnimationEnd: AnimationEvent;
-  AnimationEndCapture: AnimationEvent;
-  AnimationIteration: AnimationEvent;
-  AnimationIterationCapture: AnimationEvent;
-  TransitionEnd: TransitionEvent;
-  TransitionEndCapture: TransitionEvent;
+export type PascalCaseEventNames =
+  | "Copy"
+  | "Cut"
+  | "Paste"
+  | "CompositionEnd"
+  | "CompositionStart"
+  | "CompositionUpdate"
+  | "Focus"
+  | "FocusIn"
+  | "FocusOut"
+  | "Blur"
+  | "Change"
+  | "Input"
+  | "Reset"
+  | "Submit"
+  | "Invalid"
+  | "Load"
+  | "Error"
+  | "KeyDown"
+  | "KeyPress"
+  | "KeyUp"
+  | "AuxClick"
+  | "Click"
+  | "ContextMenu"
+  | "DblClick"
+  | "Drag"
+  | "DragEnd"
+  | "DragEnter"
+  | "DragExit"
+  | "DragLeave"
+  | "DragOver"
+  | "DragStart"
+  | "Drop"
+  | "MouseDown"
+  | "MouseEnter"
+  | "MouseLeave"
+  | "MouseMove"
+  | "MouseOut"
+  | "MouseOver"
+  | "MouseUp"
+  | "TouchCancel"
+  | "TouchEnd"
+  | "TouchMove"
+  | "TouchStart"
+  | "PointerDown"
+  | "PointerMove"
+  | "PointerUp"
+  | "PointerCancel"
+  | "PointerEnter"
+  | "PointerLeave"
+  | "PointerOver"
+  | "PointerOut"
+  | "GotPointer"
+  | "LostPointer"
+  | "Scroll"
+  | "Wheel"
+  | "AnimationStart"
+  | "AnimationEnd"
+  | "AnimationIteration"
+  | "TransitionEnd"
+
+export type GetEvent<K extends string> = Lowercase<K> extends keyof HTMLElementEventMap
+  ? HTMLElementEventMap[Lowercase<K>]
+  : Event
+
+export type QwikCaptureEventMap = {
+  [K in PascalCaseEventNames as `${K}Capture`]: GetEvent<K>
+}
+
+export type QwikDomEventMap = {
+  [K in PascalCaseEventNames]: Lowercase<K> extends keyof HTMLElementEventMap
+  ? HTMLElementEventMap[Lowercase<K>]
+  : Event
 };
+
+interface QwikEventMap extends QwikDomEventMap, QwikCaptureEventMap { }
 
 export type PreventDefault = {
   [K in keyof QwikEventMap as `prevent${'default' | 'Default'}:${Lowercase<K>}`]?: boolean;
@@ -202,8 +161,8 @@ export type ComponentKnownEvents = {
  */
 export interface ComponentBaseProps
   extends PreventDefault,
-    ComponentCustomEvents,
-    ComponentKnownEvents {
+  ComponentCustomEvents,
+  ComponentKnownEvents {
   class?: string | { [className: string]: boolean };
   className?: string | undefined;
   style?: Record<string, string | number> | string | undefined;
@@ -218,7 +177,7 @@ export interface ComponentBaseProps
   'host:tagName'?: JSXTagName;
   children?: JSXChildren;
 }
-export interface QwikAttributes extends QwikProps, QwikEvents {}
+export interface QwikAttributes extends QwikProps, QwikEvents { }
 
 /**
  * @public

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -16,7 +16,10 @@ export type PascalCaseEventNames =
   | 'FocusOut'
   | 'Blur'
   | 'Change'
+  | 'BeforeInput'
   | 'Input'
+  | 'Select'
+  | 'Search'
   | 'Reset'
   | 'Submit'
   | 'Invalid'
@@ -56,21 +59,26 @@ export type PascalCaseEventNames =
   | 'PointerLeave'
   | 'PointerOver'
   | 'PointerOut'
-  | 'GotPointer'
-  | 'LostPointer'
+  | 'GotPointerCapture'
+  | 'LostPointerCapture'
   | 'Scroll'
   | 'Wheel'
   | 'AnimationStart'
   | 'AnimationEnd'
   | 'AnimationIteration'
-  | 'TransitionEnd';
+  | 'TransitionEnd'
+  | 'GotPointerCapture'
+  | 'LostPointerCapture'
+  | 'GestureStart'
+  | 'GestureChange'
+  | 'GestureEnd';
 
 export type GetEvent<K extends string> = Lowercase<K> extends keyof HTMLElementEventMap
   ? HTMLElementEventMap[Lowercase<K>]
   : Event;
 
-type QwikEventMap = {
-  [K in PascalCaseEventNames as `${K}${'' | 'Capture'}`]: GetEvent<K>;
+export type QwikEventMap = {
+  [K in PascalCaseEventNames as `${K}`]: GetEvent<K>;
 };
 
 export type PreventDefault = {

--- a/packages/qwik/src/optimizer/src/manifest.ts
+++ b/packages/qwik/src/optimizer/src/manifest.ts
@@ -1,3 +1,4 @@
+import type { QwikEventMap } from '../../core/render/jsx/types/jsx-qwik-attributes';
 import type { NormalizedQwikPluginOptions } from './plugins/plugin';
 import type {
   GeneratedOutputBundle,
@@ -96,73 +97,107 @@ function prioritorizeSymbolNames(manifest: QwikManifest) {
   });
 }
 
-// User triggered events should have priority
-const EVENT_PRIORITY = [
+type UserEvents = {
+  [K in keyof QwikEventMap as `on${K}$`]: null;
+};
+const USER_EVENTS: UserEvents = {
+  onLoad$: null,
+  onError$: null,
+
+  // Clipboard Events
+  onCopy$: null,
+  onPaste$: null,
+  onCut$: null,
+
+  // Composition Events
+  onCompositionStart$: null,
+  onCompositionUpdate$: null,
+  onCompositionEnd$: null,
+
   // Click Events
-  'onClick$',
-  'onDblClick$',
-  'onContextMenu$',
-  'onAuxClick$',
+  onClick$: null,
+  onDblClick$: null,
+  onContextMenu$: null,
+  onAuxClick$: null,
 
   // Pointer Events
-  'onPointerDown$',
-  'onPointerUp$',
-  'onPointerMove$',
-  'onPointerOver$',
-  'onPointerEnter$',
-  'onPointerLeave$',
-  'onPointerOut$',
-  'onPointerCancel$',
-  'onGotPointerCapture$',
-  'onLostPointerCapture$',
+  onPointerDown$: null,
+  onPointerUp$: null,
+  onPointerMove$: null,
+  onPointerOver$: null,
+  onPointerEnter$: null,
+  onPointerLeave$: null,
+  onPointerOut$: null,
+  onPointerCancel$: null,
+  onGotPointerCapture$: null,
+  onLostPointerCapture$: null,
 
   // Touch Events
-  'onTouchStart$',
-  'onTouchEnd$',
-  'onTouchMove$',
-  'onTouchCancel$',
+  onTouchStart$: null,
+  onTouchEnd$: null,
+  onTouchMove$: null,
+  onTouchCancel$: null,
+
+  // Drag & Drop Events
+  onDrag$: null,
+  onDragStart$: null,
+  onDragEnd$: null,
+  onDragEnter$: null,
+  onDragOver$: null,
+  onDragLeave$: null,
+  onDragExit$: null,
+  onDrop$: null,
 
   // Mouse Events
-  'onMouseDown$',
-  'onMouseUp$',
-  'onMouseMove$',
-  'onMouseEnter$',
-  'onMouseLeave$',
-  'onMouseOver$',
-  'onMouseOut$',
-  'onWheel$',
+  onMouseDown$: null,
+  onMouseUp$: null,
+  onMouseMove$: null,
+  onMouseEnter$: null,
+  onMouseLeave$: null,
+  onMouseOver$: null,
+  onMouseOut$: null,
+  onWheel$: null,
 
   // Gesture Events
-  'onGestureStart$',
-  'onGestureChange$',
-  'onGestureEnd$',
+  onGestureStart$: null,
+  onGestureChange$: null,
+  onGestureEnd$: null,
 
   // Keyboard Events
-  'onKeyDown$',
-  'onKeyUp$',
-  'onKeyPress$',
+  onKeyDown$: null,
+  onKeyUp$: null,
+  onKeyPress$: null,
 
   // Input/Change Events
-  'onInput$',
-  'onChange$',
-  'onSearch$',
-  'onInvalid$',
-  'onBeforeInput$',
-  'onSelect$',
+  onInput$: null,
+  onChange$: null,
+  onSearch$: null,
+  onInvalid$: null,
+  onBeforeInput$: null,
+  onSelect$: null,
 
   // Focus/Blur Events
-  'onFocusIn$',
-  'onFocusOut$',
-  'onFocus$',
-  'onBlur$',
+  onFocusIn$: null,
+  onFocusOut$: null,
+  onFocus$: null,
+  onBlur$: null,
 
   // Form Events
-  'onSubmit$',
-  'onReset$',
+  onSubmit$: null,
+  onReset$: null,
 
   // Scroll Events
-  'onScroll$',
-].map((n) => n.toLowerCase());
+  onScroll$: null,
+
+  // Animation Events
+  onAnimationStart$: null,
+  onAnimationIteration$: null,
+  onAnimationEnd$: null,
+  onTransitionEnd$: null,
+};
+
+// User triggered events should have priority
+const EVENT_PRIORITY = Object.keys(USER_EVENTS).map((n) => n.toLowerCase());
 
 const FUNCTION_PRIORITY = [
   'useClientEffect$',


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Circling back to a previous PR, It seems like unnecessary maintainence overhead to have a map of pascal case events and their DOM Event types. 

Typescript already has an Event Map that we can use and will ensure that Qwik's Pascal Cased event names are always in sync with their DOM equivalents. If new events are needed, maintainers will just need to add a new Event Name to the union, and everything else will automatically be correct.

Also fixes the naming of Focusin and Focusout to be proper pascal case (FocusIn, FocusOut), first mentioned in #508. Further, manifest.ts is modified to ensure a type error if it becomes out of sync with Event types.

Note: I haven't checked it this change resolves the above mentioned issue. However, the naming change is still desirable for consistency.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
