### PR TITLE
perf: drastically improve resuming perf (phase 1)

### DIFF
--- a/packages/qwik/src/core/container/pause.ts
+++ b/packages/qwik/src/core/container/pause.ts
@@ -233,8 +233,6 @@ export const _pauseFromContexts = async (
       id = getQId(el);
       if (!id) {
         console.warn('Missing ID', el);
-      } else {
-        id = ELEMENT_ID_PREFIX + id;
       }
       elementToIndex.set(el, id);
     }
@@ -261,7 +259,7 @@ export const _pauseFromContexts = async (
       } else if (isQwikElement(obj)) {
         const elID = getElementID(obj);
         if (elID) {
-          return elID + suffix;
+          return ELEMENT_ID_PREFIX + elID + suffix;
         }
         return null;
       }
@@ -413,8 +411,9 @@ export const _pauseFromContexts = async (
     }
 
     if (canRender) {
-      if (elementCaptured && props) {
-        metaValue.h = mustGetObjId(props) + ' ' + mustGetObjId(renderQrl);
+      if (elementCaptured && renderQrl) {
+        const propsId = getObjId(props);
+        metaValue.h = mustGetObjId(renderQrl) + (propsId ? ' ' + propsId : '');
         add = true;
       }
 
@@ -569,7 +568,7 @@ const collectElement = (el: VirtualElement, collector: Collector) => {
 };
 
 export const collectElementData = (elCtx: QContext, collector: Collector, dynamic: boolean) => {
-  if (elCtx.$props$) {
+  if (elCtx.$props$ && !isEmptyObj(elCtx.$props$)) {
     collectValue(elCtx.$props$, collector, dynamic);
   }
   if (elCtx.$componentQrl$) {
@@ -775,4 +774,8 @@ const getTextID = (node: Text, containerState: ContainerState) => {
   parent.insertBefore(open, node);
   parent.insertBefore(close, node.nextSibling);
   return ELEMENT_ID_PREFIX + id;
+};
+
+const isEmptyObj = (obj: Record<string, any>) => {
+  return Object.keys(obj).length === 0;
 };

--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -1,6 +1,6 @@
 import { assertDefined, assertTrue } from '../error/assert';
 import { getDocument } from '../util/dom';
-import { assertElement, assertQwikElement, isComment, isElement, isText } from '../util/element';
+import { assertElement, assertQwikElement, isElement, isText } from '../util/element';
 import { logDebug, logWarn } from '../util/log';
 import {
   ELEMENT_ID,
@@ -17,26 +17,27 @@ import { directGetAttribute, directSetAttribute } from '../render/fast-calls';
 import { createParser, OBJECT_TRANSFORMS, Parser, UNDEFINED_PREFIX } from './serializers';
 import {
   ContainerState,
-  FILTER_ACCEPT,
-  FILTER_REJECT,
-  FILTER_SKIP,
+  // FILTER_ACCEPT,
+  // FILTER_REJECT,
+  // FILTER_SKIP,
   getContainerState,
   GetObject,
   isContainer,
   SHOW_COMMENT,
-  SHOW_ELEMENT,
+  // SHOW_ELEMENT,
   SnapshotState,
   strToInt,
 } from './container';
 import { findClose, QwikElement, VirtualElementImpl } from '../render/dom/virtual-element';
 import { getDomListeners } from '../state/listeners';
-import { domToVnode } from '../render/dom/visitor';
+// import { domToVnode } from '../render/dom/visitor';
 import { parseSubscription, Subscriptions } from '../state/common';
 import { createProxy } from '../state/store';
 import { qSerialize } from '../util/qdev';
 import { pauseContainer } from './pause';
 import { getContext, HOST_FLAG_MOUNTED } from '../state/context';
 import { QObjectFlagsSymbol } from '../state/constants';
+import { domToVnode } from '../render/dom/visitor';
 
 export const resumeIfNeeded = (containerEl: Element): void => {
   const isResumed = directGetAttribute(containerEl, QContainerAttr);
@@ -67,72 +68,81 @@ export const resumeContainer = (containerEl: Element) => {
 
   const containerState = getContainerState(containerEl);
   moveStyles(containerEl, containerState);
-  const meta = JSON.parse(unescapeText(script.textContent || '{}')) as SnapshotState;
+
+  const pauseState = JSON.parse(unescapeText(script.textContent || '{}')) as SnapshotState;
 
   // Collect all elements
-  const elements = new Map<string, QwikElement | Node>();
+  const elements = new Map<number, QwikElement | Node>();
+  let node: Comment | null = null;
+  let container = 0;
 
-  const getObject: GetObject = (id) => {
-    return getObjectImpl(id, elements, meta.objs, containerState);
-  };
+  // Collect all virtual elements
+  const elementWalker = doc.createNodeIterator(containerEl, SHOW_COMMENT);
 
-  const elementWalker = doc.createTreeWalker(containerEl, SHOW_COMMENT | SHOW_ELEMENT, {
-    acceptNode(node: Element | Comment) {
-      if (isComment(node)) {
-        const data = node.data;
-        if (data.startsWith('qv ')) {
-          const close = findClose(node);
-          const virtual = new VirtualElementImpl(node, close);
-          const id = directGetAttribute(virtual, ELEMENT_ID);
-          if (id) {
-            const elCtx = getContext(virtual, containerState);
-            elCtx.$id$ = id;
-            elements.set(ELEMENT_ID_PREFIX + id, virtual);
-            maxId = Math.max(maxId, strToInt(id));
-          }
-        } else if (data.startsWith('t=')) {
-          const id = data.slice(2);
-          elements.set(ELEMENT_ID_PREFIX + data.slice(2), getTextNode(node));
-          maxId = Math.max(maxId, strToInt(id));
+  while ((node = elementWalker.nextNode() as Comment)) {
+    const data = node.data;
+    if (container === 0) {
+      if (data.startsWith('qv ')) {
+        const close = findClose(node);
+        const virtual = new VirtualElementImpl(node, close);
+        const id = directGetAttribute(virtual, ELEMENT_ID);
+        if (id) {
+          const elCtx = getContext(virtual, containerState);
+          const index = strToInt(id);
+          elCtx.$id$ = id;
+          elements.set(index, virtual);
         }
-        return FILTER_SKIP;
+      } else if (data.startsWith('t=')) {
+        const id = data.slice(2);
+        const index = strToInt(id);
+        elements.set(index, getTextNode(node));
       }
-      if (isContainer(node)) {
-        return FILTER_REJECT;
-      }
-      return node.hasAttribute(ELEMENT_ID) ? FILTER_ACCEPT : FILTER_SKIP;
-    },
-  });
+    }
+    if (data === 'cq') {
+      container++;
+    } else if (data === '/cq') {
+      container--;
+    }
+  }
 
-  let el: Node | null = null;
-  while ((el = elementWalker.nextNode())) {
+  // Collect all elements
+  const slotPath = containerEl.getElementsByClassName('qc📦').length !== 0;
+  containerEl.querySelectorAll('[q\\:id]').forEach((el) => {
+    if (slotPath && el.closest('[q\\:container]') !== containerEl) {
+      return;
+    }
+
     assertElement(el);
     const id = directGetAttribute(el, ELEMENT_ID);
     assertDefined(id, `resume: element missed q:id`, el);
     const elCtx = getContext(el, containerState);
     elCtx.$id$ = id;
     elCtx.$vdom$ = domToVnode(el);
-    elements.set(ELEMENT_ID_PREFIX + id, el);
+    elements.set(strToInt(id), el);
     maxId = Math.max(maxId, strToInt(id));
-  }
+  });
+  containerState.$elementIndex$ = maxId;
 
-  containerState.$elementIndex$ = ++maxId;
+  const parser = createParser(containerState, doc);
 
-  const parser = createParser(getObject, containerState, doc);
+  const getObject: GetObject = (id) => {
+    return getObjectImpl(id, elements, pauseState.objs, containerState);
+  };
 
   // Revive proxies with subscriptions into the proxymap
-  reviveValues(meta.objs, parser);
-  reviveSubscriptions(meta.objs, meta.subs, getObject, containerState, parser);
+  reviveValues(pauseState.objs, parser);
+
+  reviveSubscriptions(pauseState.objs, pauseState.subs, getObject, containerState, parser);
 
   // Rebuild target objects
-  for (const obj of meta.objs) {
+  for (const obj of pauseState.objs) {
     reviveNestedObjects(obj, getObject, parser);
   }
 
-  for (const elementID of Object.keys(meta.ctx)) {
-    assertTrue(elementID.startsWith('#'), 'elementId must start with #');
-    const ctxMeta = meta.ctx[elementID];
-    const el = elements.get(elementID);
+  for (const elementID of Object.keys(pauseState.ctx)) {
+    const ctxMeta = pauseState.ctx[elementID];
+    const index = strToInt(elementID);
+    const el = elements.get(index);
     assertDefined(el, `resume: cant find dom node for id`, elementID);
     assertQwikElement(el);
     const elCtx = getContext(el, containerState);
@@ -163,14 +173,15 @@ export const resumeContainer = (containerEl: Element) => {
 
     // Restore sequence scoping
     if (host) {
-      const [props, renderQrl] = host.split(' ');
+      const [renderQrl, props] = host.split(' ') as [string | undefined, string | undefined];
       const styleIds = el.getAttribute(QScopedStyle);
-      assertDefined(props, `resume: props missing in host metadata`, host);
       assertDefined(renderQrl, `resume: renderQRL missing in host metadata`, host);
       elCtx.$scopeIds$ = styleIds ? styleIds.split(' ') : null;
       elCtx.$flags$ = HOST_FLAG_MOUNTED;
-      elCtx.$props$ = getObject(props);
       elCtx.$componentQrl$ = getObject(renderQrl);
+      if (props) {
+        elCtx.$props$ = getObject(props);
+      }
     }
   }
 
@@ -219,7 +230,7 @@ const reviveSubscriptions = (
 };
 
 const reviveNestedObjects = (obj: any, getObject: GetObject, parser: Parser) => {
-  if (parser.fill(obj)) {
+  if (parser.fill(obj, getObject)) {
     return;
   }
 
@@ -238,7 +249,7 @@ const reviveNestedObjects = (obj: any, getObject: GetObject, parser: Parser) => 
 
 const getObjectImpl = (
   id: string,
-  elements: Map<string, QwikElement | Node>,
+  elements: Map<number, QwikElement | Node>,
   objs: any[],
   containerState: ContainerState
 ) => {
@@ -249,8 +260,9 @@ const getObjectImpl = (
   );
 
   if (id.startsWith(ELEMENT_ID_PREFIX)) {
-    assertTrue(elements.has(id), `missing element for id:`, id);
-    return elements.get(id);
+    const index = strToInt(id.slice(ELEMENT_ID_PREFIX.length));
+    assertTrue(elements.has(index), `missing element for id:`, index);
+    return elements.get(index);
   }
   const index = strToInt(id);
   assertTrue(objs.length > index, 'resume: index is out of bounds', id);
@@ -305,4 +317,12 @@ export const appendQwikDevTools = (containerEl: Element) => {
     pause: () => pauseContainer(containerEl),
     state: getContainerState(containerEl),
   };
+};
+
+export const getID = (stuff: string) => {
+  const index = stuff.indexOf('q:id=');
+  if (index > 0) {
+    return strToInt(stuff.slice(index + 5));
+  }
+  return -1;
 };

--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -101,6 +101,9 @@ export const resumeContainer = (containerEl: Element) => {
   }
 
   // Collect all elements
+  // If there are nested container, we are forced to take a slower path.
+  // In order to check if there are nested containers, we use the `'qc📦'` class.
+  // This is because checking for class is the fastest way for the browser to find it.
   const slotPath = containerEl.getElementsByClassName('qc📦').length !== 0;
   containerEl.querySelectorAll('[q\\:id]').forEach((el) => {
     if (slotPath && el.closest('[q\\:container]') !== containerEl) {

--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -17,26 +17,21 @@ import { directGetAttribute, directSetAttribute } from '../render/fast-calls';
 import { createParser, OBJECT_TRANSFORMS, Parser, UNDEFINED_PREFIX } from './serializers';
 import {
   ContainerState,
-  // FILTER_ACCEPT,
-  // FILTER_REJECT,
-  // FILTER_SKIP,
   getContainerState,
   GetObject,
   isContainer,
   SHOW_COMMENT,
-  // SHOW_ELEMENT,
   SnapshotState,
   strToInt,
 } from './container';
 import { findClose, QwikElement, VirtualElementImpl } from '../render/dom/virtual-element';
 import { getDomListeners } from '../state/listeners';
-// import { domToVnode } from '../render/dom/visitor';
 import { parseSubscription, Subscriptions } from '../state/common';
 import { createProxy } from '../state/store';
 import { qSerialize } from '../util/qdev';
 import { pauseContainer } from './pause';
 import { getContext, HOST_FLAG_MOUNTED } from '../state/context';
-import { QObjectFlagsSymbol } from '../state/constants';
+import { QObjectFlagsSymbol, QObjectImmutable } from '../state/constants';
 import { domToVnode } from '../render/dom/visitor';
 
 export const resumeIfNeeded = (containerEl: Element): void => {
@@ -181,6 +176,13 @@ export const resumeContainer = (containerEl: Element) => {
       elCtx.$componentQrl$ = getObject(renderQrl);
       if (props) {
         elCtx.$props$ = getObject(props);
+      } else {
+        elCtx.$props$ = createProxy(
+          {
+            [QObjectFlagsSymbol]: QObjectImmutable,
+          },
+          containerState
+        );
       }
     }
   }

--- a/packages/qwik/src/core/container/serializers.ts
+++ b/packages/qwik/src/core/container/serializers.ts
@@ -344,14 +344,10 @@ export const serializeValue = (
 export interface Parser {
   prepare(data: string): any;
   subs(obj: any, subs: Subscriptions[]): boolean;
-  fill(obj: any): boolean;
+  fill(obj: any, getObject: GetObject): boolean;
 }
 
-export const createParser = (
-  getObject: GetObject,
-  containerState: ContainerState,
-  doc: Document
-): Parser => {
+export const createParser = (containerState: ContainerState, doc: Document): Parser => {
   const fillMap = new Map<any, Serializer<any>>();
   const subsMap = new Map<any, Serializer<any>>();
 
@@ -380,7 +376,7 @@ export const createParser = (
       }
       return false;
     },
-    fill(obj: any) {
+    fill(obj: any, getObject: GetObject) {
       const serializer = fillMap.get(obj);
       if (serializer) {
         serializer.fill!(obj, getObject, containerState);

--- a/packages/qwik/src/core/container/store.unit.tsx
+++ b/packages/qwik/src/core/container/store.unit.tsx
@@ -62,7 +62,7 @@ storeSuite('should serialize content', async () => {
 
   equal(JSON.parse(script.textContent!), {
     ctx: {
-      '#1': {
+      '1': {
         r: '1 2 f m 8 i 7 6 k! m l 0',
       },
     },

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -124,6 +124,10 @@ export const renderSSR = async (node: JSXNode, opts: RenderSSROptions) => {
     'q:base': opts.base,
     children: root === 'html' ? [node] : [headNodes, node],
   };
+  if (root !== 'html') {
+    containerAttributes.class =
+      'qc📦' + containerAttributes.class ? ' ' + containerAttributes.class : '';
+  }
   containerState.$envData$ = {
     url: opts.url,
     ...opts.envData,

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -126,7 +126,7 @@ export const renderSSR = async (node: JSXNode, opts: RenderSSROptions) => {
   };
   if (root !== 'html') {
     containerAttributes.class =
-      'qc📦' + containerAttributes.class ? ' ' + containerAttributes.class : '';
+      'qc📦' + (containerAttributes.class ? ' ' + containerAttributes.class : '');
   }
   containerState.$envData$ = {
     url: opts.url,

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -543,10 +543,12 @@ export const renderNode = (
     if (key != null) {
       openingElement += ' q:key="' + key + '"';
     }
-    if ('ref' in props || useSignal || listenersNeedId(listeners)) {
-      const newID = getNextIndex(rCtx);
-      openingElement += ' q:id="' + newID + '"';
-      elCtx.$id$ = newID;
+    if ('ref' in props || useSignal || listeners.length > 0) {
+      if ('ref' in props || useSignal || listenersNeedId(listeners)) {
+        const newID = getNextIndex(rCtx);
+        openingElement += ' q:id="' + newID + '"';
+        elCtx.$id$ = newID;
+      }
       ssrCtx.$contexts$.push(elCtx);
     }
     if (flags & IS_HEAD) {
@@ -894,9 +896,6 @@ export const escapeAttr = (s: string) => {
 };
 
 export const listenersNeedId = (listeners: Listener[]) => {
-  if (listeners.length === 0) {
-    return false;
-  }
   return listeners.some((l) => l[1].$captureRef$ && l[1].$captureRef$.length > 0);
 };
 

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -822,7 +822,7 @@ renderSSRSuite('containerTagName', async () => {
       <UseClientEffect></UseClientEffect>
       <section></section>
     </>,
-    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="/manu/folder">
+    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="/manu/folder" class="qc📦">
       <link rel="stylesheet" href="/global.css">
       <!--qv q:id=0 q:key=sX:-->
         <style q:style="17nc-0">.host {color: red}</style>
@@ -863,7 +863,7 @@ renderSSRSuite('containerAttributes', async () => {
       <div></div>
     </>,
     `
-    <app prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev">
+    <app prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev" class='qc📦 thing'>
      <div></div>
     </app>
     `,
@@ -871,6 +871,7 @@ renderSSRSuite('containerAttributes', async () => {
       containerTagName: 'app',
       containerAttributes: {
         prefix: 'something',
+        class: 'thing',
       },
     }
   );

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -19,7 +19,7 @@ import { getValidManifest } from '../optimizer/src/manifest';
 import { applyPrefetchImplementation } from './prefetch-implementation';
 import type { QContext } from '../core/state/context';
 
-const DOCTYPE = '<!DOCTYPE html><!--cq-->';
+const DOCTYPE = '<!DOCTYPE html>';
 
 /**
  * Creates a server-side `document`, renders to root node to the document,
@@ -101,6 +101,7 @@ export async function renderToStream(
   if (containerTagName === 'html') {
     stream.write(DOCTYPE);
   } else {
+    stream.write('<!--cq-->');
     if (opts.qwikLoader) {
       if (opts.qwikLoader.include === undefined) {
         opts.qwikLoader.include = 'never';
@@ -205,7 +206,9 @@ export async function renderToStream(
   });
 
   // End of container
-  stream.write('<!--/cq-->');
+  if (containerTagName !== 'html') {
+    stream.write('<!--/cq-->');
+  }
 
   // Flush remaining chunks in the buffer
   flush();

--- a/starters/apps/e2e/src/components/containers/container.tsx
+++ b/starters/apps/e2e/src/components/containers/container.tsx
@@ -1,16 +1,15 @@
-import { component$, useStyles$, useStore, useWatch$ } from '@builder.io/qwik';
+import { component$, useStyles$, useResource$, Resource, useSignal } from '@builder.io/qwik';
 
 interface ContainerProps {
   url: string;
 }
 
 export const Containers = component$(() => {
+  const signal = useSignal(0);
   return (
-    <div class="my-app p-20">
-      <Container url="/e2e/slot"></Container>
+    <div>
+      <button onClick$={() => signal.value++}>{signal.value}</button>
       <Container url="/e2e/two-listeners"></Container>
-      <Container url="/e2e/lexical-scope"></Container>
-      <Container url="/e2e/await"></Container>
     </div>
   );
 });
@@ -35,23 +34,30 @@ export const Container = component$((props: ContainerProps) => {
       margin-bottom: 10px;
     }
     `);
-  const state = useStore({
-    url: '',
-    html: '',
-  });
 
-  useWatch$(async ({ track }) => {
+  const resource = useResource$<{ url: string; html: string }>(async ({ track }) => {
     track(props, 'url');
     const url = `http://localhost:3300${props.url}?fragment&loader=false`;
     const res = await fetch(url);
-    state.url = await res.text();
-    state.html = await res.text();
+    return {
+      url,
+      html: await res.text(),
+    };
   });
 
   return (
     <div class="container">
-      <div class="url">{state.url}</div>
-      <div class="frame" dangerouslySetInnerHTML={state.html} />
+      <Resource
+        value={resource}
+        onResolved={({ url, html }) => {
+          return (
+            <>
+              <div class="url">{url}</div>
+              <div class="frame" dangerouslySetInnerHTML={html} />
+            </>
+          );
+        }}
+      />
     </div>
   );
 });

--- a/starters/apps/e2e/src/components/containers/container.tsx
+++ b/starters/apps/e2e/src/components/containers/container.tsx
@@ -37,7 +37,7 @@ export const Container = component$((props: ContainerProps) => {
 
   const resource = useResource$<{ url: string; html: string }>(async ({ track }) => {
     track(props, 'url');
-    const url = `http://localhost:3300${props.url}?fragment&loader=false`;
+    const url = `http://localhost:${(globalThis as any).PORT}${props.url}?fragment&loader=false`;
     const res = await fetch(url);
     return {
       url,

--- a/starters/apps/e2e/src/components/no-resume/no-resume.tsx
+++ b/starters/apps/e2e/src/components/no-resume/no-resume.tsx
@@ -1,0 +1,13 @@
+import { component$ } from '@builder.io/qwik';
+
+export const NoResume = component$(() => {
+  return (
+    <button
+      onClick$={() => {
+        document.body.style.background = 'black';
+      }}
+    >
+      Click me
+    </button>
+  );
+});

--- a/starters/apps/e2e/src/entry.ssr.tsx
+++ b/starters/apps/e2e/src/entry.ssr.tsx
@@ -25,6 +25,7 @@ import { RefRoot } from './components/ref/ref';
 import { Signals } from './components/signals/signals';
 import { Attributes } from './components/attributes/attributes';
 import { EventsClient } from './components/events/events-client';
+import { NoResume } from './components/no-resume/no-resume';
 
 /**
  * Entry point for server-side pre-rendering.
@@ -58,6 +59,7 @@ export default function (opts: RenderToStreamOptions) {
     '/e2e/signals': () => <Signals />,
     '/e2e/attributes': () => <Attributes />,
     '/e2e/events-client': () => <EventsClient />,
+    '/e2e/no-resume': () => <NoResume />,
   };
 
   const url = new URL(opts.envData!.url);

--- a/starters/apps/e2e/src/root.tsx
+++ b/starters/apps/e2e/src/root.tsx
@@ -74,6 +74,9 @@ export const Root = component$(() => {
       <p>
         <a href="/e2e/events-client">Event client</a>
       </p>
+      <p>
+        <a href="/e2e/no-resume">No resume</a>
+      </p>
     </section>
   );
 });

--- a/starters/dev-server.ts
+++ b/starters/dev-server.ts
@@ -143,6 +143,7 @@ export {
       define: {
         'globalThis.qSerialize': true,
         'globalThis.qDev': !isProd,
+        'globalThis.PORT': port,
       },
       plugins: [
         ...plugins,
@@ -172,6 +173,7 @@ export {
       plugins: [...plugins, optimizer.qwikVite()],
       define: {
         'globalThis.qDev': !isProd,
+        'globalThis.PORT': port,
       },
     })
   );

--- a/starters/e2e/e2e.containers.spec.ts
+++ b/starters/e2e/e2e.containers.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('no resume', () => {
+test.describe('container', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/e2e/container');
   });

--- a/starters/e2e/e2e.containers.spec.ts
+++ b/starters/e2e/e2e.containers.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('no resume', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/e2e/container');
+  });
+
+  test('should handle counter', async ({ page }) => {
+    const button = page.locator('button');
+
+    await expect(button).toHaveText('0');
+    await button.click();
+    await expect(button).toHaveText('1');
+  });
+
+  test('should handle inner counter', async ({ page }) => {
+    const anchor = page.locator('a');
+
+    await expect(anchor).toHaveText('1 / 1');
+    await anchor.click();
+    await expect(anchor).toHaveText('2 / 3');
+  });
+});

--- a/starters/e2e/e2e.noresume.spec.ts
+++ b/starters/e2e/e2e.noresume.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('no resume', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/e2e/no-resume');
+  });
+
+  test('should handle to click', async ({ page }) => {
+    const button = page.locator('button');
+    await button.click();
+
+    const body = page.locator('body');
+    await expect(body).toHaveCSS('background-color', 'rgb(0, 0, 0)');
+  });
+});


### PR DESCRIPTION
# What is it?

Resuming already is pretty fast, but we were using some DOM API in a very unoptimal way, createTreeWalker is extremelly fast since it can walk the DOM at C++ speed, but we implemented a heavy acceptNode() function, which is a footgun.

Instead we implement the same thing in a different way, that least to a massive 14x improvement for a big DOM.
https://twitter.com/manucorporat/status/1588506463986933761

This is not the end, resuming does already a lot of stuff eagarly that it does not really have to do, but it was easy to implement it this way.

Follow up PR will improve perf in another 10x factor, getting the total improvement of around x100 times fast, ie, from 1 second to around 1ms

