### PR TITLE
chore(starter): add eslint rule for consistent type imports

### DIFF
--- a/starters/apps/base/.eslintrc.cjs
+++ b/starters/apps/base/.eslintrc.cjs
@@ -36,5 +36,6 @@ module.exports = {
     'no-case-declarations': 'off',
     'no-console': 'off',
     '@typescript-eslint/no-unused-vars': ['error'],
+    '@typescript-eslint/consistent-type-imports': 'warn',
   },
 };


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Docs / tests
- [ ] Bug

# Description

It is generally recommended to use `type` to import types, this eslint rule warns when `type` wasn't used to import types.

Warns:
```ts
import { DocumentHead } from '@builder.io/qwik-city';
```

OK:
```ts
import type { DocumentHead } from '@builder.io/qwik-city';
```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- warns when `type` is not used to import types.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
