### PR TITLE
Make Content-Type json validation less rigid so it works with things like application/manifest+json (Fixes #983)

### DIFF
--- a/packages/qwik-city/middleware/request-handler/endpoint-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/endpoint-handler.ts
@@ -18,7 +18,7 @@ export function endpointHandler<T = any>(
   }
 
   // check so we can know later on if we should JSON.stringify the body
-  const isJson = headers.get('Content-Type')!.includes('application/json');
+  const isJson = headers.get('Content-Type')!.includes('json');
 
   return response(status, headers, async ({ write }) => {
     const body = pendingBody !== undefined ? await pendingBody : resolvedBody;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

There are Content-Types that are variations of `application/json`, like `application/manifest+json`, which is needed to output a route like `/manifest.webmanifest.ts`. This PR make it less rigid so it works with those variations.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case

Using `routes/manifest.webmanifest.ts` needs to print  `application/manifest+json`.

- 2. Another use case

`application/ld+json` and other variations.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
