### PR TITLE
On input

### DIFF
--- a/packages/docs/src/routes/examples/apps/reactivity/auto-complete/app.tsx
+++ b/packages/docs/src/routes/examples/apps/reactivity/auto-complete/app.tsx
@@ -48,7 +48,7 @@ export const AutoComplete = component$(() => {
     <div>
       <input
         type="text"
-        onKeyup$={(ev) => (state.searchInput = (ev.target as HTMLInputElement).value)}
+        onInput$={(ev) => (state.searchInput = (ev.target as HTMLInputElement).value)}
       />
       <SuggestionsListComponent state={state}></SuggestionsListComponent>
     </div>

--- a/packages/docs/src/routes/tutorial/hooks/use-watch/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-watch/problem/app.tsx
@@ -17,7 +17,7 @@ export const App = component$(() => {
     <>
       <input
         value={store.value}
-        onKeyUp$={(event) => (store.value = (event.target as HTMLInputElement).value)}
+        onInput$={(event) => (store.value = (event.target as HTMLInputElement).value)}
       />
       <br />
       Current value: {store.value}

--- a/packages/docs/src/routes/tutorial/hooks/use-watch/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-watch/solution/app.tsx
@@ -17,7 +17,7 @@ export const App = component$(() => {
     <>
       <input
         value={store.value}
-        onKeyUp$={(event) => (store.value = (event.target as HTMLInputElement).value)}
+        onInput$={(event) => (store.value = (event.target as HTMLInputElement).value)}
       />
       <br />
       Current value: {store.value}

--- a/packages/docs/src/routes/tutorial/introduction/listeners/index.mdx
+++ b/packages/docs/src/routes/tutorial/introduction/listeners/index.mdx
@@ -7,6 +7,6 @@ contributors:
 
 In this tutorial, we will add an event listener to the input. We will use the `keyup` event to listen to changes on the input. The goal is to update the `org` as the user types.
 
-Use the `onKeyUp$` property on the `<input>` element to add an event listener.
+Use the `onInput$` property on the `<input>` element to add an event listener.
 
 Notice that the assignment to the store (`github.org = ...`) automatically triggers the component re-rendering.

--- a/packages/docs/src/routes/tutorial/introduction/listeners/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/introduction/listeners/solution/app.tsx
@@ -12,7 +12,7 @@ export const App = component$(() => {
         GitHub username:
         <input
           value={github.org}
-          onKeyUp$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
+          onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
         />
       </span>
       <div>

--- a/packages/docs/src/routes/tutorial/introduction/resource/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/introduction/resource/problem/app.tsx
@@ -28,7 +28,7 @@ export const App = component$(() => {
         GitHub username:
         <input
           value={github.org}
-          onKeyUp$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
+          onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
         />
       </span>
       <div>

--- a/packages/docs/src/routes/tutorial/introduction/resource/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/introduction/resource/solution/app.tsx
@@ -28,7 +28,7 @@ export const App = component$(() => {
         GitHub username:
         <input
           value={github.org}
-          onKeyUp$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
+          onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
         />
       </span>
       <div>

--- a/packages/docs/src/routes/tutorial/introduction/store/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/introduction/store/solution/app.tsx
@@ -12,7 +12,7 @@ export const App = component$(() => {
         GitHub username:
         <input
           value={github.org}
-          onKeyUp$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
+          onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
         />
       </span>
       <div>

--- a/packages/docs/src/routes/tutorial/qrl/closures/index.mdx
+++ b/packages/docs/src/routes/tutorial/qrl/closures/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lazy Lading Closures
+title: Lazy Loading Closures
 contributors:
   - manucorporat
   - adamdbradley

--- a/packages/docs/src/routes/tutorial/qrl/closures/index.mdx
+++ b/packages/docs/src/routes/tutorial/qrl/closures/index.mdx
@@ -5,7 +5,7 @@ contributors:
   - adamdbradley
 ---
 
-A closure can be converted into a lazy-loaded reference using the `$()` function. This generates a `QRL<Function>` type. A QRL is a lazy-loadable reference of the closure. In our case, we have extracted the closure associated with the `onKeyUp` event into the component body. Because it is no longer inlined we need to change how the JSX refers to it from `onKeyUp$` to `onKeyUpQrl`.
+A closure can be converted into a lazy-loaded reference using the `$()` function. This generates a `QRL<Function>` type. A QRL is a lazy-loadable reference of the closure. In our case, we have extracted the closure associated with the `onInput` event into the component body. Because it is no longer inlined we need to change how the JSX refers to it from `onInput$` to `onInputQrl`.
 
 Notice that our closure closes over the `store` that is captured by the Optimizer and then restored as needed.
 

--- a/packages/docs/src/routes/tutorial/qrl/closures/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/qrl/closures/problem/app.tsx
@@ -2,17 +2,19 @@ import { component$, useStore, $ } from '@builder.io/qwik';
 
 export const App = component$(() => {
   const store = useStore({ name: '' });
-  const onKeyUp$ = $(async (event: KeyboardEvent) => {
+  // This fires on every change of the input value
+  const onInput$ = $(async (event: KeyboardEvent) => {
     const input = event.target as HTMLInputElement;
-    if (event.key === 'Enter') {
-      alert(store.name);
-    } else {
-      store.name = input.value;
-    }
+    store.name = input.value;
+  });
+  // This fires on confirmations like Enter or focus change
+  const onChange$ = $(async (event: KeyboardEvent) => {
+    if (store.name) alert(store.name);
   });
   return (
     <>
-      Enter your name followed by the enter key: <input onKeyUp$={onKeyUp$} value={store.name} />
+      Enter your name followed by the enter key:{' '}
+      <input onInput$={onInput$} onChange$={onChange$} value={store.name} />
     </>
   );
 });

--- a/packages/docs/src/routes/tutorial/qrl/closures/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/qrl/closures/solution/app.tsx
@@ -2,19 +2,19 @@ import { component$, useStore, $ } from '@builder.io/qwik';
 
 export const App = component$(() => {
   const store = useStore({ name: '' });
-  const onKeyUp$ = $(async (event: KeyboardEvent) => {
+  // This fires on every change of the input value
+  const onInput$ = $(async (event: KeyboardEvent) => {
     const input = event.target as HTMLInputElement;
-    if (event.key === 'Enter') {
-      await $(() => {
-        alert(store.name);
-      })();
-    } else {
-      store.name = input.value;
-    }
+    store.name = input.value;
+  });
+  // This fires on confirmations like Enter or focus change
+  const onChange$ = $(async (event: KeyboardEvent) => {
+    if (store.name) alert(store.name);
   });
   return (
     <>
-      Enter your name followed by the enter key: <input onKeyUp$={onKeyUp$} value={store.name} />
+      Enter your name followed by the enter key:{' '}
+      <input onInput$={onInput$} onChange$={onChange$} value={store.name} />
     </>
   );
 });

--- a/packages/docs/src/routes/tutorial/reactivity/resource/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/reactivity/resource/problem/app.tsx
@@ -28,7 +28,7 @@ export const App = component$(() => {
         GitHub username:
         <input
           value={github.org}
-          onKeyUp$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
+          onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
         />
       </span>
       <div>

--- a/packages/docs/src/routes/tutorial/reactivity/resource/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/reactivity/resource/solution/app.tsx
@@ -28,7 +28,7 @@ export const App = component$(() => {
         GitHub username:
         <input
           value={github.org}
-          onKeyUp$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
+          onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
         />
       </span>
       <div>

--- a/starters/apps/starter-partytown.test/src/components/app/app.tsx
+++ b/starters/apps/starter-partytown.test/src/components/app/app.tsx
@@ -56,7 +56,7 @@ export const App = component$(() => {
           Try interacting with this component by changing{' '}
           <input
             value={state.name}
-            onKeyUp$={(event) => {
+            onInput$={(event) => {
               const input = event.target as HTMLInputElement;
               state.name = input.value;
             }}


### PR DESCRIPTION
# What is it?

- [x] Docs / tests

# Description

The examples use onKeyUp, which is only for keyboard events, and it is also laggy since the event happens after the change is already visible.

Instead, use onInput, which works immediately for every input change, and instead of checking for the Enter key use onChange.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
