### PR TITLE
feat: add human readable URL parsing/encoding of JS data structures

### DIFF
--- a/packages/qwik-city/runtime/src/url-params-encoding.ts
+++ b/packages/qwik-city/runtime/src/url-params-encoding.ts
@@ -1,0 +1,262 @@
+/**
+ * Encode a params into a URL query string.
+ *
+ * The encoding is done to remain human readable, but at the same time can deal with complex types
+ * such as `Date`, `Object` and `Array`.
+ *
+ * @public
+ * @param template - URL path which may contain slugs: `/foo/:bar`
+ * @param params - Key/value map of parameters to encode into the URL
+ * @returns URL string
+ */
+export function encodeParamsToUrl(template: string, params?: Record<string, any>): string {
+  const keys = Object.keys(params || {}).sort();
+  let out = template
+    .split('/')
+    .map((part) => {
+      if (isSlug(part)) {
+        let key = part.slice(1, -1);
+        if (key.startsWith('...')) {
+          key = key.slice(3);
+          return encodeValue(get(key));
+        } else {
+          return encodePathSegment(get(key));
+        }
+      } else {
+        return part;
+      }
+    })
+    .join('/');
+
+  out += keys.length ? '?' + encodeKeyValuePairs(params, keys) : '';
+  return out;
+
+  function get(key: string): any {
+    if (params) {
+      const index = keys.indexOf(key);
+      if (index !== -1) {
+        keys.splice(index, 1);
+        return params[key];
+      }
+    }
+  }
+}
+
+/**
+ * Decode the URL path/search into params
+ *
+ * @public
+ * @param template - URL path which may contain slugs: `/foo/:bar`
+ * @param path - URL path
+ * @param search - URL search string
+ * @returns
+ */
+export function decodeParamsFromUrl(
+  template: string,
+  path: string,
+  search?: string
+): Record<string, any> {
+  const params: Record<string, any> = {};
+  const templateParts = template.split('/');
+  const pathParts = path.split('/');
+  for (let i = 0; i < templateParts.length; i++) {
+    const tPart = templateParts[i];
+    const pPart = pathParts.shift() || '';
+    if (isSlug(tPart)) {
+      const key = tPart.slice(1, -1);
+      if (key.startsWith('...')) {
+        params[key.slice(3)] = decodeValue([pPart, ...pathParts].join('/'));
+      } else {
+        params[key] = decodeValue(pPart);
+      }
+    } else {
+      if (tPart !== pPart) {
+        throw new Error(`URL path does not match template: ${path} != ${template}`);
+      }
+    }
+  }
+  // DECODE SEARCH
+  search && decodeText(0, search, params, false);
+  return params;
+}
+
+function decodeText(idx: number, text: string, params: any, isArray: boolean): number {
+  let arrayIdx = 0;
+  while (idx < text.length) {
+    const key = isArray ? arrayIdx++ : (consume((v) => v) as string);
+    const value = consume(decodeValue);
+    params[key] = value;
+    const ch = text.charCodeAt(idx);
+    if (isSep(ch)) idx++;
+    if (isClosed(ch)) {
+      idx++;
+      break;
+    }
+  }
+
+  return idx;
+
+  function consume(decodeValue: (value: string) => any): any {
+    const ch = text!.charCodeAt(idx++);
+    if (ch === CharCode.openBracket) {
+      const array: any[] = [];
+      idx = decodeText(idx, text, array, true);
+      return array;
+    } else if (ch === CharCode.openBrace) {
+      const obj = {};
+      idx = decodeText(idx, text, obj, false);
+      return obj;
+    } else {
+      const start = idx - 1;
+      let ch: number = 0;
+      while (idx < text!.length && !isSep((ch = text!.charCodeAt(idx))) && !isClosed(ch)) {
+        idx++;
+      }
+      return decodeValue(text!.slice(start, isSep(ch) ? idx++ : idx));
+    }
+  }
+}
+
+function isClosed(ch: number): boolean {
+  return ch === CharCode.closeBracket || ch === CharCode.closeBrace;
+}
+
+function isOpen(ch: number): boolean {
+  return ch === CharCode.openBrace || ch === CharCode.openBracket;
+}
+
+function isSep(ch: number): boolean {
+  return ch === CharCode.ampersand || ch === CharCode.equal;
+}
+
+function decodeValue(value: string): any {
+  debugger;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (value === 'null') return null;
+  if (value === 'undefined') return undefined;
+  if (value.charCodeAt(0) === CharCode.at && isNumber(value, 1))
+    return new Date(Number(value.slice(1)));
+  if (isNumber(value)) return Number(value);
+  if (value.startsWith('~')) value = value.substring(1);
+  return decodeURIComponent(value.replace(/\+/g, ' '));
+}
+
+function encodeKeyValuePairs(params: undefined | Record<string, any>, keys?: string[]): string {
+  return !params
+    ? ''
+    : (keys || Object.keys(params).sort())
+        .map((key) => {
+          const value = params[key];
+          return `${key}=${encodeValue(value)}`;
+        })
+        .join('&');
+}
+
+function isSlug(part: string): boolean {
+  return part.startsWith('[') && part.endsWith(']');
+}
+
+function encodePathSegment(value: any): string {
+  return encodeValue(value).replace(/\//g, '%2F');
+}
+
+function encodeValue(value: any): string {
+  switch (typeof value) {
+    case 'string':
+      const ch = value.charCodeAt(0);
+      if (
+        (ch === CharCode.at && isNumber(value.slice(1))) ||
+        value === 'true' ||
+        value === 'false' ||
+        value === 'null' ||
+        value === 'undefined' ||
+        isNumber(value)
+      ) {
+        return '~' + encode(value);
+      }
+      return encode(value);
+    case 'boolean':
+    case 'undefined':
+    case 'number':
+      // For numbers no need to serialize `+` as in `1e+2`
+      return String(value).replace(/\+/g, '');
+    case 'object':
+      if (value === null) {
+        return 'null';
+      } else if (Array.isArray(value)) {
+        return '[' + value.map(encodeValue).join('&') + ']';
+      } else if (value instanceof Date) {
+        return '@' + value.getTime();
+      } else {
+        return '{' + encodeKeyValuePairs(value) + '}';
+      }
+    default:
+      // case 'function':
+      throw new Error('Functions are not supported in URL params');
+  }
+}
+
+function encode(value: string): string {
+  let out = '';
+  let lastIdx = 0;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value.charCodeAt(i);
+    if (
+      ch === CharCode.tilde ||
+      ch === CharCode.percent ||
+      ch === CharCode.plus ||
+      isSep(ch) ||
+      isClosed(ch) ||
+      isOpen(ch)
+    ) {
+      out += value.substring(lastIdx, i) + '%' + ch.toString(16);
+      lastIdx = i + 1;
+    }
+    if (ch === CharCode.space) {
+      out += value.substring(lastIdx, i) + '+';
+      lastIdx = i + 1;
+    }
+  }
+  return out + value.substring(lastIdx);
+}
+
+function isNumber(value: string, start: number = 0): boolean {
+  if (value === 'NaN') return true;
+  for (let i = start; i < value.length; i++) {
+    const ch = value.charCodeAt(i);
+    if (!isNumberChar(ch)) return false;
+  }
+  return true;
+}
+
+function isNumberChar(charCode: number): boolean {
+  return (
+    (charCode >= CharCode.num_0 && charCode <= CharCode.num_9) ||
+    charCode === CharCode.dot ||
+    charCode === CharCode.minus ||
+    charCode === CharCode.e ||
+    charCode === CharCode.minus
+  );
+}
+
+const enum CharCode {
+  num_0 = 48,
+  num_9 = 57,
+  plus = 43,
+  minus = 45,
+  e = 101,
+  E = 69,
+  dot = 46,
+  space = 32,
+  at = 64,
+  equal = 61,
+  openBrace = 123,
+  closeBrace = 125,
+  openBracket = 91,
+  closeBracket = 93,
+  ampersand = 38,
+  backTick = 96,
+  percent = 37,
+  tilde = 126,
+}

