### PR TITLE
remove inline from clock.css import

### DIFF
--- a/packages/docs/src/routes/examples/apps/visibility/clock/app.tsx
+++ b/packages/docs/src/routes/examples/apps/visibility/clock/app.tsx
@@ -1,5 +1,5 @@
 import { component$, useStore, useStyles$, useClientEffect$ } from '@builder.io/qwik';
-import styles from './clock.css?inline';
+import styles from './clock.css';
 
 export default component$(() => {
   const items = new Array(60).fill(null).map((_, index) => 'item ' + index);


### PR DESCRIPTION
clock render example for v0.13.3 does not render clock correctly at https://qwik.builder.io/playground

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Clock should display on screen

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
