### PR TITLE
ui: fix header font size

### DIFF
--- a/packages/docs/src/routes/docs/docs.css
+++ b/packages/docs/src/routes/docs/docs.css
@@ -4,6 +4,7 @@
 }
 
 .docs .docs-container {
+  overflow: hidden;
   @apply pt-[80px];
   @apply px-8;
 
@@ -111,7 +112,7 @@
 
 .docs article h2 {
   line-height: 1.2;
-  font-size: 48px;
+  font-size: 30px;
   font-weight: 800;
   scroll-margin-top: var(--scroll-margin-top);
   margin-top: 70px;
@@ -249,12 +250,19 @@ h6 a:hover .icon {
   overflow: hidden;
 }
 
+.docs main.no-right-menu .on-this-page {
+  display: none;
+}
+
 @media (min-width: 1280px) {
   .docs main.no-right-menu .docs-container {
     margin-right: 6rem;
   }
 }
 
-.docs main.no-right-menu .on-this-page {
-  display: none;
+@media (max-width: 768px) {
+  .docs article h2 {
+    font-size: 1.2rem;
+    margin-top: 2rem;
+  }
 }


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
Improve headers font sizes on desktop and mobile.

# Use cases and why

<!-- Actual / expected behaviour if it's a bug -->

- Before
- ![Screen Shot 2022-10-17 at 3 47 17 PM](https://user-images.githubusercontent.com/4918140/196118980-3cb2c405-ac03-4c48-9ac3-3ac163164451.png)
![Screen Shot 2022-10-17 at 3 47 00 PM](https://user-images.githubusercontent.com/4918140/196118966-118a6acb-7cdc-4b54-9f9b-68bd80b0426a.png)


- After
![Screen Shot 2022-10-17 at 3 45 37 PM](https://user-images.githubusercontent.com/4918140/196118721-1c13563e-3228-45d1-9083-2b0b51dd9cd5.png)
![Screen Shot 2022-10-17 at 3 42 55 PM](https://user-images.githubusercontent.com/4918140/196118731-f069e9f9-1d9a-4a89-9520-7cb979b7a649.png)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
