### PR TITLE
Change default redirect status

### DIFF
--- a/packages/docs/src/routes/qwikcity/routing/redirects/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/redirects/index.mdx
@@ -36,9 +36,10 @@ throw response.redirect('/login', 301); // Moved Permanently
 
 [Common redirect status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages):
 
+- `302`: Found. This response code means that the URI of requested resource has been changed temporarily. Further changes in the URI might be made in the future. Therefore, this same URI should be used by the client in future requests.
 - `307`: Temporary Redirect. The server sends this response to direct the client to get the requested resource at another URI with the same method that was used in the prior request. This has the same semantics as the 302 Found HTTP response code, with the exception that the user agent must not change the HTTP method used: if a POST was used in the first request, a POST must be used in the second request.
 - `308`: Permanent Redirect. This means that the resource is now permanently located at another URI, specified by the `Location` HTTP Response header. This has the same semantics as the 301 Moved Permanently HTTP response code, with the exception that the user agent must not change the HTTP method used: if a POST was used in the first request, a POST must be used in the second request.
 
-If you do not provide a status code, Qwik City will default to a `307` Temporary Redirect status.
+If you do not provide a status code, Qwik City will default to a `302` Temporary Redirect status.
 
 Read more about redirect status codes [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages).

--- a/packages/qwik-city/middleware/request-handler/redirect-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/redirect-handler.ts
@@ -9,7 +9,7 @@ export class RedirectResponse {
 
   constructor(public url: string, status?: number, headers?: Headers) {
     this.location = url;
-    this.status = isRedirectStatus(status) ? status : HttpStatus.TemporaryRedirect;
+    this.status = isRedirectStatus(status) ? status : HttpStatus.Found;
     this.headers = headers || createHeaders();
     this.headers.set('Location', this.location);
     this.headers.delete('Cache-Control');

--- a/packages/qwik-city/middleware/request-handler/user-response.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.ts
@@ -49,7 +49,7 @@ export async function loadUserResponse(
       // must have a trailing slash
       if (!pathname.endsWith('/')) {
         // add slash to existing pathname
-        throw new RedirectResponse(pathname + '/' + url.search, HttpStatus.TemporaryRedirect);
+        throw new RedirectResponse(pathname + '/' + url.search, HttpStatus.Found);
       }
     } else {
       // should not have a trailing slash
@@ -57,7 +57,7 @@ export async function loadUserResponse(
         // remove slash from existing pathname
         throw new RedirectResponse(
           pathname.slice(0, pathname.length - 1) + url.search,
-          HttpStatus.TemporaryRedirect
+          HttpStatus.Found
         );
       }
     }

--- a/packages/qwik-city/middleware/request-handler/user-response.unit.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.unit.ts
@@ -150,7 +150,7 @@ test('user manual redirect, PageModule', async () => {
       {
         onRequest: async ({ response }) => {
           await wait();
-          response.status = 307;
+          response.status = 302;
           response.headers.set('Location', '/redirect');
         },
         default: () => {},
@@ -161,7 +161,7 @@ test('user manual redirect, PageModule', async () => {
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, RedirectResponse);
-    equal(e.status, 307);
+    equal(e.status, 302);
     equal(e.location, '/redirect');
     equal(e.headers.get('Location'), '/redirect');
   }
@@ -185,7 +185,7 @@ test('throw redirect', async () => {
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, RedirectResponse);
-    equal(e.status, 307);
+    equal(e.status, 302);
     equal(e.headers.get('Location'), '/redirect');
   }
 });
@@ -219,7 +219,7 @@ test('remove trailing slash, PageModule', async () => {
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, RedirectResponse);
-    equal(e.status, 307);
+    equal(e.status, 302);
     equal(e.location, '/somepath?qs=true');
   }
 });
@@ -237,7 +237,7 @@ test('add trailing slash, PageModule', async () => {
     equal(true, false, 'Should have thrown');
   } catch (e: any) {
     instance(e, RedirectResponse);
-    equal(e.status, 307);
+    equal(e.status, 302);
     equal(e.location, '/somepath/?qs=true');
   }
 });


### PR DESCRIPTION
Co-authored by: Cody Lundquist <cody.lundquist@gmail.com>

# What is it?

The current default redirect status code forces the redirect method to be the same as the original request, forcing the post-redirect-get pattern that is so common in web dev to not work unless the status is set by the user.

Using a 302 keeps the same behavior as a 307, but removes the restriction that the methods must be the same.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
