### PR TITLE
makes menu sticky 🥁

### DIFF
--- a/packages/docs/src/components/header/header.css
+++ b/packages/docs/src/components/header/header.css
@@ -1,23 +1,11 @@
 .header-container {
   height: calc(var(--header-height));
-  margin-bottom: 6px;
-  background: white;
-  position: relative;
-  z-index: 100;
-}
-
-@media (min-width: 1024px) {
-  .header-container {
-    background: #ffffff9e;
-    backdrop-filter: blur(23px) saturate(4.5);
-  }
-}
-
-.fixed-header .header-container {
-  position: fixed;
+  position: sticky;
+  background: rgb(255 255 255 / 50%);
+  backdrop-filter: blur(2rem) saturate(4);
   top: 0;
-  width: 100%;
-  z-index: 40;
+  box-shadow: 0 0 1rem #0001;
+  border-bottom: 1px solid rgb(255 255 255 / 15%);
 }
 
 header li {

--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -1,37 +1,5 @@
 @import 'prism-themes/themes/prism-dracula.css';
 
-/* latin */
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url(/fonts/poppins-400.woff2?v=1) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
-    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* latin */
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: url(/fonts/poppins-500.woff2?v=1) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
-    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* latin */
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
-  src: url(/fonts/poppins-700.woff2?v=1) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
-    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
 
 code[class*='language-'],
 pre[class*='language-'] {
@@ -53,7 +21,7 @@ pre[class*='language-'] {
 }
 
 html {
-  font-family: Poppins, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI,
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI,
     Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     Segoe UI Symbol, 'Noto Color Emoji';
   color: #0e201a;
@@ -86,7 +54,7 @@ select {
 }
 
 body {
-  @apply antialiased h-screen;
+  @apply antialiased;
 }
 
 @media (max-width: 1023px) {


### PR DESCRIPTION
# What is it?

- [ 🥁] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Makes top menu sticky so you can see cool blurry saturated colors underneath

## Actual code changes

- removed poppins font as it isn't in the project
- removed height from body (not needed)
- made menu always sticky and tweaked filter

# Use cases and why

Because it looks nice

<img width="1289" alt="Screenshot 2022-11-17 at 1 56 55 PM" src="https://user-images.githubusercontent.com/334226/202546711-2c4ff028-c5ff-44c1-a582-5038cf89b50e.png">


# Checklist:

- [ 🥁] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [🥁 ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
