### PR TITLE
Fixes issue on HTTP/2 headers for resolving origin

### DIFF
--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -24,7 +24,7 @@ import { updateBuildContext } from '../build';
 import { getErrorHtml } from '../../middleware/request-handler/error-handler';
 import { getExtension, normalizePath } from '../../utils/fs';
 import { getMenuLoader, getPathParams } from '../../runtime/src/routing';
-import { fromNodeHttp } from '../../middleware/node/http';
+import { fromNodeHttp, getUrl } from '../../middleware/node/http';
 import { resolveRequestHandlers } from '../../middleware/request-handler/resolve-request-handlers';
 import { formatError } from './format-error';
 
@@ -58,7 +58,8 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
 
   return async (req: Connect.IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
     try {
-      const url = new URL(req.originalUrl!, `http://${req.headers.host}`);
+      //const url = new URL(req.originalUrl!, `http://${req.headers.host}`);
+      const url = getUrl(req);
 
       if (skipRequest(url.pathname) || isVitePing(url.pathname, req.headers)) {
         next();

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -58,7 +58,6 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
 
   return async (req: Connect.IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
     try {
-      //const url = new URL(req.originalUrl!, `http://${req.headers.host}`);
       const url = getUrl(req);
 
       if (skipRequest(url.pathname) || isVitePing(url.pathname, req.headers)) {

--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Http2ServerRequest } from 'node:http2';
 import type {
   ServerRequestMode,
   ServerRequestEvent,
@@ -7,6 +8,9 @@ import type {
 const { ORIGIN, PROTOCOL_HEADER, HOST_HEADER = 'host' } = process.env;
 
 function getOrigin(req: IncomingMessage) {
+  if (req instanceof Http2ServerRequest) {
+    return `${req.scheme}://${req.authority}`;
+  }
   const headers = req.headers;
   const protocol =
     (PROTOCOL_HEADER && headers[PROTOCOL_HEADER]) ||

--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -5,17 +5,16 @@ import type {
   ServerRequestEvent,
 } from '@builder.io/qwik-city/middleware/request-handler';
 
-const { ORIGIN, PROTOCOL_HEADER, HOST_HEADER = 'host' } = process.env;
+const { ORIGIN, PROTOCOL_HEADER, HOST_HEADER } = process.env;
 
 function getOrigin(req: IncomingMessage) {
-  if (req instanceof Http2ServerRequest) {
-    return `${req.scheme}://${req.authority}`;
-  }
   const headers = req.headers;
   const protocol =
     (PROTOCOL_HEADER && headers[PROTOCOL_HEADER]) ||
     ((req.socket as any).encrypted || (req.connection as any).encrypted ? 'https' : 'http');
-  const host = headers[HOST_HEADER];
+  const hostHeader = HOST_HEADER ?? (
+    req instanceof Http2ServerRequest ? ':authority' : 'host');
+  const host = headers[hostHeader];
 
   return `${protocol}://${host}`;
 }

--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -12,8 +12,7 @@ function getOrigin(req: IncomingMessage) {
   const protocol =
     (PROTOCOL_HEADER && headers[PROTOCOL_HEADER]) ||
     ((req.socket as any).encrypted || (req.connection as any).encrypted ? 'https' : 'http');
-  const hostHeader = HOST_HEADER ?? (
-    req instanceof Http2ServerRequest ? ':authority' : 'host');
+  const hostHeader = HOST_HEADER ?? (req instanceof Http2ServerRequest ? ':authority' : 'host');
   const host = headers[hostHeader];
 
   return `${protocol}://${host}`;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Fixes remaining issue of #2797 for about dev server.
Because of HTTP/2 headers differ from 1.1, some changes were needed to `getUrl()`.
I have made it used `http2.Http2ServerRequest` if the req object comes from HTTP/2.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
