### PR TITLE
ignore .pnpm-store folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ qwik-app/
 # Yarn
 .yarn/*
 !.yarn/releases
+.pnpm-store/*


### PR DESCRIPTION
I'm using [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) to launch the project and `.pnpm-store` folder is created with several files. 
Please let's add it to .gitignore to prevent wrong commits from "devcontainers user"