### PR TITLE
fixed typo

### DIFF
--- a/packages/docs/src/routes/docs/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/components/state/index.mdx
@@ -36,7 +36,7 @@ The example above, the App component is using `useStore()` to create a reactive 
 Just accessing the `state.count` property will cause the component to be updated if the count changes, when the property is changed in the click handler.
 
 
-## Passing an store to other components
+## Passing a store to other components
 
 One of the nice features of Qwik is that the state can be passed to other components, and both can read and write to it, allowing data to flow across the tree in all directions.
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fixed simple typo in the docs in the header "Passing an store to other components". Instead it should read "Passing **a** store to other components

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
