### PR TITLE
initial PoC for style scope inherit

### DIFF
--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -67,8 +67,10 @@ export interface AriaAttributes {
 // @public (undocumented)
 export type AriaRole = 'alert' | 'alertdialog' | 'application' | 'article' | 'banner' | 'button' | 'cell' | 'checkbox' | 'columnheader' | 'combobox' | 'complementary' | 'contentinfo' | 'definition' | 'dialog' | 'directory' | 'document' | 'feed' | 'figure' | 'form' | 'grid' | 'gridcell' | 'group' | 'heading' | 'img' | 'link' | 'list' | 'listbox' | 'listitem' | 'log' | 'main' | 'marquee' | 'math' | 'menu' | 'menubar' | 'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'navigation' | 'none' | 'note' | 'option' | 'presentation' | 'progressbar' | 'radio' | 'radiogroup' | 'region' | 'row' | 'rowgroup' | 'rowheader' | 'scrollbar' | 'search' | 'searchbox' | 'separator' | 'slider' | 'spinbutton' | 'status' | 'switch' | 'tab' | 'table' | 'tablist' | 'tabpanel' | 'term' | 'textbox' | 'timer' | 'toolbar' | 'tooltip' | 'tree' | 'treegrid' | 'treeitem' | (string & {});
 
+// Warning: (ae-forgotten-export) The symbol "ComponentQRLOption" needs to be exported by the entry point index.d.ts
+//
 // @public
-export const component$: <PROPS extends {}>(onMount: OnRenderFn<PROPS>) => Component<PROPS>;
+export const component$: <PROPS extends {}>(onMount: OnRenderFn<PROPS>, options?: ComponentQRLOption) => Component<PROPS>;
 
 // @public
 export type Component<PROPS extends {}> = FunctionComponent<PublicProps<PROPS>>;
@@ -82,7 +84,7 @@ export interface ComponentBaseProps {
 }
 
 // @public
-export const componentQrl: <PROPS extends {}>(componentQrl: QRL<OnRenderFn<PROPS>>) => Component<PROPS>;
+export const componentQrl: <PROPS extends {}>(componentQrl: QRL<OnRenderFn<PROPS>>, options?: ComponentQRLOption) => Component<PROPS>;
 
 // @public
 export interface Context<STATE extends object> {

--- a/packages/qwik/src/core/component/component.public.ts
+++ b/packages/qwik/src/core/component/component.public.ts
@@ -7,7 +7,7 @@ import { jsx } from '../render/jsx/jsx-runtime';
 import { SERIALIZABLE_STATE } from '../container/serializers';
 import { qTest } from '../util/qdev';
 import { Virtual } from '../render/jsx/utils.public';
-import { assertQrl } from '../qrl/qrl-class';
+import { ComponentQRLOption, assertQrl } from '../qrl/qrl-class';
 import type { ValueOrPromise } from '../util/types';
 import { _IMMUTABLE } from '../state/constants';
 
@@ -133,7 +133,8 @@ export type EventHandler<T> = QRL<(value: T) => any>;
  */
 // </docs>
 export const componentQrl = <PROPS extends {}>(
-  componentQrl: QRL<OnRenderFn<PROPS>>
+  componentQrl: QRL<OnRenderFn<PROPS>>,
+  options?: ComponentQRLOption
 ): Component<PROPS> => {
   // Return a QComponent Factory function.
   function QwikComponent(props: PublicProps<PROPS>, key: string | null): JSXNode {
@@ -143,6 +144,7 @@ export const componentQrl = <PROPS extends {}>(
     return jsx(
       Virtual,
       {
+        ['q:cmpOption']: options,
         [OnRenderProp]: componentQrl,
         [QSlot]: props[QSlot],
         [_IMMUTABLE]: (props as any)[_IMMUTABLE],
@@ -214,8 +216,11 @@ export const isQwikComponent = (component: any): component is Component<any> => 
  * @public
  */
 // </docs>
-export const component$ = <PROPS extends {}>(onMount: OnRenderFn<PROPS>): Component<PROPS> => {
-  return componentQrl<PROPS>($(onMount));
+export const component$ = <PROPS extends {}>(
+  onMount: OnRenderFn<PROPS>,
+  options?: ComponentQRLOption
+): Component<PROPS> => {
+  return componentQrl<PROPS>($(onMount), options);
 };
 
 /**

--- a/packages/qwik/src/core/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/qrl/qrl-class.ts
@@ -47,6 +47,10 @@ export interface QRLInternalMethods<TYPE> {
   $resolveLazy$(containerEl?: Element): ValueOrPromise<TYPE>;
 }
 
+export type ComponentQRLOption = {
+  styleScope: 'inherit' | undefined;
+};
+
 export interface QRLInternal<TYPE = any> extends QRL<TYPE>, QRLInternalMethods<TYPE> {}
 
 export const createQRL = <TYPE>(

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -238,8 +238,12 @@ const renderNodeVirtual = (
   beforeClose?: (stream: StreamWriter) => ValueOrPromise<void>
 ) => {
   const props = node.props;
+
   const renderQrl = props[OnRenderProp];
   if (renderQrl) {
+    if (props['q:cmpOption']) {
+      elCtx.$componentQrlOptions$ = props['q:cmpOption'];
+    }
     elCtx.$componentQrl$ = renderQrl;
     return renderSSRComponent(rCtx, ssrCtx, stream, elCtx, node, flags, beforeClose);
   }

--- a/packages/qwik/src/core/state/context.ts
+++ b/packages/qwik/src/core/state/context.ts
@@ -1,6 +1,6 @@
 import type { OnRenderFn } from '../component/component.public';
 import { destroyWatch, SubscriberEffect } from '../use/use-task';
-import type { QRLInternal } from '../qrl/qrl-class';
+import type { ComponentQRLOption, QRLInternal } from '../qrl/qrl-class';
 import type { QRL } from '../qrl/qrl.public';
 import type { StyleAppend } from '../use/use-core';
 import type { ProcessedJSXNode } from '../render/dom/render-dom';
@@ -35,6 +35,7 @@ export interface QContext {
   $id$: string;
   $props$: Record<string, any> | null;
   $componentQrl$: QRLInternal<OnRenderFn<any>> | null;
+  $componentQrlOptions$: ComponentQRLOption | null;
   li: Listener[];
   $seq$: any[] | null;
   $watches$: SubscriberEffect[] | null;
@@ -132,6 +133,7 @@ export const createContext = (element: Element | VirtualElement): QContext => {
     $props$: null,
     $vdom$: null,
     $componentQrl$: null,
+    $componentQrlOptions$: null,
     $contexts$: null,
     $dynamicSlots$: null,
     $parent$: null,
@@ -153,6 +155,7 @@ export const cleanupContext = (elCtx: QContext, subsManager: SubscriptionManager
     subsManager.$clearSub$(el);
   }
   elCtx.$componentQrl$ = null;
+  elCtx.$componentQrlOptions$ = null;
   elCtx.$seq$ = null;
   elCtx.$watches$ = null;
   elCtx.$flags$ = 0;

--- a/packages/qwik/src/core/use/use-styles.ts
+++ b/packages/qwik/src/core/use/use-styles.ts
@@ -148,6 +148,9 @@ const _useStyles = (
     elCtx.$scopeIds$ = [];
   }
   if (scoped) {
+    if (elCtx.$parent$ && elCtx.$componentQrlOptions$?.styleScope === 'inherit') {
+      elCtx.$scopeIds$.push(...(elCtx.$parent$.$scopeIds$ || []));
+    }
     elCtx.$scopeIds$.push(styleContent(styleId));
   }
   if (hasStyle(containerState, styleId)) {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Add a way to declare component$ which shares parent component styling scope.

# Use cases and why

Will complete this feature request ( https://github.com/BuilderIO/qwik/issues/2726 )

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
