### PR TITLE
fix: depend upon wrangler@latest

### DIFF
--- a/starters/adaptors/cloudflare-pages/package.json
+++ b/starters/adaptors/cloudflare-pages/package.json
@@ -5,7 +5,7 @@
     "serve": "wrangler pages dev ./dist"
   },
   "devDependencies": {
-    "wrangler": "beta"
+    "wrangler": "latest"
   },
   "__qwik__": {
     "priority": 40,


### PR DESCRIPTION
The current dependency of `beta` is hopelessly out of date.
