### PR TITLE
fix(ssrdevmiddleware): skip request in Vite Dev Server if detecting a ping.

### DIFF
--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -55,7 +55,7 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
     try {
       const url = new URL(req.originalUrl!, `http://${req.headers.host}`);
 
-      if (skipRequest(url.pathname)) {
+      if (skipRequest(url.pathname) || isVitePing(url.pathname, req.headers)) {
         next();
         return;
       }
@@ -280,6 +280,10 @@ function skipRequest(pathname: string) {
     }
   }
   return false;
+}
+
+function isVitePing(url: string, headers: Connect.IncomingMessage['headers']) {
+  return url === '/' && headers.accept === '*/*' && headers['sec-fetch-mode'] === 'no-cors';
 }
 
 const SKIP_SRC_EXTS: { [ext: string]: boolean } = {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

After loading your app locally and then stopping the Vite dev server, Vite starts up a ping to the WebSocket connection by running a fetch on it over and over again until you start back up the server.  When you do, that ping will trigger the `onGet` handler for the `/` route which can cause side effects and confusion for developers.  You can see the behavior here: https://github.com/vitejs/vite/blob/7a6d4bc0d7fa614d3ac469ca35352a23aaef8232/packages/vite/src/client/client.ts#L300-L322

This might be a naive approach because there is very little to use to detect this particular issue. I'm pretty sure that no one will want to use this combination of headers anyway. If you think it's too brittle, I'm fine just living with the issue.

# Use cases and why

Use [this Stackblitz](https://stackblitz.com/edit/qwik-starter-ccb5nb?file=src%2Froutes%2Findex.tsx) to repro the issue by loading up the route `/a/b/c` in the built-in browser, stop the server and then restart it. You will notice that the `console.log()` within the `onGet` of the `/` route gets called.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
