### PR TITLE
fix: not to deconstruct request at all

### DIFF
--- a/packages/qwik-city/middleware/request-handler/user-response.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.ts
@@ -127,11 +127,7 @@ export async function loadUserResponse(
 
         // create user request event, which is a narrowed down request context
         const requstEv: RequestEvent = {
-          request: {
-            ...request,
-            // in netlify edge, deconstructing request would drop headers
-            headers: request.headers,
-          },
+          request,
           url: new URL(url),
           params: { ...params },
           response,


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Related to https://github.com/BuilderIO/qwik/pull/1003

At the last time, `headers` can't be access, now encountering `request.formData` attrs, and there'll be more attrs would be used.

Tried to do Proxy getter wrapper, but some methods will do the prototype or internal stuff check.

Not sure why request need to be deconstruct at the first place.  

Direct pass request reference test fines locally, also Cloudflare middleware also using this approach.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
