### PR TITLE
fix(header.css): make header menu sticky. This effects the landing, m…

### DIFF
--- a/packages/docs/src/components/header/header.css
+++ b/packages/docs/src/components/header/header.css
@@ -1,16 +1,7 @@
 .header-container {
   height: calc(var(--header-height));
-  margin-bottom: 6px;
-  background: var(--bg-color);
-  position: relative;
-  z-index: 100;
-}
-
-@media (min-width: 1024px) {
-  .header-container {
-    background: var(--bg-header-color);
-    backdrop-filter: blur(23px) saturate(4.5);
-  }
+  background: var(--bg-header-color);
+  @apply backdrop-blur-xl backdrop-saturate-200 sticky top-0 mb-2 z-20;
 }
 
 .fixed-header .header-container {
@@ -21,9 +12,7 @@
 }
 
 header li {
-  @apply px-2 text-right;
-  @apply py-4 md:py-0;
-
+  @apply px-2 text-right py-4 md:py-0;
   font-size: 14px;
   font-weight: 500;
 }

--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -186,7 +186,7 @@ select {
 }
 
 body {
-  @apply antialiased h-screen;
+  @apply antialiased;
 }
 
 @media (max-width: 1023px) {


### PR DESCRIPTION
…edia and showcase + darkmode

# What is it?

- [ *] Feature / enhancement
- [ *] Bug
- [ ] Docs / tests

# Description

Makes menu sticky to top on landing, media, and, showcase at all sizes and doesn't break darkmode

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Menu should stick to the top

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality



### Please see [loom](https://www.loom.com/share/f9052ba35cb54d75b4cf8ea6064c1bdb)