### PR TITLE
Add note regarding destructuring assignment of state

### DIFF
--- a/packages/docs/src/routes/docs/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/components/state/index.mdx
@@ -13,6 +13,9 @@ It's important to notice that state in Qwik is not component state, but rather a
 
 The reactive object returned by `useStore()` is just like any other object, but it's reactive. If you change a property of the object, any component that depends on it will be updated.
 
+> **NOTE**
+> Make sure to keep a reference to the reactive object and not only to its properties, for reactivity to work. e.g. doing `let { count } = useStore({ count: 0 })` and then mutating `count` won't trigger updates of components that depends on it.
+
 ### Example
 
 An example showing how `useStore` is used in the Counter example to keep track of the count.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This PR introduces a simple note to avoid people from assuming that they can use direct references to properties of the reactive object returned by `useStore` and then realizing that reactivity doesn't work in that case.

Based on https://discord.com/channels/842438759945601056/843151429479956510/1023347860600803368

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
