### PR TITLE
fix: clean up non-existent node related variables from qwik city starter

### DIFF
--- a/starters/apps/qwik-city/src/routes/api/index@foo.tsx
+++ b/starters/apps/qwik-city/src/routes/api/index@foo.tsx
@@ -1,7 +1,7 @@
 import { component$, Host, useClientEffect$, useStore } from '@builder.io/qwik';
 
 export default component$(() => {
-  const store = useStore({ timestamp: '', os: '', arch: '', node: '' });
+  const store = useStore({ timestamp: '' });
 
   useClientEffect$(async () => {
     const url = `/api/builder.io/oss.json`;
@@ -9,9 +9,6 @@ export default component$(() => {
     const data: any = await rsp.json();
 
     store.timestamp = data.timestamp;
-    store.os = data.os;
-    store.arch = data.arch;
-    store.node = data.node;
   });
 
   return (
@@ -28,12 +25,6 @@ export default component$(() => {
       </ul>
 
       <p>Timestamp: {store.timestamp}</p>
-      <p>
-        Node: <span>{store.node}</span>
-      </p>
-      <p>
-        OS: <span>{store.os}</span>
-      </p>
     </Host>
   );
 });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Clean up non-existent variables from Qwik City starter, since the node API has already been removed.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
