### PR TITLE
Fix: Let developers make their own error pages design

### DIFF
--- a/packages/qwik-city/middleware/request-handler/error-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/error-handler.ts
@@ -69,37 +69,8 @@ export function getErrorHtml(status: number, e: any) {
 }
 
 function minimalHtmlResponse(status: number, message?: string, stack?: string) {
-  const width = typeof message === 'string' ? '600px' : '300px';
-  const color = status >= 500 ? COLOR_500 : COLOR_400;
-  if (status < 500) {
-    stack = '';
-  }
 
-  return `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="Status" content="${status}"/>
-  <title>${status} ${message}</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-    body { color: ${color}; background-color: #fafafa; padding: 30px; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Roboto, sans-serif; }
-    p { max-width: ${width}; margin: 60px auto 30px auto; background: white; border-radius: 4px; box-shadow: 0px 0px 50px -20px ${color}; overflow: hidden; }
-    strong { display: inline-block; padding: 15px; background: ${color}; color: white; }
-    span { display: inline-block; padding: 15px; }
-    pre { max-width: 580px; margin: 0 auto; }
-  </style>
-</head>
-<body>
-  <p>
-    <strong>${status}</strong>
-    <span>${message}</span>
-  </p>
-  ${stack ? `<pre><code>${stack}</code></pre>` : ``}
-</body>
-</html>
-`;
+  return `<script>
+    window.location.href = '/errors/err-${status}-page';
+  </script>`;
 }
-
-const COLOR_400 = '#006ce9';
-const COLOR_500 = '#713fc2';

--- a/starters/apps/basic/src/routes/errors/err-404-page/index.tsx
+++ b/starters/apps/basic/src/routes/errors/err-404-page/index.tsx
@@ -1,0 +1,19 @@
+import { component$, useStylesScoped$ } from '@builder.io/qwik';
+import type { DocumentHead } from '@builder.io/qwik-city';
+
+export default component$(() => {
+    useStylesScoped$(`body { color: #006ce9; background-color: #fafafa; padding: 30px; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Roboto, sans-serif; }
+    p { max-width: 600px; margin: 60px auto 30px auto; background: white; border-radius: 4px; box-shadow: 0px 0px 50px -20px #006ce9; overflow: hidden; }
+    strong { display: inline-block; padding: 15px; background: #006ce9; color: white; }
+    span { display: inline-block; padding: 15px; }
+    pre { max-width: 580px; margin: 0 auto; }`)
+    return (
+        <p>
+            <strong>404</strong>
+            <span>Not Found</span>
+        </p>
+    )
+})
+export const head: DocumentHead = {
+    title: '404 Not Found',
+};


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug

# Description

Make simple changes to let developers make their own error pages and design as they want
**the developer should make designs for each error page**
if this PR merged and accepted, I'll update the rest of files and make more error pages to be ready for design

# Checklist:

- [ ] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
