### PR TITLE
docs: fix FAQ typo

### DIFF
--- a/packages/docs/src/routes/docs/faq/index.mdx
+++ b/packages/docs/src/routes/docs/faq/index.mdx
@@ -176,7 +176,7 @@ No. Partial hydration (or island architecture), popularized by [Astro](https://a
 
 For this to work, developers need to manually define the islands, and then manually describe in which situations they should be hydrated. The islands also cannot communicate with each other.
 
-Instead, Qwik components do not hydrate at all. Qwik achieves this through a powerful serialization system that serializes only the necessary state in the reactivity graph. This way, the app can resume without eagarly running any JS.
+Instead, Qwik components do not hydrate at all. Qwik achieves this through a powerful serialization system that serializes only the necessary state in the reactivity graph. This way, the app can resume without eagerly running any JS.
 
 We think resumability scales without the negative trade-offs of partial hydration.
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Just a small FAQ typo fix.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
