### PR TITLE
Update Qwik City starter to latest

### DIFF
--- a/starters/apps/qwik-city/package.json
+++ b/starters/apps/qwik-city/package.json
@@ -14,7 +14,7 @@
   },
   "type": "module",
   "devDependencies": {
-    "@builder.io/qwik-city": "0.0.32",
+    "@builder.io/qwik-city": "latest",
     "vite-tsconfig-paths": "3.5.0"
   }
 }

--- a/starters/apps/qwik-city/package.json
+++ b/starters/apps/qwik-city/package.json
@@ -14,7 +14,7 @@
   },
   "type": "module",
   "devDependencies": {
-    "@builder.io/qwik-city": "0.0.30",
+    "@builder.io/qwik-city": "0.0.32",
     "vite-tsconfig-paths": "3.5.0"
   }
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

The Qwik City Starter in the CLI is two versions of Qwik City behind, and is giving errors. Upgrading resolves the errors.

Fixes: #1005 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
