### PR TITLE
feat: add useRequestHeaders hook

### DIFF
--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -1,27 +1,27 @@
-import type { ViteDevServer, Connect } from 'vite';
-import type { ServerResponse } from 'http';
+import type { RenderToStringResult } from '@builder.io/qwik/server';
 import fs from 'fs';
+import type { ServerResponse } from 'http';
 import { join, resolve } from 'path';
-import type { BuildContext } from '../types';
-import type { RouteModule } from '../../runtime/src/library/types';
+import type { Connect, ViteDevServer } from 'vite';
 import type { QwikViteDevResponse } from '../../../qwik/src/optimizer/src/plugins/vite';
-import { loadUserResponse, updateRequestCtx } from '../../middleware/request-handler/user-response';
-import { getQwikCityEnvData, pageHandler } from '../../middleware/request-handler/page-handler';
-import { updateBuildContext } from '../build';
+import { fromNodeHttp } from '../../middleware/node/http';
 import { endpointHandler } from '../../middleware/request-handler/endpoint-handler';
 import {
   errorResponse,
   ErrorResponse,
   notFoundHandler,
 } from '../../middleware/request-handler/error-handler';
+import { getQwikCityEnvData, pageHandler } from '../../middleware/request-handler/page-handler';
 import {
   redirectResponse,
   RedirectResponse,
 } from '../../middleware/request-handler/redirect-handler';
-import { getExtension, normalizePath } from '../../utils/fs';
-import type { RenderToStringResult } from '@builder.io/qwik/server';
+import { loadUserResponse, updateRequestCtx } from '../../middleware/request-handler/user-response';
 import { getRouteParams } from '../../runtime/src/library/routing';
-import { fromNodeHttp } from '../../middleware/node/http';
+import type { RouteModule } from '../../runtime/src/library/types';
+import { getExtension, normalizePath } from '../../utils/fs';
+import { updateBuildContext } from '../build';
+import type { BuildContext } from '../types';
 
 export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
   const matchRouteRequest = (pathname: string) => {
@@ -115,7 +115,7 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
 
           // qwik city vite plugin should handle dev ssr rendering
           // but add the qwik city user context to the response object
-          const envData = getQwikCityEnvData(userResponse);
+          const envData = getQwikCityEnvData(userResponse, requestCtx.request);
           if (ctx.isDevServerClientOnly) {
             // because we stringify this content for the client only
             // dev server, there's some potential stringify issues

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -264,6 +264,11 @@ export const useLocation: () => RouteLocation;
 // @alpha (undocumented)
 export const useNavigate: () => RouteNavigate;
 
+// Warning: (ae-forgotten-export) The symbol "RequestHeaders" needs to be exported by the entry point index.d.ts
+//
+// @alpha (undocumented)
+export const useRequestHeaders: () => RequestHeaders | undefined;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/qwik-city/runtime/src/index.ts
+++ b/packages/qwik-city/runtime/src/index.ts
@@ -1,3 +1,8 @@
+export { Link } from './library/link-component';
+export type { LinkProps } from './library/link-component';
+export { Html, QwikCity } from './library/qwik-city-component';
+export { Content, RouterOutlet } from './library/router-outlet-component';
+export { ServiceWorkerRegister } from './library/sw-component';
 export type {
   ContentHeading,
   ContentMenu,
@@ -7,25 +12,23 @@ export type {
   DocumentLink,
   DocumentMeta,
   DocumentStyle,
-  RequestHandler,
-  RequestEvent,
-  RouteParams,
-  ResponseContext,
-  RequestContext,
+  EndpointHandler,
   QwikCityPlan,
+  RequestContext,
+  RequestEvent,
+  RequestHandler,
   ResolvedDocumentHead,
+  ResponseContext,
   RouteData,
   RouteLocation,
+  RouteParams,
   StaticGenerateHandler,
 } from './library/types';
-
-export { RouterOutlet, Content } from './library/router-outlet-component';
-export { Html, QwikCity } from './library/qwik-city-component';
-export { Link } from './library/link-component';
-export type { LinkProps } from './library/link-component';
-export { ServiceWorkerRegister } from './library/sw-component';
-export { useDocumentHead, useLocation, useContent, useNavigate } from './library/use-functions';
 export { useEndpoint } from './library/use-endpoint';
-
-// @deprecated
-export type { EndpointHandler } from './library/types';
+export {
+  useContent,
+  useDocumentHead,
+  useLocation,
+  useNavigate,
+  useRequestHeaders,
+} from './library/use-functions';

--- a/packages/qwik-city/runtime/src/library/types.ts
+++ b/packages/qwik-city/runtime/src/library/types.ts
@@ -1,6 +1,6 @@
+import type { NoSerialize } from '@builder.io/qwik';
 import type { ErrorResponse } from '../../../middleware/request-handler/error-handler';
 import type { RedirectResponse } from '../../../middleware/request-handler/redirect-handler';
-import type { NoSerialize } from '@builder.io/qwik';
 
 export interface RouteModule<BODY = unknown> {
   onDelete?: RequestHandler<BODY>;
@@ -41,6 +41,10 @@ export interface RouteLocation {
 
 export interface RouteNavigate {
   path: string;
+}
+
+export interface RequestHeaders {
+  [key: string]: string;
 }
 
 export type MutableRouteLocation = Mutable<RouteLocation>;
@@ -324,6 +328,10 @@ export interface EndpointResponse {
   status: number;
 }
 
+export interface EndpointRequest {
+  headers: RequestHeaders;
+}
+
 export interface ClientPageData extends Omit<EndpointResponse, 'status'> {
   status?: number;
   prefetch?: string[];
@@ -344,6 +352,7 @@ export interface QwikCityRenderDocument extends Document {}
 export interface QwikCityEnvData {
   params: RouteParams;
   response: EndpointResponse;
+  request: EndpointRequest;
 }
 
 export type GetEndpointData<T> = T extends RequestHandler<infer U> ? U : T;

--- a/packages/qwik-city/runtime/src/library/use-functions.ts
+++ b/packages/qwik-city/runtime/src/library/use-functions.ts
@@ -5,7 +5,7 @@ import {
   RouteLocationContext,
   RouteNavigateContext,
 } from './contexts';
-import type { RouteLocation, ResolvedDocumentHead, RouteNavigate, QwikCityEnvData } from './types';
+import type { QwikCityEnvData, ResolvedDocumentHead, RouteLocation, RouteNavigate } from './types';
 
 /**
  * @alpha
@@ -29,3 +29,8 @@ export const useLocation = (): RouteLocation => useContext(RouteLocationContext)
 export const useNavigate = (): RouteNavigate => useContext(RouteNavigateContext);
 
 export const useQwikCityEnv = () => noSerialize(useEnvData<QwikCityEnvData>('qwikcity'));
+
+/**
+ * @alpha
+ */
+export const useRequestHeaders = () => useQwikCityEnv()?.request.headers;


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

I've added a new hook to Qwik City to expose request headers during SSR - `useRequestHeaders`

This hook can be used by applications that rely on external APIs that require authentication tokens. Tokens can be stored as a cookie and then retrieved during SSR in a `useResource$` hook and passed on to the API.

Currently, the only way to access headers is in the onGet methods.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. SPAs that use a GraphQL API that want to make use of SSR without adding onGet(/etc) methods will use the `useResource$` hook to run queries from both environments but need to forward the access tokens onto the API.

# Checklist:

- [X] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
