### PR TITLE
docs(tutorial): improved <Slot /> description

### DIFF
--- a/packages/docs/src/routes/tutorial/projection/slots/index.mdx
+++ b/packages/docs/src/routes/tutorial/projection/slots/index.mdx
@@ -6,7 +6,7 @@ In simple cases, projection allows content from the parent component to be proje
 
 ### Example
 
-In this example, we have created `<Collapsable>` component that toggles between open and closed states. Currently, when the `<Collapsable>` is closed it shows its own content. Change that to an additional `<Slot>` to project the `q:slot="closed"` content from the parent instead.
+In this example, we have created `<Collapsable>` component that toggles between open and closed states. Currently, when the `<Collapsable>` is closed it shows content that was implemented within `<Collapsable>`. Change that to an additional `<Slot>` to project the `q:slot="closed"` content from the parent instead.
 
 ## Unprojected Slots
 

--- a/packages/docs/src/routes/tutorial/projection/slots/index.mdx
+++ b/packages/docs/src/routes/tutorial/projection/slots/index.mdx
@@ -6,7 +6,7 @@ In simple cases, projection allows content from the parent component to be proje
 
 ### Example
 
-In this example, we have created `<Collapsable>` component that toggles between open and closed states. Currently, when the `<Collapsable>` is closed it does not show any content. Add additional `<Slot>` to project the `q:slot="closed"` content.
+In this example, we have created `<Collapsable>` component that toggles between open and closed states. Currently, when the `<Collapsable>` is closed it shows its own content. Change that to an additional `<Slot>` to project the `q:slot="closed"` content from the parent instead.
 
 ## Unprojected Slots
 

--- a/packages/docs/src/routes/tutorial/projection/slots/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/projection/slots/problem/app.tsx
@@ -6,8 +6,7 @@ export const App = component$(() => {
     <Collapsable>
       <div q:slot="closed">▶ (collapsed summary)</div>
       <div q:slot="open">
-        ▼
-        <div> Content that should be displayed when the collapse component is open. </div>
+        ▼<div> Content that should be displayed when the collapse component is open. </div>
       </div>
     </Collapsable>
   );
@@ -18,7 +17,7 @@ export const Collapsable = component$(() => {
   const store = useStore({ open: true });
   return (
     <div onClick$={() => (store.open = !store.open)}>
-      {store.open ?  <Slot name="open" />  :  `▶` }
+      {store.open ? <Slot name="open" /> : `▶`}
       {/* Instead, project content from the parent named "closed" here */}
     </div>
   );

--- a/packages/docs/src/routes/tutorial/projection/slots/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/projection/slots/problem/app.tsx
@@ -4,8 +4,11 @@ export const App = component$(() => {
   console.log('Render: <App>');
   return (
     <Collapsable>
-      <span q:slot="closed">(collapsed summary)</span>
-      Content that should be displayed when the collapse component is open.
+      <div q:slot="closed">▶ (collapsed summary)</div>
+      <div q:slot="open">
+        ▼
+        <div> Content that should be displayed when the collapse component is open. </div>
+      </div>
     </Collapsable>
   );
 });
@@ -15,19 +18,8 @@ export const Collapsable = component$(() => {
   const store = useStore({ open: true });
   return (
     <div onClick$={() => (store.open = !store.open)}>
-      {store.open ? (
-        <div>
-          ▼
-          <div>
-            <Slot />
-          </div>
-        </div>
-      ) : (
-        <div>
-          ▶︎
-          {/* Project content name "closed" here */}
-        </div>
-      )}
+      {store.open ?  <Slot name="open" />  :  `▶` }
+      {/* Instead, project content from the parent named "closed" here */}
     </div>
   );
 });

--- a/packages/docs/src/routes/tutorial/projection/slots/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/projection/slots/solution/app.tsx
@@ -6,8 +6,7 @@ export const App = component$(() => {
     <Collapsable>
       <div q:slot="closed">▶ (collapsed summary)</div>
       <div q:slot="open">
-        ▼
-        <div> Content that should be displayed when the collapse component is open. </div>
+        ▼<div> Content that should be displayed when the collapse component is open. </div>
       </div>
     </Collapsable>
   );
@@ -18,7 +17,7 @@ export const Collapsable = component$(() => {
   const store = useStore({ open: true });
   return (
     <div onClick$={() => (store.open = !store.open)}>
-      {store.open ?  <Slot name="open" />  :  <Slot name="closed" /> }
+      {store.open ? <Slot name="open" /> : <Slot name="closed" />}
     </div>
   );
 });

--- a/packages/docs/src/routes/tutorial/projection/slots/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/projection/slots/solution/app.tsx
@@ -4,8 +4,11 @@ export const App = component$(() => {
   console.log('Render: <App>');
   return (
     <Collapsable>
-      <span q:slot="closed">(collapsed summary)</span>
-      Content that should be displayed when the collapse component is open.
+      <div q:slot="closed">▶ (collapsed summary)</div>
+      <div q:slot="open">
+        ▼
+        <div> Content that should be displayed when the collapse component is open. </div>
+      </div>
     </Collapsable>
   );
 });
@@ -15,19 +18,7 @@ export const Collapsable = component$(() => {
   const store = useStore({ open: true });
   return (
     <div onClick$={() => (store.open = !store.open)}>
-      {store.open ? (
-        <div>
-          ▼
-          <div>
-            <Slot />
-          </div>
-        </div>
-      ) : (
-        <div>
-          ▶︎
-          <Slot name="closed" />
-        </div>
-      )}
+      {store.open ?  <Slot name="open" />  :  <Slot name="closed" /> }
     </div>
   );
 });


### PR DESCRIPTION

As per the brief exchange over in discord:
https://discord.com/channels/842438759945601056/996551595359740145/1022017984245530664

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Moved content into parent so `<Slot />` usage is purely when/where

# Use cases and why

Based on the overview of the philosophy behind `<Slot />` provided in projection/basic, this seemed more true to the spirit of <Slot /> preferred usage. @mhevery liked the idea when mentioned in Discord and suggested providing the update. Happy to help! 🙂

# Checklist:

- [X] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
