### PR TITLE
docs: Fix Discord invite links in `/docs/faq/`

### DIFF
--- a/packages/docs/src/routes/docs/faq/index.mdx
+++ b/packages/docs/src/routes/docs/faq/index.mdx
@@ -168,7 +168,7 @@ We think resumability scales without the negative trade-offs of partial hydratio
 
 ### Does Qwik have community?
 
-YES, there is a growing community of Qwik developers at [Discord](https://discord.gg/8qZ7q5Z) and [Github](https://github.com/BuilderIO/qwik), they are making amazing contributions to the framework, building sites at scale and helping each other. [Join us](https://discord.gg/8qZ7q5Z).
+YES, there is a growing community of Qwik developers at [Discord](https://qwik.builder.io/chat) and [Github](https://github.com/BuilderIO/qwik), they are making amazing contributions to the framework, building sites at scale and helping each other. [Join us](https://qwik.builder.io/chat).
 
 
 ### Is Qwik production ready?


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The current Discord invite links under the [`Does Qwik have community?` heading](https://qwik.builder.io/docs/faq/#does-qwik-have-community) appear to be stale... 

<img width="2056" alt="Screenshot 2022-09-20 at 4 14 44 PM" src="https://user-images.githubusercontent.com/671696/191357216-36005eed-5f1a-4e30-bbde-ff6369cd013c.png">

...while the URL in the header and footer (namely, https://qwik.builder.io/chat) redirects to a working invite page.  

Ergo, I've swapped the URL from the header and footer into the body of the FAQ entry.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
