### PR TITLE
Don't generate _routes.json for cloudflare

### DIFF
--- a/packages/docs/src/routes/qwikcity/adaptors/cloudflare-pages/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/cloudflare-pages/index.mdx
@@ -85,34 +85,6 @@ export { onRequest } from '../server/entry.cloudflare-pages';
 - [Cloudflare Pages Functions](https://developers.cloudflare.com/pages/platform/functions/)
 - [Function Invocation Route Config](https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/)
 
-### Cloudflare Pages Function Invocation Routes
-
-Cloudflare Page's [function-invocation-routes config](https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/) can be used to include, or exclude, certain paths to be used by the worker functions. Having a `_routes.json` file gives developers more granular control over when your Function is invoked.
-
-This is useful to determine if a page response should be Server-Side Rendered (SSR) or if the response should use a static-site generated (SSG) `index.html` file instead.
-
-By default, the Cloudflare Pages adaptor _does not_ include a `public/_routes.json` config, but rather it is auto-generated from the build by the Cloudflare adaptor. An example of an auto-generate `dist/_routes.json` would be:
-
-```json
-{
-  "include": ["/*"],
-  "exclude": [
-    "/_headers",
-    "/_redirects",
-    "/build/*",
-    "/favicon.ico",
-    "/manifest.json",
-    "/service-worker.js",
-    "/about"
-  ],
-  "version": 1
-}
-```
-
-In the above example, it's saying _all_ pages should be SSR'd. However, the root static files such as `/favicon.ico` and any static assets in `/build/*` should be excluded from the Functions, and instead treated as a static file.
-
-In most cases the generated `dist/_routes.json` file is ideal. However, if you need more granular control over each path, you can instead provide you're own `public/_routes.json` file. When the project provides its own `public/_routes.json` file, then the Cloudflare adaptor will not auto-generate the routes config and instead use the committed one within the `public` directory.
-
 ### Context
 
 You may access Cloudflare Page's environment variables in the endpoint method's `platform` param:

--- a/packages/qwik-city/adaptors/cloudflare-pages/vite/index.ts
+++ b/packages/qwik-city/adaptors/cloudflare-pages/vite/index.ts
@@ -32,23 +32,6 @@ export function cloudflarePagesAdaptor(opts: CloudflarePagesAdaptorOptions = {})
         publicDir: false,
       };
     },
-
-    async generate({ clientOutDir, basePathname }) {
-      const routesJsonPath = join(clientOutDir, '_routes.json');
-      const hasRoutesJson = fs.existsSync(routesJsonPath);
-      if (!hasRoutesJson && opts.functionRoutes !== false) {
-        const routesJson = {
-          version: 1,
-          include: [basePathname + '*'],
-          exclude: [
-            basePathname + 'build/*',
-            basePathname + 'assets/*',
-            basePathname + '*/q-data.json',
-          ],
-        };
-        await fs.promises.writeFile(routesJsonPath, JSON.stringify(routesJson, undefined, 2));
-      }
-    },
   });
 }
 
@@ -56,14 +39,6 @@ export function cloudflarePagesAdaptor(opts: CloudflarePagesAdaptorOptions = {})
  * @alpha
  */
 export interface CloudflarePagesAdaptorOptions {
-  /**
-   * Determines if the build should generate the function invocation routes `_routes.json` file.
-   *
-   * https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/
-   *
-   * Defaults to `true`.
-   */
-  functionRoutes?: boolean;
   /**
    * Determines if the adaptor should also run Static Site Generation (SSG).
    */


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently, a `_routes.json` is generated by Cloudflare Pages adapter to exclude static assets.

However, this is not necessary since the Pages by default will exclude all static assets (https://developers.cloudflare.com/pages/platform/functions/routing/#function-invocation-routes)

Besides, currently the generated `_routes.json` is not correct since the service worker script is not excluded.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
