### PR TITLE
feat: deprecate `preventDefault()`

### DIFF
--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -3,8 +3,24 @@ export interface SyntheticEvent<T = Element, E = Event>
 
 interface BaseSyntheticEvent<E = object, C = any, T = any> {
   nativeEvent: E;
+  /**
+   * @deprecated 
+   * 
+   * Qwik cannot reliably capture `event.currentTarget`
+   * 
+   * Instead, you can use `event.target`
+   * 
+   * or 
+   * 
+   * ```tsx
+   * onClick$={(event, currentEvent) => {
+   * // use currentEvent here
+   * }}
+   * ``` 
+   * 
+   */
   currentTarget: C;
-  target: T;
+  target: C;
   bubbles: boolean;
   cancelable: boolean;
   eventPhase: number;
@@ -26,7 +42,7 @@ interface BaseSyntheticEvent<E = object, C = any, T = any> {
    *  onClick$={(event) => {
    *    // event.preventDefault() would not work here
    *    // because of Qwik's async nature
-   *    trackAnalyticsEvent(event.currentTarget)
+   *    trackAnalyticsEvent(event.target)
    *    singlePageNavigate('/about');
    *  }}
    * >

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -12,6 +12,27 @@ interface BaseSyntheticEvent<E = object, C = any, T = any> {
   stopPropagation(): void;
   isPropagationStopped(): boolean;
   persist(): void;
+   /**
+   * @deprecated Qwik does not allow `preventDefault()`.
+   * Add a `preventdefault:{event}` attribute to the element instead.
+   * 
+   * @see https://qwik.builder.io/docs/components/events/#prevent-default
+   * 
+   * @example
+   * <a
+      href="/about"
+      preventdefault:click // This will prevent the default behavior of the "click" event.
+      onClick$={(event) => {
+        // event.preventDefault() would not work here
+        // because of Qwik's async nature
+        trackAnalyticsEvent(event.currentTarget)
+        singlePageNavigate('/about');
+      }}
+    >
+      About
+    </a>
+   */
+  preventDefault(): void;
   timeStamp: number;
   type: string;
 }

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -12,12 +12,12 @@ interface BaseSyntheticEvent<E = object, C = any, T = any> {
   stopPropagation(): void;
   isPropagationStopped(): boolean;
   persist(): void;
-   /**
+  /**
    * @deprecated Qwik does not allow `preventDefault()`.
    * Add a `preventdefault:{event}` attribute to the element instead.
-   * 
+   *
    * @see https://qwik.builder.io/docs/components/events/#prevent-default
-   * 
+   *
    * @example
    * ```tsx
    * <a

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -19,18 +19,20 @@ interface BaseSyntheticEvent<E = object, C = any, T = any> {
    * @see https://qwik.builder.io/docs/components/events/#prevent-default
    * 
    * @example
+   * ```tsx
    * <a
-      href="/about"
-      preventdefault:click // This will prevent the default behavior of the "click" event.
-      onClick$={(event) => {
-        // event.preventDefault() would not work here
-        // because of Qwik's async nature
-        trackAnalyticsEvent(event.currentTarget)
-        singlePageNavigate('/about');
-      }}
-    >
-      About
-    </a>
+   *  href="/about"
+   *  preventdefault:click // This will prevent the default behavior of the "click" event.
+   *  onClick$={(event) => {
+   *    // event.preventDefault() would not work here
+   *    // because of Qwik's async nature
+   *    trackAnalyticsEvent(event.currentTarget)
+   *    singlePageNavigate('/about');
+   *  }}
+   * >
+   *  About
+   *</a>
+   * ```
    */
   preventDefault(): void;
   timeStamp: number;


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Instead of removing `preventDefault()` from the event type entirely, this will provide guidance on how to achieve the intended result by using the `preventdefault:{event}` attribute

# Screenshot

![image](https://user-images.githubusercontent.com/18399089/197416574-1617d76f-ebd2-4c7a-82b6-63def854e734.png)
