### PR TITLE
Cheat Sheet - Perform a fetch request every time the state changes example causes error

### DIFF
--- a/packages/docs/src/routes/docs/cheat-sheet/index.mdx
+++ b/packages/docs/src/routes/docs/cheat-sheet/index.mdx
@@ -150,7 +150,7 @@ export const Fetch = component$(() => {
     responseJson: undefined,
   });
 
-  useWatch$(async (track) => {
+  useWatch$(async ({ track }) => {
     track(state, 'url');
     const res = await fetch(state.url);
     const json = await res.json();


### PR DESCRIPTION
# What is it?

  

- [ ] Feature / enhancement

- [ ] Bug

- [x] Docs / tests

  

# Description

docs(packages/docs/src/routes/docs/cheat-sheet/index.mdx)  

Cheat sheet example "Perform a fetch request every time the state changes" will cause an error because useWatch$ track parameter is not destructured.

https://qwik.builder.io/docs/cheat-sheet/#perform-a-fetch-request-every-time-the-state-changes

  

# Use cases and why

  

<!-- Actual / expected behaviour if it's a bug -->

  

- 1. One use case

- 2. Another use case

  

# Checklist:

  

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)

- [x] I have performed a self-review of my own code

- [x] I have made corresponding changes to the documentation

- [ ] Added new tests to cover the fix / functionality
