### PR TITLE
Create settings.json

### DIFF
--- a/starters/features/tailwind/.vscode/settings.json
+++ b/starters/features/tailwind/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "css.lint.unknownAtRules": "ignore",
+}


### PR DESCRIPTION
Setting for vscode to ignore `@tailwind utilities;` CSS validation errors

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

When you add tailwind you will get some warnings on "unknown at rules" 
![image](https://user-images.githubusercontent.com/468006/198134953-d22751a6-c1f8-44f0-9b4a-6da24b8677ae.png)

This simple vscode setting will disable such warnings

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
