### PR TITLE
Remove reference to Vercel until it's available

### DIFF
--- a/starters/apps/base/README.md
+++ b/starters/apps/base/README.md
@@ -33,7 +33,7 @@ Inside your project, you'll see the following directory structure:
 
 ## Add Integrations
 
-Use the `npm run qwik add` command to add additional integrations. Some examples of integrations include: Cloudflare, Netlify or Vercel server, and the [Static Site Generator (SSG)](https://qwik.builder.io/qwikcity/static-site-generation/static-site-config/).
+Use the `npm run qwik add` command to add additional integrations. Some examples of integrations include: Cloudflare, Netlify or Express server, and the [Static Site Generator (SSG)](https://qwik.builder.io/qwikcity/static-site-generation/static-site-config/).
 
 ```shell
 npm run qwik add # or `yarn qwik add`


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The ReadMe in the starter projects mentions a Vercel adaptor that doesn't actually exist. I think we should remove it for now because it is confusing and frustrating people when they can not find it in the CLI. We can add it back once a Vercel integration exists.

I changed the Vercel reference to Express for now.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
