### PR TITLE
docs: remove useless fragment in qwik vs react section

### DIFF
--- a/packages/docs/src/routes/docs/cheat/qwik-react/index.mdx
+++ b/packages/docs/src/routes/docs/cheat/qwik-react/index.mdx
@@ -303,15 +303,13 @@ export const Presidents = component$(() => {
     { name: 'Grover Cleveland', years: '1885-1889' },
   ];
   return (
-    <>
-      <ul>
-        {presidents.map((president) => (
-          <li>
-            {president.name} ({president.years})
-          </li>
-        ))}
-      </ul>
-    </>
+    <ul>
+      {presidents.map((president) => (
+        <li>
+          {president.name} ({president.years})
+        </li>
+      ))}
+    </ul>
   );
 });
 ```


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This PR removes an unneeded `Fragment` in Cheat sheet [Qwik vs React] example.

# Use cases and why

The fragment is unneeded and removing it let React users what truly differs between both examples.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
