### PR TITLE
docs: Update Vercel Edge Get Started Link

### DIFF
--- a/packages/docs/src/routes/qwikcity/adaptors/vercel-edge/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/vercel-edge/index.mdx
@@ -48,7 +48,7 @@ To deploy the application for development:
 npm run deploy
 ```
 
-Notice that you might need a [Vercel account](https://docs.Vercel.com/get-started/) in order to complete this step!
+Notice that you might need a [Vercel account](https://vercel.com/docs/concepts/get-started) in order to complete this step!
 
 ## Production deploy
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The current Vercel get started link is dead. This PR updates it to the latest one

Old: https://docs.Vercel.com/get-started/
New: https://vercel.com/docs/concepts/get-started

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
