### PR TITLE
fix: qwik-city frontmatter

### DIFF
--- a/packages/qwik-city/buildtime/markdown/frontmatter.ts
+++ b/packages/qwik-city/buildtime/markdown/frontmatter.ts
@@ -1,20 +1,57 @@
 import type { Transformer } from 'unified';
-import type { BuildContext } from '../types';
+import type { BuildContext, FrontmatterAttrs } from '../types';
 import { normalizePath } from '../utils/fs';
 import { visit } from 'unist-util-visit';
+import type { ResolvedDocumentHead } from '../../runtime/src';
 
 export function parseFrontmatter(ctx: BuildContext): Transformer {
   return (mdast, vfile) => {
-    const attrs: string[] = [];
+    const attrs: FrontmatterAttrs = {};
 
     visit(mdast, 'yaml', (node: any) => {
-      if (typeof node.value === 'string' && node.value.length > 0) {
-        attrs.push(node.value);
-      }
+      parseFrontmatterAttrs(attrs, node.value);
     });
 
-    if (attrs.length > 0) {
+    if (Object.keys(attrs).length > 0) {
       ctx.frontmatter.set(normalizePath(vfile.path), attrs);
     }
   };
+}
+
+export function parseFrontmatterAttrs(attrs: FrontmatterAttrs, yaml: string) {
+  if (typeof yaml === 'string') {
+    yaml = yaml.trim();
+    if (yaml !== '') {
+      const lines = yaml.split(/\r?\n|\r|\n/g);
+      for (const line of lines) {
+        const parts = line.split(':');
+        if (parts.length > 1) {
+          const attrName = parts[0].trim();
+          const attrValue = parts.slice(1).join(':').trim();
+          attrs[attrName] = attrValue;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function frontmatterAttrsToDocumentHead(attrs: FrontmatterAttrs | undefined) {
+  if (attrs && Object.keys(attrs).length > 0) {
+    const head: Required<ResolvedDocumentHead> = { title: '', meta: [], styles: [], links: [] };
+
+    for (const attrName in attrs) {
+      const attrValue = attrs[attrName];
+      if (attrName === 'title') {
+        head.title = attrValue;
+      } else if (attrName === 'description') {
+        head.meta.push({
+          name: attrName,
+          content: attrValue,
+        });
+      }
+    }
+    return head;
+  }
+  return null;
 }

--- a/packages/qwik-city/buildtime/markdown/frontmatter.unit.ts
+++ b/packages/qwik-city/buildtime/markdown/frontmatter.unit.ts
@@ -1,0 +1,55 @@
+import * as assert from 'uvu/assert';
+import { test } from 'uvu';
+import { frontmatterAttrsToDocumentHead, parseFrontmatterAttrs } from './frontmatter';
+import type { FrontmatterAttrs } from '../types';
+
+test('frontmatter, one line', async () => {
+  const attrs: FrontmatterAttrs = {};
+  const yaml = `title: Some Title`;
+  parseFrontmatterAttrs(attrs, yaml);
+  assert.equal(attrs.title, 'Some Title');
+});
+
+test('frontmatter, colons', async () => {
+  const attrs: FrontmatterAttrs = {};
+  const yaml = `title: Some : Crazy : Title`;
+  parseFrontmatterAttrs(attrs, yaml);
+  assert.equal(attrs.title, 'Some : Crazy : Title');
+});
+
+test('frontmatter, multiline', async () => {
+  const attrs: FrontmatterAttrs = {};
+  const yaml = `
+  title: Some Title
+  description: Some Description`;
+  parseFrontmatterAttrs(attrs, yaml);
+  assert.equal(attrs.title, 'Some Title');
+  assert.equal(attrs.description, 'Some Description');
+});
+
+test('frontmatter, no attrs head', async () => {
+  const head = frontmatterAttrsToDocumentHead(undefined);
+  assert.equal(head, null);
+});
+
+test('frontmatter, attrs head title', async () => {
+  const attrs: FrontmatterAttrs = {
+    title: 'My Title',
+  };
+  const head = frontmatterAttrsToDocumentHead(attrs);
+  assert.equal(head!.title, 'My Title');
+  assert.equal(head!.meta.length, 0);
+});
+
+test('frontmatter, attrs head description', async () => {
+  const attrs: FrontmatterAttrs = {
+    description: 'My Description',
+  };
+  const head = frontmatterAttrsToDocumentHead(attrs);
+  assert.equal(head!.title, '');
+  assert.equal(head!.meta.length, 1);
+  assert.equal(head!.meta[0].name, 'description');
+  assert.equal(head!.meta[0].content, 'My Description');
+});
+
+test.run();

--- a/packages/qwik-city/buildtime/markdown/rehype.ts
+++ b/packages/qwik-city/buildtime/markdown/rehype.ts
@@ -6,11 +6,12 @@ import { valueToEstree } from 'estree-util-value-to-estree';
 import { headingRank } from 'hast-util-heading-rank';
 import { toString } from 'hast-util-to-string';
 import { visit } from 'unist-util-visit';
-import type { ContentHeading, DocumentMeta, ResolvedDocumentHead } from '../../runtime/src';
+import type { ContentHeading } from '../../runtime/src';
 import { dirname, resolve } from 'path';
 import type { BuildContext } from '../types';
 import { existsSync } from 'fs';
 import { normalizePath } from '../utils/fs';
+import { frontmatterAttrsToDocumentHead } from './frontmatter';
 
 export function rehypePage(ctx: BuildContext): Transformer {
   return (ast, vfile) => {
@@ -57,27 +58,8 @@ function updateContentLinks(mdast: Root, sourcePath: string) {
 
 function exportContentHead(ctx: BuildContext, mdast: Root, sourcePath: string) {
   const attrs = ctx.frontmatter.get(sourcePath);
-  if (Array.isArray(attrs) && attrs.length > 0) {
-    const head: Required<ResolvedDocumentHead> = { title: '', meta: [], styles: [], links: [] };
-
-    for (const attr of attrs) {
-      const parts = attr.split(':');
-      if (parts.length > 1) {
-        const attrName = parts.shift()!;
-        const attrValue = parts.join(':').trim();
-
-        if (attrName === 'title') {
-          head.title = attrValue;
-        } else {
-          const meta: DocumentMeta = {
-            [attrName.startsWith('og:') ? 'property' : 'name']: attrName,
-            content: attrValue,
-          };
-          head.meta.push(meta);
-        }
-      }
-    }
-
+  const head = frontmatterAttrsToDocumentHead(attrs);
+  if (head) {
     createExport(mdast, 'head', head);
   }
 }

--- a/packages/qwik-city/buildtime/markdown/syntax-highlight.ts
+++ b/packages/qwik-city/buildtime/markdown/syntax-highlight.ts
@@ -2,7 +2,7 @@ import type { Transformer } from 'unified';
 import { toString } from 'hast-util-to-string';
 import { visit } from 'unist-util-visit';
 import { refractor } from 'refractor';
-import tsxLang from 'refractor/lang/tsx';
+import tsxLang from 'refractor/lang/tsx.js';
 
 export function rehypeSyntaxHighlight(): Transformer {
   refractor.register(tsxLang);

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -5,11 +5,15 @@ export interface BuildContext {
   layouts: BuildLayout[];
   entries: BuildEntry[];
   menus: BuildMenu[];
-  frontmatter: Map<string, string[]>;
+  frontmatter: Map<string, FrontmatterAttrs>;
   diagnostics: Diagnostic[];
   target: 'ssr' | 'client';
   isDevServer: boolean;
   isDevServerClientOnly: boolean;
+}
+
+export interface FrontmatterAttrs {
+  [attrName: string]: string;
 }
 
 export interface Diagnostic {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8229,7 +8229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:0.7.4":
+"source-map@npm:0.7.4, source-map@npm:^0.7.3":
   version: 0.7.4
   resolution: "source-map@npm:0.7.4"
   checksum: 01cc5a74b1f0e1d626a58d36ad6898ea820567e87f18dfc9d24a9843a351aaa2ec09b87422589906d6ff1deed29693e176194dc88bcae7c9a852dc74b311dbf5
@@ -8247,13 +8247,6 @@ __metadata:
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
-  languageName: node
-  linkType: hard
-
-"source-map@npm:^0.7.3":
-  version: 0.7.3
-  resolution: "source-map@npm:0.7.3"
-  checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes parsing markdown frontmatter and setting `document.title` and adding a `<meta name="description">`