### PR TITLE
docs(docs): control text overflow in sidebar

### DIFF
--- a/packages/docs/src/components/sidebar/sidebar.css
+++ b/packages/docs/src/components/sidebar/sidebar.css
@@ -96,8 +96,12 @@
   @apply whitespace-nowrap;
 }
 
+details li {
+  @apply py-1 pl-3 block hover:bg-slate-200 overflow-hidden text-ellipsis;
+}
+
 .menu li a {
-  @apply py-1 pl-3 block text-slate-900 hover:bg-slate-200;
+  @apply text-slate-900;
 }
 
 .menu li a.is-active {


### PR DESCRIPTION
Text overflow has been added to replace the oveflowing text with ellipsis i.e '...'

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
The sidebar sub-menu texts overflow for long title. This change fixes the issue.

# Use cases and why
### Before:
<img width="1440" alt="before change" src="https://user-images.githubusercontent.com/26207583/194782164-d2edce03-1a73-4e58-bc80-2327ac44ce48.png">

### After:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26207583/194782194-c84bbe3f-3816-40b5-b188-d57679a0e16c.png">

<!-- Actual / expected behaviour if it's a bug -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
