### PR TITLE
fix(scoped styles): fix pseudo-element logic

### DIFF
--- a/packages/qwik/src/core/style/scoped-stylesheet.ts
+++ b/packages/qwik/src/core/style/scoped-stylesheet.ts
@@ -31,6 +31,7 @@ export const scopeStylesheet = (css: string, scopeId: string): string => {
     DEBUG && console.log(css);
     DEBUG && console.log(new Array(idx).fill(' ').join('') + '^');
     DEBUG && console.log('MODE', ...stack.map(modeToString), modeToString(mode));
+    const chIdx = idx;
     let ch = css.charCodeAt(idx++);
     if (ch === BACKSLASH) {
       idx++;
@@ -109,7 +110,7 @@ export const scopeStylesheet = (css: string, scopeId: string): string => {
                 lastIdx = idx; // skip over ":global("
               } else if (newMode === pseudoElement) {
                 // We are entering pseudoElement `::foo`; insert scoping in front of it.
-                insertScopingSelector(findStart(idx - 1));
+                insertScopingSelector(chIdx);
               }
               mode = newMode;
               ch == SPACE; // Pretend not an identifier so that we don't flush again on elementClassIdSelector
@@ -123,19 +124,6 @@ export const scopeStylesheet = (css: string, scopeId: string): string => {
   }
   flush(idx);
   return out.join('');
-
-  function findStart(idx: number) {
-    let isIdentCh = isIdent(css.charCodeAt(idx));
-    let isPrevIdentCh = idx > 0 ? isIdent(css.charCodeAt(idx - 1)) : true;
-
-    while (idx > 0) {
-      if (isPrevIdentCh && !isIdentCh) break;
-      idx--;
-      isIdentCh = isPrevIdentCh;
-      isPrevIdentCh = idx > 0 ? isIdent(css.charCodeAt(idx - 1)) : true;
-    }
-    return idx;
-  }
 
   function flush(idx: number) {
     out.push(css.substring(lastIdx, idx));

--- a/packages/qwik/src/core/style/scoped-stylesheet.unit.ts
+++ b/packages/qwik/src/core/style/scoped-stylesheet.unit.ts
@@ -81,16 +81,16 @@ scopedStyles('pseudo selector with :nth', () => {
 });
 
 scopedStyles('pseudo elements', () => {
-  // equal(scopeStylesheet('::selection {}', '_'), '.⭐️_::selection {}');
-  // equal(scopeStylesheet(' ::space {}', '_'), ' .⭐️_::space {}');
+  equal(scopeStylesheet('::selection {}', '_'), '.⭐️_::selection {}');
+  equal(scopeStylesheet(' ::space {}', '_'), ' .⭐️_::space {}');
 
-  // equal(scopeStylesheet('a::before {}', '_'), 'a.⭐️_::before {}');
-  // equal(scopeStylesheet('a::after {}', '_'), 'a.⭐️_::after {}');
+  equal(scopeStylesheet('a::before {}', '_'), 'a.⭐️_::before {}');
+  equal(scopeStylesheet('a::after {}', '_'), 'a.⭐️_::after {}');
 
-  // equal(scopeStylesheet('a::first-line {}', '_'), 'a.⭐️_::first-line {}');
+  equal(scopeStylesheet('a::first-line {}', '_'), 'a.⭐️_::first-line {}');
 
-  // equal(scopeStylesheet('a.red::before {}', '_'), 'a.red.⭐️_::before {}');
-  // equal(scopeStylesheet('a.red span::before {}', '_'), 'a.red.⭐️_ span.⭐️_::before {}');
+  equal(scopeStylesheet('a.red::before {}', '_'), 'a.red.⭐️_::before {}');
+  equal(scopeStylesheet('a.red span::before {}', '_'), 'a.red.⭐️_ span.⭐️_::before {}');
   ['before', 'after', 'first-letter', 'first-line'].forEach((selector) => {
     equal(scopeStylesheet(`:${selector} {}`, '_'), `.⭐️_:${selector} {}`);
     equal(scopeStylesheet(`a:${selector} {}`, '_'), `a.⭐️_:${selector} {}`);


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

I noticed that the fix here: https://github.com/BuilderIO/qwik/pull/2738 commented out some unit tests which I was able to bring back by tweaking the logic.

# Explanation

The reason this is the correct fix in my mind is that the lookahead logic is incrementing `idx` by the length of the lookahead string, so by the time we get into this block, `idx` is no longer what it was at the start of this iteration. This allows us to flush the intended number of characters.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
