### PR TITLE
docs: add more SSG instructions

### DIFF
--- a/packages/docs/src/routes/qwikcity/static-site-generation/static-site-config/index.mdx
+++ b/packages/docs/src/routes/qwikcity/static-site-generation/static-site-config/index.mdx
@@ -19,6 +19,20 @@ qwikCityGenerate(render, {
 });
 ```
 
+You then can add the `build.ssg` script to `package.json` for building the generator code and add it to the `build` script to have it ready after each build:
+
+```json
+  "build": "npm run typecheck && npm run build.client && npm run build.ssr && npm run build.ssg",
+  "build.ssg": "vite build --ssr src/entry.static.tsx",
+```
+
+In node you can run the generation after building using:
+```bash
+node server/entry.static.js
+```
+
+Your build files will be generated into the `dist` folder, as configured in `src/entry.static.tsx`.
+
 ## SSG Config
 
 The `src/entry.static.tsx` file also includes the SSG config, which would be custom for each implementation.


### PR DESCRIPTION
Adds instructions for using SSG to not requiring the dev to fully understand the SSR setup anymore before using SSG.

# What is it?

- [x] Docs / tests

# Description

Adds instructions for using SSG to requiring a dev to NOT fully understand the SSR setup anymore before they using SSG.

# Use cases and why

- 1. t took me a while to get SSG running, I want to save other devs from the time waste.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

@adamdbradley I know you plan to add the SSG setup to the CLI (which might add these changes anyways), but I think it still makes sense to have it a bit more documented in the docs as well, e. g. for when people decide to add SSG later.