### PR TITLE
Fix `request-handler` module not found

### DIFF
--- a/scripts/qwik-city.ts
+++ b/scripts/qwik-city.ts
@@ -98,9 +98,9 @@ export async function buildQwikCity(config: BuildConfig) {
         require: './middleware/node/index.cjs',
       },
       './middleware/request-handler': {
-        types: './middleware/node/request-handler/index.d.ts',
-        import: './middleware/node/request-handler/index.mjs',
-        require: './middleware/node/request-handler/index.cjs',
+        types: './middleware/request-handler/index.d.ts',
+        import: './middleware/request-handler/index.mjs',
+        require: './middleware/request-handler/index.cjs',
       },
       './middleware/vercel-edge': {
         types: './middleware/vercel-edge/index.d.ts',


### PR DESCRIPTION
Fixes this error:

```sh
failed to load config from ~/qwik-test/adaptors/static/vite.config.ts
error during build:
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '~/qwik-test/node_modules/@builder.io/qwik-city/middleware/node/request-handler/index.mjs' imported from ~/qwik-test/node_modules/@builder.io/qwik-city/adaptors/static/vite/index.mjs
```

Most likely connected to #2525

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
