### PR TITLE
Fix plugin scoping for namespaced packages

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -179,7 +179,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         const nodeOs: typeof import('os') = await sys.dynamicImport('node:os');
         // Additional we add a prefix to scope the file to the current application so that different
         // applications can be run in parallel without generating conflicts
-        const scopePrefix = pluginOpts.scope ? `${pluginOpts.scope}-` : '';
+        const scopePrefix = pluginOpts.scope ? `${pluginOpts.scope.replaceAll('/', '--')}-` : '';
         tmpClientManifestPath = path.join(
           nodeOs.tmpdir(),
           `${scopePrefix}vite-plugin-qwik-q-manifest.json`

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -180,7 +180,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
 
         // Additionally, we add a suffix to scope the file to the current application so that
         // different applications can be run in parallel without generating conflicts.
-        const scopeSuffix = pluginOpts.scope ? `-${pluginOpts.scope.replaceAll('/', '--')}` : '';
+        const scopeSuffix = pluginOpts.scope ? `-${pluginOpts.scope.replace(/\//g, '--')}` : '';
 
         tmpClientManifestPath = path.join(
           nodeOs.tmpdir(),

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -177,9 +177,11 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         // Client build will write to this path, and SSR will read from it. For this reason,
         // the Client build should always start and finish before the SSR build.
         const nodeOs: typeof import('os') = await sys.dynamicImport('node:os');
-        // Additional we add a prefix to scope the file to the current application so that different
-        // applications can be run in parallel without generating conflicts
+
+        // Additionally, we add a prefix to scope the file to the current application so that
+        // different applications can be run in parallel without generating conflicts.
         const scopePrefix = pluginOpts.scope ? `${pluginOpts.scope.replaceAll('/', '--')}-` : '';
+
         tmpClientManifestPath = path.join(
           nodeOs.tmpdir(),
           `${scopePrefix}vite-plugin-qwik-q-manifest.json`

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -178,13 +178,13 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         // the Client build should always start and finish before the SSR build.
         const nodeOs: typeof import('os') = await sys.dynamicImport('node:os');
 
-        // Additionally, we add a prefix to scope the file to the current application so that
+        // Additionally, we add a suffix to scope the file to the current application so that
         // different applications can be run in parallel without generating conflicts.
-        const scopePrefix = pluginOpts.scope ? `${pluginOpts.scope.replaceAll('/', '--')}-` : '';
+        const scopeSuffix = pluginOpts.scope ? `-${pluginOpts.scope.replaceAll('/', '--')}` : '';
 
         tmpClientManifestPath = path.join(
           nodeOs.tmpdir(),
-          `${scopePrefix}vite-plugin-qwik-q-manifest.json`
+          `vite-plugin-qwik-q-manifest${scopeSuffix}.json`
         );
 
         if (target === 'ssr' && !pluginOpts.manifestInput) {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

This fixes a bug introduced in https://github.com/BuilderIO/qwik/pull/2398.

# Use cases and why

For namespaced packages (such as `@org/package`), the `scopePrefix` added in https://github.com/BuilderIO/qwik/pull/2398 will contain a `/` which will result in an error:

```bash
[vite-plugin-qwik] ENOENT: no such file or directory, open '/.../@org/package-vite-plugin-qwik-q-manifest.json'
```

Additionally to the fix, I changed the prefix to a suffix so the `vite-plugin-qwik` part is the actual prefix and these files are colocated. If needed, I can drop that change.

All that said, package names are optional, which means that in some edge cases, parallel builds can still conflict. An alternative might be to use a hash of something (`rootDir` maybe?).

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
