### PR TITLE
style(qwik-docs sidebar): make the sidebar submenu clickable

### DIFF
--- a/packages/docs/src/components/sidebar/sidebar.css
+++ b/packages/docs/src/components/sidebar/sidebar.css
@@ -97,7 +97,10 @@
 }
 
 details li {
-  @apply py-1 pl-3 block hover:bg-slate-200 overflow-hidden text-ellipsis;
+  @apply py-1 pl-3 hover:bg-slate-200;
+}
+details li a {
+  @apply block overflow-hidden text-ellipsis;
 }
 
 .menu li a {


### PR DESCRIPTION
…of only text

In the sidebar only the text is clickable, this change makes the whole element clickable

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
Currently only the sidebar text is clickable, this change fixes the issue.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
