### PR TITLE
feat(playground): compress source code to generate shorter shareable URLs

### DIFF
--- a/packages/docs/src/repl/repl-share-url.ts
+++ b/packages/docs/src/repl/repl-share-url.ts
@@ -27,31 +27,23 @@ export const parsePlaygroundShareUrl = (shareable: string) => {
         data.entryStrategy = entryStrategy;
       }
 
-      const filesBase64 = params.get('files')!;
-      if (typeof filesBase64 === 'string') {
-        const encoded = atob(filesBase64);
-        const compressedUint8Array = strToU8(encoded, true);
-
-        let filesStr = '';
-
-        try {
-          const filesBuf = decompressSync(compressedUint8Array);
-          filesStr = strFromU8(filesBuf);
-        } catch (error) {
-          // Treat string as not compressed
-          filesStr = decodeURIComponent(encoded);
+      if (params.has('files')) {
+        // Old URLs that didn't compress
+        // the files, used the `files` key
+        const filesBase64 = params.get('files')!;
+        if (typeof filesBase64 === 'string') {
+          data.files = parseUncompressedFiles(filesBase64);
         }
-
-        const files = JSON.parse(filesStr);
-
-        if (Array.isArray(files)) {
-          data.files = files.filter(
-            (f) => typeof f.code === 'string' && typeof f.path === 'string'
-          );
-          if (files.length > 0) {
-            return data;
-          }
+      } else if (params.has('f')) {
+        // New URLs that didn't compress
+        // the files, use the `f` key
+        const filesBase64 = params.get('f');
+        if (typeof filesBase64 === 'string') {
+          data.files = parseCompressedFiles(filesBase64);
         }
+      }
+      if (data.files.length > 0) {
+        return data;
       }
     } catch (e) {
       console.error(e);
@@ -72,10 +64,45 @@ export const createPlaygroundShareUrl = (data: PlaygroundShareUrl) => {
   const compressedString = strFromU8(compressedUint8Array, true);
   const filesBase64 = btoa(compressedString);
 
-  params.set('files', filesBase64);
+  params.set('f', filesBase64);
 
   return `/playground#${params.toString()}`;
 };
+
+function parseUncompressedFiles(filesBase64: string) {
+  const encoded = atob(filesBase64);
+  const filesStr = decodeURIComponent(encoded);
+  const files = JSON.parse(filesStr);
+
+  if (Array.isArray(files)) {
+    return files.filter((f) => typeof f.code === 'string' && typeof f.path === 'string');
+  }
+
+  return [];
+}
+
+function parseCompressedFiles(filesBase64: string) {
+  const encoded = atob(filesBase64);
+  const compressedUint8Array = strToU8(encoded, true);
+
+  let filesStr = '';
+
+  try {
+    const filesBuf = decompressSync(compressedUint8Array);
+    filesStr = strFromU8(filesBuf);
+  } catch (error) {
+    // Treat string as not compressed
+    filesStr = decodeURIComponent(encoded);
+  }
+
+  const files = JSON.parse(filesStr);
+
+  if (Array.isArray(files)) {
+    return files.filter((f) => typeof f.code === 'string' && typeof f.path === 'string');
+  }
+
+  return [];
+}
 
 interface PlaygroundShareUrl {
   version: any;

--- a/packages/docs/src/repl/repl-share-url.ts
+++ b/packages/docs/src/repl/repl-share-url.ts
@@ -1,5 +1,5 @@
 import { BUILD_MODE_OPTIONS, ENTRY_STRATEGY_OPTIONS } from './repl-options';
-// import { compressSync, decompressSync, gzipSync, strFromU8, strToU8 } from 'fflate';
+import { compressSync, decompressSync, strFromU8, strToU8 } from 'fflate';
 
 export const parsePlaygroundShareUrl = (shareable: string) => {
   if (typeof shareable === 'string' && shareable.length > 0) {
@@ -30,10 +30,18 @@ export const parsePlaygroundShareUrl = (shareable: string) => {
       const filesBase64 = params.get('files')!;
       if (typeof filesBase64 === 'string') {
         const encoded = atob(filesBase64);
-        const filesStr = decodeURIComponent(encoded);
-        // const compressedUint8Array = strToU8(compressedString);
-        // const filesBuf = decompressSync(compressedUint8Array);
-        // const filesStr = strFromU8(filesBuf);
+        const compressedUint8Array = strToU8(encoded, true);
+
+        let filesStr = '';
+
+        try {
+          const filesBuf = decompressSync(compressedUint8Array);
+          filesStr = strFromU8(filesBuf);
+        } catch (error) {
+          // Treat string as not compressed
+          filesStr = decodeURIComponent(encoded);
+        }
+
         const files = JSON.parse(filesStr);
 
         if (Array.isArray(files)) {
@@ -59,11 +67,11 @@ export const createPlaygroundShareUrl = (data: PlaygroundShareUrl) => {
   params.set('entryStrategy', data.entryStrategy);
 
   const filesStr = JSON.stringify(data.files);
-  // const filesBuf = strToU8(filesStr);
-  // const compressedUint8Array = compressSync(filesBuf);
-  // const compressedString = strFromU8(compressedUint8Array);
-  const encodedURI = encodeURIComponent(filesStr);
-  const filesBase64 = btoa(encodedURI);
+  const filesBuf = strToU8(filesStr);
+  const compressedUint8Array = compressSync(filesBuf);
+  const compressedString = strFromU8(compressedUint8Array, true);
+  const filesBase64 = btoa(compressedString);
+
   params.set('files', filesBase64);
 
   return `/playground#${params.toString()}`;


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

A previous attempt was made to compress source code files prior to generate the final base64-encoded string for the shareable URL, but it was failing.

The trick needed here to make it work is specifying `true` as the second argument to `strFromU8` and `strToU8` functions ([relevant section of the fflate docs](https://github.com/101arrowz/fflate/blob/master/docs/README.md#strfromu8)) to enable encoding to a binary string.

To not break existing playground URLs, when parsing the URL, an error while attempting to decompress the string is captured and the previous approach of simply decoding it is used.

# Use cases and why

Here are some comparisons of URL lengths (for the `files` query param):

[Example 1](https://qwik.builder.io/playground#version=0.12.1&buildMode=development&entryStrategy=hook&files=JTVCJTdCJTIycGF0aCUyMiUzQSUyMiUyRmFwcC50c3glMjIlMkMlMjJjb2RlJTIyJTNBJTIyaW1wb3J0JTIwJTdCJTIwY29tcG9uZW50JTI0JTIwJTdEJTIwZnJvbSUyMCclNDBidWlsZGVyLmlvJTJGcXdpayclM0IlNUNuJTVDbmV4cG9ydCUyMGNvbnN0JTIwQXBwJTIwJTNEJTIwY29tcG9uZW50JTI0KCgpJTIwJTNEJTNFJTIwJTdCJTVDbiUyMCUyMHJldHVybiUyMCUzQ3AlM0VIZWxsbyUyMFF3aWslM0MlMkZwJTNFJTNCJTVDbiU3RCklM0IlNUNuJTVDbmV4cG9ydCUyMGNvbnN0JTIwVGFicyUyMCUzRCUyMGNvbXBvbmVudCUyNCgoZSklMjAlM0QlM0UlMjAlN0IlNUNuJTIwJTIwcmV0dXJuJTIwKCU1Q24lMjAlMjAlMjAlMjAlM0NkaXYlM0UlNUNuJTIwJTIwJTIwJTIwJTIwJTIwJTNDZGl2JTIwcm9sZSUzRCd0YWJsaXN0JyUzRSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlM0NTbG90JTIwbmFtZSUzRCU1QyUyMnRhYmJ1dHRvbiU1QyUyMiUyRiUzRSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlM0MlMkZkaXYlM0UlNUNuJTIwJTIwJTIwJTIwJTIwJTIwJTNDU2xvdCUyMG5hbWUlM0QlNUMlMjJ0YWJwYW5lbCU1QyUyMiUyRiUzRSU1Q24lMjAlMjAlMjAlMjAlM0MlMkZkaXYlM0UlNUNuJTIwJTIwKSUzQiU1Q24lN0QpJTNCJTVDbiU1Q25leHBvcnQlMjBjb25zdCUyMFF3aWtMb2dvJTIwJTNEJTIwKCklMjAlM0QlM0UlMjAoJTVDbiUyMCUyMCUzQ3N2ZyUyMHdpZHRoJTNEJTVDJTIyMTAwJTVDJTIyJTIwaGVpZ2h0JTNEJTVDJTIyMzUlNUMlMjIlMjB2aWV3Qm94JTNEJTVDJTIyMCUyMDAlMjAxNjclMjA1MyU1QyUyMiUyMGZpbGwlM0QlNUMlMjJub25lJTVDJTIyJTIweG1sbnMlM0QlNUMlMjJodHRwJTNBJTJGJTJGd3d3LnczLm9yZyUyRjIwMDAlMkZzdmclNUMlMjIlM0UlNUNuJTIwJTIwJTIwJTIwJTNDcGF0aCU1Q24lMjAlMjAlMjAlMjAlMjAlMjBkJTNEJTVDJTIyTTgxLjk1NDUlMjA0Ni41ODU5SDc1LjU1MTNWMzUuNDA0NUM3My40MzYzJTIwMzYuODU3OSUyMDcxLjA0OTYlMjAzNy41NzQ5JTIwNjguNDg4NCUyMDM3LjU3NDlDNjUuMDE1MSUyMDM3LjU3NDklMjA2Mi40MzQ0JTIwMzYuNjI1MyUyMDYwLjgyMzklMjAzNC42NDg3QzU5LjIxMzQlMjAzMi42OTE1JTIwNTguMzk4NCUyMDI5LjIwMzQlMjA1OC4zOTg0JTIwMjQuMjIzMUM1OC4zOTg0JTIwMTkuMTI2NiUyMDU5LjM0OTIlMjAxNS41OTk3JTIwNjEuMjcwMiUyMDEzLjU0NTZDNjMuMjMlMjAxMS40NzIxJTIwNjYuMzczNCUyMDEwLjQ2NDQlMjA3MC43MDA0JTIwMTAuNDY0NEM3NC43OTQ2JTIwMTAuNDY0NCUyMDc4LjUyMDElMjAxMS4wMjY0JTIwODEuOTU0NSUyMDEyLjEzMVY0Ni41ODU5Wk03NS41NTEzJTIwMTYuMjc4Qzc0LjA5NiUyMDE1LjgzMjMlMjA3Mi40NjYxJTIwMTUuNjE5MSUyMDcwLjcwMDQlMjAxNS42MTkxQzY4LjUyNzIlMjAxNS42MTkxJTIwNjYuOTc0OSUyMDE2LjE4MTElMjA2Ni4xMDE3JTIwMTcuMzI0NEM2NS4yNDc5JTIwMTguNDg3MSUyMDY0Ljc4MjMlMjAyMC42OTYyJTIwNjQuNzgyMyUyMDIzLjk3MTJDNjQuNzgyMyUyMDI3LjA1MjQlMjA2NS4xODk3JTIwMjkuMTA2NSUyMDY2LjA0MzUlMjAzMC4yMzA0QzY2Ljg5NzMlMjAzMS4zMzUlMjA2OC4zNzE5JTIwMzEuODk3JTIwNzAuNTQ1MiUyMDMxLjg5N0M3My4zNzgxJTIwMzEuODk3JTIwNzUuNTUxMyUyMDMwLjczNDMlMjA3NS41NTEzJTIwMjkuMjgwOVYxNi4yNzhaJTVDJTIyJTVDbiUyMCUyMCUyMCUyMCUyMCUyMGZpbGwlM0QlNUMlMjJibGFjayU1QyUyMiU1Q24lMjAlMjAlMjAlMjAlMkYlM0UlNUNuJTIwJTIwJTIwJTIwJTNDcGF0aCU1Q24lMjAlMjAlMjAlMjAlMjAlMjBkJTNEJTVDJTIyTTkxLjEzMyUyMDExLjE0MjZDOTMuNDAzMyUyMDE3LjQ0MDYlMjA5NS4zMjQyJTIwMjMuNzM4NiUyMDk2Ljk5MyUyMDMwLjA5NDhDOTkuMjA1JTIwMjMuNTgzNiUyMDEwMS4wODclMjAxNy4yODU2JTIwMTAyLjU0MiUyMDExLjE0MjZIMTA4LjE1QzExMC4yNjUlMjAxNy40NDA2JTIwMTEyLjAzMSUyMDIzLjczODYlMjAxMTMuNDQ3JTIwMzAuMDk0OEMxMTUuOTclMjAyMy4xOTYlMjAxMTcuOTQ5JTIwMTYuODc4NyUyMDExOS40MDQlMjAxMS4xNDI2SDEyNS43MUMxMjMuMDMzJTIwMjAuMTczJTIwMTIwLjA2NCUyMDI4Ljc3NyUyMDExNi43ODUlMjAzNi44OTY2SDEwOS4yNTZDMTA4LjQwMiUyMDMyLjMwMzklMjAxMDcuMDQ0JTIwMjYuNzYxNyUyMDEwNS4yMiUyMDIwLjE1MzZDMTA0LjA1NiUyMDI1LjI4ODklMjAxMDIuNDQ1JTIwMzAuODg5MyUyMDEwMC4zMyUyMDM2Ljg5NjZIOTIuODAxOEM5MC4yNzkzJTIwMjcuNTE3NCUyMDg3LjU0MzQlMjAxOC45NTIyJTIwODQuNjMyOCUyMDExLjE0MjZIOTEuMTMzWiU1QyUyMiU1Q24lMjAlMjAlMjAlMjAlMjAlMjBmaWxsJTNEJTVDJTIyYmxhY2slNUMlMjIlNUNuJTIwJTIwJTIwJTIwJTJGJTNFJTVDbiUyMCUyMCUyMCUyMCUzQ3BhdGglNUNuJTIwJTIwJTIwJTIwJTIwJTIwZCUzRCU1QyUyMk0xMzIuODMyJTIwNy41NTc1OEMxMjkuOTk5JTIwNy41NTc1OCUyMDEyOS4yMDMlMjA2Ljg1OTk2JTIwMTI5LjIwMyUyMDMuOTcyNTdDMTI5LjIwMyUyMDEuMzk1MjMlMjAxMzAuMDE4JTIwMC43OTQ0OTUlMjAxMzIuODMyJTIwMC43OTQ0OTVDMTM1LjY2NSUyMDAuNzk0NDk1JTIwMTM2LjQ2JTIwMS4zOTUyMyUyMDEzNi40NiUyMDMuOTcyNTdDMTM2LjQ2JTIwNi44NTk5NiUyMDEzNS42NjUlMjA3LjU1NzU4JTIwMTMyLjgzMiUyMDcuNTU3NThaTTEyOS42NDklMjAxMS4xNDI2SDEzNi4wNTNWMzYuODk2NkgxMjkuNjQ5VjExLjE0MjZaJTVDJTIyJTVDbiUyMCUyMCUyMCUyMCUyMCUyMGZpbGwlM0QlNUMlMjJibGFjayU1QyUyMiU1Q24lMjAlMjAlMjAlMjAlMkYlM0UlNUNuJTIwJTIwJTIwJTIwJTNDcGF0aCU1Q24lMjAlMjAlMjAlMjAlMjAlMjBkJTNEJTVDJTIyTTE2Ni4zMDMlMjAxMS4xNDI2QzE2MS43NjMlMjAxNy41OTU2JTIwMTU4LjU4MSUyMDIxLjUyOTUlMjAxNTYuODE1JTIwMjIuOTQ0MUMxNTguMjclMjAyMy44OTM3JTIwMTYyLjE3JTIwMjguODkzMyUyMDE2Ny4wMDIlMjAzNi45MTZIMTU5LjYyOEMxNTMuNjEzJTIwMjcuNzg4NyUyMDE1MC43NDIlMjAyMy44NTQ5JTIwMTQ5LjMyNSUyMDIzLjI1NDJWMzYuOTE2SDE0Mi45MjJWMEgxNDkuMzI1VjIzLjIzNDhDMTUwLjc4JTIwMjIuMTY5JTIwMTUzLjk2MyUyMDE4LjEzODIlMjAxNTguODcyJTIwMTEuMTQyNkgxNjYuMzAzWiU1QyUyMiU1Q24lMjAlMjAlMjAlMjAlMjAlMjBmaWxsJTNEJTVDJTIyYmxhY2slNUMlMjIlNUNuJTIwJTIwJTIwJTIwJTJGJTNFJTVDbiUyMCUyMCUyMCUyMCUzQ3BhdGglNUNuJTIwJTIwJTIwJTIwJTIwJTIwZCUzRCU1QyUyMk00MC45NzMlMjA1Mi41MzUxTDMyLjA4NjElMjA0My42OTg1TDMxLjk1MDMlMjA0My43MTc5VjQzLjYyMUwxMy4wNTExJTIwMjQuOTU5NUwxNy43MDglMjAyMC40NjM3TDE0Ljk3MjElMjA0Ljc2NzE1TDEuOTkxMDMlMjAyMC44NTEzQy0wLjIyMDk5MiUyMDIzLjA3OTglMjAtMC42Mjg0NjclMjAyNi43MDM2JTIwMC45NjI2MzUlMjAyOS4zNzc4TDkuMDczMzclMjA0Mi44MjY1QzEwLjMxNTIlMjA0NC45JTIwMTIuNTY2JTIwNDYuMTQwMiUyMDE0Ljk5MTUlMjA0Ni4xMjA4TDE5LjAwODElMjA0Ni4wODJMNDAuOTczJTIwNTIuNTM1MVolNUMlMjIlNUNuJTIwJTIwJTIwJTIwJTIwJTIwZmlsbCUzRCU1QyUyMiUyMzE4QjZGNiU1QyUyMiU1Q24lMjAlMjAlMjAlMjAlMkYlM0UlNUNuJTIwJTIwJTIwJTIwJTNDcGF0aCU1Q24lMjAlMjAlMjAlMjAlMjAlMjBkJTNEJTVDJTIyTTQ1LjgyMzIlMjAyMC41NDExTDQ0LjAzOCUyMDE3LjI0NjhMNDMuMTA2NiUyMDE1LjU2MDlMNDIuNzM4JTIwMTQuOTAyTDQyLjY5OTIlMjAxNC45NDA4TDM3LjgwOTQlMjA2LjQ3MjM4QzM2LjU4NyUyMDQuMzQwNzUlMjAzNC4yOTc0JTIwMy4wMjMwMSUyMDMxLjgxMzclMjAzLjA0MjM5TDI3LjUyNTUlMjAzLjE1ODY1TDE0LjczODQlMjAzLjE5NzQxQzEyLjMxMyUyMDMuMjE2NzklMjAxMC4xMDElMjA0LjQ5NTc3JTIwOC44Nzg1MyUyMDYuNTY5MjdMMS4wOTc2NiUyMDIxLjk5NDVMMTUuMDEwMSUyMDQuNzI4MzFMMzMuMjQ5NiUyMDI0Ljc2NTZMMzAuMDA5MSUyMDI4LjA0MDZMMzEuOTQ5NSUyMDQzLjcxNzhMMzEuOTY4OSUyMDQzLjY3OVY0My43MTc4SDMxLjkzMDFMMzEuOTY4OSUyMDQzLjc1NjVMMzMuNDgyNCUyMDQ1LjIyOTNMNDAuODM2NCUyMDUyLjQxODdDNDEuMTQ2OSUyMDUyLjcwOTQlMjA0MS42NTE0JTIwNTIuMzYwNiUyMDQxLjQzNzklMjA1MS45OTI0TDM2Ljg5NzUlMjA0My4wNTg5TDQ0LjgxNDIlMjAyOC40MjgyTDQ1LjA2NjQlMjAyOC4xMzc1QzQ1LjE2MzQlMjAyOC4wMjEyJTIwNDUuMjYwNCUyMDI3LjkwNSUyMDQ1LjMzODElMjAyNy43ODg3QzQ2Ljg5MDQlMjAyNS42NzY0JTIwNDcuMTAzOCUyMDIyLjg0NzIlMjA0NS44MjMyJTIwMjAuNTQxMVolNUMlMjIlNUNuJTIwJTIwJTIwJTIwJTIwJTIwZmlsbCUzRCU1QyUyMiUyM0FDN0VGNCU1QyUyMiU1Q24lMjAlMjAlMjAlMjAlMkYlM0UlNUNuJTIwJTIwJTIwJTIwJTNDcGF0aCU1Q24lMjAlMjAlMjAlMjAlMjAlMjBkJTNEJTVDJTIyTTMzLjMwNzYlMjAyNC42ODgyTDE1LjAwOTklMjA0Ljc0Nzc0TDE3LjYxJTIwMjAuMzY2OEwxMi45NTMxJTIwMjQuODgyTDMxLjkxMDUlMjA0My42OTg1TDMwLjIwMyUyMDI4LjA3OTRMMzMuMzA3NiUyMDI0LjY4ODJaJTVDJTIyJTVDbiUyMCUyMCUyMCUyMCUyMCUyMGZpbGwlM0QlNUMlMjJ3aGl0ZSU1QyUyMiU1Q24lMjAlMjAlMjAlMjAlMkYlM0UlNUNuJTIwJTIwJTNDJTJGc3ZnJTNFJTVDbiklM0IlNUNuJTIyJTdEJTJDJTdCJTIycGF0aCUyMiUzQSUyMiUyRmVudHJ5LnNlcnZlci50c3glMjIlMkMlMjJjb2RlJTIyJTNBJTIyaW1wb3J0JTIwJTdCJTIwcmVuZGVyVG9TdHJpbmclMkMlMjBSZW5kZXJPcHRpb25zJTIwJTdEJTIwZnJvbSUyMCclNDBidWlsZGVyLmlvJTJGcXdpayUyRnNlcnZlciclM0IlNUNuaW1wb3J0JTIwJTdCJTIwUm9vdCUyMCU3RCUyMGZyb20lMjAnLiUyRnJvb3QnJTNCJTVDbiU1Q25leHBvcnQlMjBkZWZhdWx0JTIwZnVuY3Rpb24lMjAob3B0cyUzQSUyMFJlbmRlck9wdGlvbnMpJTIwJTdCJTVDbiUyMCUyMHJldHVybiUyMHJlbmRlclRvU3RyaW5nKCUzQ1Jvb3QlMjAlMkYlM0UlMkMlMjBvcHRzKSUzQiU1Q24lN0QlNUNuJTIyJTdEJTJDJTdCJTIycGF0aCUyMiUzQSUyMiUyRnJvb3QudHN4JTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMCU3QiUyMEFwcCUyMCU3RCUyMGZyb20lMjAnLiUyRmFwcCclM0IlNUNuJTVDbmV4cG9ydCUyMGNvbnN0JTIwUm9vdCUyMCUzRCUyMCgpJTIwJTNEJTNFJTIwJTdCJTVDbiUyMCUyMHJldHVybiUyMCglNUNuJTIwJTIwJTIwJTIwJTNDaHRtbCUzRSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlM0NoZWFkJTNFJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUzQ3RpdGxlJTNFSGVsbG8lMjBRd2lrJTNDJTJGdGl0bGUlM0UlNUNuJTIwJTIwJTIwJTIwJTIwJTIwJTNDJTJGaGVhZCUzRSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlM0Nib2R5JTNFJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUzQ0FwcCUyMCUyRiUzRSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlM0MlMkZib2R5JTNFJTVDbiUyMCUyMCUyMCUyMCUzQyUyRmh0bWwlM0UlNUNuJTIwJTIwKSUzQiU1Q24lN0QlM0IlNUNuJTIyJTdEJTVE) (larger file)

- **Not compressed:** 7552 characters
- **Compressed:** 2664 characters

(64.7% of reduction)

[Example 2](https://qwik.builder.io/playground#version=0.12.1&buildMode=development&entryStrategy=hook&files=JTVCJTdCJTIycGF0aCUyMiUzQSUyMiUyRmFwcC50c3glMjIlMkMlMjJjb2RlJTIyJTNBJTIyaW1wb3J0JTIwJTdCJTIwY29tcG9uZW50JTI0JTIwJTdEJTIwZnJvbSUyMCclNDBidWlsZGVyLmlvJTJGcXdpayclM0IlNUNuJTVDbmV4cG9ydCUyMGNvbnN0JTIwQXBwJTIwJTNEJTIwY29tcG9uZW50JTI0KCgpJTIwJTNEJTNFJTIwJTdCJTVDbiUyMCUyMHJldHVybiUyMCUzQ3AlM0VIZWxsbyUyMFF3aWslM0MlMkZwJTNFJTNCJTVDbiU3RCklM0IlNUNuJTIyJTdEJTJDJTdCJTIycGF0aCUyMiUzQSUyMiUyRmVudHJ5LnNlcnZlci50c3glMjIlMkMlMjJjb2RlJTIyJTNBJTIyaW1wb3J0JTIwJTdCJTIwcmVuZGVyVG9TdHJpbmclMkMlMjBSZW5kZXJPcHRpb25zJTIwJTdEJTIwZnJvbSUyMCclNDBidWlsZGVyLmlvJTJGcXdpayUyRnNlcnZlciclM0IlNUNuaW1wb3J0JTIwJTdCJTIwUm9vdCUyMCU3RCUyMGZyb20lMjAnLiUyRnJvb3QnJTNCJTVDbiU1Q25leHBvcnQlMjBkZWZhdWx0JTIwZnVuY3Rpb24lMjAob3B0cyUzQSUyMFJlbmRlck9wdGlvbnMpJTIwJTdCJTVDbiUyMCUyMHJldHVybiUyMHJlbmRlclRvU3RyaW5nKCUzQ1Jvb3QlMjAlMkYlM0UlMkMlMjBvcHRzKSUzQiU1Q24lN0QlNUNuJTIyJTdEJTJDJTdCJTIycGF0aCUyMiUzQSUyMiUyRnJvb3QudHN4JTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMCU3QiUyMEFwcCUyMCU3RCUyMGZyb20lMjAnLiUyRmFwcCclM0IlNUNuJTVDbmV4cG9ydCUyMGNvbnN0JTIwUm9vdCUyMCUzRCUyMCgpJTIwJTNEJTNFJTIwJTdCJTVDbiUyMCUyMHJldHVybiUyMCglNUNuJTIwJTIwJTIwJTIwJTNDaHRtbCUzRSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlM0NoZWFkJTNFJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUzQ3RpdGxlJTNFSGVsbG8lMjBRd2lrJTNDJTJGdGl0bGUlM0UlNUNuJTIwJTIwJTIwJTIwJTIwJTIwJTNDJTJGaGVhZCUzRSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlM0Nib2R5JTNFJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUzQ0FwcCUyMCUyRiUzRSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlM0MlMkZib2R5JTNFJTVDbiUyMCUyMCUyMCUyMCUzQyUyRmh0bWwlM0UlNUNuJTIwJTIwKSUzQiU1Q24lN0QlM0IlNUNuJTIyJTdEJTVE) (default code)

- **Not compressed:** 1512 characters
- **Compressed:** 428 characters

(71.7% of reduction)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
