### PR TITLE
Add Yaml Type

### DIFF
--- a/packages/qwik-city/buildtime/markdown/frontmatter.ts
+++ b/packages/qwik-city/buildtime/markdown/frontmatter.ts
@@ -10,7 +10,7 @@ export function parseFrontmatter(ctx: BuildContext): Transformer {
     const attrs: FrontmatterAttrs = {};
 
     visit(mdast, 'yaml', (node: any) => {
-      const parsedAttrs = parseFrontmatterAttrs(node.value);
+      const parsedAttrs = parseFrontmatterAttrs(node.value) as FrontmatterAttrs;
       for (const k in parsedAttrs) {
         attrs[k] = parsedAttrs[k];
       }
@@ -38,12 +38,12 @@ export function frontmatterAttrsToDocumentHead(attrs: FrontmatterAttrs | undefin
 
     for (const attrName in attrs) {
       const attrValue = attrs[attrName];
-      if (attrName === 'title') {
-        head.title = attrValue;
-      } else if (attrName === 'description') {
+      if (attrName === 'title' && attrValue) {
+        head.title = attrValue.toString();
+      } else if (attrName === 'description' && attrValue) {
         head.meta.push({
           name: attrName,
-          content: attrValue,
+          content: attrValue.toString(),
         });
       }
     }

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -13,8 +13,10 @@ export interface BuildContext {
   isDevServerClientOnly: boolean;
 }
 
+export type Yaml = string | number | boolean | null | { [attrName: string]: Yaml } | Yaml[];
+
 export interface FrontmatterAttrs {
-  [attrName: string]: any;
+  [attrName: string]: Yaml;
 }
 
 export interface Diagnostic {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

Replaces the any type for front matter attributes with a Yaml type per this comment: https://github.com/BuilderIO/qwik/pull/1075#discussion_r948311510

```typescript
export type Yaml = string | number | boolean | null | { [attrName: string]: Yaml } | Yaml[];

export interface FrontmatterAttrs {
  [attrName: string]: Yaml;
}
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
