### PR TITLE
remove `preventDefault()` from event type

### DIFF
--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -7,11 +7,8 @@ interface BaseSyntheticEvent<E = object, C = any, T = any> {
   target: T;
   bubbles: boolean;
   cancelable: boolean;
-  defaultPrevented: boolean;
   eventPhase: number;
   isTrusted: boolean;
-  preventDefault(): void;
-  isDefaultPrevented(): boolean;
   stopPropagation(): void;
   isPropagationStopped(): boolean;
   persist(): void;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

I realized that the event type should not have `preventDefault` on it due to https://qwik.builder.io/docs/components/events/#prevent-default
