### PR TITLE
fix(render-ssr.ts): fix mixed children rendering

### DIFF
--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -632,6 +632,7 @@ function walkChildren(
     } else if (prevPromise) {
       return prevPromise.then(next);
     } else {
+      currentIndex++;
       return undefined;
     }
   }, undefined);

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -278,21 +278,21 @@ renderSSRSuite('using promises', async () => {
 });
 
 renderSSRSuite('mixed children', async () => {
-    await testSSR(
-        <ul>
-            <li>0</li>
-            <li>1</li>
-            <li>2</li>
-            {Promise.resolve(<li>3</li>)}
-            <li>4</li>
-            {delay(100).then(() => (
-                <li>5</li>
-            ))}
-            {delay(10).then(() => (
-                <li>6</li>
-            ))}
-        </ul>,
-        `
+  await testSSR(
+    <ul>
+      <li>0</li>
+      <li>1</li>
+      <li>2</li>
+      {Promise.resolve(<li>3</li>)}
+      <li>4</li>
+      {delay(100).then(() => (
+        <li>5</li>
+      ))}
+      {delay(10).then(() => (
+        <li>6</li>
+      ))}
+    </ul>,
+    `
         <html q:container="paused" q:version="dev" q:render="ssr-dev">
         <ul>
         <li>0</li>
@@ -307,7 +307,7 @@ renderSSRSuite('mixed children', async () => {
         <li>6</li>
         </ul>
         </html>`
-    );
+  );
 });
 
 renderSSRSuite('DelayResource', async () => {

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -277,6 +277,39 @@ renderSSRSuite('using promises', async () => {
   );
 });
 
+renderSSRSuite('mixed children', async () => {
+    await testSSR(
+        <ul>
+            <li>0</li>
+            <li>1</li>
+            <li>2</li>
+            {Promise.resolve(<li>3</li>)}
+            <li>4</li>
+            {delay(100).then(() => (
+                <li>5</li>
+            ))}
+            {delay(10).then(() => (
+                <li>6</li>
+            ))}
+        </ul>,
+        `
+        <html q:container="paused" q:version="dev" q:render="ssr-dev">
+        <ul>
+        <li>0</li>
+        <li>1</li>
+        <li>2</li>
+        <!--qkssr-f-->
+        <li>3</li>
+        <li>4</li>
+        <!--qkssr-f-->
+        <li>5</li>
+        <!--qkssr-f-->
+        <li>6</li>
+        </ul>
+        </html>`
+    );
+});
+
 renderSSRSuite('DelayResource', async () => {
   await testSSR(
     <ul>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Wrong renders children if they are delayed and static.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
