### PR TITLE
feat(eslint): add new no-prevent-default eslint rule

### DIFF
--- a/packages/eslint-plugin-qwik/README.md
+++ b/packages/eslint-plugin-qwik/README.md
@@ -4,3 +4,4 @@
 
 - `no-use-after-await` (deprecated)
 - `valid-lexical-scope`
+- `no-prevent-default`

--- a/packages/eslint-plugin-qwik/index.ts
+++ b/packages/eslint-plugin-qwik/index.ts
@@ -1,9 +1,11 @@
 import { validLexicalScope } from './src/validLexicalScope';
 import { noUseAfterAwait } from './src/noUseAfterAwait';
+import { noPreventDefault } from './src/noPreventDefault';
 
 export const rules = {
   'no-use-after-await': noUseAfterAwait,
   'valid-lexical-scope': validLexicalScope,
+  'no-prevent-default': noPreventDefault,
 };
 
 export const configs = {
@@ -12,6 +14,7 @@ export const configs = {
     rules: {
       'qwik/no-use-after-await': 'error',
       'qwik/valid-lexical-scope': 'error',
+      'qwik/no-prevent-default': 'error',
     },
   },
   strict: {
@@ -19,6 +22,7 @@ export const configs = {
     rules: {
       'qwik/valid-lexical-scope': 'error',
       'qwik/no-use-after-await': 'error',
+      'qwik/no-prevent-default': 'error',
     },
   },
 };

--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -371,4 +371,79 @@ test('valid-lexical-scope', () => {
   });
 });
 
+test('no-prevent-default', () => {
+  ruleTester.run('no-prevent-default', rules['no-prevent-default'], {
+    valid: [
+      {
+        code: '<button onClick$={() => {}}></button>',
+      },
+      {
+        code: `
+          import { component$, $ } from '@builder.io/qwik';
+
+          export const App = component$(() => {
+            const callback = $((event) => {
+              event.preventDefault();
+            });
+            return <button onClick$={callback}></button>;
+          });
+        `,
+        options: [
+          {
+            inlineOnly: true,
+          },
+        ],
+      },
+    ],
+    invalid: [
+      {
+        code: '<button onClick$={(event) => {event.preventDefault();}}></button>',
+        errors: [{ messageId: 'errorMessage' }],
+      },
+      {
+        code: '<button onClick$={(event) => event.preventDefault()}></button>',
+        errors: [{ messageId: 'errorMessage' }],
+      },
+      {
+        code: '<button onClick$={function(event){ event.preventDefault(); }}></button>',
+        errors: [{ messageId: 'errorMessage' }],
+      },
+      {
+        code: '<button onClick$={({preventDefault}) => {preventDefault();}}></button>',
+        errors: [{ messageId: 'errorMessage' }],
+      },
+      {
+        code: '<button onClick$={({preventDefault: fn}) => {fn();}}></button>',
+        errors: [{ messageId: 'errorMessage' }],
+      },
+      {
+        code: `
+          import { component$, $ } from '@builder.io/qwik';
+
+          export const App = component$(() => {
+            const callback = $((event) => {
+              event.preventDefault();
+            });
+            return <button onClick$={callback}></button>;
+          });
+        `,
+        errors: [{ messageId: 'errorMessage' }],
+      },
+      {
+        code: `
+          import { component$, $ } from '@builder.io/qwik';
+
+          export const App = component$(() => {
+            const callback = $(function myFn(event){
+              event.preventDefault();
+            });
+            return <button onClick$={callback}></button>;
+          });
+        `,
+        errors: [{ messageId: 'errorMessage' }],
+      },
+    ],
+  });
+});
+
 export {};

