### PR TITLE
UI: Improve Mobile Header Layout

### DIFF
--- a/packages/docs/src/components/header/header.css
+++ b/packages/docs/src/components/header/header.css
@@ -43,7 +43,7 @@ header li a:hover svg {
 header .mobile-menu {
   position: absolute;
   right: 0;
-  @apply p-3 md:hidden;
+  @apply p-5 md:hidden;
 }
 
 header ul {
@@ -62,6 +62,10 @@ header .close-icon {
 }
 
 @media (max-width: 767px) {
+  .header-container {
+    padding-top: 5px;
+  }
+
   .header-open header ul {
     position: absolute;
     z-index: 10;
@@ -78,6 +82,10 @@ header .close-icon {
 
   .header-open header .close-icon {
     display: block;
+  }
+
+  .header-open .menu-toolkit li {
+    text-align: center;
   }
 }
 

--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -73,7 +73,7 @@ html {
 @media (max-width: 768px) {
   html {
     --panel-toggle-height: 56px;
-    --header-height: 70px;
+    --header-height: 80px;
   }
 }
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Improve mobile user interface in mobile screens.

# Use cases and why

- Before (iPhone 14 Pro Max)
 <span>
<img width="466" alt="Screen Shot 2022-10-16 at 6 17 28 PM" src="https://user-images.githubusercontent.com/4918140/196030053-24fc2e0c-fbd5-4ae1-82f2-cbc974a203f2.png">
<img width="467" alt="Screen Shot 2022-10-16 at 6 18 11 PM" src="https://user-images.githubusercontent.com/4918140/196030097-902ab0ca-8072-4f0b-9d81-2cd574596c99.png">
<img width="469" alt="Screen Shot 2022-10-16 at 6 22 34 PM" src="https://user-images.githubusercontent.com/4918140/196030182-5be53e8b-f287-4d1e-813a-24978479b85d.png">

</span>

- After

<img width="470" alt="Screen Shot 2022-10-16 at 6 24 23 PM" src="https://user-images.githubusercontent.com/4918140/196030313-30ceeab2-85f4-45c7-a828-5ad6a60eb611.png">
<img width="474" alt="Screen Shot 2022-10-16 at 6 25 10 PM" src="https://user-images.githubusercontent.com/4918140/196030318-d093638c-8026-4be5-b830-311837abe75b.png">
<img width="476" alt="Screen Shot 2022-10-16 at 6 25 40 PM" src="https://user-images.githubusercontent.com/4918140/196030319-e721c9f9-c4cf-474c-ab3a-b2577d016484.png">

- Desktop and tablet Retesting
![Screen Shot 2022-10-16 at 6 29 11 PM](https://user-images.githubusercontent.com/4918140/196030436-f12063c4-778a-4daf-966f-79ab624ab735.png)
![Screen Shot 2022-10-16 at 6 30 26 PM](https://user-images.githubusercontent.com/4918140/196030486-d0a9838b-23d8-438b-b33d-b715496873b9.png)

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
