### PR TITLE
docs: replace the entire parent value to update the store

### DIFF
--- a/packages/docs/src/routes/docs/components/events/index.mdx
+++ b/packages/docs/src/routes/docs/components/events/index.mdx
@@ -78,8 +78,8 @@ export const EventExample = component$(() => {
     <button
       window:onScroll$={(e) => (store.scroll = window.scrollY)}
       document:onMouseMove$={(e) => {
-        store.mouse.x = e.x;
-        store.mouse.y = e.y;
+        const { x, y } = e;
+        store.mouse = { x, y };
       }}
       onClick$={() => store.clickCount++}
     >


### PR DESCRIPTION
updating a nested store value directly doesn't reflect changes in the UI. Assign a new object to the parent value to trigger rerender

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Docs show an example where a nested store value is updated. Updating a nested store value directly doesn't reflect changes in the UI. eg:
```js
const store = useStore$({
  mouse: {x: 0, y: 0}
});

// ...
store.mouse.x =  1;
//...
```
The above would not trigger a rerender, and the UI still shows the value `0` for `mouse.x`

# Use cases and why

Instead, assign a new object to `store.mouse`:
```js
store.mouse = { x: 1, y: 0};
```
This would trigger a UI update

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
