### PR TITLE
fix: scope vite plugin qwik manifest so that apps can run in parallel

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -175,7 +175,13 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         // Client build will write to this path, and SSR will read from it. For this reason,
         // the Client build should always start and finish before the SSR build.
         const nodeOs: typeof import('os') = await sys.dynamicImport('node:os');
-        tmpClientManifestPath = path.join(nodeOs.tmpdir(), `vite-plugin-qwik-q-manifest.json`);
+        // Additional we add a prefix to scope the file to the current application so that different
+        // applications can be run in parallel without generating conflicts
+        const scopePrefix = pluginOpts.scope ? `${pluginOpts.scope}-` : '';
+        tmpClientManifestPath = path.join(
+          nodeOs.tmpdir(),
+          `${scopePrefix}vite-plugin-qwik-q-manifest.json`
+        );
 
         if (target === 'ssr' && !pluginOpts.manifestInput) {
           // This is a SSR build so we should load the client build's manifest


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug (or maybe it's a feature?)
- [ ] Docs / tests

# Description

Scope the vite-plugin-qwik-q-manifest.json file so that apps running in parallel don't conflict with each other

# Use cases and why

So that I can run multiple qwik applications in parallel, for example if I am writing a MFE application with multiple Qwik fragments.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
