### PR TITLE
docs: remove no longer used commands from getting started page

### DIFF
--- a/packages/docs/src/routes/docs/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/getting-started/index.mdx
@@ -96,7 +96,5 @@ npm start
 
 Here are some useful commands to get you started. For a complete list please refer to `package.json`.
 
-- `npm start`: alias to `npm run dev` (this currently defaults to running dev.ssr)
-- `npm run dev.client`: starts the dev server in client bootstrap mode
-- `npm run dev.ssr`: starts the dev server with SSR
+- `npm start`: alias to `npm run dev` (this currently defaults to running ssr)
 - `npm run build`: builds the application for production


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

There are commands in getting started page that no longer used in qwik apps, and I removed it in order not to confuse the developers

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
