### PR TITLE
Redirect docs and onGet usage clarification

### DIFF
--- a/packages/docs/src/routes/qwikcity/endpoint/non-200.mdx
+++ b/packages/docs/src/routes/qwikcity/endpoint/non-200.mdx
@@ -70,7 +70,9 @@ export default component$(() => {
 
 ## 3xx - Redirect
 
-Let's say that a user does a request to an invalid `skuId` such as `https://example.com/product/999/details`. In this case, we would like to return a 404 HTTP status code and render a 404 page. The place where we determine if the request is valid or not is the data endpoint by looking into the database. Even if the response is non-200, the component still gets a chance to render a page (Except in the redirect case.)
+Sometimes you want to redirect a user from the current page to another page.
+
+Let's say a user tries to go to a dashboard page, but has not logged in yet. We want them to be redirect to a log-in page so they can be authenticated.
 
 ```typescript
 // File: src/routes/dashboard.js
@@ -100,6 +102,6 @@ return response.redirect('/login', 301) // Permanent redirect
 
 Redirect status codes are between 300-399. 
 
-If you do not provide a status code, Qwik City will default to a 307 temporty redirect status.
+If you do not provide a status code, Qwik City will default to a 307 temporary redirect status.
 
 Read more about redirect status codes [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages). 

--- a/packages/docs/src/routes/qwikcity/endpoint/non-200.mdx
+++ b/packages/docs/src/routes/qwikcity/endpoint/non-200.mdx
@@ -15,6 +15,8 @@ Assume this file layout.
         - details.js     # https://example.com/product/1234/details
 ```
 
+## 404 - Not Found
+
 Let's say that a user does a request to an invalid `skuId` such as `https://example.com/product/999/details`. In this case, we would like to return a 404 HTTP status code and render a 404 page. The place where we determine if the request is valid or not is the data endpoint by looking into the database. Even if the response is non-200, the component still gets a chance to render a page (Except in the redirect case.)
 
 ```typescript
@@ -65,3 +67,39 @@ export default component$(() => {
   );
 });
 ```
+
+## 3xx - Redirect
+
+Let's say that a user does a request to an invalid `skuId` such as `https://example.com/product/999/details`. In this case, we would like to return a 404 HTTP status code and render a 404 page. The place where we determine if the request is valid or not is the data endpoint by looking into the database. Even if the response is non-200, the component still gets a chance to render a page (Except in the redirect case.)
+
+```typescript
+// File: src/routes/dashboard.js
+import {component$} from '@builder.io/qwik';
+import {DocumentHead} from '@builder.io/qwik-city';
+import {checkAuthorization} from '../utils' // Your authorization code
+import type {DashboardData} from '../types' // Your types
+
+export const onGet: EndpointHandler<DashboardData> = async ({ request, response }) => {
+	const isAuthorized = checkAuthorization(request.headers.get('cookie'));
+
+	if (!isAuthorized) {
+		// User is not authorized!
+		// Redirect to the log-in page
+		return response.redirect('/login')
+	} else {
+		// ...
+	}
+};
+```
+
+The `response.redirect` function takes a url and optionally a status code as the second argument. 
+
+```tsx
+return response.redirect('/login', 301) // Permanent redirect
+```
+
+Redirect status codes are between 300-399. 
+
+If you do not provide a status code, Qwik City will default to a 307 temporty redirect status.
+
+Read more about redirect status codes [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages). 

--- a/packages/docs/src/routes/qwikcity/endpoint/overview.mdx
+++ b/packages/docs/src/routes/qwikcity/endpoint/overview.mdx
@@ -4,7 +4,7 @@ title: Qwik City - Endpoints
 
 # Qwik City - Endpoints
 
-Endpoints are URLs that can be used to retrieve data, redirect users, or otherwise change the response.
+Endpoints are URLs that can be used to retrieve data, redirect users, or otherwise modify the response.
 
 Imagine that you have `https://example.com/product/abc123/details` and you want to get the details of the product with the id `abc123`. You can retrieve the data in two different ways:
 1. As HTML for human consumption.

--- a/packages/docs/src/routes/qwikcity/endpoint/overview.mdx
+++ b/packages/docs/src/routes/qwikcity/endpoint/overview.mdx
@@ -4,7 +4,7 @@ title: Qwik City - Endpoints
 
 # Qwik City - Endpoints
 
-Endpoints are URLs that can be used to retrieve data.
+Endpoints are URLs that can be used to retrieve data, redirect users, or otherwise change the response.
 
 Imagine that you have `https://example.com/product/abc123/details` and you want to get the details of the product with the id `abc123`. You can retrieve the data in two different ways:
 1. As HTML for human consumption.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Some users may be confused by the current docs implying the onGet function is only for data fetching.

From on Bjorn on discord:

> My understanding (which isn't a lot at this stage as I'm quite new to QwikCity) is that the idea behind endpoints is to fetch data for a component. For my use case it's solely to be used as a redirect. 
Is there another way to handle this use case, which I might be missing? 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
