### PR TITLE
fix: preview server should use the configured outDir

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -708,7 +708,7 @@ export const SRC_DIR_DEFAULT = 'src';
 
 export const CLIENT_OUT_DIR = 'dist';
 
-const SSR_OUT_DIR = 'server';
+export const SSR_OUT_DIR = 'server';
 
 const LIB_OUT_DIR = 'lib';
 

--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -153,7 +153,7 @@ export async function configureDevServer(
 
 export async function configurePreviewServer(
   middlewares: Connect.Server,
-  opts: NormalizedQwikPluginOptions,
+  ssrOutDir: string,
   sys: OptimizerSystem,
   path: Path
 ) {
@@ -161,14 +161,14 @@ export async function configurePreviewServer(
   const url: typeof import('url') = await sys.dynamicImport('node:url');
 
   const entryPreviewPaths = ['mjs', 'cjs', 'js'].map((ext) =>
-    path.join(opts.rootDir, 'server', `entry.preview.${ext}`)
+    path.join(ssrOutDir, `entry.preview.${ext}`)
   );
 
   const entryPreviewModulePath = entryPreviewPaths.find((p) => fs.existsSync(p));
   if (!entryPreviewModulePath) {
     return invalidPreviewMessage(
       middlewares,
-      `Unable to find output "server/entry.preview" module.\n\nPlease ensure "src/entry.preview.tsx" has been built before the "preview" command.`
+      `Unable to find output "${ssrOutDir}/entry.preview" module.\n\nPlease ensure "src/entry.preview.tsx" has been built before the "preview" command.`
     );
   }
 

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -23,6 +23,7 @@ import {
   QWIK_JSX_RUNTIME_ID,
   CLIENT_OUT_DIR,
   QWIK_JSX_DEV_RUNTIME_ID,
+  SSR_OUT_DIR,
 } from './plugin';
 import { createRollupError, normalizeRollupOutputOptions } from './rollup';
 import { configureDevServer, configurePreviewServer, VITE_DEV_CLIENT_QS } from './vite-server';
@@ -41,6 +42,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
   let viteCommand: 'build' | 'serve' = 'serve';
   let manifestInput: QwikManifest | null = null;
   let clientOutDir: string | null = null;
+  let ssrOutDir: string | null = null;
   const injections: GlobalInjections[] = [];
   const qwikPlugin = createPlugin(qwikViteOpts.optimizerOptions);
 
@@ -201,6 +203,10 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
 
       clientOutDir = qwikPlugin.normalizePath(
         sys.path.resolve(opts.rootDir, qwikViteOpts.client?.outDir || CLIENT_OUT_DIR)
+      );
+
+      ssrOutDir = qwikPlugin.normalizePath(
+        sys.path.resolve(opts.rootDir, qwikViteOpts.ssr?.outDir || SSR_OUT_DIR)
       );
 
       // TODO: Remove globalThis that was previously used. Left in for backwards compatibility.
@@ -531,10 +537,9 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
 
     configurePreviewServer(server) {
       return async () => {
-        const opts = qwikPlugin.getOptions();
         const sys = qwikPlugin.getSys();
         const path = qwikPlugin.getPath();
-        await configurePreviewServer(server.middlewares, opts, sys, path);
+        await configurePreviewServer(server.middlewares, ssrOutDir!, sys, path);
       };
     },
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
The SSR build that is compiled to a non-default folder cannot be used because the `outDir` for the ssr build is hardcoded.


# Use cases and why
To reproduce:
- run `npm create qwik@latest`
- use the following for the qwikVite plugin in `vite.config.ts`: `qwikVite({  ssr: { outDir: "the-other-dir" } })`
- run `npm run preview`
- notice an error stating `Unable to find output "server/entry.preview" module.`


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
