### PR TITLE
fix: docs monaco editor suggestion position weird

### DIFF
--- a/packages/docs/src/repl/monaco.tsx
+++ b/packages/docs/src/repl/monaco.tsx
@@ -304,7 +304,6 @@ const getUri = (monaco: Monaco, filePath: string) => {
 
 const defaultEditorOpts: IStandaloneEditorConstructionOptions = {
   automaticLayout: true,
-  fixedOverflowWidgets: true,
   lineDecorationsWidth: 5,
   lineNumbersMinChars: 3,
   minimap: { enabled: false },

--- a/packages/docs/src/repl/repl.css
+++ b/packages/docs/src/repl/repl.css
@@ -30,7 +30,6 @@
   left: 0;
   width: 100%;
   height: calc(100% - var(--repl-tab-height));
-  overflow: auto;
 }
 
 .repl-input-panel {


### PR DESCRIPTION
fix #1732

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

I remove the Monaco-Editor editor fixedOverflowWidgets param to fix the suggestion position weird.
The above operation cannot see all suggestions, So remove `packages/docs/src/repl/repl.css` L33 to make suggestions can see all.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- 1. [docs](https://qwik.builder.io/examples/introduction/hello-world/) write code show suggestion is weird / refer playground show correct suggestion position.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
