### PR TITLE
Reverse paren/child role descriptions.

### DIFF
--- a/packages/docs/src/routes/tutorial/projection/basic/index.mdx
+++ b/packages/docs/src/routes/tutorial/projection/basic/index.mdx
@@ -5,7 +5,7 @@ contributors:
   - adamdbradley
 ---
 
-Projection is a way of passing content to a child component that in turn controls where the content is rendered. Projection is a collaboration between the parent and child component. The parent component decides what is the content that needs to be rendered, child component decides where and if the content should be rendered.
+Projection is a way of passing content to a child component that in turn controls where the content is rendered. Projection is a collaboration between the parent and child component. The child component decides what is the content that needs to be rendered, parent component decides where and if the content should be rendered.
 
 In our example, the content of the `<Panel>` element (inside the `<App>`) is the content that needs to be projected. The `<Panel>` component wraps the content in a `<div>` tag and should project it using the `<Slot>` element.
 


### PR DESCRIPTION
Parent and child role descriptions are reversed in projections documentation.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
