### PR TITLE
feat: add qnavigatestart and qnavigateend events #2202

### DIFF
--- a/packages/qwik-city/runtime/src/client-navigate.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.ts
@@ -89,6 +89,23 @@ const scrollToHashId = (doc: Document, hash: string) => {
   return elm;
 };
 
+export const dispatchNavigationStartEvent = (data: RouteNavigate) => {
+  if (typeof document !== 'undefined')
+    document.dispatchEvent(
+      new CustomEvent('qnavigatestart', {
+        detail: data,
+      })
+    );
+};
+export const dispatchNavigationEndEvent = (data: RouteNavigate) => {
+  if (typeof document !== 'undefined')
+    document.dispatchEvent(
+      new CustomEvent('qnavigateend', {
+        detail: data,
+      })
+    );
+};
+
 export const dispatchPrefetchEvent = (prefetchData: QPrefetchData) => {
   if (typeof document !== 'undefined') {
     document.dispatchEvent(new CustomEvent('qprefetch', { detail: prefetchData }));

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -28,7 +28,11 @@ import {
 import { createDocumentHead, resolveHead } from './head';
 import { isBrowser, isServer } from '@builder.io/qwik/build';
 import { useQwikCityEnv } from './use-functions';
-import { clientNavigate } from './client-navigate';
+import {
+  clientNavigate,
+  dispatchNavigationEndEvent,
+  dispatchNavigationStartEvent,
+} from './client-navigate';
 import { loadClientData } from './use-endpoint';
 import { toPath } from './utils';
 
@@ -100,6 +104,9 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
     const url = new URL(path, routeLocation.href);
     const pathname = url.pathname;
 
+    const navigationEventData = { path };
+    dispatchNavigationStartEvent(navigationEventData);
+
     const loadRoutePromise = loadRoute(routes, menus, cacheModules, pathname);
 
     const endpointResponse = isServer ? env.response : loadClientData(url.href);
@@ -134,6 +141,7 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
 
       if (isBrowser) {
         clientNavigate(window, routeNavigate);
+        dispatchNavigationEndEvent(navigationEventData);
       }
     }
   });


### PR DESCRIPTION
Signed-off-by: Jeremy Wickersheimer <jwickers@gmail.com>

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Implement the events for issue #2202

# Use cases and why

- makes better UX possible as developpers can now hook up to those events and provide UI feedback like a loader, message if the load is long, etc ...

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
