### PR TITLE
fix: package.json type field setting error

### DIFF
--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -41,7 +41,7 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions): any {
   let mdxTransform: MdxTransform | null = null;
   let rootDir: string | null = null;
   let qwikPlugin: QwikVitePlugin | null;
-  let ssrFormat: 'esm'|'cjs' = 'esm';
+  let ssrFormat: 'esm' | 'cjs' = 'esm';
   let outDir: string | null = null;
 
   // Patch Stream APIs
@@ -285,8 +285,8 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions): any {
             }
 
             const ssrFormat2pkgTypeMap = {
-              'cjs': 'commonjs',
-              'esm': 'module'
+              cjs: 'commonjs',
+              esm: 'module',
             };
             packageJson = { ...packageJson, type: ssrFormat2pkgTypeMap[ssrFormat] || 'module' };
             const serverPackageJsonCode = JSON.stringify(packageJson, null, 2);

--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -41,7 +41,7 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions): any {
   let mdxTransform: MdxTransform | null = null;
   let rootDir: string | null = null;
   let qwikPlugin: QwikVitePlugin | null;
-  let ssrFormat = 'esm';
+  let ssrFormat: 'esm'|'cjs' = 'esm';
   let outDir: string | null = null;
 
   // Patch Stream APIs
@@ -284,8 +284,11 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions): any {
               };
             }
 
-            // set to type module to ensure mjs is used
-            packageJson = { ...packageJson, type: 'module' };
+            const ssrFormat2pkgTypeMap = {
+              'cjs': 'commonjs',
+              'esm': 'module'
+            };
+            packageJson = { ...packageJson, type: ssrFormat2pkgTypeMap[ssrFormat] || 'module' };
             const serverPackageJsonCode = JSON.stringify(packageJson, null, 2);
 
             await Promise.all([


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

when user viteConfig of ssr.format is `cjs`, the dist package.json's type field should be set to 'commonjs' instead of 'module'.
 
error is in the following:
```
ReferenceError: exports is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '/Users/vscodeProject/qwik-demo3/server/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
