### PR TITLE
feat: allow recursive class definitions

### DIFF
--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -1010,14 +1010,17 @@ export const setProperties = (
     if (prop === 'className') {
       prop = 'class';
     }
-    if (hostElm && isSignal(newValue)) {
-      addSignalSub(1, hostElm, newValue, elm, prop);
+    const sig = isSignal(newValue);
+    if (sig) {
+      if (hostElm) addSignalSub(1, hostElm, newValue, elm, prop);
       newValue = newValue.value;
     }
-    if (prop === 'class') {
-      newValue = serializeClass(newValue);
-    }
     const normalizedProp = isSvg ? prop : prop.toLowerCase();
+    if (normalizedProp === 'class') {
+      if (qDev && values.class) throw new TypeError('Can only provide one of class or className');
+      // Signals shouldn't be changed
+      if (!sig) newValue = serializeClass(newValue);
+    }
     values[normalizedProp] = newValue;
     smartSetProperty(staticCtx, elm, prop, newValue, undefined, isSvg);
   }

--- a/packages/qwik/src/core/render/execute-component.ts
+++ b/packages/qwik/src/core/render/execute-component.ts
@@ -2,7 +2,7 @@ import { assertDefined } from '../error/assert';
 import { RenderEvent } from '../util/markers';
 import { safeCall } from '../util/promises';
 import { newInvokeContext } from '../use/use-core';
-import { isArray, isObject, isString, ValueOrPromise } from '../util/types';
+import { isArray, isString, ValueOrPromise } from '../util/types';
 import type { JSXNode } from './jsx/types/jsx-node';
 import type { RenderContext } from './types';
 import { ContainerState, intToStr } from '../container/container';
@@ -119,29 +119,22 @@ export const pushRenderContext = (ctx: RenderContext): RenderContext => {
   return newCtx;
 };
 
-export const serializeClass = (obj: any) => {
-  if (isString(obj)) {
-    return obj;
-  } else if (isObject(obj)) {
-    if (isArray(obj)) {
-      return obj.join(' ');
-    } else {
-      let buffer = '';
-      let previous = false;
-      for (const key of Object.keys(obj)) {
-        const value = obj[key];
-        if (value) {
-          if (previous) {
-            buffer += ' ';
-          }
-          buffer += key;
-          previous = true;
-        }
-      }
-      return buffer;
-    }
-  }
-  return '';
+export const serializeClass = (
+  obj: string | { [className: string]: boolean } | (string | { [className: string]: boolean })[]
+): string => {
+  if (!obj) return '';
+  if (isString(obj)) return obj.trim();
+
+  if (isArray(obj))
+    return obj.reduce((result: string, o) => {
+      const classList = serializeClass(o);
+      return classList ? (result ? `${result} ${classList}` : classList) : result;
+    }, '');
+
+  return Object.entries(obj).reduce(
+    (result, [key, value]) => (value ? (result ? `${result} ${key.trim()}` : key.trim()) : result),
+    ''
+  );
 };
 
 const parseClassListRegex = /\s/;

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -166,7 +166,11 @@ export type PreventDefault<T> = {
 };
 
 export interface QwikProps<T> extends PreventDefault<T> {
-  class?: string | { [className: string]: boolean } | string[];
+  class?:
+    | Signal<string>
+    | string
+    | { [className: string]: boolean }
+    | (string | { [className: string]: boolean })[];
   dangerouslySetInnerHTML?: string;
   ref?: Ref<Element> | Signal<Element | undefined> | ((el: Element) => void);
 

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -66,8 +66,26 @@ renderSSRSuite('render class', async () => {
     '<html q:container="paused" q:version="dev" q:render="ssr-dev"><div class="stuff m-0 p-2"></div></html>'
   );
 
+  const Test = component$(() => {
+    // Extra spaces to ensure signal hasn't changed
+    const sigClass = useSignal(' myClass ');
+    return <div class={sigClass} />;
+  });
   await testSSR(
-    <div class={['stuff', '', 'm-0 p-2', null, 'active', undefined, 'container'] as any}></div>,
+    <Test />,
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+      <!--qv q:id=0 q:key=sX:-->
+      <div class=" myClass "></div>
+      <!--/qv-->
+    </html>`
+  );
+
+  await testSSR(
+    <div
+      class={
+        ['stuff', '', 'm-0 p-2', null, { active: 1 }, undefined, [{ container: 'yup' }]] as any
+      }
+    ></div>,
     `<html q:container="paused" q:version="dev" q:render="ssr-dev">
       <div class="stuff m-0 p-2 active container"></div>
     </html>`


### PR DESCRIPTION
My previous PR #2208 closed by accident when I pushed main.

# What is it?

- [x] Feature / enhancement

# Description

class and className now accept recursive objects and both are honored.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
