### PR TITLE
feat: add to package.json when present in the ssr dir

### DIFF
--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -274,10 +274,23 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions): any {
 
           if (outDir) {
             await fs.promises.mkdir(outDir, { recursive: true });
-
-            // create server package.json to ensure mjs is used
             const serverPackageJsonPath = join(outDir, 'package.json');
-            const serverPackageJsonCode = `{"type":"module"}`;
+
+            let packageJson = {};
+
+            // we want to keep the content of an existing file:
+            const packageJsonExists = fs.existsSync(serverPackageJsonPath);
+            if (packageJsonExists) {
+              const content = await (await fs.promises.readFile(serverPackageJsonPath))?.toString();
+              const contentAsJson = JSON.parse(content);
+              packageJson = {
+                ...contentAsJson,
+              };
+            }
+
+            // set to type module to ensure mjs is used
+            packageJson = { ...packageJson, type: 'module' };
+            const serverPackageJsonCode = JSON.stringify(packageJson, null, 2);
 
             await Promise.all([
               fs.promises.writeFile(join(outDir, RESOLVED_STATIC_PATHS_ID), staticPathsCode),


### PR DESCRIPTION
# What is it?

- [ x ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

When building the application a `package.json` might be already generated by another plugin. So instead of always overwriting this, we should foresee to also just append to it.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
