### PR TITLE
fix: typo in comment in qwikloader

### DIFF
--- a/scripts/submodule-qwikloader.ts
+++ b/scripts/submodule-qwikloader.ts
@@ -169,7 +169,7 @@ export async function submoduleQwikLoader(config: BuildConfig) {
 }
 
 /**
- * Load each of the qwik scripts to be inlined with esbuild "define" as const varialbles.
+ * Load each of the qwik scripts to be inlined with esbuild "define" as const variables.
  */
 export async function inlineQwikScriptsEsBuild(config: BuildConfig) {
   const variableToFileMap = [


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Sorry if annoying - feel free to ignore/close! Just noticed a minor typo fix in comments for Qwik loader as I read thru to understand how it works.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

n/a

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
