### PR TITLE
Fix Syntax Error in React Code example

### DIFF
--- a/packages/docs/src/routes/docs/cheat-sheet/index.mdx
+++ b/packages/docs/src/routes/docs/cheat-sheet/index.mdx
@@ -110,7 +110,7 @@ export function Counter() {
       <div>
         Value is: ${count}
       </div>
-      <button onClick$={() => setCount(count + 1)}>
+      <button onClick={() => setCount(count + 1)}>
         Increment
       </button>
     </>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fix the syntax error in the `onClick` of the `button` in the React code example [here](https://qwik.builder.io/docs/cheat-sheet#create-a-counter-component)

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
