### PR TITLE
feat: add config for dev inspector

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -52,6 +52,10 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     transformedModuleOutput: null,
     vendorRoots: [],
     scope: null,
+    inspectorConfig: {
+      enabled: true,
+      hotKeys: ['Alt'],
+    },
   };
 
   const init = async () => {
@@ -225,6 +229,15 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
 
     if (typeof updatedOpts.resolveQwikBuild === 'boolean') {
       opts.resolveQwikBuild = updatedOpts.resolveQwikBuild;
+    }
+
+    if (typeof updatedOpts.inspectorConfig === 'object') {
+      if ('enabled' in updatedOpts.inspectorConfig) {
+        opts.inspectorConfig.enabled = updatedOpts.inspectorConfig.enabled;
+      }
+      if ('hotKeys' in updatedOpts.inspectorConfig) {
+        opts.inspectorConfig.hotKeys = updatedOpts.inspectorConfig.hotKeys;
+      }
     }
 
     return { ...opts };
@@ -725,6 +738,10 @@ export interface QwikPluginOptions {
   transformedModuleOutput?:
     | ((transformedModules: TransformModule[]) => Promise<void> | void)
     | null;
+  inspectorConfig?: {
+    enabled?: boolean;
+    hotKeys?: string[];
+  };
 }
 
 export interface NormalizedQwikPluginOptions extends Required<QwikPluginOptions> {

--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -273,7 +273,7 @@ declare global {
   }
 }
 
-const DEV_QWIK_INSPECTOR = `
+const DEV_QWIK_INSPECTOR = (opts: NormalizedQwikPluginOptions['inspectorConfig']) => `
 <style>
 #qwik-inspector-overlay {
   position: fixed;
@@ -419,7 +419,7 @@ const DEV_QWIK_INSPECTOR = `
   }
 
   function isActive() {
-    return checkKeysArePressed(['Alt']);
+    return checkKeysArePressed(${opts.hotKeys});
   }
 
   window.addEventListener('resize', updateOverlay);
@@ -438,12 +438,12 @@ if (!window.__qwikViteLog) {
 }
 </script>`;
 
-const END_SSR_SCRIPT = `
+const END_SSR_SCRIPT = (opts: NormalizedQwikPluginOptions) => `
 <script type="module" src="/@vite/client"></script>
 ${DEV_ERROR_HANDLING}
 ${ERROR_HOST}
 ${PERF_WARNING}
-${DEV_QWIK_INSPECTOR}
+${opts.inspectorConfig.enabled && DEV_QWIK_INSPECTOR(opts.inspectorConfig)}
 `;
 
 function getViteDevIndexHtml(entryUrl: string, envData: Record<string, any>) {

--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
-import { qwikCity } from '@builder.io/qwik-city/vite';
 import { qwikVite } from '@builder.io/qwik/optimizer';
+import { qwikCity } from '@builder.io/qwik-city/vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(() => {

--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
-import { qwikVite } from '@builder.io/qwik/optimizer';
 import { qwikCity } from '@builder.io/qwik-city/vite';
+import { qwikVite } from '@builder.io/qwik/optimizer';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(() => {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

This PR makes the new dev inspector configurable by giving the devs the options to disable the inspector or assign different hot keys than the default `Alt` key.

# Use cases and why

- More flexibility especial if the `Alt` key is already used on an app

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
