### PR TITLE
docs: replace obs function by track function

### DIFF
--- a/packages/docs/src/routes/docs/components/hooks.mdx
+++ b/packages/docs/src/routes/docs/components/hooks.mdx
@@ -90,7 +90,7 @@ Reruns the `watchFn` when the observed inputs change.
 
 Use `useWatch` to observe changes on a set of inputs, and then re-execute the `watchFn` when those inputs change.
 
-The `watchFn` only executes if the observed inputs change. To observe the inputs use the `obs` function to wrap property reads. This creates subscriptions that will trigger the `watchFn` to re-run.
+The `watchFn` only executes if the observed inputs change. To observe the inputs use the `track` function to wrap property reads. This creates subscriptions that will trigger the `watchFn` to re-run.
 
 
 ### Example


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

The documentation for the [useWatch$](https://qwik.builder.io/docs/components/hooks#usewatch) hook contains an error in my opinion, it talks about the `obs` function but in the example it is the `track` function that was used. I looked at the Qwik code and I think the documentation should be changed to be consistent.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- Nope

# Checklist:

- [X] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
