### PR TITLE
docs/refactor: replaced useServerMount$ with useTask$ hook

### DIFF
--- a/packages/docs/src/routes/examples/apps/partial/hackernews-index/app.tsx
+++ b/packages/docs/src/routes/examples/apps/partial/hackernews-index/app.tsx
@@ -1,13 +1,16 @@
-import { component$, useServerMount$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useTask$, useStore, useStyles$ } from '@builder.io/qwik';
+import { isServer } from '@builder.io/qwik/build';
 import HackerNewsCSS from './hacker-news.css?inline';
 
 export const HackerNews = component$(() => {
   useStyles$(HackerNewsCSS);
   const store = useStore({ data: null });
 
-  useServerMount$(async () => {
-    const response = await fetch('https://node-hnapi.herokuapp.com/news?page=0');
-    store.data = await response.json();
+  useTask$(async () => {
+    if (isServer) {
+      const response = await fetch('https://node-hnapi.herokuapp.com/news?page=0');
+      store.data = await response.json();
+    }
   });
 
   return (


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

`useServerMount$` is now deprecated / preferred to use the new `useTask$` hook. The `HackerNews` example uses the old hook so I thought to update it. 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
