### PR TITLE
docs(qwikcity): add missing link to Custom Build Dir

### DIFF
--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -36,6 +36,7 @@
 - [Optimizer](advanced/optimizer/index.mdx)
 - [QRL](advanced/qrl/index.mdx)
 - [Qwikloader](advanced/qwikloader/index.mdx)
+- [Custom Build Directory](advanced/custom-build-dir/index.mdx)
 
 ## Community
 


### PR DESCRIPTION
re #943

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The link to the new documentation page about custom build directories was now added to the sidebar


# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
