### PR TITLE
docs: add missing terms to endpoints page sentence

### DIFF
--- a/packages/docs/src/routes/qwikcity/data/endpoints/index.mdx
+++ b/packages/docs/src/routes/qwikcity/data/endpoints/index.mdx
@@ -2,10 +2,11 @@
 title: Qwik City Endpoints and RESTful API
 contributors:
   - adamdbradley
+  - aalaap
 ---
 
 # Endpoints and RESTful API
 
 Qwik City is able to create a RESTful API for your application using Endpoints. Endpoint routes are created the same as how you would create a "page", except the filename should end with `.ts` instead of `.tsx`. An `index.ts` in the `src/routes` directory is only for data, such as a `json` response, while an `index.tsx` is for an HTML page. 
 
-Both "page" and "endpoints" are the same except for one difference: a page exports a `default component$()` to render HTML, whereas an endpoint only HTTP request and response handlers. To learn about defining a page component, you can [read more here](../../content/component/index.mdx). An endpoint route however, is used only for the purpose of responding with data.
+Both "page" and "endpoints" are the same except for one difference: a page exports a `default component$()` to render HTML, whereas an endpoint exports only HTTP request and response handlers. To learn about defining a page component, you can [read more here](../../content/component/index.mdx). An endpoint route however, is used only for the purpose of responding with data.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Adds the 'exports' word to a sentence in the endpoints page in the documentation as reported in https://github.com/BuilderIO/qwik/issues/1686

# Use cases and why

On the [Data > Endpoints](https://qwik.builder.io/qwikcity/data/endpoints/) page, the following text is present:

> Both "page" and "endpoints" are the same except for one difference: a page exports a default component$() to render HTML, whereas an endpoint only HTTP request and response handlers.

There is a missing term in the last sentence fragment that follows whereas an endpoint. I believe exports would be appropriate here:

> ...whereas an endpoint exports only HTTP request and response handlers.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
