### PR TITLE
fix: link to Vercel adaptor README

### DIFF
--- a/packages/docs/src/routes/integrations/deployments/vercel-edge/index.mdx
+++ b/packages/docs/src/routes/integrations/deployments/vercel-edge/index.mdx
@@ -38,7 +38,7 @@ To build the application for production, use the `build` command, this command w
 npm run build
 ```
 
-[Read the full guide here](https://github.com/BuilderIO/qwik/blob/main/starters/adaptors/Vercel-edge/README.md)
+[Read the full guide here](https://github.com/BuilderIO/qwik/blob/main/starters/adaptors/vercel-edge/README.md)
 
 ## Dev deploy
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Link to the full guide is broken.

Only thing that seems to be weird was that the link `https://github.com/BuilderIO/qwik/blob/main/starters/adaptors/Vercel-edge/README.md` has `Vercel` in the URL with a capital `V`. fixing to lowercase should do the job.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
