### PR TITLE
fix: Partytown Snippet inner html

### DIFF
--- a/starters/features/partytown/src/components/partytown/partytown.tsx
+++ b/starters/features/partytown/src/components/partytown/partytown.tsx
@@ -14,6 +14,5 @@ export interface PartytownProps extends PartytownConfig {}
  * You can pass setting with props
  */
 export const QwikPartytown = (props: PartytownProps): any => {
-  const innerHTML = partytownSnippet(props);
-  return <script dangerouslySetInnerHTML>{innerHTML}</script>;
+  return <script dangerouslySetInnerHTML={partytownSnippet(props)} />;
 };


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Per a discussion with a user on discord, the Partytown component in the cli sets the Partytown snippet in the script body instead of in dangerouslySetInnerHTML. This was preventing Partytown from working.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
