### PR TITLE
feat: Enable Express Port Changes

### DIFF
--- a/packages/qwik-city/runtime/src/entry.express.tsx
+++ b/packages/qwik-city/runtime/src/entry.express.tsx
@@ -28,5 +28,5 @@ app.use(notFound);
 // Start the express server
 app.listen(PORT, () => {
   /* eslint-disable */
-  console.log(`http://localhost:3000/`);
+  console.log(`http://localhost:${PORT}/`);
 });

--- a/packages/qwik-city/runtime/src/entry.express.tsx
+++ b/packages/qwik-city/runtime/src/entry.express.tsx
@@ -11,7 +11,7 @@ const buildDir = join(distDir, 'build');
 // Create the Qwik City express middleware
 const { router, notFound } = qwikCity(render);
 // Allow for dynamic port
-const PORT = process.env.PORT ?? 3000
+const PORT = process.env.PORT ?? 3000;
 // Create the express server
 const app = express();
 

--- a/packages/qwik-city/runtime/src/entry.express.tsx
+++ b/packages/qwik-city/runtime/src/entry.express.tsx
@@ -10,7 +10,8 @@ const buildDir = join(distDir, 'build');
 
 // Create the Qwik City express middleware
 const { router, notFound } = qwikCity(render);
-
+// Allow for dynamic port
+const PORT = process.env.PORT ?? 3000
 // Create the express server
 const app = express();
 
@@ -25,7 +26,7 @@ app.use(router);
 app.use(notFound);
 
 // Start the express server
-app.listen(3000, () => {
+app.listen(PORT, () => {
   /* eslint-disable */
   console.log(`http://localhost:3000/`);
 });

--- a/starters/servers/express/src/entry.express.tsx
+++ b/starters/servers/express/src/entry.express.tsx
@@ -30,5 +30,5 @@ app.use(notFound);
 // Start the express server
 app.listen(PORT, () => {
   /* eslint-disable */
-  console.log(`http://localhost:3000/`);
+  console.log(`http://localhost:${PORT}/`);
 });

--- a/starters/servers/express/src/entry.express.tsx
+++ b/starters/servers/express/src/entry.express.tsx
@@ -10,7 +10,8 @@ const buildDir = join(distDir, 'build');
 
 // Create the Qwik City express middleware
 const { router, notFound } = qwikCity(render);
-
+// Allow for dynamic port
+const PORT = process.env.PORT ?? 3000
 // Create the express server
 // https://expressjs.com/
 const app = express();
@@ -27,7 +28,7 @@ app.use(router);
 app.use(notFound);
 
 // Start the express server
-app.listen(3000, () => {
+app.listen(PORT, () => {
   /* eslint-disable */
   console.log(`http://localhost:3000/`);
 });

--- a/starters/servers/express/src/entry.express.tsx
+++ b/starters/servers/express/src/entry.express.tsx
@@ -11,7 +11,7 @@ const buildDir = join(distDir, 'build');
 // Create the Qwik City express middleware
 const { router, notFound } = qwikCity(render);
 // Allow for dynamic port
-const PORT = process.env.PORT ?? 3000
+const PORT = process.env.PORT ?? 3000;
 // Create the express server
 // https://expressjs.com/
 const app = express();


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

When deploying qwik with express for SSR to a service such as cloud run (or something else) a team should be able to control what port the application is served from. This change should be a good place to start, however there could be a better way to do this and I'm open to that feedback from the qwik core team. This was just a quick thought on how I could solve the problem that I was facing with my deployment.

# Checklist:

- [X] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality
