### PR TITLE
Update index.mdx

### DIFF
--- a/packages/docs/src/routes/docs/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/components/state/index.mdx
@@ -277,7 +277,7 @@ export default component$(() => {
 });
 ```
 
-Both [`useWatch()`](../lifecycle/index.mdx#usewatch) and [`useResource()`](../resource/index.mdx) are explained in detail in their respective sections.
+Both [`useTask()`](../lifecycle/index.mdx#useTask) and [`useResource()`](../resource/index.mdx) are explained in detail in their respective sections.
 
 ## Reactivity
 


### PR DESCRIPTION
fix typo on documentation

# What is it?

Docs / tests

# Description

Fix typo in documentation where it is linking to useWatch instead of useTask.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
