### PR TITLE
feat(plugin-options): add ability to customize layoutNameMarker ('@') via options.structure property

### DIFF
--- a/packages/docs/src/routes/qwikcity/directory-layout/index.mdx
+++ b/packages/docs/src/routes/qwikcity/directory-layout/index.mdx
@@ -3,6 +3,7 @@ title: Qwik City - file layout
 contributors:
   - manucorporat
   - mhevery
+  - Raiondesu
 ---
 
 # File Layout
@@ -40,4 +41,40 @@ import { component$ } from '@builder.io/qwik';
 export default component$(() => {
   return <>Hello World!</>;
 });
+```
+
+## Structure options
+
+You can customize how the directory and file strcture works by using the `structure` option in `vite.config`:
+
+```ts
+import { defineConfig } from 'vite';
+import { qwikVite } from '@builder.io/qwik/optimizer';
+import { qwikCity } from '@builder.io/qwik-city/vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig(() => {
+  return {
+    plugins: [
+      qwikCity({
+        structure: {
+          // structure options here
+        }
+      }),
+      qwikVite(),
+      tsconfigPaths()
+    ],
+  };
+});
+```
+
+```ts
+interface StructureOptions {
+  /**
+   * Marker for the layout name to be applied to the component.
+   * 
+   * Default is `'@'`
+   */
+  layoutNameMarker?: string;
+}
 ```

--- a/packages/docs/src/routes/qwikcity/layout/named/index.mdx
+++ b/packages/docs/src/routes/qwikcity/layout/named/index.mdx
@@ -6,6 +6,7 @@ contributors:
   - Oyemade
   - mhevery
   - nnelgxorz
+  - Raiondesu
 ---
 
 # Named Layout
@@ -23,6 +24,8 @@ src/
     ├── layout-narrow.tsx         # Default named layout
     └── index.tsx                 # https://example.com/ (Layout: layout.tsx)
 ```
