### PR TITLE
feat: add client mount for symmetry reasons

### DIFF
--- a/packages/docs/src/routes/docs/components/lifecycle/index.mdx
+++ b/packages/docs/src/routes/docs/components/lifecycle/index.mdx
@@ -95,6 +95,35 @@ export function User(props: { user: User }) {
 }
 ```
 
+## `useClientMount$()`
+
+- **Trigger:** component mount
+- **When:** before rendering and resources
+- **Times:** exactly once per component instance
+- **Platform:** browser only
+
+`useClientMount$()` registers a client-mounted hook that only runs on the browser when the component is first mounted.
+
+### Example
+
+```tsx
+export const Cmp = component$(() => {
+  const store = useStore({
+    option: string,
+  });
+  useClientMount$(() => {
+    // This code will ONLY run once in the browser, when the component is mounted
+    store.option = localStorage.getItem('option');
+  });
+  return (
+    <>
+      Localstore: {store.option}
+    </>
+  );
+});
+```
+
+
 ## `useWatch$()`
 
 - **Trigger:** component mount and on tracked state changes

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -637,6 +637,12 @@ export const useClientEffect$: (first: WatchFn, opts?: UseEffectOptions | undefi
 // @public
 export const useClientEffectQrl: (qrl: QRL<WatchFn>, opts?: UseEffectOptions) => void;
 
+// @public
+export const useClientMount$: <T>(first: MountFn<T>) => void;
+
+// @public
+export const useClientMountQrl: <T>(mountQrl: QRL<MountFn<T>>) => void;
+
 // Warning: (ae-forgotten-export) The symbol "UseContext" needs to be exported by the entry point index.d.ts
 //
 // @public

--- a/packages/qwik/src/core/container/pause.ts
+++ b/packages/qwik/src/core/container/pause.ts
@@ -65,8 +65,6 @@ import type { QRL } from '../qrl/qrl.public';
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
 // (edit ../readme.md#pauseContainer instead)
 /**
- * Serialize the current state of the application into DOM
- *
  */
 // </docs>
 export const pauseContainer = async (

--- a/packages/qwik/src/core/examples.tsx
+++ b/packages/qwik/src/core/examples.tsx
@@ -12,7 +12,8 @@ import { $, QRL } from './qrl/qrl.public';
 import { useOn, useOnDocument, useOnWindow } from './use/use-on';
 import { useStore } from './use/use-store.public';
 import { useStyles$, useStylesScoped$ } from './use/use-styles';
-import { useClientEffect$, useMount$, useServerMount$, useWatch$ } from './use/use-watch';
+import { useClientEffect$, useWatch$ } from './use/use-watch';
+import { useClientMount$, useMount$, useServerMount$ } from './use/use-mount';
 import { implicit$FirstArg } from './util/implicit_dollar';
 
 //////////////////////////////////////////////////////////
@@ -257,6 +258,19 @@ export const CmpInline = component$(() => {
   function User(props: { user: User }) {
     return <div>Name: {props.user.name}</div>;
   }
+  // </docs>
+  return Cmp;
+};
+
+() => {
+  // <docs anchor="use-client-mount">
+  const Cmp = component$(() => {
+    useClientMount$(async () => {
+      // This code will ONLY run once in the client, when the component is mounted
+    });
+
+    return <div>Cmp</div>;
+  });
   // </docs>
   return Cmp;
 };

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -85,7 +85,6 @@ export type { UseStoreOptions } from './use/use-store.public';
 export type {
   Tracker,
   WatchFn,
-  MountFn,
   UseEffectOptions,
   EagernessOptions,
   ResourceReturn,
@@ -97,12 +96,14 @@ export type {
   UseWatchOptions,
   ResourceFn,
 } from './use/use-watch';
+export type { MountFn } from './use/use-mount';
 export { useWatch$, useWatchQrl } from './use/use-watch';
 export type { ResourceProps, ResourceOptions } from './use/use-resource';
 export { useResource$, useResourceQrl, Resource } from './use/use-resource';
 export { useClientEffect$, useClientEffectQrl } from './use/use-watch';
-export { useServerMount$, useServerMountQrl } from './use/use-watch';
-export { useMount$, useMountQrl } from './use/use-watch';
+export { useServerMount$, useServerMountQrl } from './use/use-mount';
+export { useMount$, useMountQrl } from './use/use-mount';
+export { useClientMount$, useClientMountQrl } from './use/use-mount';
 export { useErrorBoundary } from './use/use-error-boundary';
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -210,7 +210,7 @@ export type PropFunction<T extends Function> = T extends (...args: infer ARGS) =
  *    - Must be runtime serializable.
  *
  * ```tsx
