### PR TITLE
docs: typo

### DIFF
--- a/packages/docs/src/routes/qwikcity/routing/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/overview/index.mdx
@@ -31,7 +31,7 @@ src/
 
 Note that the leaf file at the end of the route is named index. This is **important**. In other meta-frameworks you may be familiar with, there is a distinction made between `pages` and `data endpoints` or `API routes`. In Qwik City, there is no distinction, they are all `endpoints`.
 
-To define an endpoint, you must a define an `index.[filetype]` where [filetype] can be one of `.ts`, `.tsx`, `.js`, `.jsx`, `.md`, or `.mdx`.
+To define an endpoint, you must define an `index.[filetype]` where [filetype] can be one of `.ts`, `.tsx`, `.js`, `.jsx`, `.md`, or `.mdx`.
 
 While the following directory structure:
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fix typo: `you must a define` -> `you must define` in Qwik City/Routing/Overview section.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
