### PR TITLE
fix(tailwind.config.js): Support tailwind usage in .mdx files

### DIFF
--- a/starters/features/tailwind/tailwind.config.js
+++ b/starters/features/tailwind/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

Allow users to use tailwind in `.mdx` files out of the box without having to manually change the starter `tailwind.config.js` file

Fixes [#2002](https://github.com/BuilderIO/qwik/issues/2002)

# Use cases and why

Users should be able to use tailwind features (e.g. https://tailwindcss.com/docs/typography-plugin to style their mdx out of the box) without further configuration.

I don't believe there's any downsides by having `mdx` as a default value in the list above but if there's good reason happy for this to be closed as unnecessary.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
