### PR TITLE
Update index.mdx

### DIFF
--- a/packages/docs/src/routes/qwikcity/routing/data/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/data/index.mdx
@@ -50,8 +50,7 @@ An endpoint `onGet` function retrieves data and makes it available to the compon
 
 ```typescript
 import { Resource, component$, useStore } from '@builder.io/qwik';
-import type { RequestHandler } from '@builder.io/qwik-city';
-import { useEndpoint } from "@builder.io/qwik-city";
+import type { RequestHandler, useEndpoint } from '@builder.io/qwik-city';
 
 
 interface ProductData { ... }


### PR DESCRIPTION
1- for some reason `useEndpoint` import line does not appear in Firefox.
2- Also, 2 import lines are redundant.
For that, I change it to one single import line, hoping to solve both problems at one.

# What is it?

- [ x] Docs
- Below capture of missing line of useEndpoint import
![capture-useEndpoint](https://user-images.githubusercontent.com/14911996/187095510-e24866a2-7a3d-4f6d-b80c-e28b149289df.jpg)
