### PR TITLE
docs: fixes the name of the reference command

### DIFF
--- a/packages/docs/src/routes/docs/getting-started.mdx
+++ b/packages/docs/src/routes/docs/getting-started.mdx
@@ -60,7 +60,7 @@ At this point, you will have `qwik-app` directory, that contains the starter app
 
 Once the application is download.
 
-1. Change into the directory created by the `npm create qwik@latest`.
+1. Change into the directory created by the `npm init qwik@latest`.
 
 ```shell
 cd qwik-app


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

Correct the name of the command previously used in the doc in the paragraph  "Run the Qwik CLI in your shell"

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. None

# Checklist:

- [X] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
