### PR TITLE
fix(cli): build.types trigger condition

### DIFF
--- a/packages/qwik/src/cli/build/run-build-command.ts
+++ b/packages/qwik/src/cli/build/run-build-command.ts
@@ -61,7 +61,7 @@ export async function runBuildCommand(app: AppCommand) {
 
   let typecheck: Promise<Step> | null = null;
 
-  if (buildTypes && buildTypes.startsWith('tsc')) {
+  if (buildTypes && buildTypes.startsWith(`${pkgManager} run tsc`)) {
     let copyScript = buildTypes;
     if (!copyScript.includes('--pretty')) {
       // ensures colors flow throw when we console log the stdout


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
After this changed https://github.com/BuilderIO/qwik/commit/7d6c810b695e564dc6171bbeba29ecd409cc92dc, qwik CLI never run `build.types` script

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
