### PR TITLE
docs: Update expired asciinema recording in Getting started

### DIFF
--- a/packages/docs/src/routes/docs/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/getting-started/index.mdx
@@ -31,7 +31,7 @@ $ npm init qwik@latest
 
 The CLI will guide you through an interactive menu to set the project-name and select one of the starters:
 
-<script id="asciicast-7Ielp9cJZfy0MglQvOxBLgUqF" src="https://asciinema.org/a/7Ielp9cJZfy0MglQvOxBLgUqF.js" async></script>
+<script id="asciicast-514542" src="https://asciinema.org/a/514542.js" async></script>
 
 After your new app is created, you will see an output like the following in your terminal:
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

So the asciinema recording I added to the docs got expired (because I did not create an account). The getting started docs now show this ugly banner:

![Screenshot 2022-08-12 at 22 12 05](https://user-images.githubusercontent.com/376921/184435754-dc65763f-8743-4569-95b4-b766be699687.png)

-------------------
I have now fixed the recording and created an account at Asciinema so the recording should not expire. This is the final recording: 

https://asciinema.org/a/514542
