### PR TITLE
Improved the error message if starter id is not matched when using create-app

### DIFF
--- a/packages/create-qwik/create-app.ts
+++ b/packages/create-qwik/create-app.ts
@@ -106,7 +106,11 @@ export async function createApp(opts: CreateAppOptions) {
     }
     const starterApp = starterApps.find((s) => s.id === opts.starterId);
     if (!starterApp) {
-      throw new Error(`Invalid starter id "${opts.starterId}"`);
+      throw new Error(
+        `Invalid starter id "${opts.starterId}". It can only be one of${starterApps.map(
+          (app) => ` "${app.id}"`
+        )}.`
+      );
     }
 
     await createFromStarter(result, baseApp, starterApp);


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Since the original error message just say `Invalid starter id`, I've been stuck until I read the source code in `create-app.ts`

I think list the available options would be more clear and not to confuse users.

**Before**
```
Error: Invalid starter id "bases"
    at jt (/home/kurt/Desktop/test/node_modules/create-qwik/index.cjs:118:2335)
    at async create (/home/kurt/Desktop/test/index.js:10:18)
```

**After**
```
Error: Invalid starter id "bases". It can only be one of "basic", "base", "documentation-site", "library".
    at jt (/home/kurt/Desktop/test/node_modules/create-qwik/index.cjs:118:2335)
    at async create (/home/kurt/Desktop/test/index.js:10:18)
```


# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
