### PR TITLE
fix(client-navigate.ts): Wait to scroll the page until navigation has finished

### DIFF
--- a/packages/qwik-city/runtime/src/library/client-navigate.ts
+++ b/packages/qwik-city/runtime/src/library/client-navigate.ts
@@ -38,6 +38,16 @@ const handleScroll = async (win: Window, previousUrl: SimpleURL, newUrl: SimpleU
   const doc = win.document;
   const newHash = newUrl.hash;
 
+  const waitForDOMNodeInserted = () => {
+    return new Promise<void>((resolve) => {
+      const listener = () => {
+        resolve();
+        win.removeEventListener('DOMNodeInserted', listener);
+      };
+      win.addEventListener('DOMNodeInserted', listener);
+    });
+  };
+
   if (isSamePath(previousUrl, newUrl)) {
     // same route after path change
 
@@ -72,6 +82,8 @@ const handleScroll = async (win: Window, previousUrl: SimpleURL, newUrl: SimpleU
     } else {
       // different route and there isn't a hash
       await domWait();
+      // wait to scroll until the dom is meaningfully updated
+      await waitForDOMNodeInserted();
       win.scrollTo(0, 0);
     }
   }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

`win.scrollTo(0,0)` is being fired too early on route navigation. This causes the page to jitter to the top just before the navigation takes place. This PR aims to fix this by awaiting modification to the page before scrolling to the top.

## Replicating the problem

This problem can be replicated in the project created by `npm create qwik@latest` by simply adding content to the body until the page scrolls and clicking the "Blow my mind 🤯" button after scrolling to the bottom of the page.

## Screenshots

_before these changes:_
<img src="https://user-images.githubusercontent.com/106682128/200619469-3dd593dd-061a-4538-a507-9dd7860d6596.gif" width="400" />

_after these changes:_

<img src="https://user-images.githubusercontent.com/106682128/200620169-f7802b51-c775-419b-b288-83db4366cb72.gif" width="400" />

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

# Additional Information

I'm not entirely married to this solution, but I wanted to bring to attention the fact that this problem exists and that there is a solution for it. My implementation for `waitForDOMNodeInserted` may not be taking into consideration every edge case. I personally can't think of any edge cases to check for, but there may be one. `DOMNodeInserted` might also not be the best listener to wait on in order to solve this problem.

I ran the tests locally, but I was having some issues getting the `e2e` tests to work even on the main branch, so I must be missing something on my machine. I also am getting a weird error from stackblitz on `yarn install`, so 🤷‍♀️I don't know what that is about.

I posted a little about this issue in thie #qwik-help channel in the Builder.io discord, but as I kept digging, I realized the source of the problem was this race condition in `client-navigate.ts`.