### PR TITLE
docs(tutorial): Fixed recursive store solution

### DIFF
--- a/packages/docs/src/routes/tutorial/store/recursive/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/store/recursive/solution/app.tsx
@@ -1,7 +1,7 @@
 import { component$, useStore } from '@builder.io/qwik';
 
 export default component$(() => {
-  const store = useStore({ counter: { count: 0 } }, { deep: true });
+  const store = useStore({ counter: { count: 0 } }, { recursive: true });
 
   return (
     <>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [X] Docs / tests

# Description

In the tutorial, recursive store's solution used `deep` instead of `recursive` in `useStore` in order to configure recursiveness.
This resulted in a code that didn't work.
This PR fixes this issue.
