### PR TITLE
docs: add workaround for those running in a Docker container

### DIFF
--- a/packages/docs/src/routes/qwikcity/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/overview/index.mdx
@@ -44,3 +44,8 @@ npm create qwik@latest
 ```
 
 When prompted, choose a name for your project and Basic as your starter.
+
+> Note: the `start` script attempts to launch the site in system’s browser,
+> which in headless environments (e.g., within a container)
+> could cause the command to fail with an error.
+> Edit `package.json` to remove the `--open` flag.


### PR DESCRIPTION
Otherwise `npm start` fails with an obscure error.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Stumbled across the same problem as #1434.

# Use cases and why

N/A

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
