### PR TITLE
feat: Add device's homescreen

### DIFF
--- a/starters/apps/base/public/manifest.json
+++ b/starters/apps/base/public/manifest.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/web-manifest-combined.json",
+  "name": "qwik-project-name",
+  "short_name": "Welcome to Qwik",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#fff",
+  "description": "A Qwik project app."
+}

--- a/starters/apps/basic/src/root.tsx
+++ b/starters/apps/basic/src/root.tsx
@@ -15,6 +15,7 @@ export default component$(() => {
     <QwikCity>
       <head>
         <meta charSet="utf-8" />
+        <link rel="manifest" href="manifest.json" />
         <RouterHead />
       </head>
       <body lang="en">

--- a/starters/apps/basic/src/root.tsx
+++ b/starters/apps/basic/src/root.tsx
@@ -15,7 +15,7 @@ export default component$(() => {
     <QwikCity>
       <head>
         <meta charSet="utf-8" />
-        <link rel="manifest" href="manifest.json" />
+        <link rel="manifest" href="/manifest.json" />
         <RouterHead />
       </head>
       <body lang="en">


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement

# Description

You have to add a `manifest.json` file to use a Qwik project like a native mobile app. That's all to show Qwik in fullscreen when added to the device's homescreen.

# Use cases and why

- Prepared for PWA

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

Mobile context menu in the browser to add a Qwik App to the device's homescreen:
<img src="https://user-images.githubusercontent.com/20791239/196044780-09e1a6f4-bf9e-46d0-9b83-9b7b447596ce.jpg" width="200" />

Icon on device's homescreen:
<img src="https://user-images.githubusercontent.com/20791239/196202902-de28ea6b-f7ea-4632-a94c-81faecfdb63b.jpg" width="280" />
---

Before - Without a manifest a Qwik App shows the browser window:
<img src="https://user-images.githubusercontent.com/20791239/196044874-6e57e879-eacc-4778-a3a3-f7785a974a58.jpg" width="280" />
---

After - With a manifest.json it shown like a native app:
<img src="https://user-images.githubusercontent.com/20791239/196044998-67cd525a-757b-4637-9ee1-04dce90a631c.jpg" width="280" />
---

Reference see https://developer.mozilla.org/en-US/docs/Web/Manifest
