### PR TITLE
Docs: Refactor Media Page and add more videos

### DIFF
--- a/packages/docs/src/routes/media/index.tsx
+++ b/packages/docs/src/routes/media/index.tsx
@@ -8,22 +8,22 @@ export interface MediaEntry {
   img_src?: string;
 }
 
-export const Thumbnail = component$((props: { entry: MediaEntry }) => {
+export const ThumbnailLink = component$((props: { entry: MediaEntry }) => {
   return (
     <li>
       <a href={props.entry.href} target="_blank">
-        <img src={props.entry.img_src} aria-hidden="true" />
+        <img src={props.entry.img_src} loading="lazy" decoding="async" aria-hidden="true" />
         <p>{props.entry.title}</p>
       </a>
     </li>
   );
 });
 
-export const BulletLink = component$((props: { title: string; href: string }) => {
+export const BulletLink = component$((props: { entry: MediaEntry }) => {
   return (
     <li>
-      <a href={props.href} target="_blank">
-        {props.title}
+      <a href={props.entry.href} target="_blank">
+        {props.entry.title}
       </a>
     </li>
   );
@@ -38,9 +38,13 @@ export const Section = component$(
         </h2>
 
         <ul class={props.preview_style}>
-          {MEDIA[props.title].map((entry) => (
-            <Thumbnail entry={entry} />
-          ))}
+          {MEDIA[props.title].map((entry) => {
+            return props.preview_style === 'thumbnails' ? (
+              <ThumbnailLink entry={entry} />
+            ) : (
+              <BulletLink entry={entry} />
+            );
+          })}
         </ul>
       </section>
     );
@@ -101,23 +105,23 @@ export const MEDIA = {
     {
       href: 'https://www.youtube.com/watch?v=BxGbnLb5i9Q',
       img_src: 'http://i3.ytimg.com/vi/BxGbnLb5i9Q/hqdefault.jpg',
-      title: 'Qwik: Under-The-Hood of a Resumable JavaScript Framework'
+      title: 'Qwik: Under-The-Hood of a Resumable JavaScript Framework',
     },
     {
       href: 'https://www.youtube.com/watch?v=qKCX7Qz1oG8',
       img_src: 'http://i3.ytimg.com/vi/qKCX7Qz1oG8/hqdefault.jpg',
-      title: 'Is Qwik + RxJS actually possible?'
+      title: 'Is Qwik + RxJS actually possible?',
     },
     {
       href: 'https://www.youtube.com/watch?v=dbxP9FX5j2o',
       img_src: 'http://i3.ytimg.com/vi/dbxP9FX5j2o/hqdefault.jpg',
-      title: 'Qwik-ifying React SPA to create the fastest possible website'
+      title: 'Qwik-ifying React SPA to create the fastest possible website',
     },
     {
       href: 'https://www.youtube.com/watch?v=Ts2IWXMYiXk',
       img_src: 'http://i3.ytimg.com/vi/Ts2IWXMYiXk/hqdefault.jpg',
-      title: 'Après Angular : place à Qwik !'
-    }
+      title: 'Après Angular : place à Qwik !',
+    },
   ],
   podcasts: [
     {

--- a/packages/docs/src/routes/media/index.tsx
+++ b/packages/docs/src/routes/media/index.tsx
@@ -2,176 +2,66 @@ import { component$, useStyles$ } from '@builder.io/qwik';
 import type { DocumentHead } from '@builder.io/qwik-city';
 import styles from './media.css?inline';
 
+export interface MediaEntry {
+  title: string;
+  href: string;
+  img_src?: string;
+}
+
+export const Thumbnail = component$((props: { entry: MediaEntry }) => {
+  return (
+    <li>
+      <a href={props.entry.href} target="_blank">
+        <img src={props.entry.img_src} aria-hidden="true" />
+        <p>{props.entry.title}</p>
+      </a>
+    </li>
+  );
+});
+
+export const BulletLink = component$((props: { title: string; href: string }) => {
+  return (
+    <li>
+      <a href={props.href} target="_blank">
+        {props.title}
+      </a>
+    </li>
+  );
+});
+
+export const Section = component$(
+  (props: { title: keyof typeof MEDIA; preview_style: 'thumbnails' | 'bullets' }) => {
+    return (
+      <section>
+        <h2 id={props.title}>
+          <a href={`#${props.title}`}>Videos</a>
+        </h2>
+
+        <ul class={props.preview_style}>
+          {MEDIA[props.title].map((entry) => (
+            <Thumbnail entry={entry} />
+          ))}
+        </ul>
+      </section>
+    );
+  }
+);
+
 export default component$(() => {
   useStyles$(styles);
   return (
     <div class="media">
       <h1>Qwik Presentations, Talks, Videos and Podcasts</h1>
 
-      <section>
-        <h2 id="videos">
-          <a href="#videos">Videos</a>
-        </h2>
+      <Section title="videos" preview_style="thumbnails" />
 
-        <ul class="thumbnails">
-          <li>
-            <a href="https://youtu.be/x2eF3YLiNhY" target="_blank">
-              <img src="http://i3.ytimg.com/vi/x2eF3YLiNhY/hqdefault.jpg" aria-hidden="true" />
-              <p>Qwik… the world's first O(1) JavaScript framework?</p>
-            </a>
-          </li>
-          <li>
-            <a href="https://youtu.be/z14c3u9q8rI" target="_blank">
-              <img src="http://i3.ytimg.com/vi/z14c3u9q8rI/hqdefault.jpg" aria-hidden="true" />
-              <p>Qwik JS and the future of frameworks</p>
-            </a>
-          </li>
-        </ul>
-      </section>
+      <Section title="podcasts" preview_style="thumbnails" />
 
-      <section>
-        <h2 id="podcasts">
-          <a href="#podcasts">Podcasts</a>
-        </h2>
+      <Section title="presentations" preview_style="thumbnails" />
 
-        <ul class="thumbnails">
-          <li>
-            <a href="https://www.youtube.com/watch?v=_PDpoJUacuc" target="_blank">
-              <img src="http://i3.ytimg.com/vi/_PDpoJUacuc/hqdefault.jpg" aria-hidden="true" />
-              <p>Build Resumable Apps with Qwik</p>
-            </a>
-          </li>
-          <li>
-            <a href="https://www.youtube.com/watch?v=iJZaT-AvJ-o" target="_blank">
-              <img src="http://i3.ytimg.com/vi/iJZaT-AvJ-o/hqdefault.jpg" aria-hidden="true" />
-              <p>Introducing Qwik w/ Misko Hevery &amp; Shai Reznik</p>
-            </a>
-          </li>
-          <li>
-            <a href="https://www.youtube.com/watch?v=LbMRs7l4czI" target="_blank">
-              <img src="http://i3.ytimg.com/vi/LbMRs7l4czI/hqdefault.jpg" aria-hidden="true" />
-              <p>Resumable Apps in Qwik</p>
-            </a>
-          </li>
-          <li>
-            <a href="https://www.youtube.com/watch?v=0tCuUQe_ZA0" target="_blank">
-              <img src="http://i3.ytimg.com/vi/0tCuUQe_ZA0/hqdefault.jpg" aria-hidden="true" />
-              <p>Qwik: A no-hydration instant-on personalized web applications</p>
-            </a>
-          </li>
-          <li>
-            <a href="https://www.youtube.com/watch?v=7MgNMIPISY4" target="_blank">
-              <img src="http://i3.ytimg.com/vi/7MgNMIPISY4/hqdefault.jpg" aria-hidden="true" />
-              <p>QWIK - Set of great demos by Misko Hevery</p>
-            </a>
-          </li>
-        </ul>
-      </section>
+      <Section title="blogs" preview_style="bullets" />
 
-      <section>
-        <h2 id="presentations">
-          <a href="#presentations">Presentations</a>
-        </h2>
-
-        <ul class="thumbnails">
-          <li>
-            <a href="https://www.youtube.com/watch?v=0dC11DMR3fU&amp;t=154s" target="_blank">
-              <img src="http://i3.ytimg.com/vi/0dC11DMR3fU/hqdefault.jpg" aria-hidden="true" />
-              <p>WWC22 - Qwik + Partytown: How to remove 99% of JavaScript from main thread</p>
-            </a>
-          </li>
-          <li>
-            <a href="https://www.youtube.com/watch?v=GHbNaDSWUX8" target="_blank">
-              <img src="http://i3.ytimg.com/vi/GHbNaDSWUX8/hqdefault.jpg" aria-hidden="true" />
-              <p>Qwik Workshop Part 1 - Live Coding</p>
-            </a>
-          </li>
-          <li>
-            <a href="https://www.youtube.com/watch?v=Jf_E1_19aB4&t=629s" target="_blank">
-              <img src="http://i3.ytimg.com/vi/Jf_E1_19aB4/hqdefault.jpg" aria-hidden="true" />
-              <p>Qwik framework overview</p>
-            </a>
-          </li>
-        </ul>
-      </section>
-
-      <section>
-        <h2 id="blogs">
-          <a href="#blogs">Blogs</a>
-        </h2>
-
-        <ul class="bullets">
-          <li>
-            <a href="https://www.builder.io/blog/hydration-is-pure-overhead" target="_blank">
-              Hydration is Pure Overhead
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://dev.to/mhevery/a-first-look-at-qwik-the-html-first-framework-af"
-              target="_blank"
-            >
-              HTML-first, JavaScript last: the secret to web speed!
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://dev.to/builderio/a-first-look-at-qwik-the-html-first-framework-af"
-              target="_blank"
-            >
-              A first look at Qwik - the HTML first framework
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://dev.to/mhevery/death-by-closure-and-how-qwik-solves-it-44jj"
-              target="_blank"
-            >
-              Death by Closure (and how Qwik solves it)
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://dev.to/mhevery/qwik-the-answer-to-optimal-fine-grained-lazy-loading-2hdp"
-              target="_blank"
-            >
-              Qwik: the answer to optimal fine-grained lazy loading
-            </a>
-          </li>
-        </ul>
-      </section>
-
-      <section>
-        <h2 id="resources">
-          <a href="#resources">Resources</a>
-        </h2>
-
-        <ul class="bullets">
-          <li>
-            <a
-              href="https://docs.google.com/presentation/d/1Jj1iw0lmaecxtUpqyNdF1aBzbCVnSlbPGLbOpN2xydc/edit#slide=id.g13225ffe116_6_234"
-              target="_blank"
-            >
-              Qwik: Instant-on, resumable WebApps - Google Presentation
-            </a>
-          </li>
-          <li>
-            <a href="/logos/qwik-logo.svg" target="_blank">
-              Qwik SVG Logo [svg]
-            </a>
-          </li>
-          <li>
-            <a href="/logos/qwik.svg" target="_blank">
-              Qwik Logo and Text [svg]
-            </a>
-          </li>
-          <li>
-            <a href="/logos/qwik.png" target="_blank">
-              Qwik Logo and Text [png]
-            </a>
-          </li>
-        </ul>
-      </section>
+      <Section title="resources" preview_style="bullets" />
 
       <section>
         <h2>Add Media</h2>
@@ -192,4 +82,97 @@ export default component$(() => {
 
 export const head: DocumentHead = {
   title: 'Qwik Presentations, Talks, Videos and Podcasts',
+};
+
+// Media Listing
+
+export const MEDIA = {
+  videos: [
+    {
+      href: 'https://youtu.be/x2eF3YLiNhY',
+      img_src: 'http://i3.ytimg.com/vi/x2eF3YLiNhY/hqdefault.jpg',
+      title: "Qwik… the world's first O(1) JavaScript framework?",
+    },
+    {
+      href: 'https://youtu.be/z14c3u9q8rI',
+      img_src: 'http://i3.ytimg.com/vi/z14c3u9q8rI/hqdefault.jpg',
+      title: 'Qwik JS and the future of frameworks',
+    }
+  ],
+  podcasts: [
+    {
+      href: 'https://www.youtube.com/watch?v=_PDpoJUacuc',
+      img_src: 'http://i3.ytimg.com/vi/_PDpoJUacuc/hqdefault.jpg',
+      title: 'Build Resumable Apps with Qwik',
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=iJZaT-AvJ-o',
+      img_src: 'http://i3.ytimg.com/vi/iJZaT-AvJ-o/hqdefault.jpg',
+      title: 'Introducing Qwik w/ Misko Hevery & Shai Reznik',
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=LbMRs7l4czI',
+      img_src: 'http://i3.ytimg.com/vi/LbMRs7l4czI/hqdefault.jpg',
+      title: 'Resumable Apps in Qwik',
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=0tCuUQe_ZA0',
+      img_src: 'http://i3.ytimg.com/vi/0tCuUQe_ZA0/hqdefault.jpg',
+      title: 'Qwik: A no-hydration instant-on personalized web applications',
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=7MgNMIPISY4',
+      img_src: 'http://i3.ytimg.com/vi/7MgNMIPISY4/hqdefault.jpg',
+      title: 'QWIK - Set of great demos by Misko Hevery',
+    },
+  ],
+  presentations: [
+    {
+      href: 'https://www.youtube.com/watch?v=0dC11DMR3fU&amp;t=154s',
+      img_src: 'http://i3.ytimg.com/vi/0dC11DMR3fU/hqdefault.jpg',
+      title: 'WWC22 - Qwik + Partytown: How to remove 99% of JavaScript from main thread',
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=GHbNaDSWUX8',
+      img_src: 'http://i3.ytimg.com/vi/GHbNaDSWUX8/hqdefault.jpg',
+      title: 'Qwik Workshop Part 1 - Live Coding',
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=Jf_E1_19aB4&t=629s',
+      img_src: 'http://i3.ytimg.com/vi/Jf_E1_19aB4/hqdefault.jpg',
+      title: 'Qwik framework overview',
+    },
+  ],
+  blogs: [
+    {
+      href: 'https://www.builder.io/blog/hydration-is-pure-overhead',
+      title: 'Hydration is Pure Overhead',
+    },
+    {
+      href: 'https://dev.to/mhevery/a-first-look-at-qwik-the-html-first-framework-af',
+      title: 'HTML-first, JavaScript last: the secret to web speed!',
+    },
+    {
+      href: 'https://dev.to/builderio/a-first-look-at-qwik-the-html-first-framework-af',
+      title: 'A first look at Qwik - the HTML first framework',
+    },
+    {
+      href: 'https://dev.to/mhevery/death-by-closure-and-how-qwik-solves-it-44jj',
+      title: 'Death by Closure (and how Qwik solves it)',
+    },
+
+    {
+      href: 'https://dev.to/mhevery/qwik-the-answer-to-optimal-fine-grained-lazy-loading-2hdp',
+      title: 'Qwik: the answer to optimal fine-grained lazy loading',
+    },
+  ],
+  resources: [
+    {
+      href: 'https://docs.google.com/presentation/d/1Jj1iw0lmaecxtUpqyNdF1aBzbCVnSlbPGLbOpN2xydc/edit#slide=id.g13225ffe116_6_234',
+      title: 'Qwik: Instant-on, resumable WebApps - Google Presentation',
+    },
+    { href: '/logos/qwik-logo.svg', title: 'Qwik SVG Logo [svg]' },
+    { href: '/logos/qwik.svg', title: 'Qwik Logo and Text [svg]' },
+    { href: '/logos/qwik.png', title: 'Qwik Logo and Text [png]' },
+  ],
 };

--- a/packages/docs/src/routes/media/index.tsx
+++ b/packages/docs/src/routes/media/index.tsx
@@ -31,7 +31,7 @@ export const BulletLink = component$((props: { entry: MediaEntry }) => {
 
 export const Section = component$(
   (props: { title: keyof typeof MEDIA; preview_style: 'thumbnails' | 'bullets' }) => {
-    let capitalized = [props.title[0].toUpperCase(), ...props.title.slice(1)].join("");
+    const capitalized = [props.title[0].toUpperCase(), ...props.title.slice(1)].join('');
     return (
       <section>
         <h2 id={props.title}>
@@ -93,7 +93,7 @@ export const head: DocumentHead = {
 
 // Helper function to allow autocompletions for Media Entries and Record keys
 export function mediaObj<T extends string>(obj: Record<T, MediaEntry[]>) {
-  return obj
+  return obj;
 }
 
 export const MEDIA = mediaObj({

--- a/packages/docs/src/routes/media/index.tsx
+++ b/packages/docs/src/routes/media/index.tsx
@@ -11,7 +11,7 @@ export interface MediaEntry {
 export const ThumbnailLink = component$((props: { entry: MediaEntry }) => {
   return (
     <li>
-      <a href={props.entry.href} target="_blank">
+      <a href={props.entry.href} target="_blank" rel="noreferrer">
         <img src={props.entry.img_src} loading="lazy" decoding="async" aria-hidden="true" />
         <p>{props.entry.title}</p>
       </a>
@@ -22,7 +22,7 @@ export const ThumbnailLink = component$((props: { entry: MediaEntry }) => {
 export const BulletLink = component$((props: { entry: MediaEntry }) => {
   return (
     <li>
-      <a href={props.entry.href} target="_blank">
+      <a href={props.entry.href} target="_blank" rel="noreferrer">
         {props.entry.title}
       </a>
     </li>

--- a/packages/docs/src/routes/media/index.tsx
+++ b/packages/docs/src/routes/media/index.tsx
@@ -97,6 +97,26 @@ export const MEDIA = {
       href: 'https://youtu.be/z14c3u9q8rI',
       img_src: 'http://i3.ytimg.com/vi/z14c3u9q8rI/hqdefault.jpg',
       title: 'Qwik JS and the future of frameworks',
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=BxGbnLb5i9Q',
+      img_src: 'http://i3.ytimg.com/vi/BxGbnLb5i9Q/hqdefault.jpg',
+      title: 'Qwik: Under-The-Hood of a Resumable JavaScript Framework'
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=qKCX7Qz1oG8',
+      img_src: 'http://i3.ytimg.com/vi/qKCX7Qz1oG8/hqdefault.jpg',
+      title: 'Is Qwik + RxJS actually possible?'
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=dbxP9FX5j2o',
+      img_src: 'http://i3.ytimg.com/vi/dbxP9FX5j2o/hqdefault.jpg',
+      title: 'Qwik-ifying React SPA to create the fastest possible website'
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=Ts2IWXMYiXk',
+      img_src: 'http://i3.ytimg.com/vi/Ts2IWXMYiXk/hqdefault.jpg',
+      title: 'Après Angular : place à Qwik !'
     }
   ],
   podcasts: [

--- a/packages/docs/src/routes/media/index.tsx
+++ b/packages/docs/src/routes/media/index.tsx
@@ -31,10 +31,11 @@ export const BulletLink = component$((props: { entry: MediaEntry }) => {
 
 export const Section = component$(
   (props: { title: keyof typeof MEDIA; preview_style: 'thumbnails' | 'bullets' }) => {
+    let capitalized = [props.title[0].toUpperCase(), ...props.title.slice(1)].join("");
     return (
       <section>
         <h2 id={props.title}>
-          <a href={`#${props.title}`}>Videos</a>
+          <a href={`#${props.title}`}>{capitalized}</a>
         </h2>
 
         <ul class={props.preview_style}>
@@ -90,7 +91,12 @@ export const head: DocumentHead = {
 
 // Media Listing
 
-export const MEDIA = {
+// Helper function to allow autocompletions for Media Entries and Record keys
+export function mediaObj<T extends string>(obj: Record<T, MediaEntry[]>) {
+  return obj
+}
+
+export const MEDIA = mediaObj({
   videos: [
     {
       href: 'https://youtu.be/x2eF3YLiNhY',
@@ -199,4 +205,4 @@ export const MEDIA = {
     { href: '/logos/qwik.svg', title: 'Qwik Logo and Text [svg]' },
     { href: '/logos/qwik.png', title: 'Qwik Logo and Text [png]' },
   ],
-};
+});


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Refactors the media page to remove templating duplication, and keep data out of the JSX.

Adds more videos that I had previously seen on my Youtube feed.

# Checklist:

- [x ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
