### PR TITLE
Docs: English doc linked to Italian resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ If you're not able to use the dev container, follow these instructions:
 
 ## Prerequisite
 
-To build platform binding and wasm, make sure you have installed [Rust](https://www.rust-lang.org/it/tools/install).
+To build platform binding and wasm, make sure you have installed [Rust](https://www.rust-lang.org/tools/install).
 
-> On Windows, Rust requires [C++ build tools](https://visualstudio.microsoft.com/it/visual-cpp-build-tools/). You can also select _Desktop development with C++_
+> On Windows, Rust requires [C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). You can also select _Desktop development with C++_
 > while installing Visual Studio.
 
 > Alternatively, if Rust is not available you can run `yarn build.platform.copy` to download bindings from CDN


### PR DESCRIPTION
CONTRIBUTING.md in its native English form was linking to Visual Studio C++ build tools and the Rust downloader in their Italian versions.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X ] Docs / tests

# Description

CONTRIBUTING.md in its native English form was linking to Visual Studio C++ build tools and the Rust downloader in their Italian versions.

# Use cases and why

Just avoiding anything that could cause a new contributor to stumble

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
