### PR TITLE
feat: add static file handler to node middleware

### DIFF
--- a/packages/qwik-city/middleware/node/api.md
+++ b/packages/qwik-city/middleware/node/api.md
@@ -16,6 +16,7 @@ import type { ServerResponse } from 'node:http';
 export function createQwikCity(opts: QwikCityNodeRequestOptions): {
     router: (req: IncomingMessage, res: ServerResponse, next: NodeRequestNextFunction) => Promise<void>;
     notFound: (req: IncomingMessage, res: ServerResponse, next: (e: any) => void) => Promise<void>;
+    staticFile: (req: IncomingMessage, res: ServerResponse, next: (e?: any) => void) => Promise<void>;
 };
 
 // @alpha (undocumented)
@@ -28,12 +29,16 @@ export interface NodeRequestNextFunction {
 export function qwikCity(render: Render, opts?: RenderOptions_2): {
     router: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: NodeRequestNextFunction) => Promise<void>;
     notFound: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: (e: any) => void) => Promise<void>;
+    staticFile: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: (e?: any) => void) => Promise<void>;
 };
 
 // Warning: (ae-forgotten-export) The symbol "QwikCityHandlerOptions" needs to be exported by the entry point index.d.ts
 //
 // @alpha (undocumented)
 export interface QwikCityNodeRequestOptions extends QwikCityHandlerOptions {
+    static?: {
+        root?: string;
+    };
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/qwik-city/middleware/node/index.ts
+++ b/packages/qwik-city/middleware/node/index.ts
@@ -67,8 +67,11 @@ export function createQwikCity(opts: QwikCityNodeRequestOptions) {
         const target = join(staticFolder, url.pathname);
         const stream = createReadStream(target);
 
-        stream.on('error', next);
+        if (opts.static?.cacheControl) {
+          res.setHeader('Cache-Control', opts.static.cacheControl);
+        }
 
+        stream.on('error', next);
         stream.pipe(res);
 
         return;
@@ -96,6 +99,8 @@ export interface QwikCityNodeRequestOptions extends QwikCityHandlerOptions {
   static?: {
     /** The root folder for statics files. Defaults to /dist */
     root?: string;
+    /** Set the Cache-Control header for all static files */
+    cacheControl?: string;
   };
 }
 

--- a/packages/qwik-city/middleware/node/index.ts
+++ b/packages/qwik-city/middleware/node/index.ts
@@ -1,12 +1,16 @@
-import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { QwikCityHandlerOptions } from '../request-handler/types';
-import { errorHandler, requestHandler } from '../request-handler';
-import { fromNodeHttp, getUrl } from './http';
-import { patchGlobalFetch } from './node-fetch';
-import type { Render } from '@builder.io/qwik/server';
 import type { RenderOptions } from '@builder.io/qwik';
+import type { Render } from '@builder.io/qwik/server';
 import { getNotFound } from '@qwik-city-not-found-paths';
 import qwikCityPlan from '@qwik-city-plan';
+import { isStaticPath } from '@qwik-city-static-paths';
+import { createReadStream } from 'node:fs';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { errorHandler, requestHandler } from '../request-handler';
+import type { QwikCityHandlerOptions } from '../request-handler/types';
+import { fromNodeHttp, getUrl } from './http';
+import { patchGlobalFetch } from './node-fetch';
 
 // @builder.io/qwik-city/middleware/node
 
@@ -15,6 +19,9 @@ import qwikCityPlan from '@qwik-city-plan';
  */
 export function createQwikCity(opts: QwikCityNodeRequestOptions) {
   patchGlobalFetch();
+
+  const staticFolder =
+    opts.static?.root ?? join(fileURLToPath(import.meta.url), '..', '..', 'dist');
 
   const router = async (
     req: IncomingMessage,
@@ -52,16 +59,45 @@ export function createQwikCity(opts: QwikCityNodeRequestOptions) {
     }
   };
 
+  const staticFile = async (req: IncomingMessage, res: ServerResponse, next: (e?: any) => void) => {
+    try {
+      const url = getUrl(req);
+
+      if (isStaticPath(url.pathname)) {
+        const target = join(staticFolder, url.pathname);
+        const stream = createReadStream(target);
+
+        stream.on('error', next);
+
+        stream.pipe(res);
+
+        return;
+      }
+
+      return next();
+    } catch (e) {
+      console.error(e);
+      next(e);
+    }
+  };
+
   return {
     router,
     notFound,
+    staticFile,
   };
 }
 
 /**
  * @alpha
  */
-export interface QwikCityNodeRequestOptions extends QwikCityHandlerOptions {}
+export interface QwikCityNodeRequestOptions extends QwikCityHandlerOptions {
+  /** Options for serving static files */
+  static?: {
+    /** The root folder for statics files. Defaults to /dist */
+    root?: string;
+  };
+}
 
 /**
  * @alpha


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

I've added a first draft function to the node middleware that allows us to stream static files.

Qwik already handles routing and does a lot of upfront optimisations. There should not be a need to rely on large, slow libraries like express or even fastify to serve static files. These libraries also come with a lot of unnecessary dependencies.

With this change we can start deploying apps on raw node http servers.

# Use cases and why

- 1. Smaller builds with fewer dependencies
- 3. Quicker startup times with prebuilt static paths

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
