### PR TITLE
fix(netlify-edge): add netlify-cli dependency

### DIFF
--- a/starters/adaptors/netlify-edge/package.json
+++ b/starters/adaptors/netlify-edge/package.json
@@ -5,7 +5,8 @@
     "serve": "netlify dev"
   },
   "devDependencies": {
-    "@netlify/vite-plugin-netlify-edge": "1.1.0"
+    "@netlify/vite-plugin-netlify-edge": "1.1.0",
+    "netlify-cli": "^12.0.11"
   },
   "__qwik__": {
     "priority": 30,


### PR DESCRIPTION
fix #1951

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Adds the netlify-cli devDependency to the package.json with the integration, 
lettting users run `npm run serve`

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. To add the netlify integration (`npm run qwik add netlify-edge`) and be able to run `npm run serve` right after.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
