### PR TITLE
feat: Add platform field to RequestEvent

### DIFF
--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -51,7 +51,7 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
             requestCtx,
             params,
             routeModules,
-            {}, // TODO: Need to get actual platform object
+            {},
             ctx.opts.trailingSlash
           );
 

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -51,6 +51,7 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
             requestCtx,
             params,
             routeModules,
+            {}, // TODO: Need to get actual platform object
             ctx.opts.trailingSlash
           );
 

--- a/packages/qwik-city/middleware/cloudflare-pages/api.md
+++ b/packages/qwik-city/middleware/cloudflare-pages/api.md
@@ -10,6 +10,8 @@ import type { RenderOptions } from '@builder.io/qwik/server';
 // @alpha (undocumented)
 export interface EventPluginContext {
     // (undocumented)
+    env: Record<string, any>;
+    // (undocumented)
     next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
     // (undocumented)
     request: Request;
@@ -18,7 +20,7 @@ export interface EventPluginContext {
 }
 
 // @alpha (undocumented)
-export function qwikCity(render: Render, opts?: QwikCityCloudflarePagesOptions): ({ request, next, waitUntil }: EventPluginContext) => Promise<Response>;
+export function qwikCity(render: Render, opts?: QwikCityCloudflarePagesOptions): ({ request, next, env, waitUntil }: EventPluginContext) => Promise<Response>;
 
 // Warning: (ae-forgotten-export) The symbol "QwikCityRequestOptions" needs to be exported by the entry point index.d.ts
 //

--- a/packages/qwik-city/middleware/express/index.ts
+++ b/packages/qwik-city/middleware/express/index.ts
@@ -17,7 +17,7 @@ export function qwikCity(render: Render, opts?: QwikCityExpressOptions) {
     try {
       const requestCtx = fromExpressHttp(req, res);
       try {
-        const rsp = await requestHandler(requestCtx, render, opts);
+        const rsp = await requestHandler(requestCtx, render, {}, opts);
         if (!rsp) {
           next();
         }

--- a/packages/qwik-city/middleware/netlify-edge/index.ts
+++ b/packages/qwik-city/middleware/netlify-edge/index.ts
@@ -44,8 +44,16 @@ export function qwikCity(render: Render, opts?: QwikCityNetlifyOptions) {
         },
       };
 
+<<<<<<< HEAD
       // check if the next middleware is able to handle this request
       // useful if the request is for a static asset but app uses a catchall route
+=======
+      const handledResponse = await requestHandler<Response>(requestCtx, render, {}, opts);
+      if (handledResponse) {
+        return handledResponse;
+      }
+
+>>>>>>> Add platform field to RequestEvent
       const nextResponse = await next();
 
       if (nextResponse.status === 404) {

--- a/packages/qwik-city/middleware/netlify-edge/index.ts
+++ b/packages/qwik-city/middleware/netlify-edge/index.ts
@@ -44,22 +44,17 @@ export function qwikCity(render: Render, opts?: QwikCityNetlifyOptions) {
         },
       };
 
-<<<<<<< HEAD
-      // check if the next middleware is able to handle this request
-      // useful if the request is for a static asset but app uses a catchall route
-=======
       const handledResponse = await requestHandler<Response>(requestCtx, render, {}, opts);
       if (handledResponse) {
         return handledResponse;
       }
 
->>>>>>> Add platform field to RequestEvent
       const nextResponse = await next();
 
       if (nextResponse.status === 404) {
         // next middleware unable to handle request
         // send request to qwik city request handler
-        const handledResponse = await requestHandler<Response>(requestCtx, render, opts);
+        const handledResponse = await requestHandler<Response>(requestCtx, render, {}, opts);
         if (handledResponse) {
           return handledResponse;
         }

--- a/packages/qwik-city/middleware/request-handler/endpoint-handler.unit.ts
+++ b/packages/qwik-city/middleware/request-handler/endpoint-handler.unit.ts
@@ -21,7 +21,7 @@ test('onRequest, async return callback, async callback data', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   instance(userResponse.pendingBody, Promise);
   equal(userResponse.resolvedBody, undefined);
 
@@ -46,7 +46,7 @@ test('onRequest, async return callback, sync callback data', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   instance(userResponse.pendingBody, Promise);
   equal(userResponse.resolvedBody, undefined);
 
@@ -71,7 +71,7 @@ test('onRequest, sync return callback, async callback data', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   instance(userResponse.pendingBody, Promise);
   equal(userResponse.resolvedBody, undefined);
 
@@ -95,7 +95,7 @@ test('onRequest, sync return callback, sync callback data', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   instance(userResponse.pendingBody, Promise);
   equal(userResponse.resolvedBody, undefined);
 
@@ -116,7 +116,7 @@ test('onRequest, sync return number', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   equal(userResponse.pendingBody, undefined);
   equal(userResponse.resolvedBody, 88);
 
@@ -139,7 +139,7 @@ test('onRequest, async return string', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   equal(userResponse.pendingBody, undefined);
   equal(userResponse.resolvedBody, `mph`);
 
@@ -160,7 +160,7 @@ test('onRequest, sync return string', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   equal(userResponse.pendingBody, undefined);
   equal(userResponse.resolvedBody, `mph`);
 
@@ -182,7 +182,7 @@ test('onRequest, async return object', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   equal(userResponse.pendingBody, undefined);
   equal(userResponse.resolvedBody, { mph: 88 });
 
@@ -203,7 +203,7 @@ test('onRequest, sync return object', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   equal(userResponse.pendingBody, undefined);
   equal(userResponse.resolvedBody, { mph: 88 });
 
@@ -225,7 +225,7 @@ test('onRequest, user manually set content-type', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   equal(userResponse.pendingBody, undefined);
   equal(userResponse.resolvedBody, 88);
 
@@ -251,7 +251,7 @@ test('onGet preference over onRequest', async () => {
       },
     },
   ];
-  const userResponse = await loadUserResponse(requestCtx, {}, routeModules);
+  const userResponse = await loadUserResponse(requestCtx, {}, routeModules, {});
   await endpointHandler(requestCtx, userResponse);
 
   equal(calledOnGet, true);
@@ -266,7 +266,7 @@ test('405, not a page', async () => {
     request.headers.set('Accept', 'application/json');
     const routeModules: RouteModule[] = [];
 
-    await loadUserResponse(requestCtx, {}, routeModules, false);
+    await loadUserResponse(requestCtx, {}, routeModules, {}, false);
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, ErrorResponse);
@@ -285,7 +285,7 @@ test('405, is a page, accept json header', async () => {
       },
     ];
 
-    await loadUserResponse(requestCtx, {}, routeModules, false);
+    await loadUserResponse(requestCtx, {}, routeModules, {}, false);
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, ErrorResponse);

--- a/packages/qwik-city/middleware/request-handler/request-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/request-handler.ts
@@ -14,6 +14,7 @@ import { RedirectResponse, redirectResponse } from './redirect-handler';
 export async function requestHandler<T = any>(
   requestCtx: QwikCityRequestContext,
   render: Render,
+  platform: Record<string, any>,
   opts?: QwikCityRequestOptions
 ): Promise<T | null> {
   try {
@@ -25,7 +26,13 @@ export async function requestHandler<T = any>(
       const { mods, params } = loadedRoute;
 
       // build endpoint response from each module in the hierarchy
-      const userResponse = await loadUserResponse(requestCtx, params, mods, trailingSlash);
+      const userResponse = await loadUserResponse(
+        requestCtx,
+        params,
+        mods,
+        platform,
+        trailingSlash
+      );
 
       // status and headers should be immutable in at this point
       // body may not have resolved yet

--- a/packages/qwik-city/middleware/request-handler/user-response.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.ts
@@ -16,6 +16,7 @@ export async function loadUserResponse(
   requestCtx: QwikCityRequestContext,
   params: RouteParams,
   routeModules: RouteModule[],
+  platform: Record<string, any>,
   trailingSlash?: boolean
 ) {
   const { request, url } = requestCtx;
@@ -126,17 +127,18 @@ export async function loadUserResponse(
         };
 
         // create user request event, which is a narrowed down request context
-        const requstEv: RequestEvent = {
+        const requestEv: RequestEvent = {
           request,
           url: new URL(url),
           params: { ...params },
           response,
+          platform,
           next,
           abort,
         };
 
         // get the user's endpoint returned data
-        const syncData = reqHandler(requstEv) as any;
+        const syncData = reqHandler(requestEv) as any;
 
         if (typeof syncData === 'function') {
           // sync returned function

--- a/packages/qwik-city/middleware/request-handler/user-response.unit.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.unit.ts
@@ -19,7 +19,7 @@ test('sync endpoint, undefined body', async () => {
     },
   ];
 
-  const u = await loadUserResponse(requestCtx, {}, endpoints, trailingSlash);
+  const u = await loadUserResponse(requestCtx, {}, endpoints, {}, trailingSlash);
   equal(u.status, 204);
   equal(u.headers.get('name'), 'value');
   equal(u.pendingBody, undefined);
@@ -41,7 +41,7 @@ test('async endpoint, resolved data, render blocking', async () => {
     },
   ];
 
-  const u = await loadUserResponse(requestCtx, {}, endpoints, trailingSlash);
+  const u = await loadUserResponse(requestCtx, {}, endpoints, {}, trailingSlash);
   equal(u.status, 204);
   equal(u.headers.get('name'), 'value');
   equal(u.pendingBody, undefined);
@@ -71,7 +71,7 @@ test('onPost priority over onRequest, dont call onGet', async () => {
     },
   ];
 
-  const u = await loadUserResponse(requestCtx, {}, endpoints, trailingSlash);
+  const u = await loadUserResponse(requestCtx, {}, endpoints, {}, trailingSlash);
   equal(u.status, 200);
   equal(calledOnGet, false);
   equal(calledOnPost, true);
@@ -92,7 +92,7 @@ test('catchall onRequest', async () => {
     },
   ];
 
-  const u = await loadUserResponse(requestCtx, {}, endpoints, trailingSlash);
+  const u = await loadUserResponse(requestCtx, {}, endpoints, {}, trailingSlash);
   equal(u.status, 200);
   equal(calledOnRequest, true);
 });
@@ -113,7 +113,7 @@ test('user manual redirect, PageModule', async () => {
       },
     ];
 
-    await loadUserResponse(requestCtx, {}, endpoints, trailingSlash);
+    await loadUserResponse(requestCtx, {}, endpoints, {}, trailingSlash);
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, RedirectResponse);
@@ -137,7 +137,7 @@ test('throw redirect', async () => {
       },
     ];
 
-    await loadUserResponse(requestCtx, {}, endpoints, trailingSlash);
+    await loadUserResponse(requestCtx, {}, endpoints, {}, trailingSlash);
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, RedirectResponse);
@@ -151,7 +151,7 @@ test('no handler for endpoint', async () => {
     const requestCtx = mockRequestContext();
     const trailingSlash = false;
     const routeModules: RouteModule[] = [{ onDelete: () => {} }, { onPost: () => {} }, {}];
-    await loadUserResponse(requestCtx, {}, routeModules, trailingSlash);
+    await loadUserResponse(requestCtx, {}, routeModules, {}, trailingSlash);
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, ErrorResponse);
@@ -168,7 +168,7 @@ test('remove trailing slash, PageModule', async () => {
         default: () => {},
       },
     ];
-    await loadUserResponse(requestCtx, {}, routeModules, trailingSlash);
+    await loadUserResponse(requestCtx, {}, routeModules, {}, trailingSlash);
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, RedirectResponse);
@@ -186,7 +186,7 @@ test('add trailing slash, PageModule', async () => {
         default: () => {},
       },
     ];
-    await loadUserResponse(requestCtx, {}, routeModules, trailingSlash);
+    await loadUserResponse(requestCtx, {}, routeModules, {}, trailingSlash);
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, RedirectResponse);

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -175,6 +175,7 @@ export interface RequestEvent {
     // (undocumented)
     next: () => Promise<void>;
     params: RouteParams;
+    platform: Record<string, any>;
     // (undocumented)
     request: RequestContext;
     // (undocumented)

--- a/packages/qwik-city/runtime/src/library/types.ts
+++ b/packages/qwik-city/runtime/src/library/types.ts
@@ -271,6 +271,9 @@ export interface RequestEvent {
   /** URL Route params which have been parsed from the current url pathname. */
   params: RouteParams;
 
+  /** Platform specific data and functions */
+  platform: Record<string, any>;
+
   next: () => Promise<void>;
   abort: () => void;
 }


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Adds a platform field to the RequestEvent, allowing platform specific (Netlify, Cloudlfare) data and functions to be used in on* requests.

Closes: #1066 

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
