### PR TITLE
docs: fix incorrect `useStore` option (`recursive`)

### DIFF
--- a/packages/docs/src/routes/docs/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/components/state/index.mdx
@@ -10,6 +10,7 @@ contributors:
   - RATIU5
   - manucorporat
   - literalpie
+  - fum4
 ---
 
 # State

--- a/packages/docs/src/routes/docs/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/components/state/index.mdx
@@ -112,7 +112,7 @@ export default component$(() => {
     {
       nested: { fields: { are: 'not tracked' } },
     },
-    { deep: true }
+    { recursive: true }
   );
 
   return (
@@ -134,7 +134,7 @@ export default component$(() => {
     {
       letters: ['A', 'B', 'C'],
     },
-    { deep: true }
+    { recursive: true }
   );
 
   return (


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The `recursive` option (`useStore`) is incorrectly documented as `deep`.

(Not sure I am supposed to add my name to the contributors list if only modifying docs. Sorry if not, the hype is strong)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
