### PR TITLE
fix(docs): update React integration name to `qwik-react`

### DIFF
--- a/packages/docs/src/routes/docs/faq/index.mdx
+++ b/packages/docs/src/routes/docs/faq/index.mdx
@@ -151,7 +151,7 @@ Depends, if you are coming from React, porting your components to Qwik should be
 YES! Qwik can run React components natively, check out `@builder.io/qwik-react` by adding it to your Qwik app:
 
 ```
-npm run qwik add react
+npm run qwik add qwik-react
 ```
 
 You will be amazed!


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The correct integration name for React is `qwik-react`

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
