### PR TITLE
 docs(contributing): Add install note for wasm-pack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you're not able to use the dev container, follow these instructions:
 
 ## Prerequisite
 
-To build platform binding and wasm, make sure you have installed [Rust](https://www.rust-lang.org/tools/install).
+To build platform binding and wasm, make sure you have installed [Rust](https://www.rust-lang.org/tools/install). Also follow directions for your platform to install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/).
 
 > On Windows, Rust requires [C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). You can also select _Desktop development with C++_
 > while installing Visual Studio.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

To avoid running into unexpected `wasm-pack` failures when doing full build, adds note to Contributing docs about installation of `wasm-pack`, linking to site showing installation command for each platform.

# Use cases and why

Trying to run the full qwik project build with `pnpm build.full` on macOS, kept running into the following, which may be self-explanatory if you're familiar with the Rust ecosystem, but confused me:

<img width="569" alt="qwik-wasm-pack" src="https://user-images.githubusercontent.com/3682072/206203227-46347a34-e077-4045-b946-672c12708f97.png">

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
