### PR TITLE
fix: should replace @builder.io/qwik with a path relative to dist when dts bundling

### DIFF
--- a/packages/qwik/src/server/server-modules.d.ts
+++ b/packages/qwik/src/server/server-modules.d.ts
@@ -1,6 +1,4 @@
-import { QwikManifest } from './index';
-
 declare module '@qwik-client-manifest' {
-  const manifest: QwikManifest;
+  const manifest: import('./index').QwikManifest;
   export { manifest };
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

fix #2625 

it seems that current replace `@builder.io/qwik` with `corePath`  cause unresolved type in final dts bundle. 

You can see the changes made by this pr below:

## Before

```
/// <reference path="./server-modules.d.ts" />

import type { QwikManifest } from './core/optimizer';
import type { SnapshotResult } from './core';
import type { StreamWriter } from './core';
import type { SymbolMapper } from './core/optimizer';
import type { SymbolMapperFn } from './core/optimizer';
```
![image](https://user-images.githubusercontent.com/41503212/212127908-bf614d1e-ae39-4d5b-a257-aba49a1816cf.png)



## After

```
/// <reference path="./server-modules.d.ts" />

import type { QwikManifest } from './optimizer';
import type { SnapshotResult } from '.';
import type { StreamWriter } from '.';
import type { SymbolMapper } from './optimizer';
import type { SymbolMapperFn } from './optimizer';
```

![image](https://user-images.githubusercontent.com/41503212/212127225-cb59f5d6-4dc9-4edd-acad-97eb25fe67f1.png)


# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
