### PR TITLE
docs: restore proper event target in isEditingContent function

### DIFF
--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -40,15 +40,9 @@ export interface DocSearchProps {
 }
 
 export function isEditingContent(event: QwikKeyboardEvent<HTMLElement>): boolean {
-  const element = event.currentTarget;
-  const tagName = element.tagName;
+  const { isContentEditable, tagName } = event.target;
 
-  return (
-    element.isContentEditable ||
-    tagName === 'INPUT' ||
-    tagName === 'SELECT' ||
-    tagName === 'TEXTAREA'
-  );
+  return isContentEditable || tagName === 'INPUT' || tagName === 'SELECT' || tagName === 'TEXTAREA';
 }
 
 export const DocSearch = component$((props: DocSearchProps) => {

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -42,6 +42,6 @@
 
 ## Community
 
-- [Github](https://github.com/BuilderIO/qwik)
+- [GitHub](https://github.com/BuilderIO/qwik)
 - [@QwikDev](https://twitter.com/QwikDev)
 - [Discord](https://qwik.builder.io/chat)


### PR DESCRIPTION
'event.currentTarget' points to null in most cases. Changed to 'event.target'. Also, this commit fix one typo

fix #1896 re #1827 re #1919

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

 Typing '/' inside textareas, inputs etc. triggers the search modal. Problem was that someone change `event.target` to `event.currentTarget` in #1827 . I just restore `event.target`.

I also fix one type in 'Github' -> 'GitHub' missed in #1919 

# Use cases and why

There was console error on official page, when you hit '/' inside monaco editor:
<img width="747" alt="Screenshot 2022-10-30 at 13 05 57" src="https://user-images.githubusercontent.com/20875935/198877548-37b08f59-b344-486b-b7f4-f89fb498f04f.png">


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
