### PR TITLE
Use req.url as the base path to construct the url in the express middleware

### DIFF
--- a/packages/qwik-city/middleware/express/index.ts
+++ b/packages/qwik-city/middleware/express/index.ts
@@ -50,7 +50,7 @@ export function qwikCity(render: Render, opts?: QwikCityExpressOptions) {
 export interface QwikCityExpressOptions extends QwikCityRequestOptions {}
 
 function fromExpressHttp(req: Request, res: Response) {
-  const url = new URL(req.path, `${req.protocol}://${req.headers.host}`);
+  const url = new URL(req.url, `${req.protocol}://${req.headers.host}`);
   const requestHeaders = createHeaders();
   const nodeRequestHeaders = req.headers;
   for (const key in nodeRequestHeaders) {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

When using the request object from an endpoint, currently there is a slight difference between dev and serve (express middleware). The request.url in dev includes search string but when using express middleware the search query is missing.

# Use cases and why

Actual:

request.url => `/path`

Expected: 

request.url => `/path?param=1`

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
