### PR TITLE
docs: restoring correct display of docs-container

### DIFF
--- a/packages/docs/src/routes/docs/docs.css
+++ b/packages/docs/src/routes/docs/docs.css
@@ -4,7 +4,6 @@
 }
 
 .docs .docs-container {
-  overflow: hidden;
   @apply pt-[80px];
   @apply px-8;
 


### PR DESCRIPTION
overflow: hidden on docs-container caused clipping elements outline and # signs next to the headers on hover and focus

fix #1916 re #1808

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

There was `overflow: hidden` on `.docs-container`. This property couses few problems with proper content display. 
Overflow was unnecessarily added in #1808 

# Use cases and why

1. Trimming outline
    before:
    <img width="341" alt="Screenshot 2022-10-29 at 21 32 27" src="https://user-images.githubusercontent.com/20875935/198849568-92458bde-6e7b-4772-bceb-ad108a3e817e.png">


    now:
    <img width="323" alt="Screenshot 2022-10-29 at 21 32 37" src="https://user-images.githubusercontent.com/20875935/198849588-53e34b7a-9179-4edc-877f-e63684aea5f1.png">

2. Trimming # in headers on hover
    hover before:
    <img width="337" alt="Screenshot 2022-10-29 at 21 34 47" src="https://user-images.githubusercontent.com/20875935/198849673-645620ea-18c2-4124-8d76-c40790819d23.png">


    hover now:
    <img width="330" alt="Screenshot 2022-10-29 at 21 34 41" src="https://user-images.githubusercontent.com/20875935/198849692-f60468c0-e894-4822-a824-2a3b4bb8eea8.png">



# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
