### PR TITLE
Fix request handler return type

### DIFF
--- a/packages/qwik-city/runtime/src/library/types.ts
+++ b/packages/qwik-city/runtime/src/library/types.ts
@@ -291,7 +291,7 @@ export type RequestHandler<BODY = unknown> = (ev: RequestEvent) => RequestHandle
  */
 export type EndpointHandler<BODY = unknown> = RequestHandler<BODY>;
 
-export type RequestHandlerBody<BODY> = BODY | string | number | boolean | undefined | null | void;
+export type RequestHandlerBody<BODY> = BODY | RedirectResponse | string | number | boolean | undefined | null | void;
 
 export type RequestHandlerBodyFunction<BODY> = () =>
   | RequestHandlerBody<BODY>

--- a/packages/qwik-city/runtime/src/library/types.ts
+++ b/packages/qwik-city/runtime/src/library/types.ts
@@ -291,7 +291,15 @@ export type RequestHandler<BODY = unknown> = (ev: RequestEvent) => RequestHandle
  */
 export type EndpointHandler<BODY = unknown> = RequestHandler<BODY>;
 
-export type RequestHandlerBody<BODY> = BODY | RedirectResponse | string | number | boolean | undefined | null | void;
+export type RequestHandlerBody<BODY> =
+  | BODY
+  | RedirectResponse
+  | string
+  | number
+  | boolean
+  | undefined
+  | null
+  | void;
 
 export type RequestHandlerBodyFunction<BODY> = () =>
   | RequestHandlerBody<BODY>


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

The response.redirect() function now returns a Redirect Repsonse, so 

```tsx
export onGet: RequestHandler<MyType> = ({ response }) => {
  if (some_condition) { return response.redirect('redirect-url') }
 // ...
}
```

is throwing a type error. Adding Redirect Reponse as a possible return type fixes the issue.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
