### PR TITLE
docs: add mutable to the Greeter component

### DIFF
--- a/packages/docs/src/routes/docs/components/rendering/index.mdx
+++ b/packages/docs/src/routes/docs/components/rendering/index.mdx
@@ -49,7 +49,7 @@ const Parent = component$(() => {
 
   return (
     <>
-      <button onClick$={(store.step *= -1)}>direction</button>
+      <button onClick$={() => (store.step *= -1)}>direction</button>
       <button onClick$={() => (store.count += store.step)}>{store.step}</button>
       <Greeter name={mutable('World_' + store.count)} />
     </>

--- a/packages/docs/src/routes/docs/components/rendering/index.mdx
+++ b/packages/docs/src/routes/docs/components/rendering/index.mdx
@@ -51,7 +51,7 @@ const Parent = component$(() => {
     <>
       <button onClick$={(store.step *= -1)}>direction</button>
       <button onClick$={() => (store.count += store.step)}>{store.step}</button>
-      <Greeter name={'World_' + store.count} />
+      <Greeter name={mutable('World_' + store.count)} />
     </>
   );
 });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

add mutable to the Greeter component. otherwise it's going to throw an exception 

```
Code(19): Props are immutable by default. If you need to change a value of a passed in prop, please wrap the prop with "mutable()" <:virtual name={mutable(...)}> 
 - Component: :virtual 
 - Prop: name 
 - Old value: World_2 
 - New value: World_1 Error: Code(19): Props are immutable by default.
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
