### PR TITLE
feat: Expose event types

### DIFF
--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -304,6 +304,42 @@ export type MountFn<T> = () => ValueOrPromise<T>;
 // @alpha @deprecated (undocumented)
 export const mutable: <T>(v: T) => T;
 
+// @public (undocumented)
+export type NativeAnimationEvent = AnimationEvent;
+
+// @public (undocumented)
+export type NativeClipboardEvent = ClipboardEvent;
+
+// @public (undocumented)
+export type NativeCompositionEvent = CompositionEvent;
+
+// @public (undocumented)
+export type NativeDragEvent = DragEvent;
+
+// @public (undocumented)
+export type NativeFocusEvent = FocusEvent;
+
+// @public (undocumented)
+export type NativeKeyboardEvent = KeyboardEvent;
+
+// @public (undocumented)
+export type NativeMouseEvent = MouseEvent;
+
+// @public (undocumented)
+export type NativePointerEvent = PointerEvent;
+
+// @public (undocumented)
+export type NativeTouchEvent = TouchEvent;
+
+// @public (undocumented)
+export type NativeTransitionEvent = TransitionEvent;
+
+// @public (undocumented)
+export type NativeUIEvent = UIEvent;
+
+// @public (undocumented)
+export type NativeWheelEvent = WheelEvent;
+
 // @public
 export type NoSerialize<T> = (T & {
     __no_serialize__: true;
@@ -360,8 +396,56 @@ export const qrl: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: st
 // @internal (undocumented)
 export const qrlDEV: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: string, opts: QRLDev, lexicalScopeCapture?: any[]) => QRL<T>;
 
+// Warning: (ae-forgotten-export) The symbol "SyntheticEvent" needs to be exported by the entry point index.d.ts
+//
+// @beta (undocumented)
+export interface QwikAnimationEvent<T = Element> extends SyntheticEvent<T, NativeAnimationEvent> {
+    // (undocumented)
+    animationName: string;
+    // (undocumented)
+    elapsedTime: number;
+    // (undocumented)
+    pseudoElement: string;
+}
+
+// @beta (undocumented)
+export interface QwikChangeEvent<T = Element> extends SyntheticEvent<T> {
+    // (undocumented)
+    target: EventTarget & T;
+}
+
+// @beta (undocumented)
+export interface QwikClipboardEvent<T = Element> extends SyntheticEvent<T, NativeClipboardEvent> {
+    // (undocumented)
+    clipboardData: DataTransfer;
+}
+
+// @beta (undocumented)
+export interface QwikCompositionEvent<T = Element> extends SyntheticEvent<T, NativeCompositionEvent> {
+    // (undocumented)
+    data: string;
+}
+
 // @public (undocumented)
 export interface QwikDOMAttributes extends DOMAttributes<any> {
+}
+
+// @beta (undocumented)
+export interface QwikDragEvent<T = Element> extends QwikMouseEvent<T, NativeDragEvent> {
+    // (undocumented)
+    dataTransfer: DataTransfer;
+}
+
+// @beta (undocumented)
+export interface QwikFocusEvent<T = Element> extends SyntheticEvent<T, NativeFocusEvent> {
+    // (undocumented)
+    relatedTarget: EventTarget | null;
+    // (undocumented)
+    target: EventTarget & T;
+}
+
+// @beta (undocumented)
+export interface QwikFormEvent<T = Element> extends SyntheticEvent<T> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IntrinsicHTMLElements" needs to be exported by the entry point index.d.ts
@@ -377,6 +461,12 @@ export interface QwikIntrinsicElements extends IntrinsicHTMLElements {
     //
     // (undocumented)
     script: QwikScriptHTMLAttributes<HTMLScriptElement>;
+}
+
+// @beta (undocumented)
+export interface QwikInvalidEvent<T = Element> extends SyntheticEvent<T> {
+    // (undocumented)
+    target: EventTarget & T;
 }
 
 // @public (undocumented)
@@ -397,6 +487,142 @@ export namespace QwikJSX {
     // (undocumented)
     export interface IntrinsicElements extends QwikIntrinsicElements {
     }
+}
+
+// @beta (undocumented)
+export interface QwikKeyboardEvent<T = Element> extends SyntheticEvent<T, NativeKeyboardEvent> {
+    // (undocumented)
+    altKey: boolean;
+    // (undocumented)
+    charCode: number;
+    // (undocumented)
+    ctrlKey: boolean;
+    getModifierState(key: string): boolean;
+    key: string;
+    // (undocumented)
+    keyCode: number;
+    // (undocumented)
+    locale: string;
+    // (undocumented)
+    location: number;
+    // (undocumented)
+    metaKey: boolean;
+    // (undocumented)
+    repeat: boolean;
+    // (undocumented)
+    shiftKey: boolean;
+    // (undocumented)
+    which: number;
+}
+
+// @beta (undocumented)
+export interface QwikMouseEvent<T = Element, E = NativeMouseEvent> extends SyntheticEvent<T, E> {
+    // (undocumented)
+    altKey: boolean;
+    // (undocumented)
+    button: number;
+    // (undocumented)
+    buttons: number;
+    // (undocumented)
+    clientX: number;
+    // (undocumented)
+    clientY: number;
+    // (undocumented)
+    ctrlKey: boolean;
+    getModifierState(key: string): boolean;
+    // (undocumented)
+    metaKey: boolean;
+    // (undocumented)
+    movementX: number;
+    // (undocumented)
+    movementY: number;
+    // (undocumented)
+    pageX: number;
+    // (undocumented)
+    pageY: number;
+    // (undocumented)
+    relatedTarget: EventTarget | null;
+    // (undocumented)
+    screenX: number;
+    // (undocumented)
+    screenY: number;
+    // (undocumented)
+    shiftKey: boolean;
+    // (undocumented)
+    x: number;
+    // (undocumented)
+    y: number;
+}
+
+// @beta (undocumented)
+export interface QwikPointerEvent<T = Element> extends QwikMouseEvent<T, NativePointerEvent> {
+    // (undocumented)
+    height: number;
+    // (undocumented)
+    isPrimary: boolean;
+    // (undocumented)
+    pointerId: number;
+    // (undocumented)
+    pointerType: 'mouse' | 'pen' | 'touch';
+    // (undocumented)
+    pressure: number;
+    // (undocumented)
+    tiltX: number;
+    // (undocumented)
+    tiltY: number;
+    // (undocumented)
+    width: number;
+}
+
+// @beta (undocumented)
+export interface QwikTouchEvent<T = Element> extends SyntheticEvent<T, NativeTouchEvent> {
+    // (undocumented)
+    altKey: boolean;
+    // (undocumented)
+    changedTouches: TouchList;
+    // (undocumented)
+    ctrlKey: boolean;
+    getModifierState(key: string): boolean;
+    // (undocumented)
+    metaKey: boolean;
+    // (undocumented)
+    shiftKey: boolean;
+    // (undocumented)
+    targetTouches: TouchList;
+    // (undocumented)
+    touches: TouchList;
+}
+
+// @beta (undocumented)
+export interface QwikTransitionEvent<T = Element> extends SyntheticEvent<T, NativeTransitionEvent> {
+    // (undocumented)
+    elapsedTime: number;
+    // (undocumented)
+    propertyName: string;
+    // (undocumented)
+    pseudoElement: string;
+}
+
+// @beta (undocumented)
+export interface QwikUIEvent<T = Element> extends SyntheticEvent<T, NativeUIEvent> {
+    // (undocumented)
+    detail: number;
+    // Warning: (ae-forgotten-export) The symbol "AbstractView" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    view: AbstractView;
+}
+
+// @beta (undocumented)
+export interface QwikWheelEvent<T = Element> extends QwikMouseEvent<T, NativeWheelEvent> {
+    // (undocumented)
+    deltaMode: number;
+    // (undocumented)
+    deltaX: number;
+    // (undocumented)
+    deltaY: number;
+    // (undocumented)
+    deltaZ: number;
 }
 
 // @alpha

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -304,40 +304,40 @@ export type MountFn<T> = () => ValueOrPromise<T>;
 // @alpha @deprecated (undocumented)
 export const mutable: <T>(v: T) => T;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeAnimationEvent = AnimationEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeClipboardEvent = ClipboardEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeCompositionEvent = CompositionEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeDragEvent = DragEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeFocusEvent = FocusEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeKeyboardEvent = KeyboardEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeMouseEvent = MouseEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativePointerEvent = PointerEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeTouchEvent = TouchEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeTransitionEvent = TransitionEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeUIEvent = UIEvent;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NativeWheelEvent = WheelEvent;
 
 // @public

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -114,3 +114,36 @@ export { noSerialize, mutable } from './state/common';
 export { _IMMUTABLE } from './state/constants';
 
 export { version } from './version';
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Qwik Events
+//////////////////////////////////////////////////////////////////////////////////////////
+export type {
+  NativeAnimationEvent,
+  NativeClipboardEvent,
+  NativeCompositionEvent,
+  NativeDragEvent,
+  NativeFocusEvent,
+  NativeKeyboardEvent,
+  NativeMouseEvent,
+  NativePointerEvent,
+  NativeTouchEvent,
+  NativeTransitionEvent,
+  NativeUIEvent,
+  NativeWheelEvent,
+  QwikAnimationEvent,
+  QwikClipboardEvent,
+  QwikCompositionEvent,
+  QwikDragEvent,
+  QwikPointerEvent,
+  QwikFocusEvent,
+  QwikFormEvent,
+  QwikInvalidEvent,
+  QwikChangeEvent,
+  QwikKeyboardEvent,
+  QwikMouseEvent,
+  QwikTouchEvent,
+  QwikUIEvent,
+  QwikWheelEvent,
+  QwikTransitionEvent,
+} from './render/jsx/types/jsx-qwik-events';

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -136,6 +136,29 @@ export type QwikEventMap<T> = {
   AnimationIterationCapture: QwikAnimationEvent<T>;
   TransitionEnd: QwikTransitionEvent<T>;
   TransitionEndCapture: QwikTransitionEvent<T>;
+
+  //Audio / Video Events
+  AudioProcess: Event;
+  CanPlay: Event;
+  CanPlayThrough: Event;
+  Complete: Event;
+  DurationChange: Event;
+  Emptied: Event;
+  Ended: Event;
+  LoadedData: Event;
+  LoadedMetadata: Event;
+  Pause: Event;
+  Play: Event;
+  Playing: Event;
+  Progress: Event;
+  RateChange: Event;
+  Seeked: Event;
+  Seeking: Event;
+  Stalled: Event;
+  Suspend: Event;
+  TimeUpdate: Event;
+  VolumeChange: Event;
+  Waiting: Event;
 };
 
 export type PreventDefault<T> = {

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -16,38 +16,53 @@ interface BaseSyntheticEvent<E = object, C = any, T = any> {
   type: string;
 }
 
-type NativeAnimationEvent = AnimationEvent;
-type NativeClipboardEvent = ClipboardEvent;
-type NativeCompositionEvent = CompositionEvent;
-type NativeDragEvent = DragEvent;
-type NativeFocusEvent = FocusEvent;
-type NativeKeyboardEvent = KeyboardEvent;
-type NativeMouseEvent = MouseEvent;
-type NativeTouchEvent = TouchEvent;
-type NativePointerEvent = PointerEvent;
-type NativeTransitionEvent = TransitionEvent;
-type NativeUIEvent = UIEvent;
-type NativeWheelEvent = WheelEvent;
+export type NativeAnimationEvent = AnimationEvent;
+export type NativeClipboardEvent = ClipboardEvent;
+export type NativeCompositionEvent = CompositionEvent;
+export type NativeDragEvent = DragEvent;
+export type NativeFocusEvent = FocusEvent;
+export type NativeKeyboardEvent = KeyboardEvent;
+export type NativeMouseEvent = MouseEvent;
+export type NativeTouchEvent = TouchEvent;
+export type NativePointerEvent = PointerEvent;
+export type NativeTransitionEvent = TransitionEvent;
+export type NativeUIEvent = UIEvent;
+export type NativeWheelEvent = WheelEvent;
 
+/**
+ * @beta
+ */
 export interface QwikAnimationEvent<T = Element> extends SyntheticEvent<T, NativeAnimationEvent> {
   animationName: string;
   elapsedTime: number;
   pseudoElement: string;
 }
 
+/**
+ * @beta
+ */
 export interface QwikClipboardEvent<T = Element> extends SyntheticEvent<T, NativeClipboardEvent> {
   clipboardData: DataTransfer;
 }
 
+/**
+ * @beta
+ */
 export interface QwikCompositionEvent<T = Element>
   extends SyntheticEvent<T, NativeCompositionEvent> {
   data: string;
 }
 
+/**
+ * @beta
+ */
 export interface QwikDragEvent<T = Element> extends QwikMouseEvent<T, NativeDragEvent> {
   dataTransfer: DataTransfer;
 }
 
+/**
+ * @beta
+ */
 export interface QwikPointerEvent<T = Element> extends QwikMouseEvent<T, NativePointerEvent> {
   pointerId: number;
   pressure: number;
@@ -59,21 +74,36 @@ export interface QwikPointerEvent<T = Element> extends QwikMouseEvent<T, NativeP
   isPrimary: boolean;
 }
 
+/**
+ * @beta
+ */
 export interface QwikFocusEvent<T = Element> extends SyntheticEvent<T, NativeFocusEvent> {
   relatedTarget: EventTarget | null;
   target: EventTarget & T;
 }
 
+/**
+ * @beta
+ */
 export interface QwikFormEvent<T = Element> extends SyntheticEvent<T> {}
 
+/**
+ * @beta
+ */
 export interface QwikInvalidEvent<T = Element> extends SyntheticEvent<T> {
   target: EventTarget & T;
 }
 
+/**
+ * @beta
+ */
 export interface QwikChangeEvent<T = Element> extends SyntheticEvent<T> {
   target: EventTarget & T;
 }
 
+/**
+ * @beta
+ */
 export interface QwikKeyboardEvent<T = Element> extends SyntheticEvent<T, NativeKeyboardEvent> {
   altKey: boolean;
   charCode: number;
@@ -95,6 +125,9 @@ export interface QwikKeyboardEvent<T = Element> extends SyntheticEvent<T, Native
   which: number;
 }
 
+/**
+ * @beta
+ */
 export interface QwikMouseEvent<T = Element, E = NativeMouseEvent> extends SyntheticEvent<T, E> {
   altKey: boolean;
   button: number;
@@ -119,6 +152,9 @@ export interface QwikMouseEvent<T = Element, E = NativeMouseEvent> extends Synth
   y: number;
 }
 
+/**
+ * @beta
+ */
 export interface QwikTouchEvent<T = Element> extends SyntheticEvent<T, NativeTouchEvent> {
   altKey: boolean;
   changedTouches: TouchList;
@@ -133,11 +169,17 @@ export interface QwikTouchEvent<T = Element> extends SyntheticEvent<T, NativeTou
   touches: TouchList;
 }
 
+/**
+ * @beta
+ */
 export interface QwikUIEvent<T = Element> extends SyntheticEvent<T, NativeUIEvent> {
   detail: number;
   view: AbstractView;
 }
 
+/**
+ * @beta
+ */
 export interface QwikWheelEvent<T = Element> extends QwikMouseEvent<T, NativeWheelEvent> {
   deltaMode: number;
   deltaX: number;
@@ -145,6 +187,9 @@ export interface QwikWheelEvent<T = Element> extends QwikMouseEvent<T, NativeWhe
   deltaZ: number;
 }
 
+/**
+ * @beta
+ */
 export interface QwikTransitionEvent<T = Element> extends SyntheticEvent<T, NativeTransitionEvent> {
   elapsedTime: number;
   propertyName: string;

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -16,17 +16,29 @@ interface BaseSyntheticEvent<E = object, C = any, T = any> {
   type: string;
 }
 
+/** @beta */
 export type NativeAnimationEvent = AnimationEvent;
+/** @beta */
 export type NativeClipboardEvent = ClipboardEvent;
+/** @beta */
 export type NativeCompositionEvent = CompositionEvent;
+/** @beta */
 export type NativeDragEvent = DragEvent;
+/** @beta */
 export type NativeFocusEvent = FocusEvent;
+/** @beta */
 export type NativeKeyboardEvent = KeyboardEvent;
+/** @beta */
 export type NativeMouseEvent = MouseEvent;
+/** @beta */
 export type NativeTouchEvent = TouchEvent;
+/** @beta */
 export type NativePointerEvent = PointerEvent;
+/** @beta */
 export type NativeTransitionEvent = TransitionEvent;
+/** @beta */
 export type NativeUIEvent = UIEvent;
+/** @beta */
 export type NativeWheelEvent = WheelEvent;
 
 /**


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

We now have awesome event types that work great in inline event handlers. But because these types are not exported, people are unable to use them when creating QRLs that are not inline.

This PR exposes those types for developers.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
