### PR TITLE
docs: fix typo

### DIFF
--- a/packages/docs/src/routes/qwikcity/data/retrieve/index.mdx
+++ b/packages/docs/src/routes/qwikcity/data/retrieve/index.mdx
@@ -79,7 +79,7 @@ export default component$(() => {
 ```
 
 1. Notice that the data request handler and the component are defined in the same file. The data is serviced by the `onGet` function and the component is by the modules default export.
-2. The component uses `useEndpoint()` function to retrieve the data. The `useEndpoint()` function invokes `onGet` function directly on the server but using `fetch()` on the client. Your component does not need to think about server/client differences when using data. The `useEndpoint()` function returns an object of type `ResourceReturn`. `Resources` are promise-like objects that can be serialized by Qwik.
+2. The component uses `useEndpoint()` function to retrieve the data. The `useEndpoint()` function invokes `onGet` function directly on the server but using `fetch()` on the client. Your component does not need to think about server/client differences when using data. The `useEndpoint()` function returns an object of type `ResourceReturn`. A `Resource` is a promise-like object that can be serialized by Qwik.
 3. The `onGet` function is invoked before the component. This allows the `onGet` to return 404 or redirect in case the data is not available.
 4. Notice the use of `<Resource>` JSX element. The purpose of `Resource` is to allow the client to render different states of the `useEndpoint()` resource.
 5. On the server the `<Resource>` element will pause rendering until the `Resource` is resolved or rejected. This is because we don't want the server to render `loading...`. (The server needs to know when the component is ready for serialization into HTML.)

--- a/packages/docs/src/routes/qwikcity/data/retrieve/index.mdx
+++ b/packages/docs/src/routes/qwikcity/data/retrieve/index.mdx
@@ -79,7 +79,7 @@ export default component$(() => {
 ```
 
 1. Notice that the data request handler and the component are defined in the same file. The data is serviced by the `onGet` function and the component is by the modules default export.
-2. The component uses `useEndpoint()` function to retrieve the data. The `useEndpoint()` function invokes `onGet` function directly on the server but using `fetch()` on the client. Your component does not need to think about server/client differences when using data. The `useEndpoint()` function returns an object of type `ResourceReturn`. `Resource`s are promise-like objects that can be serialized by Qwik.
+2. The component uses `useEndpoint()` function to retrieve the data. The `useEndpoint()` function invokes `onGet` function directly on the server but using `fetch()` on the client. Your component does not need to think about server/client differences when using data. The `useEndpoint()` function returns an object of type `ResourceReturn`. `Resources` are promise-like objects that can be serialized by Qwik.
 3. The `onGet` function is invoked before the component. This allows the `onGet` to return 404 or redirect in case the data is not available.
 4. Notice the use of `<Resource>` JSX element. The purpose of `Resource` is to allow the client to render different states of the `useEndpoint()` resource.
 5. On the server the `<Resource>` element will pause rendering until the `Resource` is resolved or rejected. This is because we don't want the server to render `loading...`. (The server needs to know when the component is ready for serialization into HTML.)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

i changed `Resource`s to `Resources` in "# Using onGet in a Component" line 82


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
