### PR TITLE
test: add uvu launch debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,18 +9,32 @@
       "port": 9229,
       "request": "attach",
       "skipFiles": ["<node_internals>/**"],
-      "type": "pwa-node"
+      "type": "node"
     },
     {
       "type": "node",
       "name": "vscode-jest-tests",
       "request": "launch",
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
+      "internalConsoleOptions": "neverOpen", 
       "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
       "cwd": "${workspaceFolder}",
       "args": ["--runInBand", "--watchAll=false"]
+    },    
+    {
+      "name": "uvu Current File",
+      "type": "node",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/node_modules/tsm/bin.js",
+      "args": [
+        "${workspaceFolder}/node_modules/uvu/bin.js", 
+        "${fileDirname}", 
+        "${fileBasename}", 
+        "--tsmconfig", 
+        "${workspaceFolder}/tsm.cjs"
+      ],
+      "console": "integratedTerminal"
     }
   ]
 }


### PR DESCRIPTION
When the `*.unit.ts` is the opened one, in VS Code's debugger, launch `uvu Current File` to test the current file with `uvu`.