### PR TITLE
docs: add translate no in repl

### DIFF
--- a/packages/docs/src/repl/repl-input-panel.tsx
+++ b/packages/docs/src/repl/repl-input-panel.tsx
@@ -15,7 +15,7 @@ export const ReplInputPanel = ({
   enableInputDelete,
 }: ReplInputPanelProps) => {
   return (
-    <div class="repl-panel repl-input-panel">
+    <div class="repl-panel repl-input-panel" translate="no">
       <ReplTabButtons>
         {input.files.map((f) =>
           f.hidden ? null : (

--- a/packages/docs/src/repl/repl-tab-buttons.tsx
+++ b/packages/docs/src/repl/repl-tab-buttons.tsx
@@ -1,6 +1,6 @@
 export const ReplTabButtons = (props: ReplTabButtonsProps) => {
   return (
-    <div class="repl-tab-buttons">
+    <div class="repl-tab-buttons" translate="no">
       <div class="repl-tab-buttons-inner">{props.children}</div>
     </div>
   );


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

<img width="775" alt="image" src="https://user-images.githubusercontent.com/27342882/200536777-bcd9fc4f-c9b0-49bc-8a93-54e29244945b.png">

When using a translator, the editor area should not be translated so that it does not interfere with practice.

# Use cases and why

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [] Added new tests to cover the fix / functionality
