### PR TITLE
Remove emotion from qwik-react

### DIFF
--- a/packages/qwik-react/package.json
+++ b/packages/qwik-react/package.json
@@ -19,9 +19,6 @@
   },
   "devDependencies": {
     "@builder.io/qwik": "workspace:*",
-    "@emotion/react": "11.10.4",
-    "@emotion/server": "11.10.0",
-    "@emotion/styled": "11.10.4",
     "@mui/material": "5.10.9",
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",
@@ -32,9 +29,6 @@
   },
   "peerDependencies": {
     "@builder.io/qwik": ">=0.0.38",
-    "@emotion/react": ">=11.9.0",
-    "@emotion/server": ">=11.4.0",
-    "@emotion/styled": ">=11.9.3",
     "@types/react": ">=18.0.1",
     "@types/react-dom": ">=18.0.0",
     "react": ">=18.0.0",

--- a/packages/qwik-react/src/react/client.tsx
+++ b/packages/qwik-react/src/react/client.tsx
@@ -1,15 +1,6 @@
-/** @jsxImportSource @emotion/react */
-import { CacheProvider } from '@emotion/react';
-import createCache from '@emotion/cache';
-
-const key = 'css';
-const cache = createCache({ key });
-
 const Cmp = ({ Cmp, ev, ...props }: any) => {
   return (
-    <CacheProvider value={cache}>
       <Cmp {...props} />
-    </CacheProvider>
   );
 };
 

--- a/packages/qwik-react/src/react/server.tsx
+++ b/packages/qwik-react/src/react/server.tsx
@@ -1,27 +1,10 @@
-/** @jsxImportSource @emotion/react */
-
-import { CacheProvider } from '@emotion/react';
 import { renderToString } from 'react-dom/server';
-import createEmotionServer from '@emotion/server/create-instance';
-import createCache from '@emotion/cache';
 export { createElement } from 'react';
 export { renderToString } from '@builder.io/qwik/server';
 
-const key = 'css';
-const cache = createCache({ key });
-export const { extractCriticalToChunks, constructStyleTagsFromChunks } = createEmotionServer(cache);
-
-export function getGlobalStyleTag(html: string) {
-  const chunks = extractCriticalToChunks(html);
-  const style = constructStyleTagsFromChunks(chunks);
-  return style;
-}
-
 export function render(App: any, props: any) {
   const html = renderToString(
-    <CacheProvider value={cache}>
       <App {...props} />
-    </CacheProvider>
   );
 
   return html;

--- a/packages/qwik-react/src/server/index.ts
+++ b/packages/qwik-react/src/server/index.ts
@@ -16,11 +16,9 @@ export async function renderToString(
   // Pass in the manifest that was generated from the client build
   const mod = await import('../react/server');
   const result = await mod.renderToString(rootNode, opts);
-  const styles = mod.getGlobalStyleTag(result.html);
-  const finalHtml = result.html.replace('</head>', styles + '</head>');
   return {
     ...result,
-    html: finalHtml,
+    html: result.html,
   };
 }
 

--- a/packages/qwik-react/src/vite/index.ts
+++ b/packages/qwik-react/src/vite/index.ts
@@ -1,7 +1,7 @@
 export function qwikReact(): any {
-  const OPTIMIZE_DEPS = ['react', 'react-dom/client', 'hoist-non-react-statics', '@emotion/react'];
+  const OPTIMIZE_DEPS = ['react', 'react-dom/client', 'hoist-non-react-statics'];
 
-  const DEDUPE = ['react', 'react-dom', '@emotion/react'];
+  const DEDUPE = ['react', 'react-dom'];
 
   return {
     name: 'vite-plugin-qwik-react',

--- a/packages/qwik-react/vite.config.ts
+++ b/packages/qwik-react/vite.config.ts
@@ -13,12 +13,6 @@ export default defineConfig(() => {
       },
       rollupOptions: {
         external: [
-          '@emotion/server',
-          '@emotion/cache',
-          '@emotion/core',
-          '@emotion/react',
-          '@emotion/react/jsx-runtime',
-          '@emotion/server/create-instance',
           'react/jsx-runtime',
           'react',
           'react-dom/client',


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

This removes the @emotion dependencies from qwik-react.

# Use cases and why

qwik-react should not dictate any specific CSS-in-JS style library and it is not needed in order to get react components to render in Qwik.

By proxy it also fixes: https://github.com/BuilderIO/qwik/issues/1508 but only because there's an import related bug with emotion (unrelated to the idea of removing it entirely from qwik-react).

I'm guessing this change is going to require additional work as it would likely break imports of react components using emotion CSS. I believe there should be another plugin or package to solve that issue though, rather than solving it inside qwik-react. I don't use emotionCSS and have not actually tested what happens when you import a React component that does use it. But I'm hoping to at least start the discussion that this particular CSS in JS solution doesn't belong in the `qwik-react` package, and hopefully figure out where (if anywhere) it does belong.

I'd be happy to help develop that solution as well, but I'm assuming there's a reason it was put in here in the first place, so I would love to hear what that reason was and maybe I am entirely wrong about this. 🙏

I started a discussion here as well: https://github.com/BuilderIO/qwik/discussions/1719 But they don't seem to get much attention.

# Checklist:

- [X] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
