### PR TITLE
Inline causes the clock to not show

### DIFF
--- a/packages/docs/src/routes/tutorial/hooks/use-client-effect/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-client-effect/solution/app.tsx
@@ -1,5 +1,5 @@
 import { component$, useStore, useStyles$, useClientEffect$ } from '@builder.io/qwik';
-import styles from './clock.css?inline';
+import styles from './clock.css';
 
 interface ClockStore {
   hour: number;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

clock.css is not correctly loaded which causes the clock to not show.
Error: Cannot find module './clock.css?inline' or its corresponding type declarations.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
