### PR TITLE
docs: add example of using :global() css selector

### DIFF
--- a/packages/docs/src/routes/docs/components/styles/index.mdx
+++ b/packages/docs/src/routes/docs/components/styles/index.mdx
@@ -136,6 +136,36 @@ export const CmpStyles = component$(() => {
 
 > Please note that you need to add `?inline` to your styles import.
 
+### `:global()` selector
+
+Using `useStylesScoped$` will scope all child selectors in a ruleset to the component. If you need to style child components rendered through a `<Slot />`, you will need to break out of the scoped styles using the `:global()` selector.
+
+```
+import { useStylesScoped$ } from '@builder.io/qwik';
+
+export const List = component$(() => {
+  useStylesScoped$(`
+    .list {
+      display: flex;
+
+      > :global(*nth-child(3)) {
+        width: 100%
+      }
+    }
+  `);
+
+  return (
+    <div class="list">
+      <Slot />
+    </div>;
+  );
+});
+```
+
+This will render a css selector of `.list.⭐️8vzca0-0 > *:nth-child(3)`, allowing you to target child components. This could be considered the equivalent of using `::ng-deep` in Angular.
+
+> Beware that this may have unintended effects that cascade down your component tree.
+
 ## Preprocessors
 
 ### `.scss`, `.sass`, `.less`, `.styl`, `.stylus`


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

There is currently no way to know that the :global() selector exists without having css-modules experience or reading through the scoped-stylesheet file.

Adding ::ng-deep keyword may make it easier for Angular developers to find as well.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Angular developers search for `ng-deep` to find something similar
- 2. Developers can find the new information

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
