### PR TITLE
fix: client redirect for trailing slash

### DIFF
--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -96,7 +96,7 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
 
   useWatch$(async ({ track }) => {
     const locale = getLocale('');
-    const { routes, menus, cacheModules } = await import('@qwik-city-plan');
+    const { routes, menus, cacheModules, trailingSlash } = await import('@qwik-city-plan');
     const path = track(() => routeNavigate.path);
     const url = new URL(path, routeLocation.href);
     const pathname = url.pathname;
@@ -111,6 +111,19 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
       const [params, mods, menu] = loadedRoute;
       const contentModules = mods as ContentModule[];
       const pageModule = contentModules[contentModules.length - 1] as PageModule;
+
+      // ensure correct trailing slash
+      if (pathname.endsWith('/')) {
+        if (!trailingSlash) {
+          url.pathname = pathname.slice(0, -1);
+          routeNavigate.path = toPath(url);
+          return;
+        }
+      } else if (trailingSlash) {
+        url.pathname += '/';
+        routeNavigate.path = toPath(url);
+        return;
+      }
 
       // Update route location
       routeLocation.href = url.href;

--- a/starters/apps/qwikcity-test/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/starters/apps/qwikcity-test/src/components/breadcrumbs/breadcrumbs.tsx
@@ -27,19 +27,19 @@ export const Breadcrumbs = component$(() => {
 export function createBreadcrumbs(menu: ContentMenu | undefined, pathname: string) {
   if (menu?.items) {
     for (const breadcrumbA of menu.items) {
-      if (breadcrumbA.href === pathname) {
+      if (matchesHref(breadcrumbA.href, pathname)) {
         return [breadcrumbA];
       }
 
       if (breadcrumbA.items) {
         for (const breadcrumbB of breadcrumbA.items) {
-          if (breadcrumbB.href === pathname) {
+          if (matchesHref(breadcrumbB.href, pathname)) {
             return [breadcrumbA, breadcrumbB];
           }
 
           if (breadcrumbB.items) {
             for (const breadcrumbC of breadcrumbB.items) {
-              if (breadcrumbC.href === pathname) {
+              if (matchesHref(breadcrumbC.href, pathname)) {
                 return [breadcrumbA, breadcrumbB, breadcrumbC];
               }
             }
@@ -50,4 +50,15 @@ export function createBreadcrumbs(menu: ContentMenu | undefined, pathname: strin
   }
 
   return [];
+}
+
+function matchesHref(href: string | undefined, pathname: string) {
+  if (href) {
+    if (href.endsWith('/') && !pathname.endsWith('/')) {
+      pathname += '/';
+    } else if (!href.endsWith('/') && pathname.endsWith('/')) {
+      href += '/';
+    }
+  }
+  return href === pathname;
 }

--- a/starters/apps/qwikcity-test/src/routes/docs/menu.md
+++ b/starters/apps/qwikcity-test/src/routes/docs/menu.md
@@ -8,7 +8,7 @@
 ## Components
 
 - [Basics](/qwikcity-test/docs/components/basics/)
-- [Listeners](/qwikcity-test/docs/components/listeners/)
+- [Listeners](/qwikcity-test/docs/components/listeners)
 
 ## Anchors
 

--- a/starters/e2e/qwikcity/menu.spec.ts
+++ b/starters/e2e/qwikcity/menu.spec.ts
@@ -88,7 +88,7 @@ function tests() {
     expect(await breadcrumb1.innerText()).toBe('Basics');
 
     /***********  Docs: components/listeners  ***********/
-    await linkNavigate(ctx, '[data-test-menu-link="/qwikcity-test/docs/components/listeners/"]');
+    await linkNavigate(ctx, '[data-test-menu-link="/qwikcity-test/docs/components/listeners"]');
     await assertPage(ctx, {
       pathname: '/qwikcity-test/docs/components/listeners/',
       title: 'Docs: components listeners - Qwik',


### PR DESCRIPTION
If a client-side <Link> does not have a trailing slash and should, or has a trailing slash and shouldn't, if they use that navigation it'll use the correct url.