### PR TITLE
refactor: use class prop without casting to any

### DIFF
--- a/packages/qwik/src/core/render/dom/render.unit.tsx
+++ b/packages/qwik/src/core/render/dom/render.unit.tsx
@@ -617,7 +617,7 @@ renderSuite('should render class array correctly', async () => {
 
   await render(
     fixture.host,
-    <div class={['stuff', '', 'm-0 p-2', null, 'active', undefined, 'container'] as any}></div>
+    <div class={['stuff', '', 'm-0 p-2', null, 'active', undefined, 'container']}></div>
   );
   await expectRendered(fixture, `<div class="stuff m-0 p-2 active container"></div>`);
 });
@@ -856,17 +856,15 @@ export const RenderClasses = component$(() => {
         Div 1
       </div>
       <div
-        class={
-          [
-            'stuff',
-            '',
-            'm-0 p-2',
-            state.count % 2 === 0 ? null : 'almost-null',
-            'active',
-            undefined,
-            'container',
-          ] as any
-        }
+        class={[
+          'stuff',
+          '',
+          'm-0 p-2',
+          state.count % 2 === 0 ? null : 'almost-null',
+          'active',
+          undefined,
+          'container',
+        ]}
       >
         Div 2
       </div>

--- a/packages/qwik/src/core/render/execute-component.ts
+++ b/packages/qwik/src/core/render/execute-component.ts
@@ -9,11 +9,10 @@ import type { RenderContext } from './types';
 import { ContainerState, intToStr } from '../container/container';
 import { fromCamelToKebabCase } from '../util/case';
 import { qError, QError_stringifyClassOrStyle } from '../error/error';
-import { seal, qDev } from '../util/qdev';
+import { seal } from '../util/qdev';
 import { EMPTY_ARRAY } from '../util/flyweight';
 import { SkipRender } from './jsx/utils.public';
 import { handleError } from './error-handling';
-import { verifySerializable } from '../state/common';
 import { HOST_FLAG_DIRTY, HOST_FLAG_MOUNTED, QContext } from '../state/context';
 
 export interface ExecuteComponentOutput {
@@ -124,10 +123,6 @@ export const pushRenderContext = (ctx: RenderContext): RenderContext => {
 export const serializeClass = (obj: ClassList): string => {
   if (!obj) return '';
   if (isString(obj)) return obj.trim();
-
-  if (qDev) {
-    verifySerializable(obj);
-  }
 
   if (isArray(obj))
     return obj.reduce((result: string, o) => {

--- a/packages/qwik/src/core/render/execute-component.ts
+++ b/packages/qwik/src/core/render/execute-component.ts
@@ -4,14 +4,16 @@ import { safeCall } from '../util/promises';
 import { newInvokeContext } from '../use/use-core';
 import { isArray, isString, ValueOrPromise } from '../util/types';
 import type { JSXNode } from './jsx/types/jsx-node';
+import type { ClassList } from './jsx/types/jsx-qwik-attributes';
 import type { RenderContext } from './types';
 import { ContainerState, intToStr } from '../container/container';
 import { fromCamelToKebabCase } from '../util/case';
 import { qError, QError_stringifyClassOrStyle } from '../error/error';
-import { seal } from '../util/qdev';
+import { seal, qDev } from '../util/qdev';
 import { EMPTY_ARRAY } from '../util/flyweight';
 import { SkipRender } from './jsx/utils.public';
 import { handleError } from './error-handling';
+import { verifySerializable } from '../state/common';
 import { HOST_FLAG_DIRTY, HOST_FLAG_MOUNTED, QContext } from '../state/context';
 
 export interface ExecuteComponentOutput {
@@ -119,11 +121,13 @@ export const pushRenderContext = (ctx: RenderContext): RenderContext => {
   return newCtx;
 };
 
-export const serializeClass = (
-  obj: string | { [className: string]: boolean } | (string | { [className: string]: boolean })[]
-): string => {
+export const serializeClass = (obj: ClassList): string => {
   if (!obj) return '';
   if (isString(obj)) return obj.trim();
+
+  if (qDev) {
+    verifySerializable(obj);
+  }
 
   if (isArray(obj))
     return obj.reduce((result: string, o) => {

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -165,11 +165,16 @@ export type PreventDefault<T> = {
   [K in keyof QwikEventMap<T> as `preventdefault:${Lowercase<K>}`]?: boolean;
 };
 
-export type BaseClassList = string | string[] | { [cl: string]: boolean };
+export type BaseClassList =
+  | string
+  | undefined
+  | null
+  | Record<string, boolean | string | number | null | undefined>
+  | BaseClassList[];
 export type ClassList = BaseClassList | BaseClassList[];
 
 export interface QwikProps<T> extends PreventDefault<T> {
-  class?: ClassList | undefined;
+  class?: ClassList | Signal<ClassList> | undefined;
   dangerouslySetInnerHTML?: string | undefined;
   ref?: Ref<Element> | Signal<Element | undefined> | ((el: Element) => void) | undefined;
 

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -69,7 +69,7 @@ renderSSRSuite('render class', async () => {
   const Test = component$(() => {
     // Extra spaces to ensure signal hasn't changed
     const sigClass = useSignal(' myClass ');
-    return <div class={sigClass as any} />;
+    return <div class={sigClass} />;
   });
   await testSSR(
     <Test />,
@@ -82,9 +82,7 @@ renderSSRSuite('render class', async () => {
 
   await testSSR(
     <div
-      class={
-        ['stuff', '', 'm-0 p-2', null, { active: 1 }, undefined, [{ container: 'yup' }]] as any
-      }
+      class={['stuff', '', 'm-0 p-2', null, { active: 1 }, undefined, [{ container: 'yup' }]]}
     ></div>,
     `<html q:container="paused" q:version="dev" q:render="ssr-dev">
       <div class="stuff m-0 p-2 active container"></div>


### PR DESCRIPTION
# What is it?

- [ x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Remove casting when use class prop


# Use cases and why

Before https://github.com/BuilderIO/qwik/pull/2230

```jsx
// Component.jsx
import clsx from 'clsx'

<div class={clsx(["docs", props.class])}>Some text</div>
```

 After https://github.com/BuilderIO/qwik/pull/2230:
```jsx
// Component.jsx
// no more external package for class merging

<div class={["docs", props.class] as any}>Some text</div>
```
But if my `props.class` is a signal, the class result always `docs untrackValue`, after this PR type-check will complain and I can fix easier.


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
