### PR TITLE
docs: include vercel edge in the adaptors overview

### DIFF
--- a/packages/docs/src/routes/qwikcity/adaptors/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/overview/index.mdx
@@ -20,6 +20,7 @@ Qwik City comes pre-bundle with:
 
 - [cloudflare-pages](../cloudflare-pages/index.mdx)
 - [netlify-edge](../netlify-edge/index.mdx)
+- [vercel-edge](../vercel-edge/index.mdx)
 - [node](../node/index.mdx)
 
 ## Production build

--- a/packages/docs/src/routes/qwikcity/adaptors/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/overview/index.mdx
@@ -14,7 +14,7 @@ npm run qwik add
 
 ## Adaptors and Middleware
 
-Qwik City middleware is a glue code that connects server rendering framework (such as Cloudflare, Netlify, Express etc.) with the Qwik City meta-framework.
+Qwik City middleware is a glue code that connects server rendering framework (such as Cloudflare, Netlify, Vercel, Express etc.) with the Qwik City meta-framework.
 
 Qwik City comes pre-bundle with:
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

To in nclude vercel edge in the qwic city adaptors overview.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