- * import { importedFn } from './import/example';
+ *
  * import { createContext, useContext, useContextProvider } from './use/use-context';
  * import { useRef } from './use/use-ref';
  * import { Resource, useResource$ } from './use/use-resource';
@@ -223,9 +223,7 @@ export type PropFunction<T extends Function> = T extends (...args: infer ARGS) =
  *   function localFn() {}
  *   // Valid Examples
  *   $(greet); // greet is importable
- *   $(importedFn); // importedFn is importable
  *   $(() => greet()); // greet is importable;
- *   $(() => importedFn()); // importedFn is importable
  *   $(() => console.log(store)); // store is serializable.
  *
  *   // Compile time errors

--- a/packages/qwik/src/core/readme.md
+++ b/packages/qwik/src/core/readme.md
@@ -146,7 +146,18 @@ Registers a server mount hook that runs only in the server when the component is
 
 <docs code="./examples.tsx#use-server-mount"/>
 
-@see `useMount`
+@see `useMount`, `useClientMount`
+@public
+
+# `useClientMount`
+
+Registers a client mount hook that runs only in the browser when the component is first mounted.
+
+### Example
+
+<docs code="./examples.tsx#use-client-mount"/>
+
+@see `useMount`, `useServerMount`
 @public
 
 # `useStyles`

