### PR TITLE
docs: fix `Resource` type and names

### DIFF
--- a/packages/docs/src/routes/qwikcity/routing/data/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/data/index.mdx
@@ -11,11 +11,11 @@ Let's implement `https://example.com/product/abc123` so that we can retrieve the
 The first step is to structure the directories and files so that we can create the `/product/abc123` route.
 
 ```
-- src/
-  - routes/
-    - product/
-      - [skuId]/
-        - index.tsx     # https://example.com/product/1234
+src/
+└── routes/
+    └── product/
+        └── [skuId]/
+            └── index.tsx     # https://example.com/product/1234
 ```
 
 ## Implement onGet
@@ -57,10 +57,10 @@ interface ProductData { ... }
 export const onGet: RequestHandler<EndpointData> = async ({ params }) => { ... };
 
 export default component$(() => {
-  const resource = useEndpoint<typeof onGet>(); // equivalent to useEndpoint<EndpointData>
+  const productData = useEndpoint<typeof onGet>(); // equivalent to useEndpoint<EndpointData>
   return (
     <Resource
-      resource={resource}
+      resource={productData}
       onPending={() => <div>Loading...</div>}
       onError={() => <div>Error</div>}
       onResolved={(product) => (
@@ -76,7 +76,7 @@ export default component$(() => {
 ```
 
 1. Notice that the data endpoint and the component are defined in the same file. The data endpoint is serviced by the `onGet` function and the component is by the modules default export.
-2. The component uses `useEndpoint()` function to retrieve the data. The `useEndpoint()` function invokes `onGet` function directly on the server but using `fetch()` on the client. Your component does not need to think about server/client differences when using data. The `useEndpoint()` function returns an object of type `Resource`. `Resource`s are promise-like objects that can be serialized by Qwik.
+2. The component uses `useEndpoint()` function to retrieve the data. The `useEndpoint()` function invokes `onGet` function directly on the server but using `fetch()` on the client. Your component does not need to think about server/client differences when using data. The `useEndpoint()` function returns an object of type `ResourceReturn`. `Resource`s are promise-like objects that can be serialized by Qwik.
 3. The `onGet` function is invoked before the component. This allows the `onGet` to return 404 or redirect in case the data is not available.
 4. Notice the use of `<Resource>` JSX element. The purpose of `Resource` is to allow the client to render different states of the `useEndpoint()` resource.
 5. On the server the `<Resource>` element will pause rendering until the `Resource` is resolved or rejected. This is because we don't want the server to render `loading...`. (The server needs to know when the component is ready for serialization into HTML.)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

`Resource` is not the correct type that `useEndpoint` returns

Plus the `resource` variable name is confusing because it makes for 3 "Resource" right after the other on the JSX example :)


# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
