### PR TITLE
docs: mobile sidebar fix

### DIFF
--- a/packages/docs/src/components/sidebar/sidebar.css
+++ b/packages/docs/src/components/sidebar/sidebar.css
@@ -25,7 +25,7 @@
 
 .breadcrumbs {
   @apply fixed z-10 w-[100%];
-  top: var(--header-height);
+  top: calc(var(--header-height) + var(--builder-bar-height));
   @apply border-b;
   @apply px-1;
   @apply flex;

--- a/packages/docs/src/components/theme-toggle/theme-toggle.css
+++ b/packages/docs/src/components/theme-toggle/theme-toggle.css
@@ -1,12 +1,7 @@
-.theme-toggle-container {
-  display: flex;
-  justify-content: flex-end;
-}
-
 .theme-toggle {
-  --size: 2rem;
-  --icon-fill: hsl(210 10% 30%);
-  --icon-fill-hover: hsl(210 10% 15%);
+  --size: 22px;
+  --icon-fill: hsl(210 10% 15%);
+  --icon-fill-hover: hsl(210 10% 30%);
 
   display: block;
 
@@ -27,14 +22,8 @@
 }
 
 [data-theme='dark'] .theme-toggle {
-  --icon-fill: hsl(210 10% 70%);
-  --icon-fill-hover: hsl(210 15% 90%);
-}
-
-@media (hover: none) {
-  .theme-toggle {
-    --size: 48px;
-  }
+  --icon-fill: hsl(210 10% 100%);
+  --icon-fill-hover: hsl(210 15% 70%);
 }
 
 .theme-toggle > svg {

--- a/packages/docs/src/components/theme-toggle/theme-toggle.tsx
+++ b/packages/docs/src/components/theme-toggle/theme-toggle.tsx
@@ -45,18 +45,23 @@ export const ThemeToggle = component$(() => {
   });
 
   return (
-    <div class={'theme-toggle-container'}>
-      <button
-        type="button"
-        class={'theme-toggle'}
-        id="theme-toggle"
-        title="Toggles light & dark"
-        aria-label={state.theme}
-        aria-live="polite"
-        onClick$={onClick$}
-      >
-        <SunAndMoon />
-      </button>
-    </div>
+    <>
+      <span class="md:hidden">
+        <button onClick$={onClick$}>{state.theme === 'light' ? 'Dark' : 'Light'} theme</button>
+      </span>
+      <span class="hidden md:block">
+        <button
+          type="button"
+          class="theme-toggle"
+          id="theme-toggle"
+          title="Toggles light & dark"
+          aria-label={state.theme}
+          aria-live="polite"
+          onClick$={onClick$}
+        >
+          <SunAndMoon />
+        </button>
+      </span>
+    </>
   );
 });

--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -254,7 +254,7 @@ body {
 
   .menu-close svg {
     position: fixed;
-    top: 20px;
+    top: calc(20px + var(--builder-bar-height));
     width: 24px;
     height: 24px;
     cursor: pointer;

--- a/packages/qwik/src/core/render/dom/render.unit.tsx
+++ b/packages/qwik/src/core/render/dom/render.unit.tsx
@@ -737,8 +737,8 @@ renderSuite('should render foreignObject properly', async () => {
           </svg>
           <feGaussianBlur class="is-html">bye</feGaussianBlur>
         </foreignObject>
-        <text className="is-svg">Hello</text>
-        <text className="is-svg">Bye</text>
+        <text class="is-svg">Hello</text>
+        <text class="is-svg">Bye</text>
       </svg>
       <text class="is-html">end</text>
     </div>
@@ -846,7 +846,7 @@ export const RenderClasses = component$(() => {
   return (
     <>
       <button
-        className="increment"
+        class="increment"
         onClick$={inlinedQrl(Counter_add, 'Counteradd', [state, { value: 1 }])}
       >
         +
@@ -894,7 +894,7 @@ export const Counter = component$((props: { step?: number }) => {
       </button>
       <span>{state.count}</span>
       <button
-        className="increment"
+        class="increment"
         onClick$={inlinedQrl(Counter_add, 'Counteradd', [state, { value: step }])}
       >
         +

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -49,7 +49,7 @@ renderSSRSuite('render aria value', async () => {
 
 renderSSRSuite('render className', async () => {
   await testSSR(
-    <body className="stuff"></body>,
+    <body class="stuff"></body>,
     '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body class="stuff"></body></html>'
   );
 });
@@ -1384,7 +1384,7 @@ export const ScopedStyles1 = component$(() => {
 
   return (
     <div class="host">
-      <div className="div">
+      <div class="div">
         Scoped1
         <Slot></Slot>
         <p>Que tal?</p>

--- a/starters/apps/e2e/src/components/styles/styles.tsx
+++ b/starters/apps/e2e/src/components/styles/styles.tsx
@@ -47,7 +47,7 @@ export const Child = component$((props: { index: number }) => {
 
   return (
     <div class="child-container">
-      <div className="child">Child {props.index}</div>
+      <div class="child">Child {props.index}</div>
     </div>
   );
 });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
- fixes #2499 (screenshot 1)
- textual representation of theme toggle to match other links in the mobile menu (screenshot 2)
- adjusted position of close button on mobile view (screenshot 3)
- aligned toolkit icon sizes and hover effects on dark and light mode on desktop (screenshot 4)
- replaced legacy `className` usag


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality


# Screenshots
1)
![Bildschirmfoto 2022-12-22 um 21 41 51](https://user-images.githubusercontent.com/3241476/209222679-4b3dc23b-6ddd-4f5e-85e2-745ad90c650b.png)

2)
![Bildschirmfoto 2022-12-22 um 21 41 09](https://user-images.githubusercontent.com/3241476/209222642-63fb2438-700a-4492-899a-36b2271244c6.png)
![Bildschirmfoto 2022-12-22 um 21 41 18](https://user-images.githubusercontent.com/3241476/209222646-7153f8eb-8529-4db1-b266-ca61d841e64a.png)

3) 
![Bildschirmfoto 2022-12-22 um 21 41 34](https://user-images.githubusercontent.com/3241476/209222758-e03ebd6f-96ab-4c2e-b098-f48616eb9922.png)

4)
![Bildschirmfoto 2022-12-22 um 21 42 07](https://user-images.githubusercontent.com/3241476/209222787-ad183c99-9ab8-4206-8018-770606207ff4.png)
![Bildschirmfoto 2022-12-22 um 21 42 19](https://user-images.githubusercontent.com/3241476/209222790-411eb99b-81f8-4eac-8d17-c198da279587.png)
