### PR TITLE
docs: add `<RenderOnce>` REVERT

### DIFF
--- a/packages/docs/src/routes/docs/components/rendering/index.mdx
+++ b/packages/docs/src/routes/docs/components/rendering/index.mdx
@@ -102,22 +102,3 @@ Most current-generation frameworks have a synchronous `render()` process. Synchr
 ## DOM update buffering
 
 The asynchronous nature of `render()` means that users may see an intermediate rendering of the UI as components download. Seeing an intermediate state is undesirable; therefore, Qwik will buffer all DOM updates and only flush the DOM operations once all of the components have been downloaded and their JSX functions executed. The result is that the UI will update as an atomic operation, and the user will not see the intermediate steps.
-
-## `<RenderOnce>`
-
-Qwik provides a Component called `<RenderOnce>`. It prevents re-renderings of nested children. Values which are connected to a state will always get updated.
-
-```
-import { component$, RenderOnce } from '@builder.io/qwik';
-
-export const App = component$(() => {
-  return (
-    <div>
-      <RenderOnce>
-        <span>i'll be just rendered once</span>
-      </RenderOnce>
-      <span>i can re-render if i need to</span>
-    </div>
-  );
-});
-```


### PR DESCRIPTION
Reverts BuilderIO/qwik#2848

As discussed with @shairez , we remove that part again since it is a more internal API.