### PR TITLE
fix(adaptors): fix error during build on Windows

### DIFF
--- a/packages/qwik-city/static/main-thread.ts
+++ b/packages/qwik-city/static/main-thread.ts
@@ -7,6 +7,7 @@ import type {
 } from './types';
 import { msToString } from '../utils/format';
 import { getPathnameForDynamicRoute, normalizePathname } from '../utils/pathname';
+import { pathToFileURL } from 'node:url';
 
 export async function mainThread(sys: System) {
   const opts = sys.getOptions();
@@ -14,7 +15,8 @@ export async function mainThread(sys: System) {
 
   const main = await sys.createMainProcess();
   const log = await sys.createLogger();
-  const qwikCityPlan: QwikCityPlan = (await import(opts.qwikCityPlanModulePath)).default;
+  const qwikCityPlan: QwikCityPlan = (await import(pathToFileURL(opts.qwikCityPlanModulePath).href))
+    .default;
 
   const queue: StaticRoute[] = [];
   const active = new Set<string>();

--- a/packages/qwik-city/static/worker-thread.ts
+++ b/packages/qwik-city/static/worker-thread.ts
@@ -8,6 +8,7 @@ import type { QwikCityRequestContext } from '../middleware/request-handler/types
 import type { RequestContext } from '../runtime/src/library/types';
 import { createHeaders } from '../middleware/request-handler/headers';
 import { requestHandler } from '../middleware/request-handler';
+import { pathToFileURL } from 'node:url';
 
 export async function workerThread(sys: System) {
   const ssgOpts = sys.getOptions();
@@ -15,8 +16,8 @@ export async function workerThread(sys: System) {
 
   const opts: StaticGenerateHandlerOptions = {
     ...ssgOpts,
-    render: (await import(ssgOpts.renderModulePath)).default,
-    qwikCityPlan: (await import(ssgOpts.qwikCityPlanModulePath)).default,
+    render: (await import(pathToFileURL(ssgOpts.renderModulePath).href)).default,
+    qwikCityPlan: (await import(pathToFileURL(ssgOpts.qwikCityPlanModulePath).href)).default,
   };
 
   sys.createWorkerProcess(async (msg) => {


### PR DESCRIPTION
fix #1892

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
Imports with absolute paths don't work on Windows without path normalization: this change uses  `pathToFileURL` in files that consume the paths created by adaptors.

# Use cases and why
Fix on Windows:

```
error during build:
Error [PLUGIN_ERROR]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