--- a/packages/eslint-plugin-qwik/src/noPreventDefault.ts
+++ b/packages/eslint-plugin-qwik/src/noPreventDefault.ts
@@ -1,0 +1,155 @@
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+import type {
+  ArrowFunctionExpression,
+  BlockStatement,
+  Expression,
+  FunctionExpression,
+  ObjectPattern,
+} from '@typescript-eslint/types/dist/generated/ast-spec';
+
+const createRule = ESLintUtils.RuleCreator(
+  () => 'https://github.com/BuilderIO/qwik/tree/main/packages/eslint-plugin-qwik'
+);
+
+export const noPreventDefault = createRule({
+  name: 'no-prevent-default',
+  defaultOptions: [
+    {
+      inlineOnly: false,
+    },
+  ],
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'no preventDefault calls',
+      recommended: false,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          inlineOnly: {
+            type: 'boolean',
+          },
+        },
+        default: {
+          inlineOnly: false,
+        },
+      },
+    ],
+    messages: {
+      errorMessage:
+        "Traditional `preventDefault()` calls don't work in Qwik, use the `preventdefault:{eventName}` attribute instead.",
+    },
+  },
+
+  create(context) {
+    const inlineOnly = context.options[0]?.inlineOnly ?? false;
+
+    function handleFunctionExpression(
+      expressionNode: ArrowFunctionExpression | FunctionExpression
+    ) {
+      if (inlineOnly) {
+        const isInlineCall =
+          expressionNode.parent?.type === AST_NODE_TYPES.JSXExpressionContainer &&
+          expressionNode.parent.parent?.type === AST_NODE_TYPES.JSXAttribute &&
+          (expressionNode.parent.parent.name.name as string)?.endsWith('$');
+
+        if (!isInlineCall) {
+          return;
+        }
+      }
+
+      const firstParam = expressionNode.params?.[0];
+      const eventParamName =
+        firstParam?.type === AST_NODE_TYPES.Identifier ? firstParam.name : null;
+      const preventDefaultParamName =
+        (!eventParamName &&
+          firstParam?.type === AST_NODE_TYPES.ObjectPattern &&
+          getPreventDefaultParamName(firstParam)) ||
+        null;
+
+      if (!eventParamName && !preventDefaultParamName) {
+        return;
+      }
+
+      const isBlockStatement = expressionNode.body.type === AST_NODE_TYPES.BlockStatement;
+
+      if (isBlockStatement) {
+        (expressionNode.body as BlockStatement).body
+          .filter(
+            (statement) =>
+              statement.type === AST_NODE_TYPES.ExpressionStatement &&
+              isPreventDefaultCall(statement.expression, eventParamName, preventDefaultParamName)
+          )
+          .forEach((preventDefaultCallStatement) => {
+            context.report({
+              node: preventDefaultCallStatement,
+              messageId: 'errorMessage',
+            });
+          });
+        return;
+      }
+
+      if (
+        isPreventDefaultCall(
+          expressionNode.body as Expression,
+          eventParamName,
+          preventDefaultParamName
+        )
+      ) {
+        context.report({
+          node: expressionNode.body,
+          messageId: 'errorMessage',
+        });
+      }
+    }
+
+    return {
+      ArrowFunctionExpression(node) {
+        handleFunctionExpression(node);
+      },
+      FunctionExpression(node) {
+        handleFunctionExpression(node);
+      },
+    };
+  },
+});
+
+function isPreventDefaultCall(
+  expression: Expression,
+  eventParamName: string | null,
+  preventDefaultParamName: string | null
+) {
+  if (expression.type !== AST_NODE_TYPES.CallExpression) {
+    return false;
+  }
+
+  if (eventParamName) {
+    return (
+      expression.callee.type === AST_NODE_TYPES.MemberExpression &&
+      expression.callee.object.type === AST_NODE_TYPES.Identifier &&
+      expression.callee.object.name === eventParamName &&
+      expression.callee.property.type === AST_NODE_TYPES.Identifier &&
+      expression.callee.property.name === 'preventDefault'
+    );
+  }
+
+  return (
+    expression.callee.type === AST_NODE_TYPES.Identifier &&
+    expression.callee.name === preventDefaultParamName
+  );
+}
+
+function getPreventDefaultParamName(firstParam: ObjectPattern) {
+  const preventDefaultProp = firstParam.properties.find(
+    (prop) =>
+      prop.type === AST_NODE_TYPES.Property &&
+      prop.key.type === AST_NODE_TYPES.Identifier &&
+      prop.key.name === 'preventDefault'
+  );
+
+  if (preventDefaultProp?.value?.type === AST_NODE_TYPES.Identifier) {
+    return preventDefaultProp.value.name;
+  }
+}


### PR DESCRIPTION
add a new rule to the eslint-plugin-qwik package which warns developers not to use preventDefault, since they should be using the preventdefault attribute instead

resolves #1205

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Addition of a new eslint rule to help developers not to use `preventDefault`

The rule applies to any function expression, I figured this is the only reliable way to have the rule applied for all cases since there are cases in which I don't think we can even discern what the context is (for example if a function is in a standalone file and it is imported and used by a component).

I think this should be rather ok since I'd imagine that cases of a function not being a callback and just happening to have its first argument being an object with a function called `preventDefault` seems quite unlikely (and it would create a false positive which may just be slightly annoying).

If the above is not desirable I've added an option called `inlineOnly` which implements the check only if the function is inlined as the jsx attribute's value (which seems to me like a good enough compromise in case the normal version is too generic). 

I hope this is ok, please let me know what you think.

Also I was considering adding fixes/suggestions, but they should both remove the `preventDefault` call and add the attribute to the jsx, which based on what I said above could be only done in the inline case (since in a generic case you may not know who is going to use your function) also I'd have to do some string manipulating for the attribute making this slightly brittle, so I figured it could be better to keep things simple and just present the error/warning.

I added the rule to the plugin README list, without much details, I didn't add them since I can for now see if this change gets at least accepted and also I can see that the other rules don't have much documentation, so I wasn't sure if you'd like me to anyways (and ask here in case you'd like me to add some documentation)

# Result

![Screenshot at 2022-09-11 21-36-02](https://user-images.githubusercontent.com/61631103/189547935-795d6c32-23d0-462b-9000-a212857cba0a.png)




# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
