### PR TITLE
Export matched module

### DIFF
--- a/starters/servers/cloudflare-pages/functions/[[path]].ts
+++ b/starters/servers/cloudflare-pages/functions/[[path]].ts
@@ -2,4 +2,4 @@
 
 // Cloudflare Pages Functions
 // https://developers.cloudflare.com/pages/platform/functions/
-export { onRequest } from '../server/entry.cloudflare';
+export { onRequestGet } from '../server/entry.cloudflare';


### PR DESCRIPTION
entry.cloudflare.js exported onRequestGet not onRequest.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Cloudflare's wrangler error when running npm run serve. No issues when building but serve failed due to mismatched export.

# Use cases and why

npm run serve failed

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
