### PR TITLE
feat: Add env param to Cloudflare Middleware

### DIFF
--- a/packages/qwik-city/middleware/cloudflare-pages/api.md
+++ b/packages/qwik-city/middleware/cloudflare-pages/api.md
@@ -10,6 +10,8 @@ import type { RenderOptions } from '@builder.io/qwik/server';
 // @alpha (undocumented)
 export interface EventPluginContext {
     // (undocumented)
+    env: Record<string, any>;
+    // (undocumented)
     next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
     // (undocumented)
     request: Request;
@@ -18,7 +20,7 @@ export interface EventPluginContext {
 }
 
 // @alpha (undocumented)
-export function qwikCity(render: Render, opts?: QwikCityCloudflarePagesOptions): ({ request, next, waitUntil }: EventPluginContext) => Promise<Response>;
+export function qwikCity(render: Render, opts?: QwikCityCloudflarePagesOptions): ({ request, env, next, waitUntil }: EventPluginContext) => Promise<Response>;
 
 // Warning: (ae-forgotten-export) The symbol "QwikCityRequestOptions" needs to be exported by the entry point index.d.ts
 //

--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -8,7 +8,7 @@ import type { Render } from '@builder.io/qwik/server';
  * @alpha
  */
 export function qwikCity(render: Render, opts?: QwikCityCloudflarePagesOptions) {
-  async function onRequest({ request, next, waitUntil }: EventPluginContext) {
+  async function onRequest({ request, env, next, waitUntil }: EventPluginContext) {
     try {
       const url = new URL(request.url);
 
@@ -63,8 +63,8 @@ export function qwikCity(render: Render, opts?: QwikCityCloudflarePagesOptions) 
           });
         },
       };
-
-      const handledResponse = await requestHandler<Response>(requestCtx, render, opts);
+      let optsWithEnv: QwikCityCloudflarePagesOptions = {...(opts || {}), envData: env }; 
+      const handledResponse = await requestHandler<Response>(requestCtx, render, optsWithEnv);
       if (handledResponse) {
         return handledResponse;
       }
@@ -97,6 +97,7 @@ export interface QwikCityCloudflarePagesOptions extends QwikCityRequestOptions {
  */
 export interface EventPluginContext {
   request: Request;
+  env: Record<string, any>;
   waitUntil: (promise: Promise<any>) => void;
   next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
 }

--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -63,7 +63,7 @@ export function qwikCity(render: Render, opts?: QwikCityCloudflarePagesOptions) 
           });
         },
       };
-      let optsWithEnv: QwikCityCloudflarePagesOptions = { ...(opts || {}), envData: env };
+      const optsWithEnv: QwikCityCloudflarePagesOptions = { ...(opts || {}), envData: env };
       const handledResponse = await requestHandler<Response>(requestCtx, render, optsWithEnv);
       if (handledResponse) {
         return handledResponse;

--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -63,7 +63,7 @@ export function qwikCity(render: Render, opts?: QwikCityCloudflarePagesOptions) 
           });
         },
       };
-      let optsWithEnv: QwikCityCloudflarePagesOptions = {...(opts || {}), envData: env }; 
+      let optsWithEnv: QwikCityCloudflarePagesOptions = { ...(opts || {}), envData: env };
       const handledResponse = await requestHandler<Response>(requestCtx, render, optsWithEnv);
       if (handledResponse) {
         return handledResponse;


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Adds the Cloudflare env parameter as an envData render option. Allows users to access Cloudflare env variables in their Qwik City code.

```typescript
import { useEnvData, component$ } from '@builder.io/qwik';

export default component$(() => {
  const secret_password = useEnvData('secret');
  //....
});
```

Discussion here: #1066 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
