### PR TITLE
fix(sort_routes.ts): optional route parameters sorting

### DIFF
--- a/packages/qwik-city/buildtime/routing/sort-routes.ts
+++ b/packages/qwik-city/buildtime/routing/sort-routes.ts
@@ -9,10 +9,10 @@ export function routeSortCompare(a: BuildRoute, b: BuildRoute) {
 
     // /x < /x/y, but /[...x]/y < /[...x]
     if (!sa) {
-      return a.id.includes('[...') ? 1 : -1;
+      return a.pathname.includes('[...') ? 1 : -1;
     }
     if (!sb) {
-      return b.id.includes('[...') ? -1 : 1;
+      return b.pathname.includes('[...') ? -1 : 1;
     }
 
     const maxParts = Math.max(sa.length, sb.length);

--- a/packages/qwik-city/buildtime/routing/sort-routes.unit.ts
+++ b/packages/qwik-city/buildtime/routing/sort-routes.unit.ts
@@ -1,6 +1,7 @@
 import { test } from 'uvu';
 import { equal } from 'uvu/assert';
 import type { BuildRoute } from '../types';
+import { createFileId } from '../utils/fs';
 import { parseRoutePathname } from './parse-pathname';
 import { routeSortCompare } from './sort-routes';
 
@@ -45,7 +46,7 @@ test('routeSortCompare', () => {
 function route(r: TestRoute) {
   const pathname = r.pathname || '/';
   const route: BuildRoute = {
-    id: pathname,
+    id: createFileId('', pathname),
     filePath: pathname,
     pathname,
     ext: '.tsx',


### PR DESCRIPTION
fix #1016

# What is it?

- [ ] Feature / enhancement
- [ x] Bug
- [ ] Docs / tests

# Description
After the refactoring of route sorting, optional route parameters are not working as expected: `/[...x]/y < /[...x]`
The problem is that the check of the `...rest` is done on the route `id` and not on the `pathname`.
The units tests passed the same because in the test the `id` was initialized with the `pathname`.

@adamdbradley 

# Use cases and why
https://example.com/sku/[...skuId]/details
Should match: https://example.com/sku/1234/details

# Checklist:

- [x ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
