### PR TITLE
docs: cleanup adapters files (fixes #2421)

### DIFF
--- a/packages/docs/src/routes/qwikcity/adaptors/azure-swa/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/azure-swa/index.mdx
@@ -26,7 +26,7 @@ The adaptor will add a new `vite.config.ts` within the `adaptors/` directory, an
     └── entry.azure-swa.tsx
 ```
 
-Additionally, within the `package.json`, the `build.server` script will be updated with the Azure Static Web Apps build.
+Additionally, within the `package.json`, the `build.server` and `deploy` scripts will be updated.
 
 ## Production build
 
@@ -36,18 +36,9 @@ To build the application for production, use the `build` command, this command w
 npm run build
 ```
 
-## Local development deployment
-
-To deploy the application for local development:
-
-```shell
-npm run build
-npm run serve
-```
-
 ## Deploy to Azure
 
-After installing the integration using `npm run qwik add` the project is ready to be deployed to Azure Static Web Apps.
+After installing the integration using `npm run qwik add azure-swa` the project is ready to be deployed to Azure Static Web Apps.
 
 There are two ways to deploy:
 

--- a/packages/docs/src/routes/qwikcity/adaptors/cloudflare-pages/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/cloudflare-pages/index.mdx
@@ -26,7 +26,7 @@ The adaptor will add a new `vite.config.ts` within the `adaptors/` directory, an
     └── entry.cloudflare-pages.tsx
 ```
 
-Additionally, within the `package.json`, the `build.server` script will be updated with the Cloudflare build.
+Additionally, within the `package.json`, the `build.server` and `deploy` scripts will be updated.
 
 ## Production build
 
@@ -38,18 +38,9 @@ npm run build
 
 [Read the full guide here](https://github.com/BuilderIO/qwik/tree/main/starters/adaptors/cloudflare-pages/README.md)
 
-## Local development deployment
-
-To deploy the application for local development:
-
-```shell
-npm run build
-npm run serve
-```
-
 ## Deploy to Cloudflare Pages
 
-After installing the integration using `npm run qwik add`. The project is ready to be deployed to Cloudflare Pages. However, you will need to create a git repository and push the code to it.
+After installing the integration using `npm run qwik add cloudflare-pages`, the project is ready to be deployed to Cloudflare Pages. However, you will need to create a git repository and push the code to it.
 
 Please refer to the [Cloudflare Pages docs](https://developers.cloudflare.com/pages/framework-guides/deploy-a-qwik-site/) for more information on how to deploy your site.
 

--- a/packages/docs/src/routes/qwikcity/adaptors/netlify-edge/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/netlify-edge/index.mdx
@@ -28,7 +28,7 @@ The adaptor will add a new `vite.config.ts` within the `adaptors/` directory, an
     └── entry.netlify-edge.tsx
 ```
 
-Additionally, within the `package.json`, the `build.server` script will be updated with the Netlify Edge build.
+Additionally, within the `package.json`, the `build.server` and `deploy` scripts will be updated.
 
 ## Production build
 
@@ -52,7 +52,7 @@ Notice that you might need a [Netlify account](https://docs.netlify.com/get-star
 
 ## Production deploy
 
-After installing the integration using `npm run qwik add`. The project is ready to be deployed to Netlify. However, you will need to create a git repository and push the code to it.
+After installing the integration using `npm run qwik add netlify-edge`, the project is ready to be deployed to Netlify. However, you will need to create a git repository and push the code to it.
 
 Please refer to the Netlify docs for more information on how to deploy your site: [Netlify docs](https://docs.netlify.com/site-deploys/create-deploys/)
 

--- a/packages/docs/src/routes/qwikcity/adaptors/vercel-edge/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/vercel-edge/index.mdx
@@ -28,7 +28,7 @@ The adaptor will add a new `vite.config.ts` within the `adaptors/` directory, an
     └── entry.vercel-edge.tsx
 ```
 
-Additionally, within the `package.json`, the `build.server` script will be updated with the Vercel Edge build.
+Additionally, within the `package.json`, the `build.server` and `deploy` scripts will be updated.
 
 ## Production build
 
@@ -52,7 +52,7 @@ Notice that you might need a [Vercel account](https://vercel.com/docs/concepts/g
 
 ## Production deploy
 
-After installing the integration using `npm run qwik add`. The project is ready to be deployed to Vercel. However, you will need to create a git repository and push the code to it.
+After installing the integration using `npm run qwik add vercel-edge`, the project is ready to be deployed to Vercel. However, you will need to create a git repository and push the code to it.
 
 Please refer to the Vercel docs for more information on how to deploy your site: [Vercel docs](https://vercel.com/docs/concepts/deployments/overview)
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
fixes #2421 
since v`0.14.0` the `serve` cmd is no longer created on `package.json` files. Therefore it is now removed from the docs.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
