### PR TITLE
Docs: Tutorial onError should be onRejected

### DIFF
--- a/packages/docs/src/routes/tutorial/reactivity/resource/index.mdx
+++ b/packages/docs/src/routes/tutorial/reactivity/resource/index.mdx
@@ -50,7 +50,7 @@ On the server the `<Resource>` does not render `loading` state, instead, it paus
 <Resource
   value={resourceToRender}
   onPending={() => <div>Loading...</div>}
-  onError={(reason) => <div>Error: {reason}</div>}
+  onRejected={(reason) => <div>Error: {reason}</div>}
   onResolved={(data) => <div>{data}</div>}
 />
 ```


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

When using onError in the IDE as provided in the example it gives the following error: Property 'onError' does not exist on type 'IntrinsicAttributes & ResourceProps<string[]>'

The solution says it should be onRejected

# Use cases and why

Nope

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