--- a/packages/qwik-city/runtime/src/url-params-encoding.unit.ts
+++ b/packages/qwik-city/runtime/src/url-params-encoding.unit.ts
@@ -1,0 +1,125 @@
+import { suite } from 'uvu';
+import { equal } from 'uvu/assert';
+import { decodeParamsFromUrl, encodeParamsToUrl } from './url-params-encoding';
+
+const testEncoding = suite('url-params-encoding');
+testEncoding('paths', () => {
+  equal(encodeParamsToUrl('/path'), '/path');
+  equal(encodeParamsToUrl('/hello/[slug]', { slug: 'world' }), '/hello/world');
+  equal(
+    encodeParamsToUrl('/hello/[slug]/', { slug: 'world/universe' }),
+    '/hello/world%2Funiverse/'
+  );
+  equal(encodeParamsToUrl('/hello/[...rest]', { rest: 'world/universe' }), '/hello/world/universe');
+});
+
+testEncoding('search', () => {
+  equal(
+    encodeParamsToUrl('/path', {
+      text: '@text',
+      number: -12.3e45,
+      nan: Number.NaN,
+      true: true,
+      false: false,
+      null: null,
+      undefined: undefined,
+    }),
+    '/path?false=false&nan=NaN&null=null&number=-1.23e46&text=@text&true=true&undefined=undefined'
+  );
+  equal(
+    encodeParamsToUrl('/path', {
+      date: '@123',
+      number: '-12.3e45',
+      true: String(true),
+      false: String(false),
+      null: String(null),
+      undefined: String(undefined),
+    }),
+    '/path?date=~@123&false=~false&null=~null&number=~-12.3e45&true=~true&undefined=~undefined'
+  );
+});
+
+testEncoding('objects', () => {
+  equal(
+    encodeParamsToUrl('/path', {
+      object: { a: 1, b: 2 },
+      array: [1, 2, 3],
+      date: new Date(123456789),
+    }),
+    '/path?array=[1&2&3]&date=@123456789&object={a=1&b=2}'
+  );
+});
+
+testEncoding('example', () => {
+  equal(
+    encodeParamsToUrl('/contact/[contactId]/', {
+      contactId: 123,
+      dob: new Date(Date.parse('1980-01-01 GMT')),
+      predicate: { name: 'John', age: 42, alias: ['Jon', 'Johnny'] },
+    }),
+    '/contact/123/?dob=@315532800000&predicate={age=42&alias=[Jon&Johnny]&name=John}'
+  );
+});
+
+testEncoding.run();
+
+const testDecoding = suite('url-params-decoding');
+
+testDecoding('url', () => {
+  equal(decodeParamsFromUrl('/hello/[slug]', '/hello/world'), { slug: 'world' });
+  equal(decodeParamsFromUrl('/hello/[...rest]', '/hello/world/universe'), {
+    rest: 'world/universe',
+  });
+});
+
+testDecoding('search', () => {
+  equal(
+    decodeParamsFromUrl(
+      '/path',
+      '/path',
+      'false=false&nan=NaN&null=null&number=-1.23e46&text=@text&true=true&undefined=undefined'
+    ),
+    {
+      false: false,
+      nan: Number.NaN,
+      null: null,
+      number: -12.3e45,
+      text: '@text',
+      true: true,
+      undefined: undefined,
+    }
+  );
+  equal(decodeParamsFromUrl('/path', '/path', 'array=[1&2&3]'), {
+    array: [1, 2, 3],
+  });
+  equal(decodeParamsFromUrl('/path', '/path', 'object={a=1&b=2}'), {
+    object: { a: 1, b: 2 },
+  });
+  equal(decodeParamsFromUrl('/path', '/path', 'date=@123'), {
+    date: new Date(123),
+  });
+});
+
+testDecoding('mixed', () => {
+  assert({ a: 1 });
+  assert({ a: 1, b: '2' });
+  assert({ a: true, b: 1.2e4, date: new Date() });
+  assert({ b: [true] });
+  assert({ b: { c: 'test' } });
+});
+testDecoding('chained', () => {
+  assert({ a: [true], b: 1 });
+  assert({ a: [true, { '@123': 'date' }], b: 1 });
+});
+
+testDecoding('escape', () => {
+  assert({ a: '[a] / ? { + } = &', b: 1 });
+});
+
+function assert(value: any) {
+  const path = '/path/';
+  const search = encodeParamsToUrl(path, value).split('/path/?')[1];
+  equal(decodeParamsFromUrl(path, path, search), value);
+}
+
+testDecoding.run();


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

This is a prerequisite to have human-readable rich data encoded in URL search params.

Example: `/contact/123?name=John&age=30` 
If `/contact/[:id]` then we should expect to get: `{id: 123, name: "John", age:30}`

Notice that the above parser correctly guessed the types of the extracted JS. In addition to flat data, we should be able to encode complex data of object literals and arrays. Example:

```typescript
testEncoding('example', () => {
  equal(
    encodeParamsToUrl('/contact/[contactId]/', {
      contactId: 123,
      dob: new Date(Date.parse('1980-01-01 GMT')),
      predicate: { name: 'John', age: 42, alias: ['Jon', 'Johnny'] },
    }),
    '/contact/123/?dob=@315532800000&predicate={age=42&alias=[Jon&Johnny]&name=John}'
  );
});
```

In the above case the URL can be parsed and it will correctly retrieve the correct data:
```typescript
{
      contactId: 123,
      dob: new Date(Date.parse('1980-01-01 GMT')),
      predicate: { 
        name: 'John', 
        age: 42, 
        alias: ['Jon', 'Johnny'] 
     },
}
```


# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
