### PR TITLE
feat: allow itemprop in DocumentMeta

### DIFF
--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -131,6 +131,8 @@ export interface DocumentMeta {
     // (undocumented)
     httpEquiv?: string;
     // (undocumented)
+    itemprop?: string;
+    // (undocumented)
     key?: string;
     // (undocumented)
     name?: string;

--- a/packages/qwik-city/runtime/src/library/types.ts
+++ b/packages/qwik-city/runtime/src/library/types.ts
@@ -92,6 +92,7 @@ export interface DocumentMeta {
   name?: string;
   property?: string;
   key?: string;
+  itemprop?: string;
 }
 
 /**


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Add `itemprop` in `DocumentMeta` type.
# Use cases and why

It may be used for schema.org micro-formatting.

<!-- Actual / expected behavior if it's a bug -->



# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
