### PR TITLE
docs(qwik-v-react): fix array key consistency in docs

### DIFF
--- a/packages/docs/src/routes/docs/cheat/qwik-react/index.mdx
+++ b/packages/docs/src/routes/docs/cheat/qwik-react/index.mdx
@@ -368,7 +368,7 @@ export const Presidents = component$(() => {
   return (
     <ul>
       {presidents.map((president) => (
-        <li>
+        <li key={president.name + president.years}>
           {president.name} ({president.years})
         </li>
       ))}


### PR DESCRIPTION

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fixes array key prop docs. Rendering showed key is required but qwik vs. react did not have key.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
