### PR TITLE
Small Grammar fix for readability

### DIFF
--- a/packages/docs/src/routes/tutorial/reactivity/resource/index.mdx
+++ b/packages/docs/src/routes/tutorial/reactivity/resource/index.mdx
@@ -37,7 +37,7 @@ The `useResource$()` function returns a `ResourceReturn` object, which is a Prom
 
 ## Rendering data
 
-Use `<Resource>` to display the data of `useResource$()` function. The `<Resource>` allows you to render different content depending if the resource is `pending`, `resolved` or `rejected`.
+Use `<Resource>` to display the data of the `useResource$()` function. The `<Resource>` allows you to render different content depending if the resource is `pending`, `resolved` or `rejected`.
 
 On the server the `<Resource>` does not render `loading` state, instead, it pauses rendering until the resource is resolved and will always render as either `resolved` or `rejected`. (On the client, the `<Resource>` renders all states including `pending`.)
 


### PR DESCRIPTION
# What is it?

- [ x ] Docs / tests

# Description

From:
Use `<Resource>` to display the data of `useResource$()` function.
To:
Use `<Resource>` to display the data of the `useResource$()` function.

# Use cases and why

Makes it a little smoother to read.

- 1. Readability

# Checklist:

- [ n/a  ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ n/a ] I have performed a self-review of my own code
- [ x ] I have made corresponding changes to the documentation
- [ n/a ] Added new tests to cover the fix / functionality
