### PR TITLE
docs: deleting instructions seen in the next step

### DIFF
--- a/packages/docs/src/routes/tutorial/introduction/store/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/introduction/store/solution/app.tsx
@@ -10,10 +10,7 @@ export const App = component$(() => {
     <div>
       <span>
         GitHub username:
-        <input
-          value={github.org}
-          onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
-        />
+        <input value={github.org} />
       </span>
       <div>
         {github.repos ? (


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

Deletion of instructions in the solution of the step ["introduction - store"](https://qwik.builder.io/tutorial/introduction/store/). (These deleted instructions are the solution that is described in the next step (["introduction - listeners"](https://qwik.builder.io/tutorial/introduction/listeners/)). Note that the solution for the next step is correct)

# Use cases and why

Nope

# Checklist:

- [X] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
