### PR TITLE
Change default prefetch to Worker-Fetch

### DIFF
--- a/packages/docs/src/entry.cloudflare.tsx
+++ b/packages/docs/src/entry.cloudflare.tsx
@@ -3,7 +3,7 @@ import { qwikCity } from '@builder.io/qwik-city/middleware/cloudflare-pages';
 
 const qwikCityMiddleware = qwikCity(render, {
   prefetchStrategy: {
-    implementation: 'link-prefetch',
+    implementation: 'worker-fetch',
   },
 });
 

--- a/starters/servers/cloudflare-pages/src/entry.cloudflare.tsx
+++ b/starters/servers/cloudflare-pages/src/entry.cloudflare.tsx
@@ -3,7 +3,7 @@ import { qwikCity } from '@builder.io/qwik-city/middleware/cloudflare-pages';
 
 const qwikCityMiddleware = qwikCity(render, {
   prefetchStrategy: {
-    implementation: 'link-prefetch',
+    implementation: 'worker-fetch',
   },
 });
 

--- a/starters/servers/netlify-edge/src/entry.netlify.ts
+++ b/starters/servers/netlify-edge/src/entry.netlify.ts
@@ -3,7 +3,7 @@ import { qwikCity } from '@builder.io/qwik-city/middleware/netlify-edge';
 
 const qwikCityHandler = qwikCity(render, {
   prefetchStrategy: {
-    implementation: 'link-prefetch',
+    implementation: 'worker-fetch',
   },
 });
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Link prefetch has been shown to only work on Chrome, other browsers ignore it. Worker-fetch is a better default as it works across all browsers.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