--- a/packages/qwik/src/core/use/use-mount.ts
+++ b/packages/qwik/src/core/use/use-mount.ts
@@ -1,0 +1,251 @@
+import { isServer } from '../platform/platform';
+import { assertQrl } from '../qrl/qrl-class';
+import type { QRL } from '../qrl/qrl.public';
+import { implicit$FirstArg } from '../util/implicit_dollar';
+import type { ValueOrPromise } from '../util/types';
+import { waitAndRun } from './use-core';
+import { useSequentialScope } from './use-sequential-scope';
+
+/**
+ * @public
+ */
+export type MountFn<T> = () => ValueOrPromise<T>;
+
+// <docs markdown="../readme.md#useServerMount">
+// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
+// (edit ../readme.md#useServerMount instead)
+/**
+ * Registers a server mount hook that runs only in the server when the component is first
+ * mounted.
+ *
+ * ### Example
+ *
+ * ```tsx
+ * const Cmp = component$(() => {
+ *   const store = useStore({
+ *     users: [],
+ *   });
+ *
+ *   useServerMount$(async () => {
+ *     // This code will ONLY run once in the server, when the component is mounted
+ *     store.users = await db.requestUsers();
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       {store.users.map((user) => (
+ *         <User user={user} />
+ *       ))}
+ *     </div>
+ *   );
+ * });
+ *
+ * interface User {
+ *   name: string;
+ * }
+ * function User(props: { user: User }) {
+ *   return <div>Name: {props.user.name}</div>;
+ * }
+ * ```
+ *
+ * @see `useMount`, `useClientMount`
+ * @public
+ */
+// </docs>
+export const useServerMountQrl = <T>(mountQrl: QRL<MountFn<T>>): void => {
+  const { get, set, rCtx: ctx } = useSequentialScope<boolean>();
+  if (get) {
+    return;
+  }
+  if (isServer()) {
+    assertQrl(mountQrl);
+    mountQrl.$resolveLazy$(ctx.$renderCtx$.$static$.$containerState$.$containerEl$);
+    waitAndRun(ctx, mountQrl);
+  }
+  set(true);
+};
+
+// <docs markdown="../readme.md#useServerMount">
+// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
+// (edit ../readme.md#useServerMount instead)
+/**
+ * Registers a server mount hook that runs only in the server when the component is first
+ * mounted.
+ *
+ * ### Example
+ *
+ * ```tsx
+ * const Cmp = component$(() => {
+ *   const store = useStore({
+ *     users: [],
+ *   });
+ *
+ *   useServerMount$(async () => {
+ *     // This code will ONLY run once in the server, when the component is mounted
+ *     store.users = await db.requestUsers();
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       {store.users.map((user) => (
+ *         <User user={user} />
+ *       ))}
+ *     </div>
+ *   );
+ * });
+ *
+ * interface User {
+ *   name: string;
+ * }
+ * function User(props: { user: User }) {
+ *   return <div>Name: {props.user.name}</div>;
+ * }
+ * ```
+ *
+ * @see `useMount`, `useClientMount`
+ * @public
+ */
+// </docs>
+export const useServerMount$ = /*#__PURE__*/ implicit$FirstArg(useServerMountQrl);
+
+// <docs markdown="../readme.md#useClientMount">
+// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
+// (edit ../readme.md#useClientMount instead)
+/**
+ * Registers a client mount hook that runs only in the browser when the component is first
+ * mounted.
+ *
+ * ### Example
+ *
+ * ```tsx
+ * const Cmp = component$(() => {
+ *   useClientMount$(async () => {
+ *     // This code will ONLY run once in the client, when the component is mounted
+ *   });
+ *
+ *   return <div>Cmp</div>;
+ * });
+ * ```
+ *
+ * @see `useMount`, `useServerMount`
+ * @public
+ */
+// </docs>
+export const useClientMountQrl = <T>(mountQrl: QRL<MountFn<T>>): void => {
+  const { get, set, rCtx: ctx } = useSequentialScope<boolean>();
+  if (get) {
+    return;
+  }
+  if (!isServer()) {
+    assertQrl(mountQrl);
+    mountQrl.$resolveLazy$(ctx.$renderCtx$.$static$.$containerState$.$containerEl$);
+    waitAndRun(ctx, mountQrl);
+  }
+  set(true);
+};
+
+// <docs markdown="../readme.md#useClientMount">
+// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
+// (edit ../readme.md#useClientMount instead)
+/**
+ * Registers a client mount hook that runs only in the browser when the component is first
+ * mounted.
+ *
+ * ### Example
+ *
+ * ```tsx
+ * const Cmp = component$(() => {
+ *   useClientMount$(async () => {
+ *     // This code will ONLY run once in the client, when the component is mounted
+ *   });
+ *
+ *   return <div>Cmp</div>;
+ * });
+ * ```
+ *
+ * @see `useMount`, `useServerMount`
+ * @public
+ */
+// </docs>
+export const useClientMount$ = /*#__PURE__*/ implicit$FirstArg(useClientMountQrl);
+
+// <docs markdown="../readme.md#useMount">
+// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
+// (edit ../readme.md#useMount instead)
+/**
+ * Registers a hook to execute code when the component is mounted into the rendering tree (on
+ * component creation).
+ *
+ * ### Example
+ *
+ * ```tsx
+ * const Cmp = component$(() => {
+ *   const store = useStore({
+ *     temp: 0,
+ *   });
+ *
+ *   useMount$(async () => {
+ *     // This code will run once whenever a component is mounted in the server, or in the client
+ *     const res = await fetch('weather-api.example');
+ *     const json = (await res.json()) as any;
+ *     store.temp = json.temp;
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       <p>The temperature is: ${store.temp}</p>
+ *     </div>
+ *   );
+ * });
+ * ```
+ *
+ * @see `useServerMount`
+ * @public
+ */
+// </docs>
+export const useMountQrl = <T>(mountQrl: QRL<MountFn<T>>): void => {
+  const { get, set, rCtx: ctx } = useSequentialScope<boolean>();
+  if (get) {
+    return;
+  }
+  assertQrl(mountQrl);
+  mountQrl.$resolveLazy$(ctx.$renderCtx$.$static$.$containerState$.$containerEl$);
+  waitAndRun(ctx, mountQrl);
+  set(true);
+};
+
+// <docs markdown="../readme.md#useMount">
+// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
+// (edit ../readme.md#useMount instead)
+/**
+ * Registers a hook to execute code when the component is mounted into the rendering tree (on
+ * component creation).
+ *
+ * ### Example
+ *
+ * ```tsx
+ * const Cmp = component$(() => {
+ *   const store = useStore({
+ *     temp: 0,
+ *   });
+ *
+ *   useMount$(async () => {
+ *     // This code will run once whenever a component is mounted in the server, or in the client
+ *     const res = await fetch('weather-api.example');
+ *     const json = (await res.json()) as any;
+ *     store.temp = json.temp;
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       <p>The temperature is: ${store.temp}</p>
+ *     </div>
+ *   );
+ * });
+ * ```
+ *
+ * @see `useServerMount`
+ * @public
+ */
+// </docs>
+export const useMount$ = /*#__PURE__*/ implicit$FirstArg(useMountQrl);

