### PR TITLE
fix(eslint-plugin-qwik): handle linting tuple types properly for valid-lexical-scope rule

### DIFF
--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -269,6 +269,19 @@ export default component$(() => {
   };
 });
 `,
+      `
+        import { component$ } from "@builder.io/qwik";
+        
+        export interface Props {
+          serializableTuple: [string, number, boolean];
+        }
+
+        export const HelloWorld = component$((props: Props) => {
+          return (
+            <button onClick$={() => props.serializableTuple}></button>
+          );
+        });
+      `,
     ],
     invalid: [
       {
@@ -427,6 +440,23 @@ export default component$(() => {
         });`,
         errors: [
           'The value of the identifier ("click") can not be changed once it is captured the scope (onClick$). Check out https://qwik.builder.io/docs/advanced/optimizer for more details.',
+        ],
+      },
+      {
+        code: `
+        import { component$ } from "@builder.io/qwik";
+        
+        export interface Props {
+          nonserializableTuple: [string, number, boolean, Function];
+        }
+
+        export const HelloWorld = component$((props: Props) => {
+          return (
+            <button onClick$={() => props.nonserializableTuple}></button>
+          );
+        });`,
+        errors: [
+          'Identifier ("props") can not be captured inside the scope (onClick$) because "props.nonserializableTuple" is an instance of the "Function" class, which is not serializable. Check out https://qwik.builder.io/docs/advanced/optimizer for more details.',
         ],
       },
     ],

--- a/packages/eslint-plugin-qwik/src/validLexicalScope.ts
+++ b/packages/eslint-plugin-qwik/src/validLexicalScope.ts
@@ -343,12 +343,23 @@ function _isTypeCapturable(
   }
   const isObject = (type.flags & ts.TypeFlags.Object) !== 0;
   if (isObject) {
-    const symbolName = type.symbol.name;
-
     const arrayType = getElementTypeOfArrayType(type, checker);
     if (arrayType) {
       return _isTypeCapturable(checker, arrayType, node, opts, level + 1, seen);
     }
+
+    const tupleTypes = getTypesOfTupleType(type, checker);
+    if (tupleTypes) {
+      for (const subType of tupleTypes) {
+        const result = _isTypeCapturable(checker, subType, node, opts, level + 1, seen);
+        if (result) {
+          return result;
+        }
+      }
+      return;
+    }
+
+    const symbolName = type.symbol.name;
 
     // Element is ok
     if (type.getProperty('nextElementSibling')) {
@@ -424,6 +435,15 @@ function isSymbolCapturable(
 
 function getElementTypeOfArrayType(type: ts.Type, checker: ts.TypeChecker): ts.Type | undefined {
   return (checker as any).getElementTypeOfArrayType(type);
+}
+
+function getTypesOfTupleType(
+  type: ts.Type,
+  checker: ts.TypeChecker
+): readonly ts.Type[] | undefined {
+  return (checker as any).isTupleType(type)
+    ? checker.getTypeArguments(type as ts.TupleType)
+    : undefined;
 }
 
 function isTypeQRL(type: ts.Type): boolean {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
`TupleType` does not have a `symbol` property which caused the line: `const symbolName = type.symbol.name;` to throw an error.

When a tuple type is used, `eslint-qwik-plugin` would error out with:
```
TypeError: Cannot read properties of undefined (reading 'name')
Occurred while linting [REDACTED].tsx:1
Rule: "qwik/valid-lexical-scope"
    at r3 ([REDACTED]/node_modules/eslint-plugin-qwik/index.js:424:69352)
    at wdr ([REDACTED]/node_modules/eslint-plugin-qwik/index.js:424:70273)
    at r3 ([REDACTED]/node_modules/eslint-plugin-qwik/index.js:424:70109)
    at Pdr ([REDACTED]/node_modules/eslint-plugin-qwik/index.js:424:68153)
    at Adr ([REDACTED]/node_modules/eslint-plugin-qwik/index.js:424:68005)
    at [REDACTED]/node_modules/eslint-plugin-qwik/index.js:424:67003
    at Array.forEach (<anonymous>)
    at p ([REDACTED]/node_modules/eslint-plugin-qwik/index.js:424:66124)
    at Array.forEach (<anonymous>)
    at p ([REDACTED]/node_modules/eslint-plugin-qwik/index.js:424:67171)
```

I have updated the code to check if it's a tuple type and check the inner types (retrieved using `checker.getTypeArguments(...)`). I found this out just by brute-force grepping of the Typescript codebase and have no idea if this is the right way to do it but it works! 😅

With this change, I see these eslint errors now:
```
export type Props = {
  foobar: [string, number, Function],
};
```

```
  32:18  error  Identifier ("props") can not be captured inside the scope (useWatch$) because "props.foobar" is an instance of the "Function" class, which is not serializable. Check out https://qwik.builder.io/docs/advanced/optimizer for more details   
```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

n/a

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
