### PR TITLE
docs: right menu for Getting Started & Think Qwik

### DIFF
--- a/packages/docs/src/routes/docs/layout!.tsx
+++ b/packages/docs/src/routes/docs/layout!.tsx
@@ -9,7 +9,7 @@ import styles from './docs.css?inline';
 
 export default component$(() => {
   const loc = useLocation();
-  const noRightMenu = ['/docs/getting-started/', '/docs/overview/', '/docs/think-qwik/'].includes(
+  const noRightMenu = ['/docs/overview/'].includes(
     loc.pathname
   );
   useStyles$(styles);

--- a/packages/docs/src/routes/docs/layout!.tsx
+++ b/packages/docs/src/routes/docs/layout!.tsx
@@ -9,9 +9,7 @@ import styles from './docs.css?inline';
 
 export default component$(() => {
   const loc = useLocation();
-  const noRightMenu = ['/docs/overview/'].includes(
-    loc.pathname
-  );
+  const noRightMenu = ['/docs/overview/'].includes(loc.pathname);
   useStyles$(styles);
 
   return (


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

Fixes #2238 

In the documentation, the following 3 pages do not have a menu on the right (ON THIS PAGE, MORE, Edit this page, etc):
- [Guides -> Overwiew](https://qwik.builder.io/docs/overview/)
- [Guides -> Getting Started](https://qwik.builder.io/docs/getting-started/)
- [Guides -> Think Qwik](https://qwik.builder.io/docs/think-qwik/)

After [discussion](https://github.com/BuilderIO/qwik/issues/2238#issuecomment-1323592808), here is the solution

# Use cases and why

nope

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
