### PR TITLE
docs: pnpm link --global

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ If you can't use package linking (npm link) just copy the contents of `package/q
 
    ```diff
 
-   -- "@builder.io/qwik": "0.17.2",
+   -- "@builder.io/qwik": "0.17.4",
    -- "@builder.io/qwik-city": "0.1.0-beta13",
 
    ++ "@builder.io/qwik": "workspace:*",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,11 @@ To use your build in your project, follow these steps:
    npm install
    npm link @builder.io/qwik @builder.io/qwik-city
    ```
+   or
+   ```shell
+    pnpm install
+    pnpm link --global @builder.io/qwik @builder.io/qwik-city
+   ```
 
 If you can't use package linking (npm link) just copy the contents of `package/qwik/dist` into your projects' `node_modules/@builder.io/qwik` folder.
 
@@ -142,8 +147,8 @@ If you can't use package linking (npm link) just copy the contents of `package/q
 
    ```diff
 
-   -- "@builder.io/qwik": "0.16.2",
-   -- "@builder.io/qwik-city": "0.1.0-beta8",
+   -- "@builder.io/qwik": "0.17.2",
+   -- "@builder.io/qwik-city": "0.1.0-beta13",
 
    ++ "@builder.io/qwik": "workspace:*",
    ++ "@builder.io/qwik-city": "workspace:*",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,9 @@ To use your build in your project, follow these steps:
    npm install
    npm link @builder.io/qwik @builder.io/qwik-city
    ```
+
    or
+
    ```shell
     pnpm install
     pnpm link --global @builder.io/qwik @builder.io/qwik-city


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

My test project use npm,  but `npm link @builder.io/qwik @builder.io/qwik-city` still doesn't work, because the test project can't find the exact path in finder of qwik dist dir after `pnpm link.dist`.
So we should provide another command `pnpm link --global @builder.io/qwik @builder.io/qwik-city` .
 
# Use cases and why



# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
