### PR TITLE
fix: docs

### DIFF
--- a/packages/docs/src/routes/tutorial/tutorial.css
+++ b/packages/docs/src/routes/tutorial/tutorial.css
@@ -7,7 +7,7 @@
 
 .tutorial .repl {
   display: grid;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: 50% 50%;
   grid-template-areas:
     'repl-input-panel'
     'repl-output-panel';


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

> css issues with mobile styles for tutorials. When go to mobile, then back to desktop, the output tabs stay hidden

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
