### PR TITLE
fix: Add path and domain options to cookie deletion

### DIFF
--- a/packages/docs/src/routes/qwikcity/data/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/data/overview/index.mdx
@@ -100,10 +100,20 @@ For more information on these attributes and their values, please refer to [the 
 
 Appends a header with the provided key to the cookie. The new header will have an expired date in the `expires` field, telling the browers to remove it.
 
+```typescript
+cookie.delete('my-cookie')
+```
+
 Equivalent to calling:
 
 ```typescript
 cookie.set('my-cookie', 'deleted', new Date(0))
+```
+
+Optionally, you can set the path and/or domain when deleting the cookie. If your cookie was created with a path/domain, you must set these fields for the deletion to take effect.
+
+```typescript
+cookie.delete('my-cookie', { domain: 'https://qwik.builder.io', path: '/docs/'})
 ```
 
 **has**

--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -113,8 +113,8 @@ export class Cookie implements CookieInterface {
     this[RES_COOKIE][cookieName] = createSetCookieValue(cookieName, resolvedValue, options);
   }
 
-  delete(name: string) {
-    this.set(name, 'deleted', { expires: new Date(0) });
+  delete(name: string, options?: Pick<CookieOptions, 'path' | 'domain'>) {
+    this.set(name, 'deleted', { ...options, expires: new Date(0) });
   }
 
   headers() {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Allows users to set the path/domain when deleting a cookie. Cookies set with a path and/or domain need the fields set to be removed properly.

Fixes: #1990 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
