### PR TITLE
Corrected "it's" to "its"

### DIFF
--- a/packages/docs/src/routes/docs/components/projection/index.mdx
+++ b/packages/docs/src/routes/docs/components/projection/index.mdx
@@ -174,7 +174,7 @@ With `children` approach, the component can imperatively modify the `children` i
 
 
 ## Advanced Example
-An example of a collapsible component which conditionally projects it's content.
+An example of a collapsible component which conditionally projects its content.
 
 ```tsx
 export const Collapsible = component$(() => {


### PR DESCRIPTION
changed "it's" to "its"

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This just a typo, corrected "it's" to "its"

