### PR TITLE
fix(pathname.ts): ssg dynamic routes

### DIFF
--- a/packages/qwik-city/utils/pathname.ts
+++ b/packages/qwik-city/utils/pathname.ts
@@ -10,6 +10,9 @@ export function normalizePathname(
 
     if (pathname !== '') {
       try {
+        // remove duplicate forward slashes
+        pathname = pathname.replace(/\/+/g, '/');
+
         if (pathname.startsWith('/')) {
           pathname = pathname.slice(1);
         }

--- a/packages/qwik-city/utils/pathname.unit.ts
+++ b/packages/qwik-city/utils/pathname.unit.ts
@@ -141,6 +141,26 @@ test('dynamic rest pathname', () => {
   equal(p, '/blog/what-is-resumability');
 });
 
+test('dynamic, empty rest pathname in root', () => {
+  const p = getPathname({
+    originalPathname: '/[...id]',
+    params: {
+      id: '',
+    },
+  });
+  equal(p, '/');
+});
+
+test('dynamic, empty rest pathname in root with nested page', () => {
+  const p = getPathname({
+    originalPathname: '/[...id]/page',
+    params: {
+      id: '',
+    },
+  });
+  equal(p, '/page');
+});
+
 test('dynamic pathname', () => {
   const p = getPathname({
     originalPathname: '/docs/[category]/[slugId]',
@@ -154,7 +174,8 @@ test('dynamic pathname', () => {
 
 function getPathname(t: { originalPathname: string; params?: RouteParams }) {
   const p = parseRoutePathname(t.originalPathname);
-  return getPathnameForDynamicRoute(t.originalPathname, p.paramNames, t.params);
+  const d = getPathnameForDynamicRoute(t.originalPathname, p.paramNames, t.params);
+  return normalizePathname(d, '/', false);
 }
 
 test.run();


### PR DESCRIPTION
fix #1196

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

The issue comes from here: https://github.com/BuilderIO/qwik/blob/main/packages/qwik-city/utils/pathname.ts#L59

Using replace in this way, when the parameter is missing, results in a double `//` that is no longer normalized. 

I preferred to fix the `normalizePathname` function rather than the `getPathnameForDynamicRoute`, so as to avoid other similar situations.

# Use cases and why

When I run ssg with the following routes folder:

```
routes
    [...id]
        page
            index.tsx
        index.tsx
```

I expect in dist folder (using _myId_ and an empty value for `id`:

```
myId
    page
        index.html
    index.html

page
    index.html
index.html
```

Instead, when the `id `parameter is empty, nested page is removed.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
