### PR TITLE
Small typos fix for readability

### DIFF
--- a/packages/docs/src/routes/tutorial/props/closures/index.mdx
+++ b/packages/docs/src/routes/tutorial/props/closures/index.mdx
@@ -2,11 +2,11 @@
 title: Passing Closures
 ---
 
-Props must be serializable so that Qwik can resume and render each component independently from other components on the page. This possess a problem if we wish to pass a callback to a child component. Callbacks are functions and functions are not directly serializable, but they are serializable through the `$()` by converting them to QRLs first.
+Props must be serializable so that Qwik can resume and render each component independently from other components on the page. This poses a problem if we wish to pass a callback to a child component. Callbacks are functions and functions are not directly serializable, but they are serializable through the `$()` by converting them to QRLs first.
 
 ## QRLs
 
-Function passing across serializable boundaries must be done through QRLs. QRLs are serialized forms of a function. (See [QRL](/docs/advanced/qrl/index.mdx) in advanced section.)
+Functions passing across serializable boundaries must be done through QRLs. QRLs are serialized forms of a function. (See [QRL](/docs/advanced/qrl/index.mdx) in advanced section.)
 
 Qwik has convenience APIs which end in `$` that are equivalent to calling `$()` directly. These two lines are equivalent:
 


### PR DESCRIPTION
# What is it?

- [ x ] Docs / tests

# Description

Made "Function" plural, and changed "possess" to "poses"

# Use cases and why

- 1. Readability

# Checklist:

- [ n/a ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ n/a ] I have performed a self-review of my own code
- [ x ] I have made corresponding changes to the documentation
- [ n/a ] Added new tests to cover the fix / functionality
