### PR TITLE
feat: non-serializable response data dev error

### DIFF
--- a/packages/qwik-city/utils/format.ts
+++ b/packages/qwik-city/utils/format.ts
@@ -32,3 +32,41 @@ export function msToString(ms: number) {
   }
   return (ms / 60000).toFixed(1) + ' m';
 }
+
+export function validateSerializable(val: any) {
+  JSON.stringify(val);
+  if (!isSerializable(val)) {
+    throw new Error(`Unable to serialize value.`);
+  }
+}
+
+function isSerializable(val: any) {
+  if (
+    val == null ||
+    typeof val === 'string' ||
+    typeof val === 'boolean' ||
+    typeof val === 'number'
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(val)) {
+    for (const item of val) {
+      if (!isSerializable(item)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (val.constructor == null || val.constructor === Object) {
+    for (const prop in val) {
+      if (!isSerializable(val[prop])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/packages/qwik-city/utils/format.unit.ts
+++ b/packages/qwik-city/utils/format.unit.ts
@@ -1,33 +1,106 @@
 import { test } from 'uvu';
-import { equal } from 'uvu/assert';
-import { msToString } from './format';
+import { equal, throws } from 'uvu/assert';
+import { validateSerializable, msToString } from './format';
 
-test('msToString', () => {
-  const tests = [
-    {
-      ms: 0.05,
-      expect: '0.05 ms',
-    },
-    {
-      ms: 10.5,
-      expect: '10.5 ms',
-    },
-    {
-      ms: 100,
-      expect: '100.0 ms',
-    },
-    {
-      ms: 2000,
-      expect: '2.0 s',
-    },
-    {
-      ms: 120000,
-      expect: '2.0 m',
-    },
-  ];
-
-  tests.forEach((t) => {
+[
+  {
+    ms: 0.05,
+    expect: '0.05 ms',
+  },
+  {
+    ms: 10.5,
+    expect: '10.5 ms',
+  },
+  {
+    ms: 100,
+    expect: '100.0 ms',
+  },
+  {
+    ms: 2000,
+    expect: '2.0 s',
+  },
+  {
+    ms: 120000,
+    expect: '2.0 m',
+  },
+].forEach((t) => {
+  test(`msToString(${t.ms})`, () => {
     equal(msToString(t.ms), t.expect);
+  });
+});
+
+[
+  {
+    val: true,
+    throws: false,
+  },
+  {
+    val: false,
+    throws: false,
+  },
+  {
+    val: null,
+    throws: false,
+  },
+  {
+    val: undefined,
+    throws: false,
+  },
+  {
+    val: 'string',
+    throws: false,
+  },
+  {
+    val: 88,
+    throws: false,
+  },
+  {
+    val: {},
+    throws: false,
+  },
+  {
+    val: Object.create(null),
+    throws: false,
+  },
+  {
+    val: {
+      num: 88,
+      str: 'string',
+      bool: true,
+      nl: null,
+      undef: undefined,
+    },
+    throws: false,
+  },
+  {
+    val: new Map(),
+    throws: true,
+  },
+  {
+    val: {
+      obj: {
+        set: new Set(),
+      },
+    },
+    throws: true,
+  },
+].forEach((t) => {
+  test(`isSerializable(${JSON.stringify(t.val)})`, () => {
+    if (t.throws) {
+      throws(() => {
+        validateSerializable(t.val);
+      });
+    } else {
+      validateSerializable(t.val);
+    }
+  });
+});
+
+test(`not isSerializable if circular`, () => {
+  const obj: any = {};
+  obj.obj = obj;
+  throws(() => {
+    validateSerializable(obj);
   });
 });
 


### PR DESCRIPTION
A vite dev error will print if response data from an endpoint, like `onGet()`, is not serializable. Basically if any of the data is lost after `JSON.stringify()` then an error will be thrown since that cannot go over the network.

Closes #2281 
