### PR TITLE
fix(jsx): tabindex should be lowercase

### DIFF
--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -321,7 +321,7 @@ export interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
   slot?: string | undefined;
   spellCheck?: Booleanish | undefined;
   style?: Record<string, string | number | undefined> | string | undefined;
-  tabIndex?: number | undefined;
+  tabindex?: number | undefined;
   title?: string | undefined;
   translate?: 'yes' | 'no' | undefined;
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

A type error.  And in at least chrome and Firefox, using `tabIndex` works until the component is re-rendered, then it's removed.  Using `tabindex` works as expected.