### PR TITLE
fix(qwik-docs): search modal footer svgs are not inside the keyboard …

### DIFF
--- a/packages/docs/src/components/docsearch/footer.tsx
+++ b/packages/docs/src/components/docsearch/footer.tsx
@@ -22,7 +22,7 @@ interface CommandIconProps {
 
 export const CommandIcon = component$((props: CommandIconProps) => {
   return (
-    <svg width="15" height="15" aria-label={props.ariaLabel} role="img">
+    <svg style={{width: 15, height: 15}} aria-label={props.ariaLabel} role="img">
       <g
         fill="none"
         stroke="currentColor"

--- a/packages/docs/src/components/docsearch/footer.tsx
+++ b/packages/docs/src/components/docsearch/footer.tsx
@@ -22,7 +22,7 @@ interface CommandIconProps {
 
 export const CommandIcon = component$((props: CommandIconProps) => {
   return (
-    <svg style={{width: 15, height: 15}} aria-label={props.ariaLabel} role="img">
+    <svg style={{ width: 15, height: 15 }} aria-label={props.ariaLabel} role="img">
       <g
         fill="none"
         stroke="currentColor"


### PR DESCRIPTION
…styled buttons

The svgs for arrow keys in the search modal footer is rendered outside the footer due to height and width not applying in the svg. This pr changes the way the height and width is provided in the svg component

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
SVGs for search modal footer are rendering outside the footer due to error with width and height not applying to svg component.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
