### PR TITLE
fix(azure-swa): azure SWA request handling and generation of function.json

### DIFF
--- a/packages/qwik-city/adapters/azure-swa/vite/index.ts
+++ b/packages/qwik-city/adapters/azure-swa/vite/index.ts
@@ -20,7 +20,9 @@ export function azureSwaAdapter(opts: AzureSwaAdapterOptions = {}): any {
       await fs.promises.mkdir(serverOutDir!, { recursive: true });
       await fs.promises.writeFile(serverPackageJsonPath, serverPackageJsonCode);
 
-      const azureSwaModulePath = outputEntries.find((entryName) => entryName === 'entry.azure-swa');
+      const azureSwaModulePath = outputEntries.find(
+        (entryName) => entryName.indexOf('entry.azure-swa') === 0
+      );
 
       const funcJsonPath = join(serverOutDir!, 'function.json');
       const funcJson = JSON.stringify(

--- a/packages/qwik-city/middleware/azure-swa/index.ts
+++ b/packages/qwik-city/middleware/azure-swa/index.ts
@@ -33,6 +33,7 @@ export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
         }
       };
       const body = req.method === 'HEAD' || req.method === 'GET' ? undefined : getRequestBody();
+      const url = req.headers['x-ms-original-url']!;
       const options = {
         method: req.method,
         headers: req.headers,
@@ -42,14 +43,14 @@ export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
       const serverRequestEv: ServerRequestEvent<AzureResponse> = {
         mode: 'server',
         locale: undefined,
-        url: new URL(req.url),
+        url: new URL(url),
         platform: context,
         env: {
           get(key) {
             return process.env[key];
           },
         },
-        request: new Request(req.url, options as any),
+        request: new Request(url, options as any),
         getWritableStream: (status, headers, _cookies) => {
           res.status = status;
           headers.forEach((value, key) => (res.headers[key] = value));


### PR DESCRIPTION
This fixes two issues for Azure Static Web Apps adaptor:
- the URL was not taken from the header `x-ms-original-url`
- the function.json was missing the `scriptFile` entry

Fixes #2867

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

See above

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
