### PR TITLE
fix: default ctrl + k search event.

### DIFF
--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -1,5 +1,5 @@
 import type { SearchClient } from 'algoliasearch/lite';
-import { component$, useStore, useStyles$, useRef } from '@builder.io/qwik';
+import { component$, useStore, useStyles$, useRef, useClientEffect$, $ } from '@builder.io/qwik';
 import type { DocSearchHit, InternalDocSearchHit, StoredDocSearchHit } from './types';
 import { ButtonTranslations, DocSearchButton } from './doc-search-button';
 import { DocSearchModal, ModalTranslations } from './doc-search-modal';
@@ -39,7 +39,7 @@ export interface DocSearchProps {
   translations?: DocSearchTranslations;
 }
 
-export function isEditingContent(event: QwikKeyboardEvent<HTMLElement>): boolean {
+export function isEditingContent(event: QwikKeyboardEvent<HTMLDivElement>): boolean {
   const element = event.currentTarget;
   const tagName = element.tagName;
 
@@ -72,42 +72,49 @@ export const DocSearch = component$((props: DocSearchProps) => {
 
   const searchButtonRef = useRef();
 
+  useClientEffect$(() => {
+    const onKeyDown = $((event: QwikKeyboardEvent<HTMLDivElement>) => {
+      const checkOpen = $(() => {
+        // We check that no other DocSearch modal is showing before opening
+        // another one.
+        if (!document.body.classList.contains('DocSearch--active')) {
+          state.isOpen = true;
+        }
+      });
+
+      if (
+        (event.keyCode === 27 && state.isOpen) ||
+        // The `Cmd+K` shortcut both opens and closes the modal.
+        (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
+        // The `/` shortcut opens but doesn't close the modal because it's a character.
+        (!isEditingContent(event) && event.key === '/' && !state.isOpen)
+      ) {
+        event.preventDefault();
+
+        if (state.isOpen) {
+          state.isOpen = false;
+        } else if (!document.body.classList.contains('DocSearch--active')) {
+          checkOpen();
+        }
+      }
+
+      if (searchButtonRef && searchButtonRef.current === document.activeElement) {
+        if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
+          state.isOpen = true;
+          state.initialQuery = event.key;
+        }
+      }
+    });
+
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => window.removeEventListener('keydown', onKeyDown);
+  });
+
+
   return (
     <div
-      class="docsearch"
-      window:onKeyDown$={(event) => {
-        function open() {
-          // We check that no other DocSearch modal is showing before opening
-          // another one.
-          if (!document.body.classList.contains('DocSearch--active')) {
-            state.isOpen = true;
-          }
-        }
-        if (
-          (event.key === 'Escape' && state.isOpen) ||
-          // The `Cmd+K` shortcut both opens and closes the modal.
-          (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
-          // The `/` shortcut opens but doesn't close the modal because it's
-          // a character.
-          (!isEditingContent(event) && event.key === '/' && !state.isOpen)
-        ) {
-          // FIXME: not able to prevent
-          // event.preventDefault();
-
-          if (state.isOpen) {
-            state.isOpen = false;
-          } else if (!document.body.classList.contains('DocSearch--active')) {
-            open();
-          }
-        }
-
-        if (searchButtonRef && searchButtonRef.current === document.activeElement) {
-          if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
-            state.isOpen = true;
-            state.initialQuery = event.key;
-          }
-        }
-      }}
+      className="docsearch"
     >
       <DocSearchButton
         ref={searchButtonRef}

--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -111,11 +111,8 @@ export const DocSearch = component$((props: DocSearchProps) => {
     return () => window.removeEventListener('keydown', onKeyDown);
   });
 
-
   return (
-    <div
-      className="docsearch"
-    >
+    <div className="docsearch">
       <DocSearchButton
         ref={searchButtonRef}
         onClick$={() => {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

on `CTRL + K` it should prevent default browser event and open the search box.

# Use cases and why

Actual Behavior:
![actual](https://user-images.githubusercontent.com/80447788/197412761-3be90ae1-e3e7-43a0-8cb5-5adb96f3c89e.jpg)

Expected Behavior:
![expected](https://user-images.githubusercontent.com/80447788/197413729-89a9cf97-e021-4991-81ab-588fd0dc2894.jpg)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
