### PR TITLE
Update styled-vanilla-extract Integration Script's Version

### DIFF
--- a/starters/features/styled-vanilla-extract/package.json
+++ b/starters/features/styled-vanilla-extract/package.json
@@ -2,7 +2,7 @@
   "description": "Zero-cost CSS-in-JS for Qwik",
   "devDependencies": {
     "@vanilla-extract/css": "^1.9.2",
-    "styled-vanilla-extract": "^0.4.5"
+    "styled-vanilla-extract": "^0.5.3"
   },
   "__qwik__": {
     "displayName": "Integration: Styled-Vanilla-Extract (styling)",


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

styled-vanilla-extract is now on version 0.5.x which doesn't match the current integration script's constraint of ^0.4.5. Updating the package version in the integration script to ^0.5.3 will ensure that the integration is kept up to date within reason in the script.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Keep the integration script in line with qwik

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
