### PR TITLE
docs: expand explanation of the purpose of persisting un-projected content

### DIFF
--- a/packages/docs/src/routes/docs/components/projection/index.mdx
+++ b/packages/docs/src/routes/docs/components/projection/index.mdx
@@ -179,7 +179,7 @@ Results in:
 </my-app>
 ```
 
-Notice that the un-projected content is moved into inert `<q:template>`. This is done just in case the `Project` component re-renders and inserts a `<Slot>`. In that case, we don't want to re-render the parent component. The rendering of the two components needs to stay independent.
+Notice that the un-projected content is moved into an inert `<q:template>`. This is done just in case the `Project` component re-renders and inserts a `<Slot>`. In that case, we don't want to have to re-render the parent component just to generate the projected content. By persisting the un-projected content when the parent is initially rendered, the rendering of the two components can stay independent.
 
 ### Default slot content
 


### PR DESCRIPTION

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

I found the existing explanation a little unclear

# Use cases and why

N/A

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
