### PR TITLE
docs: typo

### DIFF
--- a/packages/docs/src/routes/qwikcity/layout/grouped/index.mdx
+++ b/packages/docs/src/routes/qwikcity/layout/grouped/index.mdx
@@ -10,7 +10,7 @@ Common purpose routes are often placed into directories so they can share layout
 
 By prefixing any directory name with two underscores `__`, then the directory name itself will not be included in the URL pathname.
 
-For example, let's say an app placed all accounts routes together in a directory, however, `/account/` could be dropped from the URL for cleaner, shorter URLs. In the example below, notice that the paths are within `src/routes/__accounts/` directory. However, the URL paths exclude `__accounts/`.
+For example, let's say an app placed all accounts routes together in a directory, however, `/accounts/` could be dropped from the URL for cleaner, shorter URLs. In the example below, notice that the paths are within `src/routes/__accounts/` directory. However, the URL paths exclude `__accounts/`.
 
 ```
 src/


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fix typo in QwikCity grouped layouts: `/account/` -> `/accounts/`

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
