### PR TITLE
Update index.mdx

### DIFF
--- a/packages/docs/src/routes/tutorial/events/synchronous/index.mdx
+++ b/packages/docs/src/routes/tutorial/events/synchronous/index.mdx
@@ -9,4 +9,4 @@ While not a common use case, you may occasionally need to process events synchro
 
 Since Qwik processes asynchronously by default, your code must be explicitly configured for synchronous calls. This example shows how to eagerly load an event handler that processes a synchronous event.
 
-> **Your task:** Convert the `onClick$` from asynchronous event to synchronous event by using `useClientEffect` and normal event registration.
+> **Your task:** Convert the `onClick$` from asynchronous event to synchronous event by using [`useClientEffect`](https://qwik.builder.io/docs/components/lifecycle/#useclienteffect) lifecycle and [normal event registration](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Add links for context. 
When getting to the synchronous events section, the user is asked to use the useClientEffect, which he has not been aware of until this point and has no reference. 
Also, some users might not have context as to what "normal event registration" is - added link to MDN.

Something else I noticed is that the "show me" produces code with a `signal` which also has not been introduced to the tutorial taker at this point.
`useStore` was shown in the ["state management"](https://qwik.builder.io/tutorial/introduction/store/) section - but not signal. 
Perhaps worth updating as well @manucorporat @adamdbradley?

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
