### PR TITLE
fix: forceConsistentCasingInFileNames in starters

### DIFF
--- a/starters/apps/base/tsconfig.json
+++ b/starters/apps/base/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "@builder.io/qwik",
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
It's possible that filename case is inconsistent, and typescript/vite/qwik plugins crash with an unrelated error. Adding `forceConsistentCasingInFileNames: true` to the starter just to enforce a good practice and prevent future errors that are difficult to debug.

https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames