### PR TITLE
docs: updated example urls

### DIFF
--- a/packages/docs/src/routes/qwikcity/static-assets/index.mdx
+++ b/packages/docs/src/routes/qwikcity/static-assets/index.mdx
@@ -15,7 +15,7 @@ All static assets are served from your server's root (`/` as in `https://example
 
 ```
 public/
-├── favicon.ico           # http://localhost:3002/favicon.ico
+├── favicon.ico           # https://example.com/favicon.ico
 └── images/
-    └── logo.png          # http://localhost:3002/images/logo.png
+    └── logo.png          # https://example.com/images/logo.png
 ```


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

changed : `http://localhost:3002/favicon.ico` -> `https://example.com/favicon.ico`

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
