### PR TITLE
feat: Add container attributes in starters

### DIFF
--- a/packages/docs/src/routes/qwikcity/data/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/data/overview/index.mdx
@@ -100,10 +100,20 @@ For more information on these attributes and their values, please refer to [the 
 
 Appends a header with the provided key to the cookie. The new header will have an expired date in the `expires` field, telling the browers to remove it.
 
+```typescript
+cookie.delete('my-cookie')
+```
+
 Equivalent to calling:
 
 ```typescript
 cookie.set('my-cookie', 'deleted', new Date(0))
+```
+
+Optionally, you can set the path and/or domain when deleting the cookie. If your cookie was created with a path/domain, you must set these fields for the deletion to take effect.
+
+```typescript
+cookie.delete('my-cookie', { domain: 'https://qwik.builder.io', path: '/docs/'})
 ```
 
 **has**

--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -113,8 +113,8 @@ export class Cookie implements CookieInterface {
     this[RES_COOKIE][cookieName] = createSetCookieValue(cookieName, resolvedValue, options);
   }
 
-  delete(name: string) {
-    this.set(name, 'deleted', { expires: new Date(0) });
+  delete(name: string, options?: Pick<CookieOptions, 'path' | 'domain'>) {
+    this.set(name, 'deleted', { ...options, expires: new Date(0) });
   }
 
   headers() {

--- a/starters/apps/base/src/entry.ssr.tsx
+++ b/starters/apps/base/src/entry.ssr.tsx
@@ -20,7 +20,7 @@ export default function (opts: RenderToStreamOptions) {
     ...opts,
     // Use container attributes to set attributes on the html tag.
     containerAttributes: {
-      lang: 'en-us'
+      lang: 'en-us',
     },
     prefetchStrategy: {
       implementation: {

--- a/starters/apps/base/src/entry.ssr.tsx
+++ b/starters/apps/base/src/entry.ssr.tsx
@@ -18,6 +18,10 @@ export default function (opts: RenderToStreamOptions) {
   return renderToStream(<Root />, {
     manifest,
     ...opts,
+    // Use container attributes to set attributes on the html tag.
+    containerAttributes: {
+      lang: 'en-us'
+    },
     prefetchStrategy: {
       implementation: {
         linkInsert: null,


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Many people want to know how to add attributes to the html tag in Qwik City. This PR adds the lang attribute to the containerAttributes, so an example is present in the starters. Also resolves an accessibility issue with the starters.

Fixes: #1983 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
