### PR TITLE
Correct param for Express res.end()

### DIFF
--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -63,7 +63,7 @@ export async function fromNodeHttp(
           res.write(chunk);
         },
         close() {
-          return new Promise((resolve) => res.end(resolve));
+          res.end();
         },
       });
       return stream;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

When using `request.json` to send data from "Endpoints", it results in the following error with NodeJS/Express connector.
```
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received type function ([Function (anonymous)])
    at __node_internal_captureLargerStackTrace (node:internal/errors:465:5)
    at new NodeError (node:internal/errors:372:5)
    at Function.from (node:buffer:323:9)
    at toBuffer (/site/node_modules/compression/index.js:286:14)
    at ServerResponse.end (/site/node_modules/compression/index.js:115:22)
    at file:///site/server/entry.express.mjs:575:37
    at new Promise (<anonymous>)
    at Object.close (file:///site/server/entry.express.mjs:575:18)
    at ensureIsPromise (node:internal/webstreams/util:172:19)
    at writableStreamDefaultControllerProcessClose (node:internal/webstreams/writablestream:1124:28)
    at writableStreamDefaultControllerAdvanceQueueIfNeeded (node:internal/webstreams/writablestream:1204:5)
    at node:internal/webstreams/writablestream:1105:7
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```
This is because a function is being passed to `Express#response.end(param)` method (I think, it was mistaken that this function accepts a callback) when it only accepts data to send to the client (no callbacks).
Here is an example repo: https://github.com/RaeesBhatti/edgio-compression-bug. Yes, it says Edgio but we found out that the problem was in QwikCity codebase. To reproduce

- `npm run build`
- `node server/entry.express.mjs`
- Open http://localhost:3000
- Click "Make API Call" button
- See the crash in server logs

# Use cases and why

The developer should be able to use the `request.json(args)` method to return JSON data from an endpoint.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
