### PR TITLE
feat/fix: Export mdx frontmatter variables to the developer

### DIFF
--- a/packages/qwik-city/buildtime/markdown/frontmatter.unit.ts
+++ b/packages/qwik-city/buildtime/markdown/frontmatter.unit.ts
@@ -4,25 +4,44 @@ import { frontmatterAttrsToDocumentHead, parseFrontmatterAttrs } from './frontma
 import type { FrontmatterAttrs } from '../types';
 
 test('frontmatter, one line', async () => {
-  const attrs: FrontmatterAttrs = {};
-  const yaml = `title: Some Title`;
-  parseFrontmatterAttrs(attrs, yaml);
+  const yaml = 'title: Some Title';
+  const attrs: FrontmatterAttrs = parseFrontmatterAttrs(yaml);
   assert.equal(attrs.title, 'Some Title');
 });
 
 test('frontmatter, colons', async () => {
-  const attrs: FrontmatterAttrs = {};
-  const yaml = `title: Some : Crazy : Title`;
-  parseFrontmatterAttrs(attrs, yaml);
+  const yaml = 'title: "Some : Crazy : Title"';
+  const attrs: FrontmatterAttrs = parseFrontmatterAttrs(yaml);
   assert.equal(attrs.title, 'Some : Crazy : Title');
 });
 
-test('frontmatter, multiline', async () => {
-  const attrs: FrontmatterAttrs = {};
-  const yaml = `
-  title: Some Title
-  description: Some Description`;
-  parseFrontmatterAttrs(attrs, yaml);
+test('frontmatter, multiline string', async () => {
+  const yaml = 'title: >-' + '\n' + '  Lorem' + '\n' + '  Ipsum';
+  const attrs: FrontmatterAttrs = parseFrontmatterAttrs(yaml);
+  assert.equal(attrs.title, 'Lorem Ipsum');
+});
+
+test('frontmatter, list', async () => {
+  const yaml = 'tags:' + '\n' + '  - tag1' + '\n' + '  - tag2';
+  const attrs: FrontmatterAttrs = parseFrontmatterAttrs(yaml);
+  assert.equal(attrs.tags, ['tag1', 'tag2']);
+});
+
+test('frontmatter, inline list', async () => {
+  const yaml = 'tags: [tag1, tag2]';
+  const attrs: FrontmatterAttrs = parseFrontmatterAttrs(yaml);
+  assert.equal(attrs.tags, ['tag1', 'tag2']);
+});
+
+test('frontmatter, dictionary', async () => {
+  const yaml = 'custom:' + '\n' + '  author: Me';
+  const attrs: FrontmatterAttrs = parseFrontmatterAttrs(yaml);
+  assert.equal(attrs.custom, { author: 'Me' });
+});
+
+test('frontmatter, multiple', async () => {
+  const yaml = 'title: Some Title' + '\n' + 'description: Some Description';
+  const attrs: FrontmatterAttrs = parseFrontmatterAttrs(yaml);
   assert.equal(attrs.title, 'Some Title');
   assert.equal(attrs.description, 'Some Description');
 });

--- a/packages/qwik-city/buildtime/markdown/rehype.ts
+++ b/packages/qwik-city/buildtime/markdown/rehype.ts
@@ -18,6 +18,7 @@ export function rehypePage(ctx: BuildContext): Transformer {
     const sourcePath = normalizePath(vfile.path);
 
     updateContentLinks(mdast, ctx.opts, sourcePath);
+    exportFrontmatter(ctx, mdast, sourcePath);
     exportContentHead(ctx, mdast, sourcePath);
     exportContentHeadings(mdast);
   };
@@ -43,6 +44,11 @@ function updateContentLinks(mdast: Root, opts: NormalizedPluginOptions, sourcePa
       }
     }
   });
+}
+
+function exportFrontmatter(ctx: BuildContext, mdast: Root, sourcePath: string) {
+  const attrs = ctx.frontmatter.get(sourcePath);
+  createExport(mdast, 'frontmatter', attrs);
 }
 
 function exportContentHead(ctx: BuildContext, mdast: Root, sourcePath: string) {

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -14,7 +14,7 @@ export interface BuildContext {
 }
 
 export interface FrontmatterAttrs {
-  [attrName: string]: string;
+  [attrName: string]: any;
 }
 
 export interface Diagnostic {

--- a/packages/qwik-city/package.json
+++ b/packages/qwik-city/package.json
@@ -69,7 +69,8 @@
     "unified": "10.1.2",
     "unist-util-visit": "4.1.0",
     "uvu": "0.5.6",
-    "vite": "3.0.2"
+    "vite": "3.0.2",
+    "yaml": "2.1.1"
   },
   "license": "MIT",
   "homepage": "https://qwik.builder.io/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -125,6 +125,7 @@ __metadata:
     uvu: 0.5.6
     vfile: 5.3.4
     vite: 3.0.2
+    yaml: 2.1.1
   languageName: unknown
   linkType: soft
 
@@ -9341,6 +9342,13 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
+"yaml@npm:2.1.1":
+  version: 2.1.1
+  resolution: "yaml@npm:2.1.1"
+  checksum: f48bb209918aa57cfaf78ef6448d1a1f8187f45c746f933268b7023dc59e5456004611879126c9bb5ea55b0a2b1c2b392dfde436931ece0c703a3d754562bb96
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently the frontmatter is not exported to the user, instead it just sets `head: { title, description }` if they are found.

This PR exports all the variables the user has defined in the frontmatter.

This PR also replaces the custom parser implementation with the `yaml` module, because the custom impl. only parsed string variables and this one accepts lists, dictionaries, multi-line strings, etc (full yaml syntax).

Also added some tests and modified some of the existing ones because they were testing for invalid yaml syntax, which should never pass. AKA: It may be a breaking change if people is using yaml incorrectly. (Specifically using semicolon `:` symbol without wrapping the string in quotes).

Fixes #1020

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case

Ability to create variables in the mdx file and make use of them.

- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
