### PR TITLE
Suppress error of service worker at http connections.

### DIFF
--- a/packages/qwik-city/buildtime/runtime-generation/generate-service-worker.ts
+++ b/packages/qwik-city/buildtime/runtime-generation/generate-service-worker.ts
@@ -143,7 +143,7 @@ function getAppBundleId(appBundles: AppBundle[], bundleName: string) {
 }
 
 const SW_UNREGISTER = `
-navigator.serviceWorker.getRegistrations().then((regs) => {
+navigator.serviceWorker?.getRegistrations().then((regs) => {
   for (const reg of regs) {
     reg.unregister();
   }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

When using dev-server at not https but http, the console reports error comes from there's no `navigator.serviceWorker`.
It is happening at the code for unregistering the service worker, so I simply ignore it.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
