### PR TITLE
typo fix to quik city overview

### DIFF
--- a/packages/docs/src/routes/qwikcity/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/overview/index.mdx
@@ -25,7 +25,7 @@ Learning Qwik and Qwik City are not two different things, Qwik City is built on 
 
 We call it a **meta-framework** for Qwik. Qwik City is to Qwik, what [Next.js](https://nextjs.org/) is to React, what [Nuxt](https://nuxtjs.org/) is to Vue, or [SvelteKit](https://kit.svelte.dev/) to Svelte.
 
-Qwik (core) and Qwik City (routing) solve problems at two layers of abstraction. **Qwik can stay stable**, without breaking changes, focusing on long-term and stable primitives, while Qwik City brings an **opinionated and performant way to build sites at scale**. We don't want to lock the ecosystem into a single correct way of building sites, in fact we encourage the community to build alternative solutions on top Qwik.
+Qwik (core) and Qwik City (routing) solve problems at two layers of abstraction. **Qwik can stay stable**, without breaking changes, focusing on long-term and stable primitives, while Qwik City brings an **opinionated and performant way to build sites at scale**. We don't want to lock the ecosystem into a single correct way of building sites, in fact we encourage the community to build alternative solutions on top of Qwik.
 
 > As a user, using Qwik City today for your app is a no-brainer. Thanks to Qwik architecture, it comes with zero overhead, meaning that no extra JS will be delivered to the browser.
 


### PR DESCRIPTION
just reading the docs and noticed a small typo, figured I could fix it quick ;)

# What is it?

- [ ✅ ] Docs / tests

# Description

just reading the docs and noticed a small typo, figured I could fix it quick ;)

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Fixes a typo so that english speaking developers can more easily read the docs

# Checklist:

- [ ✅] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [✅ ] I have performed a self-review of my own code
- [✅ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
