### PR TITLE
fix: runtimeQRL

### DIFF
--- a/packages/qwik/src/core/props/props-on.ts
+++ b/packages/qwik/src/core/props/props-on.ts
@@ -1,8 +1,7 @@
-import { parseQRL } from '../import/qrl';
+import { inlinedQrl, parseQRL } from '../import/qrl';
 import { isQrl, isSameQRL, QRLInternal } from '../import/qrl-class';
 import type { QContext } from './props';
 import { isArray } from '../util/types';
-import { $ } from '../import/qrl.public';
 import { QScopedStyle } from '../util/markers';
 
 const ON_PROP_REGEX = /^(window:|document:|)on([A-Z]|-.).*\$$/;
@@ -19,7 +18,9 @@ export const addQRLListener = (
   if (!input) {
     return undefined;
   }
-  const value = isArray(input) ? input.map(ensureQrl) : ensureQrl(input);
+  const value = isArray(input)
+    ? input.map((i, index) => ensureQrl(i, `${index}`))
+    : ensureQrl(input, '_');
 
   if (!ctx.$listeners$) {
     ctx.$listeners$ = new Map();
@@ -46,8 +47,9 @@ export const addQRLListener = (
   return existingListeners;
 };
 
-const ensureQrl = (value: any) => {
-  return isQrl(value) ? value : ($(value) as QRLInternal);
+const ensureQrl = (value: any, symbol: string) => {
+  // return isQrl(value) ? value : ($(value) as QRLInternal);
+  return isQrl(value) ? value : (inlinedQrl(value, symbol) as QRLInternal);
 };
 
 export const getDomListeners = (el: Element): Map<string, QRLInternal[]> => {

--- a/packages/qwik/src/core/render/dom/render.unit.tsx
+++ b/packages/qwik/src/core/render/dom/render.unit.tsx
@@ -1,7 +1,7 @@
 import { ElementFixture, trigger } from '../../../testing/element-fixture';
 import { expectDOM } from '../../../testing/expect-dom.unit';
 import { component$ } from '../../component/component.public';
-import { inlinedQrl, runtimeQrl } from '../../import/qrl';
+import { inlinedQrl } from '../../import/qrl';
 import { pauseContainer } from '../../object/store';
 import { useLexicalScope } from '../../use/use-lexical-scope.public';
 import { useStore } from '../../use/use-store.public';
@@ -66,16 +66,16 @@ renderSuite('should serialize events correctly', async () => {
     `
       <div
         q:id="0"
-        on:mousedown="/runtimeQRL#_"
-        on:keyup="/runtimeQRL#_"
-        on:dblclick="/runtimeQRL#_"
-        on:-dbl-click="/runtimeQRL#_"
-        on:qvisible="/runtimeQRL#_"
-        on-document:load="/runtimeQRL#_"
-        on-document:thing="/runtimeQRL#_"
-        on-document:-thing="/runtimeQRL#_"
-        on-window:scroll="/runtimeQRL#_"
-        on-window:-scroll="/runtimeQRL#_"
+        on:mousedown="/inlinedQRL#_"
+        on:keyup="/inlinedQRL#_"
+        on:dblclick="/inlinedQRL#_"
+        on:-dbl-click="/inlinedQRL#_"
+        on:qvisible="/inlinedQRL#_"
+        on-document:load="/inlinedQRL#_"
+        on-document:thing="/inlinedQRL#_"
+        on-document:-thing="/inlinedQRL#_"
+        on-window:scroll="/inlinedQRL#_"
+        on-window:-scroll="/inlinedQRL#_"
     ></div>
     `
   );
@@ -203,7 +203,7 @@ renderSuite('should render a div then a component', async () => {
     `
     <div aria-hidden="false">
       <div class="normal">Normal div</div>
-      <button q:id="1" on:click="/runtimeQRL#_">toggle</button>
+      <button q:id="1" on:click="/inlinedQRL#_">toggle</button>
     </div>`
   );
   await trigger(fixture.host, 'button', 'click');
@@ -214,13 +214,7 @@ renderSuite('should render a div then a component', async () => {
       <!--qv q:key=sX: q:id=2-->
       <div><div>this is ToggleChild</div></div>
       <!--/qv-->
-      <button
-        q:id="1"
-        on:click="/runtimeQRL#_
-/runtimeQRL#_"
-      >
-        toggle
-      </button>
+      <button q:id="1" on:click="/inlinedQRL#_" >toggle</button>
     </div>`
   );
 });
@@ -231,20 +225,12 @@ renderSuite('should process clicks', async () => {
   await render(fixture.host, <Counter step={5} />);
   await expectRendered(
     fixture,
-    '<button q:id="1" class="decrement" on:click="/runtimeQRL#_[0 1]">-</button>'
+    '<button q:id="1" class="decrement" on:click="/inlinedQRL#_[0 1]">-</button>'
   );
   await trigger(fixture.host, 'button.increment', 'click');
   await expectRendered(
     fixture,
-    `
-      <button
-        q:id="1"
-        class="decrement"
-        on:click="/runtimeQRL#_[0 1]
-/runtimeQRL#_[0 2]"
-    >
-       -
-      </button>`
+    `<button q:id="1" class="decrement" on:click="/inlinedQRL#_[0 2]" >-</button>`
   );
 });
 
@@ -631,11 +617,11 @@ export const Counter = component$((props: { step?: number }) => {
   const step = Number(props.step || 1);
   return (
     <>
-      <button class="decrement" onClick$={runtimeQrl(Counter_add, [state, { value: -step }])}>
+      <button class="decrement" onClick$={inlinedQrl(Counter_add, '_', [state, { value: -step }])}>
         -
       </button>
       <span>{state.count}</span>
-      <button class="increment" onClick$={runtimeQrl(Counter_add, [state, { value: step }])}>
+      <button class="increment" onClick$={inlinedQrl(Counter_add, '_', [state, { value: step }])}>
         +
       </button>
     </>

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -91,19 +91,19 @@ renderSSRSuite('single simple children', async () => {
 renderSSRSuite('events', async () => {
   await testSSR(
     <div onClick$={() => console.warn('hol')}>hola</div>,
-    '<html q:container="paused" q:version="dev" q:render="ssr"><div q:id="0" on:click="/runtimeQRL#_">hola</div></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr"><div q:id="0" on:click="/inlinedQRL#_">hola</div></html>'
   );
   await testSSR(
     <div document:onClick$={() => console.warn('hol')}>hola</div>,
-    '<html q:container="paused" q:version="dev" q:render="ssr"><div q:id="0" on-document:click="/runtimeQRL#_">hola</div></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr"><div q:id="0" on-document:click="/inlinedQRL#_">hola</div></html>'
   );
   await testSSR(
     <div window:onClick$={() => console.warn('hol')}>hola</div>,
-    '<html q:container="paused" q:version="dev" q:render="ssr"><div q:id="0" on-window:click="/runtimeQRL#_">hola</div></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr"><div q:id="0" on-window:click="/inlinedQRL#_">hola</div></html>'
   );
   await testSSR(
     <input onInput$={() => console.warn('hol')} />,
-    '<html q:container="paused" q:version="dev" q:render="ssr"><input q:id="0" on:input="/runtimeQRL#_"></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr"><input q:id="0" on:input="/inlinedQRL#_"></html>'
   );
 });
 
@@ -339,8 +339,8 @@ renderSSRSuite('using complex component', async () => {
     <MyCmpComplex></MyCmpComplex>,
     `<html q:container="paused" q:version="dev" q:render="ssr">
       <!--qv q:id=0 q:key=sX:-->
-      <div q:id="1" on:click="/runtimeQRL#_">
-        <button q:id="2" on:click="/runtimeQRL#_">Click</button>
+      <div q:id="1" on:click="/inlinedQRL#_">
+        <button q:id="2" on:click="/inlinedQRL#_">Click</button>
         <!--qv q:sname q:sref=0 q:key--><!--/qv-->
       </div>
       <!--/qv-->
@@ -354,8 +354,8 @@ renderSSRSuite('using complex component with slot', async () => {
     `
     <html q:container="paused" q:version="dev" q:render="ssr">
       <!--qv q:id=0 q:key=sX:-->
-      <div q:id="1" on:click="/runtimeQRL#_">
-        <button q:id="2" on:click="/runtimeQRL#_">Click</button>
+      <div q:id="1" on:click="/inlinedQRL#_">
+        <button q:id="2" on:click="/inlinedQRL#_">Click</button>
         <!--qv q:sname q:sref=0 q:key-->
         Hola
         <!--/qv-->
@@ -508,7 +508,7 @@ renderSSRSuite('component useOn()', async () => {
     <Events />,
     `<html q:container="paused" q:version="dev" q:render="ssr">
       <!--qv q:id=0 q:key=sX:-->
-      <div q:id="1" on:click="/runtimeQRL#_\n/runtimeQRL#_" on-window:click="/runtimeQRL#_" on-document:click="/runtimeQRL#_"></div>
+      <div q:id="1" on:click="/inlinedQRL#_\n/runtimeQRL#_" on-window:click="/runtimeQRL#_" on-document:click="/runtimeQRL#_"></div>
       <!--/qv-->
     </html>`
   );


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

fixes https://github.com/BuilderIO/qwik/issues/860

Not fully understand the context thus not very confident on my changes currently, just tested fine against the issue example, feel free to close it 😂. But I think there's two problems here. 

1) not able to get `runtimeQRL` on event dispatch ;

original way `window object & import` just won't works,  tried look into changes history, failed to find why `window` involved here(maybe sort of custom prefetch ?). Instead, I just directly dig into element's internal attributes to get runtime handler.

2) each time re-render will add new event handler copy, cause bind events handler function duplicately.

from the source code, every time in pure client side (no optimizer processing) calling `runtimeUrl` or `$` will generate new `qrl` object resulting failed to compare with existed $listeners and remove old on. Thinking in client side logic need to use inlineQRL instead.

WIP: have a closer look on unit testing

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
