### PR TITLE
fix: options like maxWorkers not passed to the generate method

### DIFF
--- a/packages/qwik-city/adaptors/shared/vite/index.ts
+++ b/packages/qwik-city/adaptors/shared/vite/index.ts
@@ -118,6 +118,7 @@ export function viteAdaptor(opts: ViteAdaptorPluginOptions) {
 
             const staticGenerate = await import('../../../static');
             let generateOpts: StaticGenerateOptions = {
+              ...opts,
               basePathname,
               outDir: clientOutDir,
               origin,


### PR DESCRIPTION
Signed-off-by: Jeremy Wickersheimer <jwickers@gmail.com>

# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

The adaptor config was not passed down to the generator function, for example `maxWorkers` and `maxTasksPerWorker`.

# Use cases and why

Pass down the options as defined in the adaptor parameters type StaticGenerateRenderOptions.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
