### PR TITLE
docs: fixes the designation of the 301 status

### DIFF
--- a/packages/docs/src/routes/qwikcity/routing/redirects/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/redirects/index.mdx
@@ -31,7 +31,7 @@ export const onGet: RequestHandler<DashboardData> = async ({ request, response }
 The `response.redirect()` function takes a URL and optionally a status code as the second argument.
 
 ```tsx
-throw response.redirect('/login', 301); // Permanent redirect
+throw response.redirect('/login', 301); // Moved Permanently
 ```
 
 [Common redirect status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages):


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

Fixes the designation of the 301 status : see [MDN docs for 301 status](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301)

# Use cases and why

Nope

# Checklist:

- [X] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
