### PR TITLE
doc: correct starter name in qwikcity overview

### DIFF
--- a/packages/docs/src/routes/qwikcity/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/overview/index.mdx
@@ -43,4 +43,4 @@ To follow along with this guide, run the Qwik CLI in your command line:
 npm create qwik@latest
 ```
 
-When prompted, choose a name for your project and Qwik City as your starter.
+When prompted, choose a name for your project and Basic as your starter.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

wrong starter name, qwik city starter is in Basic now

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
