### PR TITLE
docs: fix incorrect `useStore` option (`recursive`)

### DIFF
--- a/packages/docs/src/routes/docs/concepts/reactivity/index.mdx
+++ b/packages/docs/src/routes/docs/concepts/reactivity/index.mdx
@@ -91,7 +91,7 @@ export const MyComp = component$(() => {
   const store = useStore({
     person: { first: null, last: null },
     location: null
-  }, { deep: true });
+  }, { recursive: true });
 
   store.location = {street: 'main st'};
 

--- a/packages/docs/src/routes/tutorial/hooks/use-on/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-on/problem/app.tsx
@@ -7,7 +7,7 @@ export default component$(() => {
       window: { x: 0, y: 0 },
       document: { x: 0, y: 0 },
     },
-    { deep: true }
+    { recursive: true }
   );
   useOn(
     'mousemove',

--- a/packages/docs/src/routes/tutorial/hooks/use-on/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-on/solution/app.tsx
@@ -7,7 +7,7 @@ export default component$(() => {
       window: { x: 0, y: 0 },
       document: { x: 0, y: 0 },
     },
-    { deep: true }
+    { recursive: true }
   );
   useOn(
     'mousemove',

--- a/packages/docs/src/routes/tutorial/hooks/use-signal/index.mdx
+++ b/packages/docs/src/routes/tutorial/hooks/use-signal/index.mdx
@@ -5,7 +5,7 @@ contributors:
   - adamdbradley
 ---
 
-Use `useSignal()` to store any single value similar to `useStore()`. `useSignal` is heavely optimized when it comes to re-rendering components. It is able to skip re-renderings of parent components even when the signal itself is defined in the parent. `useSignal` works with all [primitve types](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) as well as with not nested / flat objects. If you need to store arrays or complex objects use [useStore](../../../docs/components/state/index.mdx) instead with the `{deep: true}` option.
+Use `useSignal()` to store any single value similar to `useStore()`. `useSignal` is heavely optimized when it comes to re-rendering components. It is able to skip re-renderings of parent components even when the signal itself is defined in the parent. `useSignal` works with all [primitve types](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) as well as with not nested / flat objects. If you need to store arrays or complex objects use [useStore](../../../docs/components/state/index.mdx) instead with the `{recursive: true}` option.
 
 Some examples would be:
 

--- a/packages/docs/src/routes/tutorial/store/serialization/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/store/serialization/problem/app.tsx
@@ -18,7 +18,7 @@ export default component$(() => {
   parent.children = [
     // insert few items here
   ];
-  const parentStore = useStore<ParentStore>(parent, { deep: true });
+  const parentStore = useStore<ParentStore>(parent, { recursive: true });
   return (
     <>
       {parentStore.name}

--- a/packages/docs/src/routes/tutorial/store/serialization/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/store/serialization/solution/app.tsx
@@ -19,7 +19,7 @@ export default component$(() => {
     { name: 'Qwik', parent },
     { name: 'Partytown', parent },
   ];
-  const parentStore = useStore<ParentStore>(parent, { deep: true });
+  const parentStore = useStore<ParentStore>(parent, { recursive: true });
   return (
     <>
       {parentStore.name}

--- a/packages/docs/src/routes/tutorial/style/styles/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/style/styles/problem/app.tsx
@@ -2,7 +2,7 @@ import { component$, useStyles$, useStore } from '@builder.io/qwik';
 
 export default component$(() => {
   useStyles$(AppCSS);
-  const store = useStore({ open: false, siblings: [0] }, { deep: true });
+  const store = useStore({ open: false, siblings: [0] }, { recursive: true });
 
   return (
     <div class="parent">

--- a/packages/docs/src/routes/tutorial/style/styles/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/style/styles/solution/app.tsx
@@ -2,7 +2,7 @@ import { component$, useStyles$, useStore } from '@builder.io/qwik';
 
 export default component$(() => {
   useStyles$(AppCSS);
-  const store = useStore({ open: false, siblings: [0] }, { deep: true });
+  const store = useStore({ open: false, siblings: [0] }, { recursive: true });
 
   return (
     <div class="parent">

--- a/packages/docs/src/routes/tutorial/understanding/capturing/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/understanding/capturing/problem/app.tsx
@@ -11,7 +11,7 @@ export default component$(() => {
       counter: { count: 1 },
       largeData: { data: 'PRETEND THIS IS LARGE DATASET' },
     },
-    { deep: true }
+    { recursive: true }
   );
   console.log('Render: <App/>');
   const counter = store.counter;

--- a/packages/docs/src/routes/tutorial/understanding/capturing/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/understanding/capturing/solution/app.tsx
@@ -11,7 +11,7 @@ export default component$(() => {
       counter: { count: 1 },
       largeData: { data: 'PRETEND THIS IS LARGE DATASET' },
     },
-    { deep: true }
+    { recursive: true }
   );
   console.log('Render: <App/>');
   const counter = store.counter;

--- a/starters/apps/e2e/src/components/lexical-scope/lexicalScope.tsx
+++ b/starters/apps/e2e/src/components/lexical-scope/lexicalScope.tsx
@@ -35,7 +35,7 @@ export const LexicalScopeChild = component$((props: LexicalScopeProps) => {
       stuff: 'foo',
     },
     {
-      deep: true,
+      recursive: true,
     }
   );
   Object.freeze(immutable);

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -11,7 +11,7 @@ export const Render = component$(() => {
   };
   parent.children.push(parent);
 
-  const state = useStore(parent, { deep: true });
+  const state = useStore(parent, { recursive: true });
   return (
     <>
       <button

--- a/starters/apps/todo-test/src/components/app/app.tsx
+++ b/starters/apps/todo-test/src/components/app/app.tsx
@@ -25,7 +25,7 @@ export const App = component$(() => {
       ],
       nextItemId: 3,
     },
-    { deep: true }
+    { recursive: true }
   );
   useContextProvider(TODOS, todos);
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The `recursive` option (`useStore`) is incorrectly documented as `deep`.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
