### PR TITLE
docs: add Vercel Edge integration to adaptors

### DIFF
--- a/packages/docs/src/routes/integrations/integration/overview/index.mdx
+++ b/packages/docs/src/routes/integrations/integration/overview/index.mdx
@@ -20,6 +20,7 @@ It will prompt you to select the integration you want to add. Once you select an
 - [Azure Static Web Apps](/integrations/deployments/azure-swa/index.mdx)
 - [Netlify Edge](/integrations/deployments/netlify-edge/index.mdx)
 - [Google Cloud Run server](/integrations/deployments/gcp-cloud-run/index.mdx)
+- [Vercel Edge](/integrations/deployments/vercel-edge/index.mdx)
 - [Nodejs Express Server](/integrations/deployments/node/index.mdx)
 - [Static Site (.html files)](/qwikcity/static-site-generation/overview/index.mdx)
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

add the missing Vercel Edge to adaptor list in integration/overview page

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
