### PR TITLE
fix(head): expose frontmatter into runtime head

### DIFF
--- a/packages/qwik-city/runtime/src/library/head.ts
+++ b/packages/qwik-city/runtime/src/library/head.ts
@@ -44,6 +44,7 @@ const resolveDocumentHead = (
   mergeArray(resolvedHead.meta, updatedHead.meta);
   mergeArray(resolvedHead.links, updatedHead.links);
   mergeArray(resolvedHead.styles, updatedHead.styles);
+  Object.assign(resolvedHead.frontmatter, updatedHead.frontmatter);
 };
 
 const mergeArray = (existingArr: { key?: string }[], newArr: { key?: string }[] | undefined) => {

--- a/packages/qwik-city/runtime/src/library/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/library/qwik-city-component.tsx
@@ -128,6 +128,7 @@ export const QwikCity = component$<QwikCityProps>(() => {
       documentHead.meta = resolvedHead.meta;
       documentHead.styles = resolvedHead.styles;
       documentHead.title = resolvedHead.title;
+      documentHead.frontmatter = resolvedHead.frontmatter;
 
       if (isBrowser) {
         clientNavigate(window, routeNavigate);


### PR DESCRIPTION
fixes #1762

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

The additional frontmatter attributes weren't correctly propagated to the `head` context used in the Qwick city runtime.

This PR adds the missing propagation of the `frontmatter` property that was generated during buildtime to the runtime.

# Use cases and why

When using the `useDocumentHead` from markdown routes, additional attributes found in the frontmatter should be correctly exposed into the `frontmatter` property.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
