### PR TITLE
feat: add node middleware connecting functions

### DIFF
--- a/packages/qwik-city/middleware/node/api.md
+++ b/packages/qwik-city/middleware/node/api.md
@@ -18,11 +18,14 @@ export function createQwikCity(opts: QwikCityNodeRequestOptions): {
     notFound: (req: IncomingMessage, res: ServerResponse, next: (e: any) => void) => Promise<void>;
     staticFile: (req: IncomingMessage, res: ServerResponse, next: (e?: any) => void) => Promise<void>;
     app: {
-        use: (fn: NodeMiddleware) => void;
+        use: (fn: NodeMiddleware | NodeMiddleware[]) => void;
         run: (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => void;
         onError: (callback: OnErrorHandler) => void;
     };
 };
+
+// @alpha (undocumented)
+export type NodeMiddleware = (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: (err: any) => void) => void;
 
 // @alpha (undocumented)
 export interface NodeRequestNextFunction {
@@ -30,13 +33,16 @@ export interface NodeRequestNextFunction {
     (err?: any): void;
 }
 
+// @alpha (undocumented)
+export type OnErrorHandler = (err: any, req: IncomingMessage, res: ServerResponse<IncomingMessage>) => void;
+
 // @alpha @deprecated (undocumented)
 export function qwikCity(render: Render, opts?: RenderOptions): {
     router: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: NodeRequestNextFunction) => Promise<void>;
     notFound: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: (e: any) => void) => Promise<void>;
     staticFile: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: (e?: any) => void) => Promise<void>;
     app: {
-        use: (fn: NodeMiddleware) => void;
+        use: (fn: NodeMiddleware | NodeMiddleware[]) => void;
         run: (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => void;
         onError: (callback: OnErrorHandler) => void;
     };
@@ -49,11 +55,6 @@ export interface QwikCityNodeRequestOptions extends ServerRenderOptions {
         cacheControl?: string;
     };
 }
-
-// Warnings were encountered during analysis:
-//
-// /Users/dustinjsilk/Sites/qwik/dist-dev/dts-out/packages/qwik-city/middleware/node/index.d.ts:16:9 - (ae-forgotten-export) The symbol "NodeMiddleware" needs to be exported by the entry point index.d.ts
-// /Users/dustinjsilk/Sites/qwik/dist-dev/dts-out/packages/qwik-city/middleware/node/index.d.ts:18:9 - (ae-forgotten-export) The symbol "OnErrorHandler" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/qwik-city/middleware/node/api.md
+++ b/packages/qwik-city/middleware/node/api.md
@@ -17,6 +17,11 @@ export function createQwikCity(opts: QwikCityNodeRequestOptions): {
     router: (req: IncomingMessage, res: ServerResponse, next: NodeRequestNextFunction) => Promise<void>;
     notFound: (req: IncomingMessage, res: ServerResponse, next: (e: any) => void) => Promise<void>;
     staticFile: (req: IncomingMessage, res: ServerResponse, next: (e?: any) => void) => Promise<void>;
+    app: {
+        use: (fn: NodeMiddleware) => void;
+        run: (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => void;
+        onError: (callback: OnErrorHandler) => void;
+    };
 };
 
 // @alpha (undocumented)
@@ -30,6 +35,11 @@ export function qwikCity(render: Render, opts?: RenderOptions): {
     router: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: NodeRequestNextFunction) => Promise<void>;
     notFound: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: (e: any) => void) => Promise<void>;
     staticFile: (req: IncomingMessage, res: ServerResponse<IncomingMessage>, next: (e?: any) => void) => Promise<void>;
+    app: {
+        use: (fn: NodeMiddleware) => void;
+        run: (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => void;
+        onError: (callback: OnErrorHandler) => void;
+    };
 };
 
 // @alpha (undocumented)
@@ -39,6 +49,11 @@ export interface QwikCityNodeRequestOptions extends ServerRenderOptions {
         cacheControl?: string;
     };
 }
+
+// Warnings were encountered during analysis:
+//
+// /Users/dustinjsilk/Sites/qwik/dist-dev/dts-out/packages/qwik-city/middleware/node/index.d.ts:16:9 - (ae-forgotten-export) The symbol "NodeMiddleware" needs to be exported by the entry point index.d.ts
+// /Users/dustinjsilk/Sites/qwik/dist-dev/dts-out/packages/qwik-city/middleware/node/index.d.ts:18:9 - (ae-forgotten-export) The symbol "OnErrorHandler" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/qwik-city/middleware/node/index.ts
+++ b/packages/qwik-city/middleware/node/index.ts
@@ -15,13 +15,19 @@ import { patchGlobalThis } from './node-fetch';
 
 // @builder.io/qwik-city/middleware/node
 
-type NodeMiddleware = (
+/**
+ * @alpha
+ */
+export type NodeMiddleware = (
   req: IncomingMessage,
   res: ServerResponse<IncomingMessage>,
   next: (err: any) => void
 ) => void;
 
-type OnErrorHandler = (
+/**
+ * @alpha
+ */
+export type OnErrorHandler = (
   err: any,
   req: IncomingMessage,
   res: ServerResponse<IncomingMessage>


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Makes it easier to use a vanilla node middleware with an express-like syntax.

Node middleware now exports an `app` object which can be used like this:

```ts
// Individually
app.use(helmet())

// Or as an arrray
app.use([
  staticFile,
  router,
  notFound,
])

// Add an error handler
app.onError((err, req, res) => {
  const code = (res.statusCode = Number(err.code || err.status) || 500)
  res.end(STATUS_CODES[code])
})

// Run the chain of middleware in an httpserver or return a middleware in `entry.preview.ts`
const server = (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => {
  app.run(req, res)
}

export default server
```

# Use cases and why

It can be difficult for the average developer to write their own methods for chaining middleware

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
