### PR TITLE
[feat] Pre-fetch Link data on anchor focus

### DIFF
--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -53,6 +53,7 @@ export const Link = component$<LinkProps>((props) => {
       }}
       data-prefetch={prefetchDataset}
       onMouseOver$={(_, elm) => prefetchLinkResources(elm as HTMLAnchorElement)}
+      onFocus$={(_, elm) => prefetchLinkResources(elm as HTMLAnchorElement)}
       onQVisible$={(_, elm) => prefetchLinkResources(elm as HTMLAnchorElement, true)}
     >
       <Slot />


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Because some desktop users navigate the internet with a keyboard only, either by choice or because of disability, add the ability to pre-fetch a Link element's resources when the anchor tag receives focus in addition to hover.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
