### PR TITLE
fix: vite resolveQwikBuild option

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -209,6 +209,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
 
     opts.vendorRoots = updatedOpts.vendorRoots ? updatedOpts.vendorRoots : [];
     opts.scope = updatedOpts.scope ?? null;
+    opts.resolveQwikBuild = !!updatedOpts.resolveQwikBuild;
 
     return { ...opts };
   };

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -209,7 +209,10 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
 
     opts.vendorRoots = updatedOpts.vendorRoots ? updatedOpts.vendorRoots : [];
     opts.scope = updatedOpts.scope ?? null;
-    opts.resolveQwikBuild = !!updatedOpts.resolveQwikBuild;
+
+    if (typeof updatedOpts.resolveQwikBuild === 'boolean') {
+      opts.resolveQwikBuild = updatedOpts.resolveQwikBuild;
+    }
 
     return { ...opts };
   };

--- a/packages/qwik/src/optimizer/src/plugins/plugin.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.unit.ts
@@ -32,6 +32,7 @@ test('defaults (buildMode: production)', async () => {
   equal(opts.buildMode, 'production');
   equal(opts.entryStrategy, { type: 'smart' });
   equal(opts.forceFullBuild, true);
+  equal(opts.resolveQwikBuild, false);
   equal(opts.debug, false);
   equal(opts.rootDir, normalizePath(cwd));
   equal(opts.input, [normalizePath(resolve(cwd, 'src', 'root.tsx'))]);
@@ -50,6 +51,7 @@ test('defaults (target: ssr)', async () => {
   equal(opts.buildMode, 'development');
   equal(opts.entryStrategy, { type: 'inline' });
   equal(opts.forceFullBuild, false);
+  equal(opts.resolveQwikBuild, false);
   equal(opts.debug, false);
   equal(opts.rootDir, normalizePath(cwd));
   equal(opts.input, [normalizePath(resolve(cwd, 'src', 'entry.ssr.tsx'))]);
@@ -67,6 +69,7 @@ test('defaults (buildMode: production, target: ssr)', async () => {
   equal(opts.buildMode, 'production');
   equal(opts.entryStrategy, { type: 'inline' });
   equal(opts.forceFullBuild, false);
+  equal(opts.resolveQwikBuild, false);
   equal(opts.debug, false);
   equal(opts.rootDir, normalizePath(cwd));
   equal(opts.input, [normalizePath(resolve(cwd, 'src', 'entry.ssr.tsx'))]);
@@ -175,11 +178,23 @@ test('manifestOutput', async () => {
   equal(opts.manifestOutput, manifestOutput);
 });
 
-test(' manifestInput', async () => {
+test('manifestInput', async () => {
   const plugin = await mockPlugin();
   const manifestInput: QwikManifest = { mapping: {}, symbols: {}, bundles: {}, version: '1' };
   const opts = plugin.normalizeOptions({ manifestInput });
   equal(opts.manifestInput, manifestInput);
+});
+
+test('resolveQwikBuild true', async () => {
+  const plugin = await mockPlugin();
+  const opts = plugin.normalizeOptions({ resolveQwikBuild: true });
+  equal(opts.resolveQwikBuild, true);
+});
+
+test('resolveQwikBuild false', async () => {
+  const plugin = await mockPlugin();
+  const opts = plugin.normalizeOptions({ resolveQwikBuild: false });
+  equal(opts.resolveQwikBuild, false);
 });
 
 async function mockPlugin() {

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -84,6 +84,7 @@ vite('command: serve, mode: production', async () => {
   equal(opts.entryStrategy, { type: 'hook' });
   equal(opts.debug, false);
   equal(opts.forceFullBuild, false);
+  equal(opts.resolveQwikBuild, false);
 
   equal(build.outDir, normalizePath(resolve(cwd, 'dist')));
   equal(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev.tsx')));
@@ -99,6 +100,7 @@ vite('command: serve, mode: production', async () => {
   equal(c.esbuild, undefined);
   equal(c.ssr, undefined);
 });
+
 vite('command: build, mode: development', async () => {
   const initOpts = {
     optimizerOptions: mockOptimizerOptions(),
@@ -115,6 +117,7 @@ vite('command: build, mode: development', async () => {
   equal(opts.entryStrategy, { type: 'hook' });
   equal(opts.debug, false);
   equal(opts.forceFullBuild, true);
+  equal(opts.resolveQwikBuild, true);
 
   equal(plugin.enforce, 'pre');
   equal(build.outDir, normalizePath(resolve(cwd, 'dist')));
@@ -147,6 +150,7 @@ vite('command: build, mode: production', async () => {
   equal(opts.entryStrategy, { type: 'smart' });
   equal(opts.debug, false);
   equal(opts.forceFullBuild, true);
+  equal(opts.resolveQwikBuild, true);
 
   equal(plugin.enforce, 'pre');
   equal(build.outDir, normalizePath(resolve(cwd, 'dist')));
@@ -178,6 +182,7 @@ vite('command: build, --mode production (client)', async () => {
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
+  equal(opts.resolveQwikBuild, true);
 
   equal(opts.target, 'client');
   equal(opts.buildMode, 'production');
@@ -204,6 +209,7 @@ vite('command: build, --ssr entry.express.tsx', async () => {
   equal(opts.entryStrategy, { type: 'inline' });
   equal(opts.debug, false);
   equal(opts.forceFullBuild, true);
+  equal(opts.resolveQwikBuild, true);
 
   equal(plugin.enforce, 'pre');
   equal(build.outDir, normalizePath(resolve(cwd, 'server')));
@@ -241,6 +247,7 @@ vite('command: serve, --mode ssr', async () => {
   equal(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'renderz.tsx'))]);
   equal(c.build.outDir, normalizePath(resolve(cwd, 'ssr-dist')));
   equal(c.publicDir, undefined);
+  equal(opts.resolveQwikBuild, false);
 });
 
 vite.run();


### PR DESCRIPTION
Vite was setting the `resolveQwikBuild` option when it was a `build`. However, it wasn't being passed down correctly when the plugin options were normalized.