### PR TITLE
docs: add link to the community groups index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm init qwik@latest
 
 - Ping us at [@QwikDev](https://twitter.com/QwikDev)
 - Join our [Discord](https://qwik.builder.io/chat) community
+- Join all the [other community groups](https://qwikcommunity.com)
 
 ## Related
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

A link to a place that summarizes all of the global and local community groups

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
