### PR TITLE
fixes(docs): adjusted h2 font size for mobile

### DIFF
--- a/packages/docs/src/routes/docs/components/events/index.mdx
+++ b/packages/docs/src/routes/docs/components/events/index.mdx
@@ -9,12 +9,7 @@ contributors:
   - adamdbradley
 ---
 
-# h1
-## h2
-### h3
-#### h4
-##### h5
-###### h6
+# Events
 
 For a web application to be interactive, there needs to be a way to respond to user events. This is done by registering callback functions in the JSX template.
 

--- a/packages/docs/src/routes/docs/components/events/index.mdx
+++ b/packages/docs/src/routes/docs/components/events/index.mdx
@@ -9,7 +9,12 @@ contributors:
   - adamdbradley
 ---
 
-# Events
+# h1
+## h2
+### h3
+#### h4
+##### h5
+###### h6
 
 For a web application to be interactive, there needs to be a way to respond to user events. This is done by registering callback functions in the JSX template.
 

--- a/packages/docs/src/routes/docs/docs.css
+++ b/packages/docs/src/routes/docs/docs.css
@@ -254,10 +254,3 @@ h6 a:hover .icon {
     margin-right: 6rem;
   }
 }
-
-@media (max-width: 768px) {
-  .docs article h2 {
-    font-size: 1.2rem;
-    margin-top: 2rem;
-  }
-}


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

After the changes made on #1808, the h2 on all screens were reduced for mobile users. this reverts part of the made changes to reset the correct hierarchy. maybe we should reduce the titles as well to an h3 on the FAQ pages. happy to get some feedback.

# Screens
![Bildschirmfoto_2023-01-12_um_22_19_18](https://user-images.githubusercontent.com/3241476/212184778-d8c47939-7f14-4d50-b4e3-c78fbfe1aafb.png)
![Bildschirmfoto_2023-01-12_um_22_17_35](https://user-images.githubusercontent.com/3241476/212184793-a58ddbae-984c-46f6-9e85-c0a9f1691b6e.png)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