--- a/packages/qwik/src/core/use/use-watch.ts
+++ b/packages/qwik/src/core/use/use-watch.ts
@@ -7,12 +7,7 @@ import { implicit$FirstArg } from '../util/implicit_dollar';
 import { assertDefined, assertEqual } from '../error/assert';
 import type { QRL } from '../qrl/qrl.public';
 import { assertQrl, createQRL, QRLInternal } from '../qrl/qrl-class';
-import {
-  codeToText,
-  qError,
-  QError_canNotMountUseServerMount,
-  QError_trackUseStore,
-} from '../error/error';
+import { codeToText, QError_trackUseStore } from '../error/error';
 import { useOn, useOnDocument } from './use-on';
 import { ContainerState, intToStr, MustGetObjID, strToInt } from '../container/container';
 import { notifyWatch, _hW } from '../render/dom/notify-render';
@@ -122,11 +117,6 @@ export type WatchFn = (ctx: WatchCtx) => ValueOrPromise<void | (() => void)>;
  * @public
  */
 export type ResourceFn<T> = (ctx: ResourceCtx<T>) => ValueOrPromise<T>;
-
-/**
- * @public
- */
-export type MountFn<T> = () => ValueOrPromise<T>;
 
 /**
  * @public
@@ -439,183 +429,6 @@ export const useClientEffectQrl = (qrl: QRL<WatchFn>, opts?: UseEffectOptions): 
  */
 // </docs>
 export const useClientEffect$ = /*#__PURE__*/ implicit$FirstArg(useClientEffectQrl);
