### PR TITLE
fix: qwik-city dev server

### DIFF
--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -115,6 +115,7 @@ function isVitePathname(pathname: string) {
     pathname.startsWith('/__open-in-editor') ||
     pathname.startsWith('/@qwik-city-plan') ||
     pathname.startsWith('/src/') ||
+    pathname.startsWith('/node_modules/') ||
     pathname.startsWith('/favicon.ico')
   );
 }


### PR DESCRIPTION
Fixes an issue where Vite's dev server was 404'ing for `/node_modules/` requests.