### PR TITLE
fix(eslint): runtime error for empty modules

### DIFF
--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -226,6 +226,7 @@ test('valid-lexical-scope', () => {
     }}></div>;
   });
       `,
+      ``,
     ],
     invalid: [
       {

--- a/packages/eslint-plugin-qwik/src/validLexicalScope.ts
+++ b/packages/eslint-plugin-qwik/src/validLexicalScope.ts
@@ -188,7 +188,17 @@ export const validLexicalScope = createRule({
       },
       Program(node) {
         const module = esTreeNodeToTSNodeMap.get(node);
-        exports = typeChecker.getExportsOfModule(typeChecker.getSymbolAtLocation(module)!);
+        const moduleSymbol = typeChecker.getSymbolAtLocation(module);
+
+        /**
+         * Despite what the type signature says,
+         * {@link typeChecker.getSymbolAtLocation} can return undefined for
+         * empty modules. This happens, for example, when creating a brand new
+         * file.
+         */
+        if (moduleSymbol) {
+          exports = typeChecker.getExportsOfModule(moduleSymbol);
+        }
       },
       'Program:exit'() {
         walkScope(scopeManager.globalScope! as any);


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug (fix)
- [x] Docs / tests

# Description

The `typeChecker.getSymbolAtLocation` method returns `undefined` for empty modules, despite what the type signature of that method says. Passing that `undefined` value to `typeChecker.getExportsOfModule` leads to a runtime error (trying to access `undefined.flags`). I added a unit test to catch that case.

![image](https://user-images.githubusercontent.com/889383/196040433-065959c7-f05c-4614-a202-d26000f476f1.png)

Calling `typeChecker.getExportsOfModule` conditionally fixes the error.

# Use cases and why

I found this problem while creating new files in Neovim with ESLint configured. I constantly got ESLint popups saying that there was an error linting the file, even though the file was empty. It was so frustrating that I decided to do the fix myself. I believe the same thing happens in VSCode, but VSCode does not show any ESLint popups if there are errors.


https://user-images.githubusercontent.com/889383/196040727-981a1603-75fc-40c1-b842-89ff2215d157.mp4



Running `yarn lint` before this fix while having an empty file in the project:

![image](https://user-images.githubusercontent.com/889383/196040592-c0e567ce-aebe-4b9d-98d1-71df14a6f1fe.png)

Running `yarn lint` after this fix:

![image](https://user-images.githubusercontent.com/889383/196040621-b879e4c9-4e6a-4989-8565-43ed6b650ae6.png)


# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation **N/A**
- [x] Added new tests to cover the fix / functionality
