### PR TITLE
feat: adding window event names/types

### DIFF
--- a/packages/qwik/src/core/use/use-on.ts
+++ b/packages/qwik/src/core/use/use-on.ts
@@ -125,8 +125,10 @@ export const useOnDocument = (event: string | string[], eventQrl: QRL<(ev: Event
  * @alpha
  */
 // </docs>
-export const useOnWindow = (event: string | string[], eventQrl: QRL<(ev: Event) => void>) =>
-  _useOn(`window:on-${event}`, eventQrl);
+export const useOnWindow = (
+  event: useOnWindowTypes[] | useOnWindowTypes,
+  eventQrl: QRL<(ev: Event) => void>
+) => _useOn(`window:on-${event}`, eventQrl);
 
 const _useOn = (eventName: string | string[], eventQrl: QRL<(ev: Event) => void>) => {
   const invokeCtx = useInvokeContext();
@@ -142,3 +144,38 @@ const _useOn = (eventName: string | string[], eventQrl: QRL<(ev: Event) => void>
   }
   elCtx.$flags$ |= HOST_FLAG_NEED_ATTACH_LISTENER;
 };
+
+type useOnWindowTypes =
+  | 'afterprint'
+  | 'appinstalled'
+  | 'beforeinstallprompt'
+  | 'beforeprint'
+  | 'beforeunload'
+  | 'blur'
+  | 'copy'
+  | 'cut'
+  | 'devicemotion'
+  | 'deviceorientation'
+  | 'deviceorientationabsolute'
+  | 'DOMContentLoaded'
+  | 'error'
+  | 'focus'
+  | 'gamepadconnected'
+  | 'gamepaddisconnected'
+  | 'hashchange'
+  | 'languagechange'
+  | 'load'
+  | 'message'
+  | 'messageerror'
+  | 'offline'
+  | 'online'
+  | 'orientationchange'
+  | 'pagehide'
+  | 'pageshow'
+  | 'paste'
+  | 'popstate'
+  | 'rejectionhandled'
+  | 'resize'
+  | 'storage'
+  | 'unhandledrejection'
+  | 'unload';


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

when using the `useOnWindow` hook, event names would autocomplete.
I have added events which were on [mdn page](https://developer.mozilla.org/en-US/docs/Web/API/Window).

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
