### PR TITLE
feat: core.prod.mjs/cjs build

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -10,9 +10,13 @@
     ".": {
       "import": {
         "min": "./dist/core.min.mjs",
+        "production": "./dist/core.prod.mjs",
         "default": "./dist/core.mjs"
       },
-      "require": "./dist/core.cjs"
+      "require": {
+        "production": "./dist/core.prod.cjs",
+        "default": "./dist/core.cjs"
+      }
     },
     "./jsx-runtime": {
       "import": "./dist/jsx-runtime.mjs",
@@ -69,6 +73,8 @@
     "core.min.mjs",
     "core.mjs",
     "core.mjs.map",
+    "core.prod.cjs",
+    "core.prod.mjs",
     "core.d.ts",
     "jsx-runtime/package.json",
     "jsx-runtime.cjs",

--- a/packages/qwik/src/core/util/qdev.ts
+++ b/packages/qwik/src/core/util/qdev.ts
@@ -1,12 +1,12 @@
-// minification can replace the `globalThis.qDev` with `false`
-// which will remove all dev code within from the build
-export const qDev = (globalThis as any).qDev === true;
-export const qSerialize = (globalThis as any).qSerialize !== false;
-export const qDynamicPlatform = (globalThis as any).qDynamicPlatform !== false;
-export const qTest = (globalThis as any).qTest === true;
+export const qDev = globalThis.qDev === true;
+export const qSerialize = globalThis.qSerialize !== false;
+export const qDynamicPlatform = globalThis.qDynamicPlatform !== false;
+export const qTest = globalThis.qTest === true;
 
 export const seal = (obj: any) => {
   if (qDev) {
     Object.seal(obj);
   }
 };
+
+declare const globalThis: any;

--- a/scripts/package-json.ts
+++ b/scripts/package-json.ts
@@ -22,9 +22,13 @@ export async function generatePackageJson(config: BuildConfig) {
       '.': {
         import: {
           min: './core.min.mjs',
+          production: './core.prod.mjs',
           default: './core.mjs',
         },
-        require: './core.cjs',
+        require: {
+          production: './core.prod.cjs',
+          default: './core.cjs',
+        },
       },
       './jsx-runtime': {
         import: './jsx-runtime.mjs',


### PR DESCRIPTION
Removes all dev, test and assert runtime from the build. The `core.mjs` file still has the runtime, with conditionals that can be used to enable dev or production. This build however, is hardcoded to production. The `core.min.mjs` build is minified and only for the browser build.