### PR TITLE
docs: improve the presentation of the example

### DIFF
--- a/packages/docs/src/routes/tutorial/welcome/overview/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/welcome/overview/problem/app.tsx
@@ -7,6 +7,7 @@ export const App = component$(() => {
       I am a static component, there is no reason to ever download me to the client.
       <br />
       <button onClick$={() => alert('Hello')}>greet!</button>
+      <hr />
       <Counter />
     </>
   );
@@ -20,6 +21,7 @@ export const Counter = component$(() => {
       user clicks on the <tt>+1</tt> button.
       <br />
       Current count: {store.count}
+      <br />
       <button onClick$={() => store.count++}>+1</button>
     </>
   );

--- a/packages/docs/src/routes/tutorial/welcome/overview/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/welcome/overview/solution/app.tsx
@@ -9,6 +9,7 @@ export const App = component$(() => {
       Qwik will never download me to the client. I am only rendered on the server.
       <br />
       <button onClick$={() => alert('Hello')}>greet!</button>
+      <hr />
       <Counter />
     </>
   );
@@ -22,6 +23,7 @@ export const Counter = component$(() => {
       user clicks on the <tt>+1</tt> button.
       <br />
       Current count: {store.count}
+      <br />
       <button onClick$={() => store.count++}>+1</button>
     </>
   );


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

In the first tutorial ([Welcome](https://qwik.builder.io/tutorial/welcome/overview/)), the example describes 2 components, one is static and the other is dynamic. Visually, it is not obvious to see the separation of the two.

Here is a proposal to make it easier to see.

Before:
![image](https://user-images.githubusercontent.com/163352/197744524-827516ac-4427-4986-84ed-f6110794d884.png)

After:
![image](https://user-images.githubusercontent.com/163352/197744583-377ac6b7-0433-42f1-ba4b-6b1c481d3925.png)


# Use cases and why

Nope

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
