### PR TITLE
Adjust Platform Field type

### DIFF
--- a/packages/docs/src/routes/docs/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/components/state/index.mdx
@@ -38,6 +38,71 @@ The example above, the App component is using `useStore()` to create a reactive 
 
 Just accessing the `state.count` property will cause the component to be updated if the count changes, when the property is changed in the click handler.
 
+### Recursive values
+
+By default, `useStore()` only tracks the top level fields in your store, which means any for any updates to register, you have to update values at the top level field.
+
+For example, this will not work:
+
+```tsx
+import { component$, useStore } from '@builder.io/qwik';
+
+export const App = component$(() => {
+  const store = useStore({
+    nested: { fields: { are: "not tracked" }}
+  })
+  
+  return (
+    <>
+      <p>{store.nested.fields.are}</p>
+      <button onClick$={() => store.nested.fields.are = "tracked"}>Click me</button>
+    </>
+  );
+});
+```
+
+In order to update this with default tracking we would have to update the top level `nested` field:
+
+```ts
+store.nested = { fields: { are: { "tracked" } } }
+```
+
+In order to make the first example work, we can pass a second argument to our useStore, and tell it to use recursion to track all the values in our store, no matter how deep.
+
+```tsx
+export const App = component$(() => {
+  const store = useStore({
+    nested: { fields: { are: "not tracked" }}
+  }, { recursion: true })
+  
+  return (
+    <>
+      <p>{store.nested.fields.are}</p>
+      <button onClick$={() => store.nested.fields.are = "tracked"}>Click me</button>
+    </>
+  );
+});
+```
+
+Now the component will update as expected. This will also track individual values inside of arrays!
+
+```tsx
+import { component$, useStore } from '@builder.io/qwik';
+
+export const App = component$(() => {
+  const store = useStore({
+    letters: ["A", "B", "C"]
+  }, { recursive: true })
+  
+  return (
+    <>
+      {store.letters.map(letter => <p>{letter}</p>)}
+      <button onClick$={() => { store.letters[2] = "Z"}}>Click me</button>
+    </>
+  );
+});
+```
+
 
 ## Passing a store to other components
 

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -174,13 +174,13 @@ export interface RequestContext {
 }
 
 // @alpha (undocumented)
-export interface RequestEvent {
+export interface RequestEvent<PLATFORM = unknown> {
     // (undocumented)
     abort: () => void;
     // (undocumented)
     next: () => Promise<void>;
     params: RouteParams;
-    platform: Record<string, any>;
+    platform: PLATFORM;
     // (undocumented)
     request: RequestContext;
     // (undocumented)
@@ -192,7 +192,7 @@ export interface RequestEvent {
 // Warning: (ae-forgotten-export) The symbol "RequestHandlerResult" needs to be exported by the entry point index.d.ts
 //
 // @alpha (undocumented)
-export type RequestHandler<BODY = unknown> = (ev: RequestEvent) => RequestHandlerResult<BODY>;
+export type RequestHandler<BODY = unknown, PLATFORM = unknown> = (ev: RequestEvent<PLATFORM>) => RequestHandlerResult<BODY>;
 
 // @alpha (undocumented)
 export type ResolvedDocumentHead = Required<DocumentHeadValue>;

--- a/packages/qwik-city/runtime/src/library/types.ts
+++ b/packages/qwik-city/runtime/src/library/types.ts
@@ -270,7 +270,7 @@ export interface ResponseContext {
 /**
  * @alpha
  */
-export interface RequestEvent {
+export interface RequestEvent<PLATFORM = unknown> {
   request: RequestContext;
   response: ResponseContext;
   url: URL;
@@ -279,7 +279,7 @@ export interface RequestEvent {
   params: RouteParams;
 
   /** Platform specific data and functions */
-  platform: Record<string, any>;
+  platform: PLATFORM;
 
   next: () => Promise<void>;
   abort: () => void;
@@ -293,7 +293,9 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 
 /**
  * @alpha
  */
-export type RequestHandler<BODY = unknown> = (ev: RequestEvent) => RequestHandlerResult<BODY>;
+export type RequestHandler<BODY = unknown, PLATFORM = unknown> = (
+  ev: RequestEvent<PLATFORM>
+) => RequestHandlerResult<BODY>;
 
 /**
  * @alpha


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

The current type of the Platform field is hardcoded to Record<string, any>.

In order to ease middleware implementations for the platform field and improve types for users, this PR adds a generic to the Request object which falls back to unknown, and types the platform field to that generic.

Also, I have added a second generic to the RequestHandler type, to allow typing of the request.

This allows for some flexibility in how we can move forward with implementations.

1. User casts the platform field.

```tsx
export const onGet: RequestHandler<SomeData> = ({ platform }) => {
 const { specific_platform_function } = platform as NetlifyContext;
 //...
}
```

2. User types the platform field.

```tsx
export const onGet: RequestHandler<SomeData, NetlifyContext> = ({ platform }) => {
 const { specific_platform_function } = platform;
 //...
}
```

3. Middleware exposes custom RequestHandler

```tsx
import { type NetlifyRequestHandler } from "...";

export const onGet: NetlifyRequestHandler<SomeData> = ({ platform }) => {
 const { specific_platform_function } = platform;
 //...
}
```

And I'm sure even more.

On the downside, this changes the public API. However, because this generic has a fallback, and because no one is using the platform field at the moment anyway, I don't forsee this as breaking anything for anyone.

Changes were discussed with @youngboy in regards to issues he was having with #1527 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
