### PR TITLE
fix: multiple cookies serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "qwik-monorepo",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "scripts": {
     "build": "tsm scripts/index.ts --tsc --build --qwikcity --api --platform-binding-wasm-copy",
     "build.full": "tsm scripts/index.ts --tsc --build --api --eslint --qwikcity --qwikreact --cli --platform-binding --wasm",

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -144,11 +144,21 @@ export async function runCreateInteractiveCli() {
 
 function checkNodeVersion() {
   const version = process.version;
-  const majorVersion = Number(version.replace('v', '').split('.')[0]);
-  if (majorVersion < 16) {
+  const [majorVersion, minorVersion] = version.replace('v', '').split('.');
+  if (Number(majorVersion) < 16) {
     console.error(
-      color.red(`Qwik requires Node.js 16 or higher. You are currently running Node.js ${version}.`)
+      color.red(
+        `Qwik requires Node.js 16.8 or higher. You are currently running Node.js ${version}.`
+      )
     );
     process.exit(1);
+  } else if (Number(majorVersion) === 16) {
+    if (Number(minorVersion) < 8) {
+      console.warn(
+        color.yellow(
+          `Node.js 16.8 or higher is recommended. You are currently running Node.js ${version}.`
+        )
+      );
+    }
   }
 }

--- a/packages/create-qwik/package.json
+++ b/packages/create-qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-qwik",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Interactive CLI for create Qwik projects and adding features.",
   "bin": "./create-qwik.cjs",
   "main": "./index.cjs",

--- a/packages/eslint-plugin-qwik/package.json
+++ b/packages/eslint-plugin-qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-qwik",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "An Open-Source sub-framework designed with a focus on server-side-rendering, lazy-loading, and styling/animation.",
   "main": "index.js",
   "author": "Builder Team",

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -137,8 +137,9 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
           // but do not end() it, call next() so qwik plugin handles rendering
           res.statusCode = userResponse.status;
           userResponse.headers.forEach((value, key) => res.setHeader(key, value));
-          for (const header in userResponse.cookie.headers()) {
-            res.setHeader('Set-Cookie', header);
+          const cookies = userResponse.cookie.headers();
+          if (cookies.length > 0) {
+            res.setHeader('Set-Cookie', cookies);
           }
           next();
           return;

--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -4,6 +4,7 @@ import type { RenderOptions } from '@builder.io/qwik';
 import type { Render } from '@builder.io/qwik/server';
 import type { RequestHandler } from '@builder.io/qwik-city';
 import qwikCityPlan from '@qwik-city-plan';
+import { mergeHeadersCookies } from '../request-handler/cookie';
 
 // @builder.io/qwik-city/middleware/cloudflare-pages
 
@@ -34,14 +35,16 @@ export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
         locale: undefined,
         url,
         request,
-        response: (status, headers, body) => {
+        response: (status, headers, cookies, body) => {
           return new Promise<Response>((resolve) => {
             let flushedHeaders = false;
             const { readable, writable } = new TransformStream();
             const writer = writable.getWriter();
 
-            const response = new Response(readable, { status, headers });
-
+            const response = new Response(readable, {
+              status,
+              headers: mergeHeadersCookies(headers, cookies),
+            });
             body({
               write: (chunk) => {
                 if (!flushedHeaders) {

--- a/packages/qwik-city/middleware/netlify-edge/index.ts
+++ b/packages/qwik-city/middleware/netlify-edge/index.ts
@@ -5,6 +5,7 @@ import type { Render } from '@builder.io/qwik/server';
 import type { RenderOptions } from '@builder.io/qwik';
 import type { RequestHandler } from '@builder.io/qwik-city';
 import qwikCityPlan from '@qwik-city-plan';
+import { mergeHeadersCookies } from '../request-handler/cookie';
 
 // @builder.io/qwik-city/middleware/netlify-edge
 
@@ -24,13 +25,15 @@ export function createQwikCity(opts: QwikCityNetlifyOptions) {
         locale: undefined,
         url,
         request,
-        response: (status, headers, body) => {
+        response: (status, headers, cookies, body) => {
           return new Promise<Response>((resolve) => {
             let flushedHeaders = false;
             const { readable, writable } = new TransformStream();
             const writer = writable.getWriter();
-
-            const response = new Response(readable, { status, headers });
+            const response = new Response(readable, {
+              status,
+              headers: mergeHeadersCookies(headers, cookies),
+            });
 
             body({
               write: (chunk) => {

--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -43,12 +43,15 @@ export function fromNodeHttp(url: URL, req: IncomingMessage, res: ServerResponse
       text: getRequestBody,
       url: url.href,
     },
-    response: async (status, headers, body) => {
+    response: async (status, headers, cookies, body) => {
       res.statusCode = status;
       headers.forEach((value, key) => res.setHeader(key, value));
+      const cookieHeaders = cookies.headers();
+      if (cookieHeaders.length > 0) {
+        res.setHeader('Set-Cookie', cookieHeaders);
+      }
       body({
         write: (chunk) => {
-          res.write;
           res.write(chunk);
         },
       }).finally(() => {

--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -121,3 +121,15 @@ export class Cookie implements CookieInterface {
     return Object.values(this[RES_COOKIE]);
   }
 }
+
+export const mergeHeadersCookies = (headers: Headers, cookies: CookieInterface) => {
+  const cookieHeaders = cookies.headers();
+  if (cookieHeaders.length > 0) {
+    const newHeaders = new Headers(headers);
+    for (const cookie of cookieHeaders) {
+      newHeaders.append('Set-Cookie', cookie);
+    }
+    return newHeaders;
+  }
+  return headers;
+};

--- a/packages/qwik-city/middleware/request-handler/endpoint-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/endpoint-handler.ts
@@ -4,12 +4,12 @@ export function endpointHandler<T = any>(
   requestCtx: QwikCityRequestContext,
   userResponse: UserResponseContext
 ): Promise<T> {
-  const { pendingBody, resolvedBody, status, headers } = userResponse;
+  const { pendingBody, resolvedBody, status, headers, cookie } = userResponse;
   const { response } = requestCtx;
 
   if (pendingBody === undefined && resolvedBody === undefined) {
     // undefined body
-    return response(status, headers, asyncNoop);
+    return response(status, headers, cookie, asyncNoop);
   }
 
   if (!headers.has('Content-Type')) {
@@ -20,7 +20,7 @@ export function endpointHandler<T = any>(
   // check so we can know later on if we should JSON.stringify the body
   const isJson = headers.get('Content-Type')!.includes('json');
 
-  return response(status, headers, async ({ write }) => {
+  return response(status, headers, cookie, async ({ write }) => {
     const body = pendingBody !== undefined ? await pendingBody : resolvedBody;
     if (body !== undefined) {
       if (isJson) {

--- a/packages/qwik-city/middleware/request-handler/error-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/error-handler.ts
@@ -1,3 +1,4 @@
+import { Cookie } from './cookie';
 import { createHeaders } from './headers';
 import { HttpStatus } from './http-status-codes';
 import type { QwikCityRequestContext } from './types';
@@ -21,6 +22,7 @@ export function errorHandler(requestCtx: QwikCityRequestContext, e: any) {
   return requestCtx.response(
     status,
     headers,
+    new Cookie(),
     async (stream) => {
       stream.write(html);
     },
@@ -41,6 +43,7 @@ export function errorResponse(requestCtx: QwikCityRequestContext, errorResponse:
   return requestCtx.response(
     errorResponse.status,
     headers,
+    new Cookie(),
     async (stream) => {
       stream.write(html);
     },

--- a/packages/qwik-city/middleware/request-handler/page-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/page-handler.ts
@@ -23,7 +23,7 @@ export function pageHandler<T = any>(
   opts?: RenderOptions,
   routeBundleNames?: string[]
 ): Promise<T> {
-  const { status, headers } = userResponse;
+  const { status, headers, cookie } = userResponse;
   const { response } = requestCtx;
   const isPageData = userResponse.type === 'pagedata';
   const requestHeaders: Record<string, string> = {};
@@ -37,7 +37,7 @@ export function pageHandler<T = any>(
     headers.set('Content-Type', 'text/html; charset=utf-8');
   }
 
-  return response(isPageData ? 200 : status, headers, async (stream) => {
+  return response(isPageData ? 200 : status, headers, cookie, async (stream) => {
     // begin http streaming the page content as it's rendering html
     try {
       const result = await render({

--- a/packages/qwik-city/middleware/request-handler/redirect-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/redirect-handler.ts
@@ -1,18 +1,21 @@
+import { Cookie as CookieI } from './cookie';
 import { createHeaders } from './headers';
 import { HttpStatus } from './http-status-codes';
-import type { QwikCityRequestContext } from './types';
+import type { Cookie, QwikCityRequestContext } from './types';
 
 export class RedirectResponse {
   public status: number;
   public headers: Headers;
+  public cookies: Cookie;
   public location: string;
 
-  constructor(public url: string, status?: number, headers?: Headers) {
+  constructor(public url: string, status?: number, headers?: Headers, cookies?: Cookie) {
     this.location = url;
     this.status = isRedirectStatus(status) ? status : HttpStatus.Found;
-    this.headers = headers || createHeaders();
+    this.headers = headers ?? createHeaders();
     this.headers.set('Location', this.location);
     this.headers.delete('Cache-Control');
+    this.cookies = cookies ?? new CookieI();
   }
 }
 
@@ -20,7 +23,12 @@ export function redirectResponse(
   requestCtx: QwikCityRequestContext,
   responseRedirect: RedirectResponse
 ) {
-  return requestCtx.response(responseRedirect.status, responseRedirect.headers, async () => {});
+  return requestCtx.response(
+    responseRedirect.status,
+    responseRedirect.headers,
+    responseRedirect.cookies,
+    async () => {}
+  );
 }
 
 export function isRedirectStatus(status: number | undefined | null): status is number {

--- a/packages/qwik-city/middleware/request-handler/test-utils.ts
+++ b/packages/qwik-city/middleware/request-handler/test-utils.ts
@@ -1,4 +1,5 @@
 import type { RequestContext } from '../../runtime/src/library/types';
+import { mergeHeadersCookies } from './cookie';
 import { createHeaders } from './headers';
 import type { QwikCityRequestContext, ResponseHandler } from './types';
 
@@ -23,10 +24,10 @@ export function mockRequestContext(opts?: {
     body: null as any,
   };
 
-  const response: ResponseHandler = async (status, headers, body) => {
+  const response: ResponseHandler = async (status, headers, cookie, body) => {
     const chunks: string[] = [];
     responseData.status = status;
-    responseData.headers = headers as any;
+    responseData.headers = mergeHeadersCookies(headers, cookie);
     responseData.body = new Promise<string>((resolve) => {
       body({
         write: (chunk) => {

--- a/packages/qwik-city/middleware/request-handler/types.ts
+++ b/packages/qwik-city/middleware/request-handler/types.ts
@@ -26,6 +26,7 @@ export interface ResponseStreamWriter extends StreamWriter {
 export type ResponseHandler<T = any> = (
   status: number,
   headers: Headers,
+  cookies: Cookie,
   body: (stream: ResponseStreamWriter) => Promise<void>,
   error?: any
 ) => Promise<T>;

--- a/packages/qwik-city/middleware/request-handler/user-response.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.ts
@@ -188,10 +188,6 @@ export async function loadUserResponse(
 
   userResponse.aborted = routeModuleIndex >= ABORT_INDEX;
 
-  for (const setCookieValue of userResponse.cookie.headers()) {
-    userResponse.headers.append('Set-Cookie', setCookieValue);
-  }
-
   if (
     !isPageDataRequest &&
     isRedirectStatus(userResponse.status) &&
@@ -202,7 +198,8 @@ export async function loadUserResponse(
     throw new RedirectResponse(
       userResponse.headers.get('Location')!,
       userResponse.status,
-      userResponse.headers
+      userResponse.headers,
+      userResponse.cookie
     );
   }
 

--- a/packages/qwik-city/middleware/request-handler/user-response.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.ts
@@ -71,7 +71,7 @@ export async function loadUserResponse(
   };
 
   const redirect = (url: string, status?: number) => {
-    return new RedirectResponse(url, status, userResponse.headers);
+    return new RedirectResponse(url, status, userResponse.headers, userResponse.cookie);
   };
 
   const error = (status: number, message?: string) => {
@@ -189,7 +189,7 @@ export async function loadUserResponse(
   userResponse.aborted = routeModuleIndex >= ABORT_INDEX;
 
   for (const setCookieValue of userResponse.cookie.headers()) {
-    userResponse.headers.set('Set-Cookie', setCookieValue);
+    userResponse.headers.append('Set-Cookie', setCookieValue);
   }
 
   if (

--- a/packages/qwik-city/middleware/vercel-edge/index.ts
+++ b/packages/qwik-city/middleware/vercel-edge/index.ts
@@ -1,5 +1,6 @@
 import type { QwikCityHandlerOptions, QwikCityRequestContext } from '../request-handler/types';
 import { notFoundHandler, requestHandler } from '../request-handler';
+import { mergeHeadersCookies } from '../request-handler/cookie';
 
 // @builder.io/qwik-city/middleware/vercel-edge
 
@@ -15,13 +16,16 @@ export function createQwikCity(opts: QwikCityVercelEdgeOptions) {
         locale: undefined,
         url,
         request,
-        response: (status, headers, body) => {
+        response: (status, headers, cookies, body) => {
           return new Promise<Response>((resolve) => {
             let flushedHeaders = false;
             const { readable, writable } = new TransformStream();
             const writer = writable.getWriter();
 
-            const response = new Response(readable, { status, headers });
+            const response = new Response(readable, {
+              status,
+              headers: mergeHeadersCookies(headers, cookies),
+            });
 
             body({
               write: (chunk) => {

--- a/packages/qwik-city/package.json
+++ b/packages/qwik-city/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/qwik-city",
-  "version": "0.0.121",
+  "version": "0.0.122",
   "description": "The meta-framework for Qwik.",
   "main": "./lib/index.qwik.mjs",
   "qwik": "./lib/index.qwik.mjs",

--- a/packages/qwik-city/static/worker-thread.ts
+++ b/packages/qwik-city/static/worker-thread.ts
@@ -63,7 +63,7 @@ async function workerRender(
       locale: undefined,
       url,
       request,
-      response: async (status, headers, body, err) => {
+      response: async (status, headers, _, body, err) => {
         if (err) {
           if (err.stack) {
             result.error = String(err.stack);

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/qwik",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "An Open-Source sub-framework designed with a focus on server-side-rendering, lazy-loading, and styling/animation.",
   "main": "./dist/core.mjs",
   "types": "./dist/core.d.ts",

--- a/starters/apps/base/package.json
+++ b/starters/apps/base/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@builder.io/qwik": "latest",
-    "@builder.io/qwik-city": "0.0.121",
+    "@builder.io/qwik-city": "0.0.122",
     "@types/eslint": "8.4.1",
     "@types/node": "latest",
     "@typescript-eslint/eslint-plugin": "5.14.0",


### PR DESCRIPTION
Long story short, fetch() apis are a mess, the spec was orginally wroten to be used only in the server, and it not a reliable implementation to support cookies, since cookies is the only feature in HTML, that requires to actually send multiple `Set-Cookie` headers, instead of concatenating all of them.

Current implementation relies on a polyfill for node, we cant use it, since it has the browser behaviour, effectively breaking cookies. Instead we need to keep the cookies untouched until the last later of the middleware, where the native layer handles it.

Native Fetch() is deno and cloudflare has the correct implementation!

https://fetch.spec.whatwg.org/#headers-class
https://github.com/denoland/deno/pull/5100/files

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
