### PR TITLE
Update the required node version

### DIFF
--- a/packages/docs/src/routes/docs/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/getting-started/index.mdx
@@ -15,7 +15,7 @@ Qwik is a new kind of framework that is [resumable](../concepts/resumable/index.
 
 ## Prerequisites
 
-- [node.js v14](https://nodejs.org/en/download/) or higher
+- [node.js v16](https://nodejs.org/en/download/) or higher
 - Your favorite IDE ([vscode](https://code.visualstudio.com/) recommended)
 - Start to [think qwik](../think-qwik/index.mdx)
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

According to the docs, running the command `npm create qwik@latest` on node 14 should create a new Qwik application. Currently the latest version require node.js v16 as per the message shown below:

```bash
Qwik requires Node.js 16 or higher. You are currently running Node.js v14.17.6.
npm ERR! code 1
npm ERR! path /
npm ERR! command failed
npm ERR! command sh -c create-qwik

npm ERR! A complete log of this run can be found in:
npm ERR!     ~/.npm/_logs/debug-0.log
```

This change addresses the version change in the documentation.
