### PR TITLE
Add getAll cookies with unit test

### DIFF
--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -97,6 +97,10 @@ export class Cookie implements CookieInterface {
     };
   }
 
+  getAll() {
+    return this[REQ_COOKIE];
+  }
+
   has(cookieName: string) {
     return !!this[REQ_COOKIE][cookieName];
   }

--- a/packages/qwik-city/middleware/request-handler/cookie.unit.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.unit.ts
@@ -30,6 +30,23 @@ test('parses cookie', () => {
   });
 });
 
+test('get all cookies', () => {
+  const cookieValues = {
+    a: 'Algorithmic Almond',
+    b: 'Code Crunchies',
+    c: 'Bug Bites',
+    d: '{"Syntax": "Snacks"}',
+  };
+  const cookieString = Object.entries(cookieValues)
+    .reduce((prev: string[], [key, value]) => {
+      return [...prev, `${key}=${value}`];
+    }, [])
+    .join(';');
+  const cookie = new Cookie(cookieString);
+  const cookies = cookie.getAll();
+  equal(cookieValues, cookies);
+});
+
 test('creates correct headers', () => {
   const data: TestData[] = [
     { key: 'a', value: '1', options: {}, expect: 'a=1' },


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Add `getAll()` cookies with unit test

# Use cases and why

There was no easy way to get **ALL** cookies from the request event. This is required if the server does not know the exact names of cookies and needs to parse through them.

See Issue #2451 

The obvious approach `(const requestCookies = event.cookie[Symbol('request-cookies')];)` does not work and an the workaround provided in issue #2451 is even worse.

# Checklist:

- [√] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [√] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [√] Added new tests to cover the fix / functionality
