### PR TITLE
feat: add query search params to loadClientData (#2250)

### DIFF
--- a/packages/qwik-city/runtime/src/use-endpoint.ts
+++ b/packages/qwik-city/runtime/src/use-endpoint.ts
@@ -29,8 +29,10 @@ export const useEndpoint = <T = unknown>() => {
 };
 
 export const loadClientData = async (href: string) => {
-  const pagePathname = new URL(href).pathname;
-  const endpointUrl = getClientEndpointPath(pagePathname);
+  const url = new URL(href);
+  const pagePathname = url.pathname;
+  const pageSearch = url.search;
+  const endpointUrl = getClientEndpointPath(pagePathname, pageSearch);
 
   dispatchPrefetchEvent({
     links: [pagePathname],

--- a/packages/qwik-city/runtime/src/utils.ts
+++ b/packages/qwik-city/runtime/src/utils.ts
@@ -33,8 +33,8 @@ export const isSamePathname = (a: SimpleURL, b: SimpleURL) => a.pathname === b.p
 export const isSameOriginDifferentPathname = (a: SimpleURL, b: SimpleURL) =>
   isSameOrigin(a, b) && !isSamePath(a, b);
 
-export const getClientEndpointPath = (pathname: string) =>
-  pathname + (pathname.endsWith('/') ? '' : '/') + 'q-data.json';
+export const getClientEndpointPath = (pathname: string, pageSearch?: string) =>
+  pathname + (pathname.endsWith('/') ? '' : '/') + 'q-data.json' + (pageSearch ?? '');
 
 export const getClientNavPath = (props: Record<string, any>, baseUrl: { href: string }) => {
   const href = props.href;

--- a/packages/qwik-city/runtime/src/utils.unit.ts
+++ b/packages/qwik-city/runtime/src/utils.unit.ts
@@ -77,6 +77,18 @@ import {
 });
 
 [
+  { pathname: '/', search: '?foo=bar', expect: '/q-data.json?foo=bar' },
+  { pathname: '/about', search: '?foo=bar', expect: '/about/q-data.json?foo=bar' },
+  { pathname: '/about/', search: '?foo=bar', expect: '/about/q-data.json?foo=bar' },
+  { pathname: '/about/', search: '?foo=bar&baz=qux', expect: '/about/q-data.json?foo=bar&baz=qux' },
+].forEach((t) => {
+  test(`getClientEndpointUrl("${t.pathname}", "${t.search}")`, () => {
+    const endpointPath = getClientEndpointPath(t.pathname, t.search);
+    equal(endpointPath, t.expect);
+  });
+});
+
+[
   {
     url: 'http://qwik.builder.io/',
     expect: '/',


### PR DESCRIPTION
Signed-off-by: Jeremy Wickersheimer <jwickers@gmail.com>

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Allow the useEdnpoint to react to location.href changes while keeping any query search params when calling the page data `q-data.json`.

# Use cases and why

Refresh a page data with any state that is stored in the URL as query search params, like a list sort with `/foo/?sort=name`.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