-
-// <docs markdown="../readme.md#useServerMount">
-// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#useServerMount instead)
-/**
- * Register's a server mount hook that runs only in the server when the component is first
- * mounted.
- *
- * ### Example
- *
- * ```tsx
- * const Cmp = component$(() => {
- *   const store = useStore({
- *     users: [],
- *   });
- *
- *   useServerMount$(async () => {
- *     // This code will ONLY run once in the server, when the component is mounted
- *     store.users = await db.requestUsers();
- *   });
- *
- *   return (
- *     <div>
- *       {store.users.map((user) => (
- *         <User user={user} />
- *       ))}
- *     </div>
- *   );
- * });
- *
- * interface User {
- *   name: string;
- * }
- * function User(props: { user: User }) {
- *   return <div>Name: {props.user.name}</div>;
- * }
- * ```
- *
- * @see `useMount`
- * @public
- */
-// </docs>
-export const useServerMountQrl = <T>(mountQrl: QRL<MountFn<T>>): void => {
-  const { get, set, rCtx: ctx } = useSequentialScope<boolean>();
-  if (get) {
-    return;
-  }
-
-  if (isServer()) {
-    waitAndRun(ctx, mountQrl);
-    set(true);
-  } else {
-    throw qError(QError_canNotMountUseServerMount, ctx.$hostElement$);
-  }
-};
-
-// <docs markdown="../readme.md#useServerMount">
-// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#useServerMount instead)
-/**
- * Register's a server mount hook that runs only in the server when the component is first
- * mounted.
- *
- * ### Example
- *
- * ```tsx
- * const Cmp = component$(() => {
- *   const store = useStore({
- *     users: [],
- *   });
- *
- *   useServerMount$(async () => {
- *     // This code will ONLY run once in the server, when the component is mounted
- *     store.users = await db.requestUsers();
- *   });
- *
- *   return (
- *     <div>
- *       {store.users.map((user) => (
- *         <User user={user} />
- *       ))}
- *     </div>
- *   );
- * });
- *
- * interface User {
- *   name: string;
- * }
- * function User(props: { user: User }) {
- *   return <div>Name: {props.user.name}</div>;
- * }
- * ```
- *
- * @see `useMount`
- * @public
- */
-// </docs>
-export const useServerMount$ = /*#__PURE__*/ implicit$FirstArg(useServerMountQrl);
-
-// <docs markdown="../readme.md#useMount">
-// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#useMount instead)
-/**
- * Register a server mount hook that runs only in the server when the component is first mounted.
- *
- * ### Example
- *
- * ```tsx
- * const Cmp = component$(() => {
- *   const store = useStore({
- *     temp: 0,
- *   });
- *
- *   useMount$(async () => {
- *     // This code will run once whenever a component is mounted in the server, or in the client
- *     const res = await fetch('weather-api.example');
- *     const json = (await res.json()) as any;
- *     store.temp = json.temp;
- *   });
- *
- *   return (
- *     <div>
- *       <p>The temperature is: ${store.temp}</p>
- *     </div>
- *   );
- * });
- * ```
- *
- * @see `useServerMount`
- * @public
- */
-// </docs>
-export const useMountQrl = <T>(mountQrl: QRL<MountFn<T>>): void => {
-  const { get, set, rCtx: ctx } = useSequentialScope<boolean>();
-  if (get) {
-    return;
-  }
-  assertQrl(mountQrl);
-  mountQrl.$resolveLazy$(ctx.$renderCtx$.$static$.$containerState$.$containerEl$);
-  waitAndRun(ctx, mountQrl);
-  set(true);
-};
-
-// <docs markdown="../readme.md#useMount">
-// !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#useMount instead)
-/**
- * Register a server mount hook that runs only in the server when the component is first mounted.
- *
- * ### Example
- *
- * ```tsx
- * const Cmp = component$(() => {
- *   const store = useStore({
- *     temp: 0,
- *   });
- *
- *   useMount$(async () => {
- *     // This code will run once whenever a component is mounted in the server, or in the client
- *     const res = await fetch('weather-api.example');
- *     const json = (await res.json()) as any;
- *     store.temp = json.temp;
- *   });
- *
- *   return (
- *     <div>
- *       <p>The temperature is: ${store.temp}</p>
- *     </div>
- *   );
- * });
- * ```
- *
- * @see `useServerMount`
- * @public
- */
-// </docs>
-export const useMount$ = /*#__PURE__*/ implicit$FirstArg(useMountQrl);
 
 export type WatchDescriptor = DescriptorBase<WatchFn>;
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Adds `useClientMount$()` and relaxes rules around useServerMount!