### PR TITLE
style: increase code-block font size to 14px

### DIFF
--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -40,7 +40,7 @@ code[class*='language-'],
 pre[class*='language-'] {
   font-family: Menlo, Monaco, 'Courier New', monospace;
   font-weight: normal;
-  font-size: 12px;
+  font-size: 14px;
   font-feature-settings: 'liga' 0, 'calt' 0;
   line-height: 18px;
   letter-spacing: 0px;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

The font size for code blocks is very small. I just made it a little bigger.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
