### PR TITLE
docs: correct typo in useStyles$() docs

### DIFF
--- a/packages/docs/src/routes/docs/components/overview/index.mdx
+++ b/packages/docs/src/routes/docs/components/overview/index.mdx
@@ -185,8 +185,8 @@ The Optimizer splits Qwik components into the host element and the behavior of t
 
 ### Styles
 
-- `useStyleScoped$()` - creates a scoped style
-- `useStyle$()` - creates a global style
+- `useStylesScoped$()` - creates a scoped style
+- `useStyles$()` - creates a global style
 
 ### Events
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

On the component overview documentation page the functions to use styles are wrongly named in singular form. In code and the rest of the documentation the plural form is used, see: `/src/core/use/use-styles.ts`.

# Use cases and why

- 1. As someone wanting to learn how to use Qwik I might get discouraged by docs not consistent with the actual code.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
