### PR TITLE
feat: Link prefetch by default, q-data caching

### DIFF
--- a/packages/qwik-city/runtime/src/constants.ts
+++ b/packages/qwik-city/runtime/src/constants.ts
@@ -1,4 +1,8 @@
+import type { ClientPageData } from './types';
+
 export const MODULE_CACHE = /*#__PURE__*/ new WeakMap<any, any>();
 
 export const POPSTATE_FALLBACK_INITIALIZED = /* @__PURE__ */ Symbol();
 export const CLIENT_HISTORY_INITIALIZED = /* @__PURE__ */ Symbol();
+
+export const CLIENT_DATA_CACHE = new Map<string, Promise<ClientPageData | undefined>>();

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -31,6 +31,7 @@ import { useQwikCityEnv } from './use-functions';
 import { clientNavigate } from './client-navigate';
 import { loadClientData } from './use-endpoint';
 import { toPath } from './utils';
+import { CLIENT_DATA_CACHE } from './constants';
 
 /**
  * @alpha
@@ -102,7 +103,7 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
 
     const loadRoutePromise = loadRoute(routes, menus, cacheModules, pathname);
 
-    const endpointResponse = isServer ? env.response : loadClientData(url.href);
+    const endpointResponse = isServer ? env.response : loadClientData(url.href, true);
 
     const loadedRoute = await loadRoutePromise;
 
@@ -124,6 +125,8 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
 
       const clientPageData = await endpointResponse;
       const resolvedHead = resolveHead(clientPageData, routeLocation, contentModules, locale);
+
+      CLIENT_DATA_CACHE.clear();
 
       // Update document head
       documentHead.links = resolvedHead.links;

--- a/packages/qwik-city/runtime/src/use-endpoint.ts
+++ b/packages/qwik-city/runtime/src/use-endpoint.ts
@@ -1,9 +1,10 @@
 import { useResource$ } from '@builder.io/qwik';
 import { useLocation, useQwikCityEnv } from './use-functions';
 import { isServer } from '@builder.io/qwik/build';
-import type { ClientPageData, GetEndpointData } from './types';
-import { getClientEndpointPath } from './utils';
+import type { GetEndpointData } from './types';
+import { getClientDataPath } from './utils';
 import { dispatchPrefetchEvent } from './client-navigate';
+import { CLIENT_DATA_CACHE } from './constants';
 
 /**
  * @alpha
@@ -13,7 +14,7 @@ export const useEndpoint = <T = unknown>() => {
   const env = useQwikCityEnv();
 
   return useResource$<GetEndpointData<T>>(async ({ track }) => {
-    const href = track(loc, 'href');
+    const href = track(() => loc.href);
 
     if (isServer) {
       if (!env) {
@@ -22,30 +23,42 @@ export const useEndpoint = <T = unknown>() => {
       return env.response.body;
     } else {
       // fetch() for new data when the pathname has changed
-      const clientData = await loadClientData(href);
+      const clientData = await loadClientData(href, true);
       return clientData && clientData.body;
     }
   });
 };
 
-export const loadClientData = async (href: string) => {
+export const loadClientData = async (href: string, clearCache?: boolean) => {
   const url = new URL(href);
   const pagePathname = url.pathname;
   const pageSearch = url.search;
-  const endpointUrl = getClientEndpointPath(pagePathname, pageSearch);
+  const clientDataPath = getClientDataPath(pagePathname, pageSearch);
+  let qData = CLIENT_DATA_CACHE.get(clientDataPath);
 
   dispatchPrefetchEvent({
     links: [pagePathname],
   });
 
-  const clientResponse = await fetch(endpointUrl);
-  const contentType = clientResponse.headers.get('content-type') || '';
-  if (clientResponse.ok && contentType.includes('json')) {
-    const clientData: ClientPageData = await clientResponse.json();
-    dispatchPrefetchEvent({
-      bundles: clientData.prefetch,
-      links: [pagePathname],
+  if (!qData) {
+    qData = fetch(clientDataPath).then((rsp) => {
+      if (rsp.ok && (rsp.headers.get('content-type') || '').includes('json')) {
+        return rsp.json().then((clientData) => {
+          dispatchPrefetchEvent({
+            bundles: clientData.prefetch,
+          });
+          if (clearCache) {
+            CLIENT_DATA_CACHE.delete(clientDataPath);
+          }
+          return clientData;
+        });
+      } else {
+        CLIENT_DATA_CACHE.delete(clientDataPath);
+      }
     });
-    return clientData;
+
+    CLIENT_DATA_CACHE.set(clientDataPath, qData);
   }
+
+  return qData;
 };

--- a/packages/qwik-city/runtime/src/utils.ts
+++ b/packages/qwik-city/runtime/src/utils.ts
@@ -33,7 +33,7 @@ export const isSamePathname = (a: SimpleURL, b: SimpleURL) => a.pathname === b.p
 export const isSameOriginDifferentPathname = (a: SimpleURL, b: SimpleURL) =>
   isSameOrigin(a, b) && !isSamePath(a, b);
 
-export const getClientEndpointPath = (pathname: string, pageSearch?: string) =>
+export const getClientDataPath = (pathname: string, pageSearch?: string) =>
   pathname + (pathname.endsWith('/') ? '' : '/') + 'q-data.json' + (pageSearch ?? '');
 
 export const getClientNavPath = (props: Record<string, any>, baseUrl: { href: string }) => {
@@ -52,15 +52,15 @@ export const getClientNavPath = (props: Record<string, any>, baseUrl: { href: st
   return null;
 };
 
-export const getPrefetchUrl = (
+export const getPrefetchDataset = (
   props: LinkProps,
   clientNavPath: string | null,
   currentLoc: { href: string }
 ) => {
-  if (props.prefetch && clientNavPath) {
+  if (props.prefetch !== false && clientNavPath) {
     const prefetchUrl = toUrl(clientNavPath, currentLoc);
     if (!isSamePathname(prefetchUrl, toUrl('', currentLoc))) {
-      return prefetchUrl + '';
+      return '';
     }
   }
   return null;

--- a/packages/qwik-city/runtime/src/utils.unit.ts
+++ b/packages/qwik-city/runtime/src/utils.unit.ts
@@ -2,9 +2,9 @@ import { test } from 'uvu';
 import { equal } from 'uvu/assert';
 import type { LinkProps } from './link-component';
 import {
-  getClientEndpointPath,
+  getClientDataPath,
   getClientNavPath,
-  getPrefetchUrl,
+  getPrefetchDataset,
   isSameOrigin,
   isSameOriginDifferentPathname,
   isSamePath,
@@ -71,7 +71,7 @@ import {
   { pathname: '/about/', expect: '/about/q-data.json' },
 ].forEach((t) => {
   test(`getClientEndpointUrl("${t.pathname}")`, () => {
-    const endpointPath = getClientEndpointPath(t.pathname);
+    const endpointPath = getClientDataPath(t.pathname);
     equal(endpointPath, t.expect);
   });
 });
@@ -83,7 +83,7 @@ import {
   { pathname: '/about/', search: '?foo=bar&baz=qux', expect: '/about/q-data.json?foo=bar&baz=qux' },
 ].forEach((t) => {
   test(`getClientEndpointUrl("${t.pathname}", "${t.search}")`, () => {
-    const endpointPath = getClientEndpointPath(t.pathname, t.search);
+    const endpointPath = getClientDataPath(t.pathname, t.search);
     equal(endpointPath, t.expect);
   });
 });
@@ -190,35 +190,56 @@ test('no prefetch, missing clientNavPath', () => {
   const props: LinkProps = { prefetch: true };
   const clientNavPath = null;
   const currentLoc = new URL('https://qwik.builder.io/contact');
-  equal(getPrefetchUrl(props, clientNavPath, currentLoc), null);
+  equal(getPrefetchDataset(props, clientNavPath, currentLoc), null);
 });
 
-test('prefetch prop not set', () => {
+test('no prefetch, path and current path the same, has querystring and hash', () => {
+  const props: LinkProps = {};
+  const clientNavPath = '/about?qs#hash';
+  const currentLoc = new URL('https://qwik.builder.io/about');
+  equal(getPrefetchDataset(props, clientNavPath, currentLoc), null);
+});
+
+test('no prefetch, path and current path the same', () => {
+  const props: LinkProps = {};
+  const clientNavPath = '/about';
+  const currentLoc = new URL('https://qwik.builder.io/about');
+  equal(getPrefetchDataset(props, clientNavPath, currentLoc), null);
+});
+
+test('valid prefetchUrl, has querystring and hash', () => {
+  const props: LinkProps = {};
+  const clientNavPath = '/about?qs#hash';
+  const currentLoc = new URL('https://qwik.builder.io/contact');
+  equal(getPrefetchDataset(props, clientNavPath, currentLoc), '');
+});
+
+test('valid prefetchUrl, trailing slash', () => {
+  const props: LinkProps = {};
+  const clientNavPath = '/about/';
+  const currentLoc = new URL('https://qwik.builder.io/contact');
+  equal(getPrefetchDataset(props, clientNavPath, currentLoc), '');
+});
+
+test('valid prefetchUrl, prefetch true', () => {
+  const props: LinkProps = { prefetch: true };
+  const clientNavPath = '/about';
+  const currentLoc = new URL('https://qwik.builder.io/contact');
+  equal(getPrefetchDataset(props, clientNavPath, currentLoc), '');
+});
+
+test('valid prefetchUrl, add by default', () => {
   const props: LinkProps = {};
   const clientNavPath = '/about';
   const currentLoc = new URL('https://qwik.builder.io/contact');
-  equal(getPrefetchUrl(props, clientNavPath, currentLoc), null);
+  equal(getPrefetchDataset(props, clientNavPath, currentLoc), '');
 });
 
-test('no prefetch, path and current path the same', () => {
-  const props: LinkProps = { prefetch: true };
-  const clientNavPath = '/about?qs#hash';
-  const currentLoc = new URL('https://qwik.builder.io/about');
-  equal(getPrefetchUrl(props, clientNavPath, currentLoc), null);
-});
-
-test('no prefetch, path and current path the same', () => {
-  const props: LinkProps = { prefetch: true };
-  const clientNavPath = '/about';
-  const currentLoc = new URL('https://qwik.builder.io/about');
-  equal(getPrefetchUrl(props, clientNavPath, currentLoc), null);
-});
-
-test('valid prefetchUrl', () => {
-  const props: LinkProps = { prefetch: true };
+test('prefetch false', () => {
+  const props: LinkProps = { prefetch: false };
   const clientNavPath = '/about';
   const currentLoc = new URL('https://qwik.builder.io/contact');
-  equal(getPrefetchUrl(props, clientNavPath, currentLoc), 'https://qwik.builder.io/about');
+  equal(getPrefetchDataset(props, clientNavPath, currentLoc), null);
 });
 
 test.run();


### PR DESCRIPTION
- Default to prefetch client-side `q-data.json` data
  - Prefetch on mouse over with a window width >= 520px
  - Prefetch on visible when the window width < 520px
- Requests to `q-data.json` are cached
  - If a prefetch starts from a mouse over, and a page transition happens, the original/in-flight request is re-used
  - Prevents double-requesting the same URL in a short period of time

Closes #2289