### PR TITLE
docs: remove redundant statement

### DIFF
--- a/packages/docs/src/routes/docs/advanced/dollar/index.mdx
+++ b/packages/docs/src/routes/docs/advanced/dollar/index.mdx
@@ -283,8 +283,6 @@ The result of Optimizer is that the `MyComp`'s `onMount` method was extracted in
 - A Parent component can refer to `MyComp` without pulling in `MyComp` implementation details.
 - The application now has more entry points, giving the bundler more ways to chunk up the codebase.
 
-See also: Capturing Lexical Scope.
-
 ## Capturing the lexical scope
 
 The Optimizer extracts expressions (usually functions) into new files and leaves behind a `QRL` pointing to the lazy-loaded location.


### PR DESCRIPTION
The removed statement is redundant since the next line is the relevant section.  Also, the statement doesn't link to anything

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
