### PR TITLE
DX: Flip loader$ generic arguments

### DIFF
--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -231,10 +231,10 @@ export interface LinkProps extends AnchorAttributes {
 }
 
 // @alpha (undocumented)
-export const loader$: <PLATFORM, B>(first: (event: RequestEventLoader_2<PLATFORM>) => B) => ServerLoader<B>;
+export const loader$: <RETURN, PLATFORM = unknown>(first: (event: RequestEventLoader_2<PLATFORM>) => RETURN) => ServerLoader<RETURN>;
 
 // @alpha (undocumented)
-export const loaderQrl: <PLATFORM, B>(loaderQrl: QRL<(event: RequestEventLoader_2<PLATFORM>) => B>) => ServerLoader<B>;
+export const loaderQrl: <RETURN, PLATFORM = unknown>(loaderQrl: QRL<(event: RequestEventLoader_2<PLATFORM>) => RETURN>) => ServerLoader<RETURN>;
 
 // Warning: (ae-forgotten-export) The symbol "MenuModuleLoader" needs to be exported by the entry point index.d.ts
 //

--- a/packages/qwik-city/runtime/src/server-functions.ts
+++ b/packages/qwik-city/runtime/src/server-functions.ts
@@ -188,9 +188,9 @@ export class ServerLoaderImpl implements ServerLoaderInternal {
 /**
  * @alpha
  */
-export const loaderQrl = <PLATFORM, B>(
-  loaderQrl: QRL<(event: RequestEventLoader<PLATFORM>) => B>
-): ServerLoader<B> => {
+export const loaderQrl = <RETURN, PLATFORM = unknown>(
+  loaderQrl: QRL<(event: RequestEventLoader<PLATFORM>) => RETURN>
+): ServerLoader<RETURN> => {
   return new ServerLoaderImpl(loaderQrl as any) as any;
 };
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Currently, when defining a loader$, you have to first specify the PLATFORM generic you can specify the RETURN generic, like this:

```typescript
export const productLoader = loader$<unknown, Product>(() => {
    // loader code
});
```

This is a rough edge, because you will likely always want to set the RETURN generic everytime, and maybe set the PLATFORM generic or maybe not.

This change moves the RETURN generic to the first position, and defaults the PLATFORM field to unknown if not specified.

```typescript
export const productLoader = loader$<Product>(() => {
    // loader code
});
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
