### PR TITLE
Remove irrelevant netlify notes from node docs

### DIFF
--- a/packages/docs/src/routes/qwikcity/adaptors/node/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/node/index.mdx
@@ -38,8 +38,6 @@ To deploy the application for development:
 npm run deploy
 ```
 
-Notice that you might need a [Netlify account](https://docs.netlify.com/get-started/) in order to complete this step!
-
 ## Production deploy
 
 Since you are choosing Node, here you are in your own, after running `npm run build`:


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Remove notes about a possible netlify account requirement from the qwikcity node integration page, as it doesn't apply.

# Use cases and why

Documentation is possibly confusing; looks like a copy/paste error left some irrelevant docs around.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
