### PR TITLE
dx: Allow typeof onGet for DocumentHead

### DIFF
--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -31,8 +31,10 @@ export interface ContentMenu {
     text: string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "GetEndpointData" needs to be exported by the entry point index.d.ts
+//
 // @alpha (undocumented)
-export type DocumentHead<T = unknown> = DocumentHeadValue | ((props: DocumentHeadProps<T>) => DocumentHeadValue);
+export type DocumentHead<T = unknown> = DocumentHeadValue | ((props: DocumentHeadProps<GetEndpointData<T>>) => DocumentHeadValue);
 
 // @alpha (undocumented)
 export interface DocumentHeadProps<T = unknown> extends RouteLocation {
@@ -230,8 +232,6 @@ export const useContent: () => ContentState;
 // @alpha (undocumented)
 export const useDocumentHead: () => Required<ResolvedDocumentHead>;
 
-// Warning: (ae-forgotten-export) The symbol "GetEndpointData" needs to be exported by the entry point index.d.ts
-//
 // @alpha (undocumented)
 export const useEndpoint: <T = unknown>() => ResourceReturn<GetEndpointData<T>>;
 

--- a/packages/qwik-city/runtime/src/library/types.ts
+++ b/packages/qwik-city/runtime/src/library/types.ts
@@ -131,7 +131,7 @@ export interface DocumentHeadProps<T = unknown> extends RouteLocation {
  */
 export type DocumentHead<T = unknown> =
   | DocumentHeadValue
-  | ((props: DocumentHeadProps<T>) => DocumentHeadValue);
+  | ((props: DocumentHeadProps<GetEndpointData<T>>) => DocumentHeadValue);
 
 export interface ContentStateInternal {
   contents: NoSerialize<ContentModule[]>;
@@ -310,3 +310,5 @@ export interface QwikCityEnvData {
   route: MutableRouteLocation;
   response: EndpointResponse;
 }
+
+export type GetEndpointData<T> = T extends RequestHandler<infer U> ? U : T;

--- a/packages/qwik-city/runtime/src/library/use-endpoint.ts
+++ b/packages/qwik-city/runtime/src/library/use-endpoint.ts
@@ -1,9 +1,7 @@
 import { useResource$ } from '@builder.io/qwik';
 import { useLocation, useQwikCityEnv } from './use-functions';
 import { isServer } from '@builder.io/qwik/build';
-import type { RequestHandler } from './types';
-
-type GetEndpointData<T> = T extends RequestHandler<infer U> ? U : T;
+import type { GetEndpointData } from './types';
 
 /**
  * @alpha


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Uses the same refinement type that is used in useLocation to allow typing DocumentHead with `typeof onGet`

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
