### PR TITLE
fix(create-interactive.ts): remove the space of project name

### DIFF
--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -47,7 +47,7 @@ export async function runCreateInteractiveCli() {
   );
   console.log(``);
 
-  const outDir: string = getOutDir(projectNameAnswer.outDir);
+  const outDir: string = getOutDir(projectNameAnswer.outDir.trim());
 
   let removeExistingOutDirPromise: Promise<void> | null = null;
 


### PR DESCRIPTION
Remove the space of name

fix #1664

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
use `trim()` remove the space of project name
```js
const outDir: string = getOutDir(projectNameAnswer.outDir.trim());
```

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
