### PR TITLE
fix: upgrade docs-site qwik and city version

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "@builder.io/partytown": "^0.6.4",
-    "@builder.io/qwik": "0.0.41",
-    "@builder.io/qwik-city": "0.0.35",
+    "@builder.io/qwik": "^0.0.100",
+    "@builder.io/qwik-city": "^0.0.100",
     "@cloudflare/kv-asset-handler": "0.2.0",
     "autoprefixer": "10.4.7",
     "fflate": "^0.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,19 +96,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@builder.io/qwik-city@npm:0.0.35":
-  version: 0.0.35
-  resolution: "@builder.io/qwik-city@npm:0.0.35"
-  dependencies:
-    "@mdx-js/mdx": 2.1.2
-    "@types/mdx": 2.0.2
-    source-map: 0.7.4
-    vfile: 5.3.4
-  checksum: ccb414d5d17d6bff40da69373e9518495e3181f1694c1be8a7d056a40e8ea3a62c91faa46b02695d75d365145417a7ae4e5e79ccc523a4187819d77382c2bf53
-  languageName: node
-  linkType: hard
-
-"@builder.io/qwik-city@workspace:packages/qwik-city":
+"@builder.io/qwik-city@^0.0.100, @builder.io/qwik-city@workspace:packages/qwik-city":
   version: 0.0.0-use.local
   resolution: "@builder.io/qwik-city@workspace:packages/qwik-city"
   dependencies:
@@ -174,14 +162,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@builder.io/qwik@npm:0.0.41":
-  version: 0.0.41
-  resolution: "@builder.io/qwik@npm:0.0.41"
-  checksum: bc587947ea7470e5ad89420bb2f889defa6c2d1e540f1b60a19cc2be695edde2d64140921ea924ed14dcbc1f87bae36db1523256bd1a36a347dbe6c78ddc0ae3
-  languageName: node
-  linkType: hard
-
-"@builder.io/qwik@workspace:*, @builder.io/qwik@workspace:packages/qwik":
+"@builder.io/qwik@^0.0.100, @builder.io/qwik@workspace:*, @builder.io/qwik@workspace:packages/qwik":
   version: 0.0.0-use.local
   resolution: "@builder.io/qwik@workspace:packages/qwik"
   languageName: unknown
@@ -7392,8 +7373,8 @@ __metadata:
   resolution: "qwik-docs@workspace:packages/docs"
   dependencies:
     "@builder.io/partytown": ^0.6.4
-    "@builder.io/qwik": 0.0.41
-    "@builder.io/qwik-city": 0.0.35
+    "@builder.io/qwik": ^0.0.100
+    "@builder.io/qwik-city": ^0.0.100
     "@cloudflare/kv-asset-handler": 0.2.0
     autoprefixer: 10.4.7
     fflate: ^0.7.3


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

fixed https://github.com/BuilderIO/qwik/issues/1037

and I think docs site no longer need to pin specific version of qwik. so add `^` version prefix to match workspace package if possible.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
