### PR TITLE
fix: cloud-run adapter not built

### DIFF
--- a/packages/qwik-city/adaptors/cloud-run/api.md
+++ b/packages/qwik-city/adaptors/cloud-run/api.md
@@ -4,15 +4,13 @@
 
 ```ts
 
-import type { StaticGenerateRenderOptions } from '../../../static';
+import { ServerAdaptorOptions } from '../../shared/vite';
 
 // @alpha (undocumented)
-export function expressAdaptor(opts?: CloudRunAdaptorOptions): any;
+export function cloudRunAdaptor(opts?: CloudRunAdaptorOptions): any;
 
 // @alpha (undocumented)
-export interface CloudRunAdaptorOptions {
-    // (undocumented)
-    staticGenerate?: Omit<StaticGenerateRenderOptions, 'outDir'> | true;
+export interface CloudRunAdaptorOptions extends ServerAdaptorOptions {
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/qwik-city/package.json
+++ b/packages/qwik-city/package.json
@@ -20,6 +20,10 @@
       "import": "./lib/adaptors/cloudflare-pages/vite/index.mjs",
       "require": "./lib/adaptors/cloudflare-pages/vite/index.cjs"
     },
+    "./adaptors/cloud-run/vite": {
+      "import": "./lib/adaptors/cloud-run/vite/index.mjs",
+      "require": "./lib/adaptors/cloud-run/vite/index.cjs"
+    },
     "./adaptors/express/vite": {
       "import": "./lib/adaptors/express/vite/index.mjs",
       "require": "./lib/adaptors/express/vite/index.cjs"

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -1,7 +1,7 @@
-import { BuildConfig, panic } from './util';
 import { Extractor, ExtractorConfig } from '@microsoft/api-extractor';
-import { join } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { BuildConfig, panic } from './util';
 
 /**
  * Create each submodule's bundled dts file, and ensure
@@ -81,6 +81,11 @@ export function apiExtractor(config: BuildConfig) {
       'vite',
       'index.d.ts'
     )
+  );
+  createTypesApi(
+    config,
+    join(config.packagesDir, 'qwik-city', 'adaptors', 'cloud-run', 'vite'),
+    join(config.packagesDir, 'qwik-city', 'lib', 'adaptors', 'cloud-run', 'vite', 'index.d.ts')
   );
   createTypesApi(
     config,


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

Cloud Run adapter wasnt set to be built into the Qwik City library.
It should now be available.

Fixes https://github.com/BuilderIO/qwik/issues/2535

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
