### PR TITLE
refactor: adjust types for useOn* methods

### DIFF
--- a/packages/docs/src/routes/tutorial/composing/use/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/composing/use/problem/app.tsx
@@ -5,8 +5,8 @@ export default component$(() => {
   useOnDocument(
     'mousemove',
     $((event: Event) => {
-      mousePosition.x = (event as MouseEvent).clientX;
-      mousePosition.y = (event as MouseEvent).clientY;
+      mousePosition.x = event.clientX;
+      mousePosition.y = event.clientY;
     })
   );
   return (

--- a/packages/docs/src/routes/tutorial/composing/use/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/composing/use/solution/app.tsx
@@ -5,8 +5,8 @@ export function useMousePosition() {
   useOnDocument(
     'mousemove',
     $((event: Event) => {
-      mousePosition.x = (event as MouseEvent).clientX;
-      mousePosition.y = (event as MouseEvent).clientY;
+      mousePosition.x = event.clientX;
+      mousePosition.y = event.clientY;
     })
   );
   return mousePosition;

--- a/packages/docs/src/routes/tutorial/hooks/use-on/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-on/problem/app.tsx
@@ -12,8 +12,8 @@ export default component$(() => {
   useOn(
     'mousemove',
     $((event) => {
-      store.element.x = (event as MouseEvent).x;
-      store.element.y = (event as MouseEvent).y;
+      store.element.x = event.x;
+      store.element.y = event.y;
     })
   );
   return (

--- a/packages/docs/src/routes/tutorial/hooks/use-on/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-on/solution/app.tsx
@@ -1,5 +1,3 @@
-import { component$, useOnDocument, $, useStore, useOn, useOnWindow } from '@builder.io/qwik';
-
 export default component$(() => {
   const store = useStore(
     {
@@ -12,22 +10,22 @@ export default component$(() => {
   useOn(
     'mousemove',
     $((event) => {
-      store.element.x = (event as MouseEvent).x;
-      store.element.y = (event as MouseEvent).y;
+      store.element.x = event.x;
+      store.element.y = event.y;
     })
   );
   useOnDocument(
     'mousemove',
     $((event) => {
-      store.document.x = (event as MouseEvent).x;
-      store.document.y = (event as MouseEvent).y;
+      store.document.x = event.x;
+      store.document.y = event.y;
     })
   );
   useOnWindow(
     'mousemove',
     $((event) => {
-      store.window.x = (event as MouseEvent).x;
-      store.window.y = (event as MouseEvent).y;
+      store.window.x = event.x;
+      store.window.y = event.y;
     })
   );
 

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -928,14 +928,17 @@ export const useMount$: (first: TaskFn, opts?: UseTaskOptions | undefined) => vo
 // @beta @deprecated (undocumented)
 export const useMountQrl: (qrl: QRL<TaskFn>, opts?: UseTaskOptions | undefined) => void;
 
+// Warning: (ae-forgotten-export) The symbol "EventNameOrString" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "EventType" needs to be exported by the entry point index.d.ts
+//
 // @alpha
-export const useOn: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;
+export const useOn: <T extends EventNameOrString<Element>>(event: T | T[], eventQrl: QRL<(ev: EventType<Element, T>) => void>) => void;
 
 // @alpha
-export const useOnDocument: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;
+export const useOnDocument: <T extends EventNameOrString<Element>>(event: T | T[], eventQrl: QRL<(ev: EventType<Element, T>) => void>) => void;
 
 // @alpha
-export const useOnWindow: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;
+export const useOnWindow: <T extends EventNameOrString<Element>>(event: T | T[], eventQrl: QRL<(ev: EventType<Element, T>) => void>) => void;
 
 // @alpha @deprecated
 export const useRef: <T extends Element = Element>(current?: T | undefined) => Ref<T>;

--- a/starters/apps/e2e/src/components/broadcast-events/broadcast-event.tsx
+++ b/starters/apps/e2e/src/components/broadcast-events/broadcast-event.tsx
@@ -4,9 +4,9 @@ export function useDocumentMouse() {
   const mousePosition = useStore({ x: 0, y: 0, inside: 'false' });
   useOnDocument(
     'mousemove',
-    $((event: Event) => {
-      mousePosition.x = (event as MouseEvent).clientX;
-      mousePosition.y = (event as MouseEvent).clientY;
+    $((event) => {
+      mousePosition.x = event.clientX;
+      mousePosition.y = event.clientY;
     })
   );
   useOnDocument(
@@ -28,9 +28,9 @@ export function useWindowMouse() {
   const mousePosition = useStore({ x: 0, y: 0, inside: 'false' });
   useOnWindow(
     'mousemove',
-    $((event: Event) => {
-      mousePosition.x = (event as MouseEvent).clientX;
-      mousePosition.y = (event as MouseEvent).clientY;
+    $((event) => {
+      mousePosition.x = event.clientX;
+      mousePosition.y = event.clientY;
     })
   );
   useOnWindow(
@@ -52,9 +52,9 @@ export function useSelfMouse() {
   const mousePosition = useStore({ x: 0, y: 0, inside: 'false' });
   useOn(
     'mousemove',
-    $((event: Event) => {
-      mousePosition.x = (event as MouseEvent).clientX;
-      mousePosition.y = (event as MouseEvent).clientY;
+    $((event) => {
+      mousePosition.x = event.clientX;
+      mousePosition.y = event.clientY;
     })
   );
   useOn(


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement

# Description

Allows autocomplete for events when using useOn* methods. Also provides the correct event type for the required QRL. The event name can be a known QwikEvent name or a string. Event type falls back to a plain Event when a string is provided.

Event names are cast to lowercase to prevent breakages. 

Updated e2e examples that were typing useOn* methods to Event when a specific event type was available.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
