### PR TITLE
Feature: Allow ()=>string arg for useStyles$

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-16
+lts/gallium

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -983,14 +983,16 @@ export interface UseStoreOptions {
     recursive?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "StylesArg" needs to be exported by the entry point index.d.ts
+//
 // @public
-export const useStyles$: (first: string) => void;
+export const useStyles$: (first: StylesArg) => void;
 
 // @public
-export const useStylesQrl: (styles: QRL<string>) => void;
+export const useStylesQrl: (styles: QRL<StylesArg>) => void;
 
 // @alpha
-export const useStylesScoped$: (first: string) => UseStylesScoped;
+export const useStylesScoped$: (first: StylesArg) => UseStylesScoped;
 
 // @alpha (undocumented)
 export interface UseStylesScoped {
@@ -999,7 +1001,7 @@ export interface UseStylesScoped {
 }
 
 // @alpha
-export const useStylesScopedQrl: (styles: QRL<string>) => UseStylesScoped;
+export const useStylesScopedQrl: (styles: QRL<StylesArg>) => UseStylesScoped;
 
 // @public
 export const useTask$: (first: TaskFn, opts?: UseTaskOptions | undefined) => void;

--- a/packages/qwik/src/core/style/qrl-styles.ts
+++ b/packages/qwik/src/core/style/qrl-styles.ts
@@ -3,7 +3,9 @@ import { hashCode } from '../util/hash_code';
 import type { QRL } from '../qrl/qrl.public';
 import { assertQrl } from '../qrl/qrl-class';
 
-export const styleKey = (qStyles: QRL<string>, index: number): string => {
+export type StylesArg = string | (() => string);
+
+export const styleKey = (qStyles: QRL<StylesArg>, index: number): string => {
   assertQrl(qStyles);
   return `${hashCode(qStyles.$hash$)}-${index}`;
 };

--- a/packages/qwik/src/core/use/use-styles.ts
+++ b/packages/qwik/src/core/use/use-styles.ts
@@ -1,4 +1,4 @@
-import { styleContent, styleKey } from '../style/qrl-styles';
+import { styleContent, styleKey, StylesArg } from '../style/qrl-styles';
 import type { QRL } from '../qrl/qrl.public';
 import { implicit$FirstArg } from '../util/implicit_dollar';
 import { getScopedStyles } from '../style/scoped-stylesheet';
@@ -40,7 +40,7 @@ export interface UseStylesScoped {
  * @public
  */
 // </docs>
-export const useStylesQrl = (styles: QRL<string>): void => {
+export const useStylesQrl = (styles: QRL<StylesArg>): void => {
   _useStyles(styles, (str) => str, false);
 };
 
@@ -94,7 +94,7 @@ export const useStyles$ = /*#__PURE__*/ implicit$FirstArg(useStylesQrl);
  * @alpha
  */
 // </docs>
-export const useStylesScopedQrl = (styles: QRL<string>): UseStylesScoped => {
+export const useStylesScopedQrl = (styles: QRL<StylesArg>): UseStylesScoped => {
   return {
     scopeId: ComponentStylesPrefixContent + _useStyles(styles, getScopedStyles, true),
   };
@@ -126,8 +126,12 @@ export const useStylesScopedQrl = (styles: QRL<string>): UseStylesScoped => {
 // </docs>
 export const useStylesScoped$ = /*#__PURE__*/ implicit$FirstArg(useStylesScopedQrl);
 
+const processStyleArg = (styleArg: StylesArg): string => {
+  return typeof styleArg === 'string' ? styleArg : styleArg();
+};
+
 const _useStyles = (
-  styleQrl: QRL<string>,
+  styleQrl: QRL<StylesArg>,
   transform: (str: string, styleId: string) => string,
   scoped: boolean
 ): string => {
@@ -163,9 +167,9 @@ const _useStyles = (
     });
   };
   if (isPromise(value)) {
-    iCtx.$waitOn$.push(value.then(appendStyle));
+    iCtx.$waitOn$.push(value.then(processStyleArg).then(appendStyle));
   } else {
-    appendStyle(value);
+    appendStyle(processStyleArg(value));
   }
   return styleId;
 };

--- a/packages/qwik/src/jsx-runtime/api.md
+++ b/packages/qwik/src/jsx-runtime/api.md
@@ -16,31 +16,32 @@ export interface FunctionComponent<P = Record<string, any>> {
 }
 
 // @public (undocumented)
-export namespace JSX {
+const jsx: <T extends string | FunctionComponent<any>>(type: T, props: T extends FunctionComponent<infer PROPS> ? PROPS : Record<string, any>, key?: string | number | null) => JSXNode<T>;
+export { jsx }
+export { jsx as jsxs }
+
+// @public (undocumented)
+namespace JSX_2 {
     // (undocumented)
-    export interface Element extends JSXNode {
+    interface Element extends JSXNode {
     }
     // (undocumented)
-    export interface ElementChildrenAttribute {
+    interface ElementChildrenAttribute {
         // (undocumented)
         children: any;
     }
     // Warning: (ae-forgotten-export) The symbol "QwikIntrinsicAttributes" needs to be exported by the entry point jsx-runtime.d.ts
     //
     // (undocumented)
-    export interface IntrinsicAttributes extends QwikIntrinsicAttributes {
+    interface IntrinsicAttributes extends QwikIntrinsicAttributes {
     }
     // Warning: (ae-forgotten-export) The symbol "QwikIntrinsicElements" needs to be exported by the entry point jsx-runtime.d.ts
     //
     // (undocumented)
-    export interface IntrinsicElements extends QwikIntrinsicElements {
+    interface IntrinsicElements extends QwikIntrinsicElements {
     }
 }
-
-// @public (undocumented)
-const jsx: <T extends string | FunctionComponent<any>>(type: T, props: T extends FunctionComponent<infer PROPS> ? PROPS : Record<string, any>, key?: string | number | null) => JSXNode<T>;
-export { jsx }
-export { jsx as jsxs }
+export { JSX_2 as JSX }
 
 // Warning: (ae-forgotten-export) The symbol "JsxDevOpts" needs to be exported by the entry point jsx-runtime.d.ts
 //


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Allow `useStyles$` and `useScopedStyles$` to receive as an argument a function that returns a string.

# Use cases and why

- 1. this allows us to provide dynamic properties to these hooks instead of hardcode strings

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
