### PR TITLE
docs: Use useClientEffect$ in debounced input example

### DIFF
--- a/packages/docs/src/routes/docs/cheat/qwik-react/index.mdx
+++ b/packages/docs/src/routes/docs/cheat/qwik-react/index.mdx
@@ -235,7 +235,7 @@ export const DebouncedInput = component$(() => {
     debouncedValue: '',
   });
 
-  useWatch$(({ track }) => {
+  useClientEffect$(({ track }) => {
     track(() => state.value);
     const debounced = setTimeout(() => {
       state.debouncedValue = state.value;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
I doubt anyone wants to debounce on the server. Therefore, `useClientEffect$` is more appropriate than `useWatch$`.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
