### PR TITLE
docs(playground): update link to repository

### DIFF
--- a/packages/docs/src/routes/examples/apps/partial/hackernews-index/app.tsx
+++ b/packages/docs/src/routes/examples/apps/partial/hackernews-index/app.tsx
@@ -40,7 +40,7 @@ export const Nav = component$(() => {
           </a>
           <a
             class="github"
-            href="http://github.com/builderio/qwikdev"
+            href="http://github.com/builderio/qwik"
             target="_blank"
             rel="noreferrer"
           >


### PR DESCRIPTION
Current link is pointing to builderio/qwikdev which results in a 404, this PR updates link to repository url builderio/qwik

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Updating anchor tag url -- current link is pointing to builderio/qwikdev which results in a 404, this PR updates link to repository url builderio/qwik.

# ~~Use cases and why~~

<!-- Actual / expected behaviour if it's a bug -->

- ~~1. One use case~~
- ~~2. Another use case~~

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] ~~Added new tests to cover the fix / functionality~~
