### PR TITLE
docs: fix path to CF env variables

### DIFF
--- a/packages/docs/src/routes/qwikcity/adaptors/cloudflare-pages/index.mdx
+++ b/packages/docs/src/routes/qwikcity/adaptors/cloudflare-pages/index.mdx
@@ -110,7 +110,7 @@ You may access Cloudflare Page's environment variables in the endpoint method's 
 
 ```javascript
 export const onRequest = async ({ platform }) => {
-  const secret = platform.env['SUPER_SECRET_TOKEN'];
+  const secret = platform['SUPER_SECRET_TOKEN'];
 };
 ```
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

fixes #2417

logging `platform` on CF pages returns:
```
{
  "ASSETS": {},
  "BAR": "bar", // <----- ENV VAR
  "CF_PAGES": "1",
  "CF_PAGES_BRANCH": "develop",
  "CF_PAGES_COMMIT_SHA": "xxxxxxxxx",
  "CF_PAGES_URL": "https://xxxxxxx.pages.dev",
  "FOO": "foo" // <----- ENV VAR
}
```

so there is no `.env` key on the received object.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
