### PR TITLE
fix(render-ssr.ts): aria value should be rendered correctly

### DIFF
--- a/packages/qwik/src/core/render/dom/render.unit.tsx
+++ b/packages/qwik/src/core/render/dom/render.unit.tsx
@@ -91,6 +91,7 @@ renderSuite('should render aria', async () => {
       aria-busy={false}
       role=""
       preventdefault:click
+      aria-hidden={undefined}
     ></div>
   );
   await expectRendered(

--- a/packages/qwik/src/core/render/dom/render.unit.tsx
+++ b/packages/qwik/src/core/render/dom/render.unit.tsx
@@ -79,6 +79,26 @@ renderSuite('should serialize boolean attributes correctly', async () => {
   await render(fixture.host, <input required={true} disabled={false}></input>);
   await expectRendered(fixture, '<input required="" />');
 });
+
+renderSuite('should render aria', async () => {
+  const fixture = new ElementFixture();
+  await render(
+    fixture.host,
+    <div
+      id="abc"
+      title="bar"
+      aria-required={true}
+      aria-busy={false}
+      role=""
+      preventdefault:click
+    ></div>
+  );
+  await expectRendered(
+    fixture,
+    '<div id="abc" title="bar" aria-required="true" aria-busy="false" role="" preventdefault:click=""></div>'
+  );
+});
+
 renderSuite('should render into a document', async () => {
   const fixture = new ElementFixture();
   fixture.document.head.appendChild(fixture.document.createElement('existing'));

--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -27,6 +27,7 @@ import {
 import { getVdom, ProcessedJSXNode, ProcessedJSXNodeImpl, renderComponent } from './render-dom';
 import type { RenderContext, RenderStaticContext } from '../types';
 import {
+  isAriaAttribute,
   parseClassList,
   pushRenderContext,
   serializeClass,
@@ -909,6 +910,12 @@ export const smartSetProperty = (
   oldValue: any,
   isSvg: boolean
 ) => {
+  // aria attribute value should be rendered as string
+  if (isAriaAttribute(prop)) {
+    setAttribute(staticCtx, elm, prop, newValue != null ? String(newValue) : newValue);
+    return;
+  }
+
   // Check if its an exception
   const exception = PROP_HANDLER_MAP[prop];
   if (exception) {

--- a/packages/qwik/src/core/render/execute-component.ts
+++ b/packages/qwik/src/core/render/execute-component.ts
@@ -178,3 +178,7 @@ export const hasStyle = (containerState: ContainerState, styleId: string) => {
 export const jsxToString = (data: any) => {
   return data == null || typeof data === 'boolean' ? '' : String(data);
 };
+
+export function isAriaAttribute(prop: string): boolean {
+  return prop.startsWith('aria-');
+}

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -799,13 +799,14 @@ function processPropValue(prop: string, value: any): string | null {
   if (prop === 'style') {
     return stringifyStyle(value);
   }
-  if (!isAriaAttribute(prop)) {
-    if (value === false || value == null) {
-      return null;
-    }
-    if (value === true) {
-      return '';
-    }
+  if (isAriaAttribute(prop)) {
+    return value != null ? String(value) : value;
+  }
+  if (value === false || value == null) {
+    return null;
+  }
+  if (value === true) {
+    return '';
   }
   return String(value);
 }

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -794,12 +794,21 @@ function processPropKey(prop: string) {
   return prop;
 }
 
+function isAriaAttribute(prop: string): boolean {
+  return prop.startsWith('aria-');
+}
+
 function processPropValue(prop: string, value: any): string | null {
   if (prop === 'style') {
     return stringifyStyle(value);
   }
-  if (value === false || value == null) {
-    return null;
+  if (!isAriaAttribute(prop)) {
+    if (value === false || value == null) {
+      return null;
+    }
+    if (value === true) {
+      return '';
+    }
   }
   return String(value);
 }

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -801,9 +801,6 @@ function processPropValue(prop: string, value: any): string | null {
   if (value === false || value == null) {
     return null;
   }
-  if (value === true) {
-    return '';
-  }
   return String(value);
 }
 

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -7,6 +7,7 @@ import {
   createRenderContext,
   executeComponent,
   getNextIndex,
+  isAriaAttribute,
   jsxToString,
   stringifyStyle,
 } from '../execute-component';
@@ -792,10 +793,6 @@ function processPropKey(prop: string) {
     return 'for';
   }
   return prop;
-}
-
-function isAriaAttribute(prop: string): boolean {
-  return prop.startsWith('aria-');
 }
 
 function processPropValue(prop: string, value: any): string | null {

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -31,8 +31,8 @@ renderSSRSuite('render attributes', async () => {
 
 renderSSRSuite('render true value attribute', async () => {
   await testSSR(
-      <div id="stuff" aria-required={true} aria-busy={false} role=""></div>,
-      `
+    <div id="stuff" aria-required={true} aria-busy={false} role=""></div>,
+    `
         <html q:container="paused" q:version="dev" q:render="ssr-dev">
             <div id="stuff" aria-required="true" role></div>
         </html>

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -31,10 +31,10 @@ renderSSRSuite('render attributes', async () => {
 
 renderSSRSuite('render true value attribute', async () => {
   await testSSR(
-    <div id="stuff" aria-required={true} aria-busy={false} role=""></div>,
+    <div id="stuff" aria-required={true} aria-busy={false} role="" preventdefault:click></div>,
     `
         <html q:container="paused" q:version="dev" q:render="ssr-dev">
-            <div id="stuff" aria-required="true" role></div>
+          <div id="stuff" aria-required="true" aria-busy="false" role preventdefault:click=""></div>
         </html>
         `
   );

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -29,7 +29,7 @@ renderSSRSuite('render attributes', async () => {
   );
 });
 
-renderSSRSuite('render true value attribute', async () => {
+renderSSRSuite('render aria value', async () => {
   await testSSR(
     <div id="stuff" aria-required={true} aria-busy={false} role="" preventdefault:click></div>,
     `

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -29,6 +29,17 @@ renderSSRSuite('render attributes', async () => {
   );
 });
 
+renderSSRSuite('render true value attribute', async () => {
+  await testSSR(
+      <div id="stuff" aria-required={true} aria-busy={false} role=""></div>,
+      `
+        <html q:container="paused" q:version="dev" q:render="ssr-dev">
+            <div id="stuff" aria-required="true" role></div>
+        </html>
+        `
+  );
+});
+
 renderSSRSuite('render className', async () => {
   await testSSR(
     <div className="stuff"></div>,

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -31,7 +31,14 @@ renderSSRSuite('render attributes', async () => {
 
 renderSSRSuite('render aria value', async () => {
   await testSSR(
-    <div id="stuff" aria-required={true} aria-busy={false} role="" preventdefault:click></div>,
+    <div
+        id="stuff"
+        aria-required={true}
+        aria-busy={false}
+        role=""
+        preventdefault:click
+        aria-hidden={undefined}
+    ></div>,
     `
         <html q:container="paused" q:version="dev" q:render="ssr-dev">
           <div id="stuff" aria-required="true" aria-busy="false" role preventdefault:click=""></div>

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -32,12 +32,12 @@ renderSSRSuite('render attributes', async () => {
 renderSSRSuite('render aria value', async () => {
   await testSSR(
     <div
-        id="stuff"
-        aria-required={true}
-        aria-busy={false}
-        role=""
-        preventdefault:click
-        aria-hidden={undefined}
+      id="stuff"
+      aria-required={true}
+      aria-busy={false}
+      role=""
+      preventdefault:click
+      aria-hidden={undefined}
     ></div>,
     `
         <html q:container="paused" q:version="dev" q:render="ssr-dev">

--- a/starters/apps/e2e/src/components/attributes/attributes.tsx
+++ b/starters/apps/e2e/src/components/attributes/attributes.tsx
@@ -117,6 +117,7 @@ export const AttributesChild = component$(() => {
               required={required.value}
               aria-hidden={state.dataAria as any}
               aria-label={state.label}
+              aria-required={required.value}
               data-stuff={'stuff: ' + state.stuff}
               tabIndex={-1}
               title={title.value}

--- a/starters/e2e/e2e.attributes.spec.ts
+++ b/starters/e2e/e2e.attributes.spec.ts
@@ -17,6 +17,7 @@ test.describe('attributes', () => {
       await expect(input).toHaveAttribute('aria-hidden', 'true');
       await expect(input).toHaveAttribute('aria-label', 'even');
       await expect(input).toHaveAttribute('tabindex', '-1');
+      await expect(input).toHaveAttribute('aria-required', 'false');
       await expect(input).not.hasAttribute('required');
       await expect(input).not.hasAttribute('title');
 
@@ -72,6 +73,7 @@ test.describe('attributes', () => {
       await expect(input).toHaveAttribute('aria-hidden', 'true');
       await expect(input).toHaveAttribute('aria-label', 'odd');
       await expect(input).toHaveAttribute('tabindex', '-1');
+      await expect(input).toHaveAttribute('aria-required', 'false');
       await expect(input).not.hasAttribute('required');
       await expect(renders).toHaveText('1');
     });
@@ -105,6 +107,7 @@ test.describe('attributes', () => {
       await expect(input).toHaveAttribute('aria-hidden', 'false');
       await expect(input).toHaveAttribute('aria-label', 'even');
       await expect(input).toHaveAttribute('tabindex', '-1');
+      await expect(input).toHaveAttribute('aria-required', 'false');
       await expect(input).not.hasAttribute('required');
       await expect(svg).toHaveAttribute('aria-hidden', 'false');
       await expect(renders).toHaveText('1');
@@ -120,6 +123,7 @@ test.describe('attributes', () => {
       await expect(input).toHaveAttribute('aria-hidden', 'true');
       await expect(input).toHaveAttribute('aria-label', 'even');
       await expect(input).toHaveAttribute('tabindex', '-1');
+      await expect(input).toHaveAttribute('aria-required', 'true');
       await expect(input).hasAttribute('required');
       await expect(renders).toHaveText('1');
     });
@@ -140,6 +144,7 @@ test.describe('attributes', () => {
       await expect(input).not.hasAttribute('aria-label');
       await expect(input).not.hasAttribute('tabindex');
       await expect(input).not.hasAttribute('required');
+      await expect(input).not.hasAttribute('aria-required');
 
       await expect(renders).toHaveText('2');
     });
@@ -159,6 +164,7 @@ test.describe('attributes', () => {
       await expect(input).not.hasAttribute('aria-label');
       await expect(input).not.hasAttribute('tabindex');
       await expect(input).not.hasAttribute('required');
+      await expect(input).not.hasAttribute('aria-required');
       await expect(label).not.hasAttribute('for');
       await expect(label).not.hasAttribute('form');
       await expect(svg).not.hasAttribute('width');
@@ -175,6 +181,7 @@ test.describe('attributes', () => {
       await expect(input).toHaveAttribute('aria-label', 'even');
       await expect(input).toHaveAttribute('tabindex', '-1');
       await expect(input).not.hasAttribute('required');
+      await expect(input).toHaveAttribute('aria-required', 'false');
       await expect(label).toHaveAttribute('for', 'even');
       await expect(label).toHaveAttribute('form', 'my-form');
       await expect(svg).toHaveAttribute('width', '15');
@@ -191,6 +198,7 @@ test.describe('attributes', () => {
       await expect(input).not.hasAttribute('aria-label');
       await expect(input).not.hasAttribute('tabindex');
       await expect(input).not.hasAttribute('required');
+      await expect(input).not.hasAttribute('aria-required');
       await expect(label).not.hasAttribute('for');
       await expect(label).not.hasAttribute('form');
       await expect(svg).not.hasAttribute('width');
@@ -206,6 +214,7 @@ test.describe('attributes', () => {
       await expect(input).toHaveAttribute('aria-label', 'even');
       await expect(input).toHaveAttribute('tabindex', '-1');
       await expect(input).not.hasAttribute('required');
+      await expect(input).toHaveAttribute('aria-required', 'false');
       await expect(label).toHaveAttribute('for', 'even');
       await expect(label).toHaveAttribute('form', 'my-form');
       await expect(svg).toHaveAttribute('width', '15');


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests

# Description

True value attribute is empty

# Use cases and why

For example, this code is not working at this time:
```tsx
export default component$(() => {
  const error = useSignal(false);
  const onSubmit = $(async () => {
    error.value = true;
    // some logic
  }
  return (
    <form preventdefault:submit onSubmit$={onSubmit}>
          <input
            type="text"
            id="login"
            name="login"
            placeholder="Login"
            required
            aria-invalid={error.value}
          />
          <input
            type="password"
            id="password"
            name="password"
            placeholder="Password"
            required
            aria-invalid={error.value}
          />
          <button type="submit">Zaloguj</button>
        </form>
  )
}
```


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
