### PR TITLE
feat: make basic deno build work

### DIFF
--- a/packages/qwik/src/cli/utils/app-command.ts
+++ b/packages/qwik/src/cli/utils/app-command.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import type { PackageJSON } from '../../../../../scripts/util';
+import { getProjectMetadataFileName } from './dev-platform';
 
 export class AppCommand {
   args: string[];
@@ -20,8 +21,9 @@ export class AppCommand {
     if (!this._rootDir) {
       const fsRoot = resolve('/');
       let testDir = process.cwd();
+      const projectMetadataFileName = getProjectMetadataFileName();
       for (let i = 0; i < 20; i++) {
-        const pkgPath = join(testDir, 'package.json');
+        const pkgPath = join(testDir, projectMetadataFileName);
         if (existsSync(pkgPath)) {
           this._rootDir = testDir;
           break;
@@ -32,7 +34,7 @@ export class AppCommand {
         testDir = dirname(testDir);
       }
       if (!this._rootDir) {
-        throw new Error(`Unable to find Qwik app package.json`);
+        throw new Error(`Unable to find Qwik app ${projectMetadataFileName}`);
       }
     }
     return this._rootDir;
@@ -44,7 +46,8 @@ export class AppCommand {
 
   get packageJson(): PackageJSON {
     if (!this._rootPkgJson) {
-      const pkgJsonPath = join(this.rootDir, 'package.json');
+      const projectMetadataFileName = getProjectMetadataFileName();
+      const pkgJsonPath = join(this.rootDir, projectMetadataFileName);
       this._rootPkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
     }
     return this._rootPkgJson!;

--- a/packages/qwik/src/cli/utils/dev-platform.ts
+++ b/packages/qwik/src/cli/utils/dev-platform.ts
@@ -1,0 +1,7 @@
+export function isDeno() {
+  return typeof Deno !== 'undefined';
+}
+export function getProjectMetadataFileName() {
+  return isDeno() ? 'deno.json' : 'package.json';
+}
+declare const Deno: any;


### PR DESCRIPTION
# It is a Feature / enhancement

Adds the basic deno platform implementation to let the ` vite build`  command pass in deno without errors. Note that many other code blocks in ` platform.ts`  are still not deno compatible.

# Why

1. To build dist files from inside deno
1. To come one step closer to the deno dev compatibility

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

-----

### Note
This is just one small step towards good deno DX. See #2287 for more.