### PR TITLE
Removed double counter/counter in the component import

### DIFF
--- a/packages/docs/src/routes/qwikcity/content/mdx/index.mdx
+++ b/packages/docs/src/routes/qwikcity/content/mdx/index.mdx
@@ -47,7 +47,7 @@ src/
 # File: src/routes/some/path/index.mdx
 title: Hello World Title
 ---
-import { Counter } from "../../../components/counter/counter";
+import { Counter } from "../../../components/counter";
 
 This is a simple hello world component.
 


### PR DESCRIPTION
This doesn't make sense and isn't followed by the other components that are imported in the examples.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ x] Docs / tests

# Description
The directory structure only has one counter level. I could be wrong but it seems strange. If it is correct an explanation would be great. 

# Use cases and why

More accurate documentation

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
