### PR TITLE
Fix/store obj

### DIFF
--- a/packages/qwik/src/core/object/store.ts
+++ b/packages/qwik/src/core/object/store.ts
@@ -354,7 +354,7 @@ export const _pauseFromContexts = async (
           suffix += '_';
         }
       }
-      const target = getProxyTarget(obj);
+      const target = isObject(obj) && getProxyTarget(obj);
       if (target) {
         suffix += '!';
         obj = target;

--- a/packages/qwik/src/core/object/store.ts
+++ b/packages/qwik/src/core/object/store.ts
@@ -340,21 +340,22 @@ export const _pauseFromContexts = async (
 
   const getObjId = (obj: any): string | null => {
     let suffix = '';
+    if (isMutable(obj)) {
+      obj = obj.mut;
+      suffix = '%';
+    }
+    if (isPromise(obj)) {
+      const { value, resolved } = getPromiseValue(obj);
+      obj = value;
+      if (resolved) {
+        suffix += '~';
+      } else {
+        suffix += '_';
+      }
+    }
+
     if (isObject(obj)) {
-      if (isMutable(obj)) {
-        obj = obj.mut;
-        suffix = '%';
-      }
-      if (isPromise(obj)) {
-        const { value, resolved } = getPromiseValue(obj);
-        obj = value;
-        if (resolved) {
-          suffix += '~';
-        } else {
-          suffix += '_';
-        }
-      }
-      const target = isObject(obj) && getProxyTarget(obj);
+      const target = getProxyTarget(obj);
       if (target) {
         suffix += '!';
         obj = target;

--- a/starters/apps/e2e/src/components/lexical-scope/lexicalScope.tsx
+++ b/starters/apps/e2e/src/components/lexical-scope/lexicalScope.tsx
@@ -1,11 +1,17 @@
 import { component$, $, useStore, mutable, noSerialize } from '@builder.io/qwik';
 
 export const LexicalScope = component$(() => {
-  return <LexicalScopeChild message={mutable('mutable message')}></LexicalScopeChild>;
+  return (
+    <LexicalScopeChild
+      message={mutable('mutable message')}
+      message2={mutable(null)}
+    />
+    )
 });
 
 interface LexicalScopeProps {
   message: string;
+  message2: string | null;
 }
 
 export const LexicalScopeChild = component$((props: LexicalScopeProps) => {
@@ -68,6 +74,7 @@ export const LexicalScopeChild = component$((props: LexicalScopeProps) => {
           h,
           i,
           props.message,
+          props.message2,
           promiseValue,
           url.href,
           date.toISOString(),

--- a/starters/apps/e2e/src/components/lexical-scope/lexicalScope.tsx
+++ b/starters/apps/e2e/src/components/lexical-scope/lexicalScope.tsx
@@ -1,12 +1,7 @@
 import { component$, $, useStore, mutable, noSerialize } from '@builder.io/qwik';
 
 export const LexicalScope = component$(() => {
-  return (
-    <LexicalScopeChild
-      message={mutable('mutable message')}
-      message2={mutable(null)}
-    />
-    )
+  return <LexicalScopeChild message={mutable('mutable message')} message2={mutable(null)} />;
 });
 
 interface LexicalScopeProps {

--- a/starters/e2e/e2e.spec.ts
+++ b/starters/e2e/e2e.spec.ts
@@ -24,7 +24,7 @@ test.describe('e2e', () => {
       const SNAPSHOT =
         '<p>1</p><p>"&lt;/script&gt;"</p><p>{"a":{"thing":12},"b":"hola","c":123,"d":false,"e":true,"f":null,"h":[1,"string",false,{"hola":1},["hello"]],"promise":{}}</p><p>undefined</p><p>null</p><p>[1,2,"hola",null,{}]</p><p>true</p><p>false</p><p>()=&gt;console.error()</p><p>mutable message</p><p>from a promise</p>';
       const RESULT =
-        '[1,"</script>",{"a":{"thing":12},"b":"hola","c":123,"d":false,"e":true,"f":null,"h":[1,"string",false,{"hola":1},["hello"]],"promise":{}},"undefined","null",[1,2,"hola",null,{}],true,false,null,"mutable message","from a promise","http://qwik.builder.com/docs?query=true","2022-07-26T17:40:30.255Z","hola()\\\\/ gi",12,"failed message",["\\b: backspace","\\f: form feed","\\n: line feed","\\r: carriage return","\\t: horizontal tab","\\u000b: vertical tab","\\u0000: null character","\': single quote","\\\\: backslash"]]';
+        '[1,"</script>",{"a":{"thing":12},"b":"hola","c":123,"d":false,"e":true,"f":null,"h":[1,"string",false,{"hola":1},["hello"]],"promise":{}},"undefined","null",[1,2,"hola",null,{}],true,false,null,"mutable message",null,"from a promise","http://qwik.builder.com/docs?query=true","2022-07-26T17:40:30.255Z","hola()\\\\/ gi",12,"failed message",["\\b: backspace","\\f: form feed","\\n: line feed","\\r: carriage return","\\t: horizontal tab","\\u000b: vertical tab","\\u0000: null character","\': single quote","\\\\: backslash"]]';
 
       function normalizeSnapshot(str: string) {
         return str.replace(' =&gt; ', '=&gt;');


### PR DESCRIPTION
# What is it?

- [x] Bug

# Description

Honestly not sure what I'm looking at, but looks like @manucorporat 's changes in https://github.com/BuilderIO/qwik/pull/1217/files#diff-c80d393c4d0acda1ba573e20ff62b3bc96a4169298f7d1af7898ccd8fb60638a stopped checking that the mutated `obj` is still a valid `object` before calling `getProxyTarget`. So now we sometime provide `null` to `getProxyTarget`, causing crashes.