### PR TITLE
docs: add one more website to the showcase

### DIFF
--- a/packages/docs/scripts/pages.json
+++ b/packages/docs/scripts/pages.json
@@ -65,5 +65,9 @@
   {
     "href": "https://pulsestax.com/",
     "tags": "saas"
+  },
+  {
+    "href": "https://www.stockideashq.com/",
+    "tags": "investing"
   }
 ]


### PR DESCRIPTION
Seeking to add my website to the showcase. It's built with qwik + Cloudflare Pages integration. :)

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

# Use cases and why

No reason. Qwik is pretty cool so far. 

# Checklist:

- [ ] My code follows the [developer guidelines of this project] (n/a)(https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code (n/a)
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality (n/a)
