### PR TITLE
docs: Add missing endpoint types to routing overview.

### DIFF
--- a/packages/docs/src/routes/qwikcity/routing/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/overview/index.mdx
@@ -25,7 +25,7 @@ In the Qwik City routes directory, `folders + an index` file map to a URL path. 
 
 Note that the leaf file at the end of the route named index. This is **important**. In other meta-frameworks you may be familiar with, there is a distinction made between `pages` and `data endpoints` or `api routes`. In Qwik City, there is no distinction, they are all `endpoints`. 
 
-To define an endpoint, you must a define an `index.[filetype]` where [filetype] can be one of:
+To define an endpoint, you must a define an `index.[filetype]` where [filetype] can be one of `.ts`, `.tsx`, `.js`, `.jsx`, `.md`, or `.mdx`.
 
 While the following directory structure: 
 


### PR DESCRIPTION
# What is it?

Adds missing allowed file extensions in the Routing Overview docs.

Closes: #1061 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
