### PR TITLE
fix: use publish instead of dev for wrangler pages deployment

### DIFF
--- a/starters/adapters/cloudflare-pages/package.json
+++ b/starters/adapters/cloudflare-pages/package.json
@@ -2,7 +2,7 @@
   "description": "Cloudflare Pages",
   "scripts": {
     "build.server": "vite build -c adapters/cloudflare-pages/vite.config.ts",
-    "deploy": "wrangler pages dev ./dist"
+    "deploy": "wrangler pages publish ./dist --branch preview"
   },
   "devDependencies": {
     "wrangler": "latest"


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Use cases and why

The deployment command for wrangler pages is `wrangler pages publish` so I believe that `wrangler pages dev` is incorrect here


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
