### PR TITLE
docs: remove top layout feature link

### DIFF
--- a/packages/docs/src/routes/qwikcity/layout/nested/index.mdx
+++ b/packages/docs/src/routes/qwikcity/layout/nested/index.mdx
@@ -81,5 +81,3 @@ The above example would render the html:
   </section>
 </main>
 ```
-
-The default is that a page will create its layout stack by climbing up each directory until it gets to the `src/routes` directory. If at any point it should stop climbing up the directories you can use the [top layout](../top/index.mdx) feature.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
removes left over of https://github.com/BuilderIO/qwik/pull/2472 and fixes https://github.com/BuilderIO/qwik/issues/2473

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
