### PR TITLE
fix: draggable must be set as attribute (#2296)

### DIFF
--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -848,6 +848,7 @@ export const PROP_HANDLER_MAP: Record<string, PropHandler | undefined> = {
   form: forceAttribute,
   tabIndex: forceAttribute,
   download: forceAttribute,
+  draggable: forceAttribute,
   [dangerouslySetInnerHTML]: setInnerHTML,
   innerHTML: noop,
 };


### PR DESCRIPTION
Because draggabe is also a property on the element, it must be set as
an attribute instead of a property as it is an enumerable and not a true
boolean.

Signed-off-by: Jeremy Wickersheimer <jwickers@gmail.com>

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

The draggable attribute is also an attribute on the element in the DOM, but in HTML this is not a true boolean value but an enumerable instead.

See developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/draggable

In the JSX we then set is as the string `"false"` for elements like A or IMG that are draggable by default, or `"true"` for other elements that aren't.
In SSR this is currently handled correctly but nodes that are added during CSR need the exception handling rule so that the behavior is consistent.

# Use cases and why

- 1. Setting `draggable="false"` on elements like A or IMG

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
