### PR TITLE
docs: fix example passing number as value for `onClick$`

### DIFF
--- a/packages/docs/src/routes/docs/components/rendering/index.mdx
+++ b/packages/docs/src/routes/docs/components/rendering/index.mdx
@@ -56,7 +56,7 @@ export const Parent = component$(() => {
 
   return (
     <>
-      <button onClick$={(store.step *= -1)}>direction</button>
+      <button onClick$={() => (store.step *= -1)}>direction</button>
       <button onClick$={() => (store.count += store.step)}>{store.step}</button>
       <Greeter name={'World_' + store.count} />
     </>


### PR DESCRIPTION
`onClick$` requires a function

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
the `onClick$` property of a JSX element needs a function, which is executed when the element is clicked

in the example, a number was being passed, instead of a function that changes the state

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->
a function that changes the state should be passed to `onClick$`, as expected from the example

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
