### PR TITLE
docs: updated `useStyleScope()` section

### DIFF
--- a/packages/docs/src/routes/docs/components/styles/index.mdx
+++ b/packages/docs/src/routes/docs/components/styles/index.mdx
@@ -71,11 +71,11 @@ export const CmpStyles = component$(() => {
 ## `useStylesScope$`
 In previous sections, we have discussed how styles can be loaded lazily as they are needed using the `useStyles$()` hook.
 Browser styles are global and apply to all DOM elements, for this reason, Qwik also provides a way to load styles that are specific to a specific component. 
-This is achieved by generating a unique class for each component and then inserting that unique class id into the stylesheet.
+This is achieved by generating a unique class for each component and then inserting that unique class id into the stylesheet. Please note that you need to add `?inline` to your styles import.
 
 ```tsx
 import {useStylesScoped$} from '@builder.io/qwik';
-import styles from './code-block.css';
+import styles from './code-block.css?inline';
 
 export const CmpStyles = component$(() => {
   useStylesScoped$(styles);


### PR DESCRIPTION
added `?inline` to reflect deprecation warnings

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
