### PR TITLE
docs: qwik-city added `groups` to routing docs

### DIFF
--- a/packages/docs/src/routes/qwikcity/routing/route-parameters/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/route-parameters/index.mdx
@@ -80,3 +80,25 @@ src/
 
 The above structure will match:
 - `https://example.com/sku/1234/5678/end-of-route`
+
+
+## Exclude folder from pathname
+In some cases you would like to move your routes into a subdirectory without affecting the pathname which qwik city is generating based on the folder structure. In this case you can create directories in parentheses (eg. `(products)`). Let's have a look at an example:
+
+```
+src/
+└── routes/
+    └── (product)/
+            ├── detail/
+            |   └──index.tsx
+            ├── preview/
+            |   └──index.tsx                
+            └── promotion/
+                └──index.tsx
+```
+The above structure will match:
+- `https://example.com/detail`
+- `https://example.com/preview`
+- `https://example.com/promotion`
+
+Note that `product` is not part of the pathname.

--- a/packages/docs/src/routes/qwikcity/routing/route-parameters/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/route-parameters/index.mdx
@@ -82,8 +82,8 @@ The above structure will match:
 - `https://example.com/sku/1234/5678/end-of-route`
 
 
-## Exclude folder from pathname
-In some cases you would like to move your routes into a subdirectory without affecting the pathname which qwik city is generating based on the folder structure. In this case you can create directories in parentheses (eg. `(products)`). Let's have a look at an example:
+## Groups
+In some cases you would like to move your routes into a subdirectory without affecting the pathname which qwik city is generating based on the folder structure. Or you have several routes on the same level which should use different layouts. In this case you can create directories in parentheses (eg. `(products)`). Let's have a look at an example:
 
 ```
 src/


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
folders in parentheses won't affect pathname of the page. updated the routing docs accordingly

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
