### PR TITLE
feat: Make Platform Type Generic

### DIFF
--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -174,13 +174,13 @@ export interface RequestContext {
 }
 
 // @alpha (undocumented)
-export interface RequestEvent {
+export interface RequestEvent<PLATFORM = unknown> {
     // (undocumented)
     abort: () => void;
     // (undocumented)
     next: () => Promise<void>;
     params: RouteParams;
-    platform: Record<string, any>;
+    platform: PLATFORM;
     // (undocumented)
     request: RequestContext;
     // (undocumented)
@@ -192,7 +192,7 @@ export interface RequestEvent {
 // Warning: (ae-forgotten-export) The symbol "RequestHandlerResult" needs to be exported by the entry point index.d.ts
 //
 // @alpha (undocumented)
-export type RequestHandler<BODY = unknown> = (ev: RequestEvent) => RequestHandlerResult<BODY>;
+export type RequestHandler<BODY = unknown, PLATFORM = unknown> = (ev: RequestEvent<PLATFORM>) => RequestHandlerResult<BODY>;
 
 // @alpha (undocumented)
 export type ResolvedDocumentHead = Required<DocumentHeadValue>;

--- a/packages/qwik-city/runtime/src/library/types.ts
+++ b/packages/qwik-city/runtime/src/library/types.ts
@@ -270,7 +270,7 @@ export interface ResponseContext {
 /**
  * @alpha
  */
-export interface RequestEvent {
+export interface RequestEvent<PLATFORM = unknown> {
   request: RequestContext;
   response: ResponseContext;
   url: URL;
@@ -279,7 +279,7 @@ export interface RequestEvent {
   params: RouteParams;
 
   /** Platform specific data and functions */
-  platform: Record<string, any>;
+  platform: PLATFORM;
 
   next: () => Promise<void>;
   abort: () => void;
@@ -293,7 +293,7 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 
 /**
  * @alpha
  */
-export type RequestHandler<BODY = unknown> = (ev: RequestEvent) => RequestHandlerResult<BODY>;
+export type RequestHandler<BODY = unknown, PLATFORM = unknown> = (ev: RequestEvent<PLATFORM>) => RequestHandlerResult<BODY>;
 
 /**
  * @alpha


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

The current type of the Platform field is hardcoded to Record<string, any>.

In order to ease middleware implementations for the platform field and improve types for users, this PR adds a generic to the Request object which falls back to unknown, and types the platform field to that generic.

Also, I have added a second generic to the RequestHandler type, to allow typing of the request.

This allows for some flexibility in how we can move forward with implementations.

1. User casts the platform field.

```tsx
export const onGet: RequestHandler<SomeData> = ({ platform }) => {
 const { specific_platform_function } = platform as NetlifyContext;
 //...
}
```

2. User types the platform field.

```tsx
export const onGet: RequestHandler<SomeData, NetlifyContext> = ({ platform }) => {
 const { specific_platform_function } = platform;
 //...
}
```

3. Middleware exposes custom RequestHandler

```tsx
import { type NetlifyRequestHandler } from "...";

export const onGet: NetlifyRequestHandler<SomeData> = ({ platform }) => {
 const { specific_platform_function } = platform;
 //...
}
```
And I'm sure even more.

On the downside, this changes the public API. However, because this generic has a fallback, and because no one is using the platform field at the moment anyway, I don't forsee this as breaking anything for anyone.

Changes were discussed with @youngboy in regards to issues he was having with #1527 

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
