### PR TITLE
fix(qwik city cloudflare pages adapter): added all q-data.json files …

### DIFF
--- a/packages/qwik-city/adaptors/cloudflare-pages/vite/index.ts
+++ b/packages/qwik-city/adaptors/cloudflare-pages/vite/index.ts
@@ -40,7 +40,11 @@ export function cloudflarePagesAdaptor(opts: CloudflarePagesAdaptorOptions = {})
         const routesJson = {
           version: 1,
           include: [basePathname + '*'],
-          exclude: [basePathname + 'build/*', basePathname + 'assets/*'],
+          exclude: [
+            basePathname + 'build/*',
+            basePathname + 'assets/*',
+            basePathname + '*/q-data.json',
+          ],
         };
         await fs.promises.writeFile(routesJsonPath, JSON.stringify(routesJson, undefined, 2));
       }


### PR DESCRIPTION
…to the generated _routes.json

fix #2193

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Added the rule "basePathname + '*/q-data.json'" to the code that generates the _routes.json file if there is not an existing _routes.json  file in the public folder.

# Use cases and why

q-data.json files are otherwise not cached while hosting on cloudflare pages.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
