### PR TITLE
docs: blackflag.dev added to demo pages on docs site

### DIFF
--- a/packages/docs/scripts/pages.json
+++ b/packages/docs/scripts/pages.json
@@ -71,6 +71,11 @@
     "tags": "portfolio"
   },
   {
+    "href": "https://www.blackflag.dev/",
+    "size": "large",
+    "tags": "site"
+  },
+  {
     "href": "https://qwik.builder.io",
     "tags": "site",
     "repo": "https://github.com/BuilderIO/qwik/tree/main/packages/docs"

--- a/packages/docs/scripts/pages.json
+++ b/packages/docs/scripts/pages.json
@@ -72,7 +72,6 @@
   },
   {
     "href": "https://www.blackflag.dev/",
-    "size": "large",
     "tags": "site"
   },
   {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Added website https://www.blackflag.dev to docs site demo page. The site should have a performance score of 100 according to Pagespeed metrics.


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