+
+> How layout name is parsed from the file can be customized using the [`structure.layoutNameMarker` option](/qwikcity/directory-layout#structure-options)
 
 - `https://example.com/`
   ```

--- a/packages/docs/src/routes/qwikcity/layout/named/index.mdx
+++ b/packages/docs/src/routes/qwikcity/layout/named/index.mdx
@@ -25,7 +25,7 @@ src/
     └── index.tsx                 # https://example.com/ (Layout: layout.tsx)
 ```
 
-> How layout name is parsed from the file can be customized using the [`structure.layoutNameMarker` option](/qwikcity/directory-layout#structure-options)
+> How layout name that is parsed from the filename can be customized using the [`structure.layoutNameMarker` option](/qwikcity/directory-layout#structure-options)
 
 - `https://example.com/`
   ```

--- a/packages/docs/src/routes/qwikcity/routing/overview/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/overview/index.mdx
@@ -7,6 +7,7 @@ contributors:
   - Oyemade
   - mhevery
   - adamdbradley
+  - Raiondesu
 ---
 
 # Routing
@@ -101,5 +102,6 @@ Qwik City also supports:
 - [Route Parameters](/qwikcity/routing/route-parameters/index.mdx)
 - [Nested layouts](/qwikcity/layout/overview/index.mdx)
 - [Menus](/qwikcity/content/menu/index.mdx)
+- [Directory & File structure cusomization](/qwikcity/directory-layout#structure-options)
 
 These are discussed later.

--- a/packages/qwik-city/buildtime/build.ts
+++ b/packages/qwik-city/buildtime/build.ts
@@ -27,7 +27,7 @@ export async function updateBuildContext(ctx: BuildContext) {
       walkServerPlugins(ctx.opts)
         .then((serverPlugins) => {
           ctx.serverPlugins = serverPlugins;
-          return walkRoutes(ctx.opts.routesDir);
+          return walkRoutes(ctx.opts.routesDir, ctx.opts.structure);
         })
         .then((sourceFiles) => {
           const resolved = resolveSourceFiles(ctx.opts, sourceFiles);

--- a/packages/qwik-city/buildtime/context.ts
+++ b/packages/qwik-city/buildtime/context.ts
@@ -1,4 +1,9 @@
-import type { NormalizedPluginOptions, BuildContext, PluginOptions } from './types';
+import type {
+  NormalizedPluginOptions,
+  BuildContext,
+  PluginOptions,
+  StructureOptions,
+} from './types';
 import { isAbsolute, resolve } from 'node:path';
 import { normalizePath } from '../utils/fs';
 
@@ -40,7 +45,12 @@ export function resetBuildContext(ctx: BuildContext | null) {
 }
 
 function normalizeOptions(rootDir: string, userOpts: PluginOptions | undefined) {
+  // TODO: maybe employ a merge-strategy here instead of all the checks?
+
   const opts: NormalizedPluginOptions = { ...userOpts } as any;
+  const defaultStructureOptions: Required<StructureOptions> = {
+    layoutNameMarker: '@',
+  };
 
   if (typeof opts.routesDir !== 'string') {
     opts.routesDir = resolve(rootDir, 'src', 'routes');
@@ -76,6 +86,11 @@ function normalizeOptions(rootDir: string, userOpts: PluginOptions | undefined) 
   }
 
   opts.mdx = opts.mdx || {};
+
+  opts.structure = {
+    ...defaultStructureOptions,
+    ...opts.structure,
+  };
 
   return opts;
 }

--- a/packages/qwik-city/buildtime/markdown/markdown-url.ts
+++ b/packages/qwik-city/buildtime/markdown/markdown-url.ts
@@ -36,7 +36,7 @@ export function getMarkdownRelativeUrl(
     }
 
     const fileName = basename(filePath);
-    const sourceFileName = getSourceFile(fileName);
+    const sourceFileName = getSourceFile(fileName, opts.structure);
     if (sourceFileName) {
       const mdDirPath = dirname(filePath);
       let pathname = getPathnameFromDirPath(opts, mdDirPath);

--- a/packages/qwik-city/buildtime/markdown/markdown-url.unit.ts
+++ b/packages/qwik-city/buildtime/markdown/markdown-url.unit.ts
@@ -78,6 +78,9 @@ const menuFilePath = join(routesDir, 'docs', 'menu.md');
         rehypeSyntaxHighlight: true,
         rehypeAutolinkHeadings: true,
       },
+      structure: {
+        layoutNameMarker: '@',
+      },
       mdx: {},
       baseUrl: '/',
     };

--- a/packages/qwik-city/buildtime/routing/resolve-source-file.ts
+++ b/packages/qwik-city/buildtime/routing/resolve-source-file.ts
@@ -116,7 +116,10 @@ export function resolveRoute(
   const filePath = sourceFile.filePath;
   const layouts: BuildLayout[] = [];
   const routesDir = opts.routesDir;
-  const { layoutName, layoutStop } = parseRouteIndexName(sourceFile.extlessName);
+  const { layoutName, layoutStop } = parseRouteIndexName(
+    sourceFile.extlessName,
+    opts.structure.layoutNameMarker
+  );
   let pathname = getPathnameFromDirPath(opts, sourceFile.dirPath);
 
   if (sourceFile.extlessName === '404') {

--- a/packages/qwik-city/buildtime/routing/resolve-source-file.unit.ts
+++ b/packages/qwik-city/buildtime/routing/resolve-source-file.unit.ts
@@ -47,11 +47,14 @@ test('resolveLayout', () => {
         rehypeSyntaxHighlight: true,
         rehypeAutolinkHeadings: true,
       },
+      structure: {
+        layoutNameMarker: '@',
+      },
       mdx: {},
       baseUrl: '/',
     };
     const sourceFile: RouteSourceFile = {
-      ...getSourceFile(c.fileName)!,
+      ...getSourceFile(c.fileName, opts.structure)!,
       dirPath: '',
       dirName: '',
       filePath: '',

--- a/packages/qwik-city/buildtime/routing/source-file.ts
+++ b/packages/qwik-city/buildtime/routing/source-file.ts
@@ -1,4 +1,4 @@
-import type { RouteSourceFileName, RouteSourceType } from '../types';
+import type { NormalizedPluginOptions, RouteSourceFileName, RouteSourceType } from '../types';
 import {
   isModuleExt,
   isEntryName,
@@ -13,7 +13,7 @@ import {
   isLayoutModule,
 } from '../../utils/fs';
 
-export function getSourceFile(fileName: string) {
+export function getSourceFile(fileName: string, opts: NormalizedPluginOptions['structure']) {
   const ext = getExtension(fileName);
   const extlessName = removeExtension(fileName);
   const isPageModule = isPageModuleExt(ext);
@@ -22,7 +22,7 @@ export function getSourceFile(fileName: string) {
   let type: RouteSourceType | null = null;
 
   if (
-    (isIndexModule(extlessName) || isErrorName(extlessName)) &&
+    (isIndexModule(extlessName, opts.layoutNameMarker) || isErrorName(extlessName)) &&
     (isPageModule || isModule || isMarkdown)
   ) {
     // route page or endpoint

--- a/packages/qwik-city/buildtime/routing/source-file.unit.ts
+++ b/packages/qwik-city/buildtime/routing/source-file.unit.ts
@@ -209,7 +209,7 @@ import { getSourceFile } from './source-file';
   },
 ].forEach((t) => {
   test(`getSourceFile ${t.fileName}`, () => {
-    const s = getSourceFile(t.fileName);
+    const s = getSourceFile(t.fileName, { layoutNameMarker: '@' });
     if (s == null || t.expect == null) {
       equal(s, t.expect, t.fileName);
     } else {

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -116,6 +116,15 @@ export interface ParsedMenuItem {
   items?: ParsedMenuItem[];
 }
 
+export interface StructureOptions {
+  /**
+   * Marker for the layout name to be applied to the component.
+   *
+   * Default is `'@'`
+   */
+  layoutNameMarker?: string;
+}
+
 /**
  * @alpha
  */
@@ -149,6 +158,12 @@ export interface PluginOptions {
    * MDX Options https://mdxjs.com/
    */
   mdx?: any;
+
+  /**
+   * Settings for the routes diretory structure
+   */
+  structure?: StructureOptions;
+
   /**
    * @deprecated Please use "basePathname" instead.
    */
@@ -161,7 +176,9 @@ export interface MdxPlugins {
   rehypeAutolinkHeadings: boolean;
 }
 
-export interface NormalizedPluginOptions extends Required<PluginOptions> {}
+export interface NormalizedPluginOptions extends Required<PluginOptions> {
+  structure: Required<StructureOptions>;
+}
 
 export interface MarkdownAttributes {
   [name: string]: string;

--- a/packages/qwik-city/utils/fs.ts
+++ b/packages/qwik-city/utils/fs.ts
@@ -3,7 +3,7 @@ import type { NormalizedPluginOptions } from '../buildtime/types';
 import { toTitleCase } from './format';
 import { normalizePathname } from './pathname';
 
-export function parseRouteIndexName(extlessName: string) {
+export function parseRouteIndexName(extlessName: string, layoutNameMarker: string) {
   let layoutName = '';
   const layoutStop = extlessName.endsWith('!');
 
@@ -11,10 +11,12 @@ export function parseRouteIndexName(extlessName: string) {
     extlessName = extlessName.slice(0, extlessName.length - 1);
   }
 
-  const namedLayoutParts = extlessName.split('@');
+  const namedLayoutParts =
+    layoutNameMarker === '' ? ['', extlessName.slice(5)] : extlessName.split(layoutNameMarker);
+
   if (namedLayoutParts.length > 1) {
     namedLayoutParts.shift();
-    layoutName = namedLayoutParts.join('@');
+    layoutName = namedLayoutParts.join(layoutNameMarker);
   }
 
   return { layoutName, layoutStop };
@@ -128,8 +130,8 @@ const MARKDOWN_EXTS: { [type: string]: boolean } = {
   '.mdx': true,
 };
 
-export function isIndexModule(extlessName: string) {
-  return /^index(|!|@.+)$/.test(extlessName);
+export function isIndexModule(extlessName: string, layoutNameMarker: string) {
+  return new RegExp(`^index(|!|${layoutNameMarker}.+)$`).test(extlessName);
 }
 
 export function isPluginModule(extlessName: string) {

--- a/packages/qwik-city/utils/fs.unit.ts
+++ b/packages/qwik-city/utils/fs.unit.ts
@@ -257,6 +257,9 @@ test('createFileId, Layout', () => {
         rehypeSyntaxHighlight: true,
         rehypeAutolinkHeadings: true,
       },
+      structure: {
+        layoutNameMarker: '@',
+      },
       mdx: {},
       baseUrl: t.basePathname,
     };
@@ -265,34 +268,36 @@ test('createFileId, Layout', () => {
   });
 });
 
-test('parseRouteIndexName', () => {
-  const t = [
-    {
-      extlessName: 'index@layout@name',
-      expect: { layoutName: 'layout@name', layoutStop: false },
-    },
-    {
-      extlessName: 'index@layoutname!',
-      expect: { layoutName: 'layoutname', layoutStop: true },
-    },
-    {
-      extlessName: 'index@layoutname',
-      expect: { layoutName: 'layoutname', layoutStop: false },
-    },
-    {
-      extlessName: 'index!',
-      expect: { layoutName: '', layoutStop: true },
-    },
-    {
-      extlessName: 'index',
-      expect: { layoutName: '', layoutStop: false },
-    },
-  ];
+['@', '', '-', ':', '!'].forEach((layoutNameMarker) => {
+  test(`parseRouteIndexName with "${layoutNameMarker}" marker`, () => {
+    const t = [
+      {
+        extlessName: `index${layoutNameMarker}layout${layoutNameMarker}name`,
+        expect: { layoutName: `layout${layoutNameMarker}name`, layoutStop: false },
+      },
+      {
+        extlessName: `index${layoutNameMarker}layoutname!`,
+        expect: { layoutName: 'layoutname', layoutStop: true },
+      },
+      {
+        extlessName: `index${layoutNameMarker}layoutname`,
+        expect: { layoutName: 'layoutname', layoutStop: false },
+      },
+      {
+        extlessName: 'index!',
+        expect: { layoutName: '', layoutStop: true },
+      },
+      {
+        extlessName: 'index',
+        expect: { layoutName: '', layoutStop: false },
+      },
+    ];
 
-  t.forEach((c) => {
-    const r = parseRouteIndexName(c.extlessName);
-    equal(r.layoutName, c.expect.layoutName, `${c.extlessName} layoutName`);
-    equal(r.layoutStop, c.expect.layoutStop, `${c.extlessName} layoutStop`);
+    t.forEach((c) => {
+      const r = parseRouteIndexName(c.extlessName, layoutNameMarker);
+      equal(r.layoutName, c.expect.layoutName, `${c.extlessName} layoutName`);
+      equal(r.layoutStop, c.expect.layoutStop, `${c.extlessName} layoutStop`);
+    });
   });
 });
 
@@ -356,6 +361,9 @@ test('parseRouteIndexName', () => {
         remarkGfm: true,
         rehypeSyntaxHighlight: true,
         rehypeAutolinkHeadings: true,
+      },
+      structure: {
+        layoutNameMarker: '@',
       },
       mdx: {},
       baseUrl: t.basePathname,


### PR DESCRIPTION
Closes #2753 

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

Adds the `structure` property to the PluginOptions type and pass it wherever it makes the most sense, in order to add the ability to add new strcture customization options down-the-line.

So far, the only option  is `layoutNameMarker` which allows to customize how the layout name is read from the `index` filename (default is `index@layout-name.ts`, where "@" is the `layoutNameMarker`).

# Use cases and why

Some environments, build systems, or code linting configs may reject or misinterpret the @ used as a layout name marker in the route name.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
