### PR TITLE
docs: add missing `recursive` option

### DIFF
--- a/packages/docs/src/routes/docs/concepts/reactivity/index.mdx
+++ b/packages/docs/src/routes/docs/concepts/reactivity/index.mdx
@@ -82,14 +82,14 @@ Notice how the set of subscriptions automatically updates as the component rende
 
 ## Deep objects
 
-So far, the examples show the store (`useStore()`) was a simple object with primitive values. However, the same behavior works on all properties of the store recursively.
+So far, the examples show the store (`useStore()`) was a simple object with primitive values. However, the same behavior can work on all properties of the store recursively by providing the `recursive` option.
 
 ```tsx
 export const MyComp = component$(() => {
   const store = useStore({
     person: { first: null, last: null },
     location: null
-  });
+  }, { recursive: true });
 
   store.location = {street: 'main st'};
 


### PR DESCRIPTION
Add the missing `recursive` option in the Reactivity's deep objects section

resolves #1692

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
