### PR TITLE
feat(runtime): add a key attribute to <Fragment>

### DIFF
--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -119,6 +119,7 @@ export type EagernessOptions = 'visible' | 'load' | 'idle';
 // @public (undocumented)
 export const Fragment: FunctionComponent<{
     children?: any;
+    key?: string;
 }>;
 
 // @public (undocumented)

--- a/packages/qwik/src/core/render/jsx/factory.unit.ts
+++ b/packages/qwik/src/core/render/jsx/factory.unit.ts
@@ -113,6 +113,11 @@ jsxSuite('Fragment', () => {
   const v = h(Fragment, null, h('div', null));
   equal(v.type, Fragment);
 });
+jsxSuite('Fragment with Key', () => {
+  // <><div/></>
+  const v = h(Fragment, { key: 'randomKey' }, h('div', null));
+  equal(v.type, Fragment);
+});
 jsxSuite('valid JSXNode', () => {
   // <div/>
   const v = h('div', null);

--- a/packages/qwik/src/core/render/jsx/jsx-runtime.ts
+++ b/packages/qwik/src/core/render/jsx/jsx-runtime.ts
@@ -174,7 +174,12 @@ export const isValidJSXChild = (node: any): boolean => {
 /**
  * @public
  */
-export const Fragment: FunctionComponent<{ children?: any }> = (props) => props.children as any;
+export const Fragment: FunctionComponent<{ children?: any; key?: string }> = (props) => {
+  if (props.key) {
+    return jsx(Fragment, { children: props.children }, props.key);
+  }
+  return props.children;
+};
 
 interface JsxDevOpts {
   fileName: string;

--- a/packages/qwik/src/core/render/jsx/jsx-runtime.unit.ts
+++ b/packages/qwik/src/core/render/jsx/jsx-runtime.unit.ts
@@ -98,7 +98,7 @@ jsxSuite('Fragment', () => {
   equal(v.type, Fragment);
 });
 jsxSuite('Fragment with key', () => {
-  const v = jsx(Fragment, { key: 'randomKey' });
+  const v = jsx(Fragment, {}, 'randomKey');
   equal(v.type, Fragment);
 });
 jsxSuite('valid JSXNode', () => {

--- a/packages/qwik/src/core/render/jsx/jsx-runtime.unit.ts
+++ b/packages/qwik/src/core/render/jsx/jsx-runtime.unit.ts
@@ -97,6 +97,10 @@ jsxSuite('Fragment', () => {
   const v = jsx(Fragment, {});
   equal(v.type, Fragment);
 });
+jsxSuite('Fragment with key', () => {
+  const v = jsx(Fragment, { key: 'randomKey' });
+  equal(v.type, Fragment);
+});
 jsxSuite('valid JSXNode', () => {
   const v = jsx('div', {});
   equal(isJSXNode(v), true);

--- a/packages/qwik/src/jsx-runtime/api.md
+++ b/packages/qwik/src/jsx-runtime/api.md
@@ -7,6 +7,7 @@
 // @public (undocumented)
 export const Fragment: FunctionComponent<{
     children?: any;
+    key?: string;
 }>;
 
 // @public (undocumented)


### PR DESCRIPTION
added a key attribute for <Fragment> to enable the usage within loops etc

fix #2565

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
Currently it is not possible to add a `key` prop on fragments which forbids the usage within a loop for example. This PR fixes #2565 where keyed fragments have been requested.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
