### PR TITLE
feat: ability to disable ssg from server

### DIFF
--- a/packages/qwik-city/adaptors/shared/vite/post-build.ts
+++ b/packages/qwik-city/adaptors/shared/vite/post-build.ts
@@ -108,7 +108,11 @@ function createStaticPathsModule(basePathname: string, staticPaths: Set<string>,
     )});`
   );
 
-  c.push(`function isStaticPath(p) {`);
+  c.push(`function isStaticPath(url) {`);
+  c.push(`  if (url.searchParams.get('qwikcity.static') === "false") {`);
+  c.push(`    return false;`);
+  c.push(`  }`);
+  c.push(`  const p = url.pathname;`);
   c.push(`  if (p.startsWith(${JSON.stringify(baseBuildPath)})) {`);
   c.push(`    return true;`);
   c.push(`  }`);

--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -15,7 +15,7 @@ export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
     try {
       const url = new URL(request.url);
 
-      if (isStaticPath(url.pathname)) {
+      if (isStaticPath(url)) {
         // known static path, let cloudflare handle it
         return next();
       }

--- a/packages/qwik-city/middleware/netlify-edge/index.ts
+++ b/packages/qwik-city/middleware/netlify-edge/index.ts
@@ -16,7 +16,7 @@ export function createQwikCity(opts: QwikCityNetlifyOptions) {
     try {
       const url = new URL(request.url);
 
-      if (isStaticPath(url.pathname) || url.pathname.startsWith('/.netlify')) {
+      if (isStaticPath(url) || url.pathname.startsWith('/.netlify')) {
         // known static path, let netlify handle it
         return context.next();
       }

--- a/packages/qwik-city/middleware/node/index.ts
+++ b/packages/qwik-city/middleware/node/index.ts
@@ -74,7 +74,7 @@ export function createQwikCity(opts: QwikCityNodeRequestOptions) {
     try {
       const url = getUrl(req);
 
-      if (isStaticPath(url.pathname)) {
+      if (isStaticPath(url)) {
         const target = join(staticFolder, url.pathname);
         const stream = createReadStream(target);
 

--- a/packages/qwik-city/middleware/request-handler/generated/static-paths.ts
+++ b/packages/qwik-city/middleware/request-handler/generated/static-paths.ts
@@ -1,3 +1,6 @@
-export function isStaticPath(pathname: string) {
-  return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(pathname);
+export function isStaticPath(url: URL) {
+  if (url.searchParams.get('qwikcity.static') === 'false') {
+    return false;
+  }
+  return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url.pathname);
 }

--- a/packages/qwik-city/middleware/vercel-edge/index.ts
+++ b/packages/qwik-city/middleware/vercel-edge/index.ts
@@ -14,7 +14,7 @@ export function createQwikCity(opts: QwikCityVercelEdgeOptions) {
     try {
       const url = new URL(request.url);
 
-      if (isStaticPath(url.pathname)) {
+      if (isStaticPath(url)) {
         // known static path, let vercel handle it
         return new Response(null, {
           headers: {


### PR DESCRIPTION
Adding `?qwikcity.static=false` querystring will force the server to not use a static index.html page and instead always SSR the path. Useful for development tools against live data.