### PR TITLE
TUTORIAL: fix minor typo in prop name (Passing closures)

### DIFF
--- a/packages/docs/src/routes/tutorial/props/closures/index.mdx
+++ b/packages/docs/src/routes/tutorial/props/closures/index.mdx
@@ -58,7 +58,7 @@ Creating a new callback for `<button>` and internally invoking the callback QRL.
 ```jsx
 <button
   onClick$={async () => {
-    await props.helloQrl?.invoke('World');
+    await props.hello$?.invoke('World');
   }}
 >
   hello


### PR DESCRIPTION
# What is it?

- [ x ] Docs / tests

# Description

Tutorial: "[Passing closures](https://qwik.builder.io/tutorial/props/closures/)".
Typo: In the last example when internally invoking the callback QRL, the callback name is not the same specified in MyComponentProps interface.

# Use cases and why

Expected: The name of the callback QRL is the same specified in interface MyComponentProps: `hello$`
Actual: The name of the callback QRL is `helloQrl`, which is not the same specified in interface MyComponentProps

# Checklist:

- [ x ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ x ] I have performed a self-review of my own code
- [ n/a ] I have made corresponding changes to the documentation
- [ n/a ] Added new tests to cover the fix / functionality
