### PR TITLE
fix: argument of type 'unknown' is used in useStyles$

### DIFF
--- a/packages/docs/src/routes/docs/components/styles/index.mdx
+++ b/packages/docs/src/routes/docs/components/styles/index.mdx
@@ -53,7 +53,7 @@ Component styles allow Qwik to lazy load the style information for the component
 
 ```tsx
 import {useStyles$} from '@builder.io/qwik';
-import styles from './code-block.css';
+import styles from './code-block.css?inline';
 
 export const CmpStyles = component$(() => {
   useStyles$(styles);

--- a/packages/docs/src/routes/examples/apps/partial/hackernews-index/app.tsx
+++ b/packages/docs/src/routes/examples/apps/partial/hackernews-index/app.tsx
@@ -1,5 +1,5 @@
 import { component$, useServerMount$, useStore, useStyles$ } from '@builder.io/qwik';
-import HackerNewsCSS from './hacker-news.css';
+import HackerNewsCSS from './hacker-news.css?inline';
 
 export const HackerNews = component$(() => {
   useStyles$(HackerNewsCSS);

--- a/packages/docs/src/routes/examples/apps/visibility/clock/app.tsx
+++ b/packages/docs/src/routes/examples/apps/visibility/clock/app.tsx
@@ -1,5 +1,5 @@
 import { component$, useStore, useStyles$, useClientEffect$ } from '@builder.io/qwik';
-import styles from './clock.css';
+import styles from './clock.css?inline';
 
 export default component$(() => {
   const items = new Array(60).fill(null).map((_, index) => 'item ' + index);

--- a/packages/docs/src/routes/tutorial/hooks/use-client-effect/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-client-effect/problem/app.tsx
@@ -1,5 +1,5 @@
 import { component$, useStore, useStyles$, useClientEffect$ } from '@builder.io/qwik';
-import styles from './clock.css';
+import styles from './clock.css?inline';
 
 interface ClockStore {
   hour: number;

--- a/packages/docs/src/routes/tutorial/hooks/use-client-effect/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-client-effect/solution/app.tsx
@@ -1,5 +1,5 @@
 import { component$, useStore, useStyles$, useClientEffect$ } from '@builder.io/qwik';
-import styles from './clock.css';
+import styles from './clock.css?inline';
 
 interface ClockStore {
   hour: number;

--- a/starters/apps/documentation-site/src/routes/docs/layout.tsx
+++ b/starters/apps/documentation-site/src/routes/docs/layout.tsx
@@ -2,7 +2,7 @@ import { component$, Slot, useStyles$ } from '@builder.io/qwik';
 import type { DocumentHead } from '@builder.io/qwik-city';
 import Menu from '~/components/menu/menu';
 import OnThisPage from '~/components/on-this-page/on-this-page';
-import styles from './docs.css';
+import styles from './docs.css?inline';
 
 export default component$(() => {
   useStyles$(styles);


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests

# Description

I started meeting the issue by creating a doc site starter app.
Then I found that inconsistent coding happens in other places as well.


# Use cases and why

Head:
<img width="912" alt="Screenshot 2022-11-14 at 01 11 06" src="https://user-images.githubusercontent.com/4471489/201552061-74fccd35-ccce-49f6-bcb0-42cac605ae40.png">


Current:
the type issue is solved by importing css or scss using ?inline


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
