### PR TITLE
docs: code block style is ugly

### DIFF
--- a/packages/docs/src/components/code-block/code-block.light.css
+++ b/packages/docs/src/components/code-block/code-block.light.css
@@ -1,172 +1,172 @@
-/**
- * https://github.com/PrismJS/prism-themes/blob/master/themes/prism-vs.css
- * VS theme by Andrew Lock (https://andrewlock.net)
- * Inspired by Visual Studio syntax coloring
- */
+/*!***/
+/* * https://github.com/PrismJS/prism-themes/blob/master/themes/prism-vs.css*/
+/* * VS theme by Andrew Lock (https://andrewlock.net)*/
+/* * Inspired by Visual Studio syntax coloring*/
+/* *!*/
 
-code[class*='language-'],
-pre[class*='language-'] {
-  color: #393a34;
-  font-family: 'Consolas', 'Bitstream Vera Sans Mono', 'Courier New', Courier, monospace;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  font-size: 1.2em;
-  line-height: 1.2em;
-  text-shadow: none;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-}
+/*code[class*='language-'],*/
+/*pre[class*='language-'] {*/
+/*  color: #393a34;*/
+/*  font-family: 'Consolas', 'Bitstream Vera Sans Mono', 'Courier New', Courier, monospace;*/
+/*  direction: ltr;*/
+/*  text-align: left;*/
+/*  white-space: pre;*/
+/*  word-spacing: normal;*/
+/*  word-break: normal;*/
+/*  font-size: 1.2em;*/
+/*  line-height: 1.2em;*/
+/*  text-shadow: none;*/
+/*  -moz-tab-size: 4;*/
+/*  -o-tab-size: 4;*/
+/*  tab-size: 4;*/
+/*  -webkit-hyphens: none;*/
+/*  -moz-hyphens: none;*/
+/*  -ms-hyphens: none;*/
+/*  hyphens: none;*/
+/*}*/
 
-pre > code[class*='language-'] {
-  font-size: 1em;
-}
+/*pre > code[class*='language-'] {*/
+/*  font-size: 1em;*/
+/*}*/
 
-pre[class*='language-']::-moz-selection,
-pre[class*='language-'] ::-moz-selection,
-code[class*='language-']::-moz-selection,
-code[class*='language-'] ::-moz-selection {
-  background: #c1def1;
-}
+/*pre[class*='language-']::-moz-selection,*/
+/*pre[class*='language-'] ::-moz-selection,*/
+/*code[class*='language-']::-moz-selection,*/
+/*code[class*='language-'] ::-moz-selection {*/
+/*  background: #c1def1;*/
+/*}*/
 
-pre[class*='language-']::selection,
-pre[class*='language-'] ::selection,
-code[class*='language-']::selection,
-code[class*='language-'] ::selection {
-  background: #c1def1;
-}
+/*pre[class*='language-']::selection,*/
+/*pre[class*='language-'] ::selection,*/
+/*code[class*='language-']::selection,*/
+/*code[class*='language-'] ::selection {*/
+/*  background: #c1def1;*/
+/*}*/
 
-/* Code blocks */
-pre[class*='language-'] {
-  padding: 1em;
-  margin: 0.5em 0;
-  overflow: auto;
-  border: 1px solid #dddddd;
-  background-color: white;
-}
+/*!* Code blocks *!*/
+/*pre[class*='language-'] {*/
+/*  padding: 1em;*/
+/*  margin: 0.5em 0;*/
+/*  overflow: auto;*/
+/*  border: 1px solid #dddddd;*/
+/*  background-color: white;*/
+/*}*/
 
-/* Inline code */
-:not(pre) > code[class*='language-'] {
-  padding: 0.2em;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  background: #f8f8f8;
-  border: 1px solid #dddddd;
-}
+/*!* Inline code *!*/
+/*:not(pre) > code[class*='language-'] {*/
+/*  padding: 0.2em;*/
+/*  padding-top: 1px;*/
+/*  padding-bottom: 1px;*/
+/*  background: #f8f8f8;*/
+/*  border: 1px solid #dddddd;*/
+/*}*/
 
-.token.comment,
-.token.prolog,
-.token.doctype,
-.token.cdata {
-  color: #008000;
-  font-style: italic;
-}
+/*.token.comment,*/
+/*.token.prolog,*/
+/*.token.doctype,*/
+/*.token.cdata {*/
+/*  color: #008000;*/
+/*  font-style: italic;*/
+/*}*/
 
-.token.namespace {
-  opacity: 0.7;
-}
+/*.token.namespace {*/
+/*  opacity: 0.7;*/
+/*}*/
 
-.token.string {
-  color: #a31515;
-}
+/*.token.string {*/
+/*  color: #a31515;*/
+/*}*/
 
-.token.punctuation,
-.token.operator {
-  color: #393a34; /* no highlight */
-}
+/*.token.punctuation,*/
+/*.token.operator {*/
+/*  color: #393a34; !* no highlight *!*/
+/*}*/
 
-.token.url,
-.token.symbol,
-.token.number,
-.token.boolean,
-.token.variable,
-.token.constant,
-.token.inserted {
-  color: #36acaa;
-}
+/*.token.url,*/
+/*.token.symbol,*/
+/*.token.number,*/
+/*.token.boolean,*/
+/*.token.variable,*/
+/*.token.constant,*/
+/*.token.inserted {*/
+/*  color: #36acaa;*/
+/*}*/
 
-.token.atrule,
-.token.keyword,
-.token.attr-value,
-.language-autohotkey .token.selector,
-.language-json .token.boolean,
-.language-json .token.number,
-code[class*='language-css'] {
-  color: #0000ff;
-}
+/*.token.atrule,*/
+/*.token.keyword,*/
+/*.token.attr-value,*/
+/*.language-autohotkey .token.selector,*/
+/*.language-json .token.boolean,*/
+/*.language-json .token.number,*/
+/*code[class*='language-css'] {*/
+/*  color: #0000ff;*/
+/*}*/
 
-.token.function {
-  color: #393a34;
-}
+/*.token.function {*/
+/*  color: #393a34;*/
+/*}*/
 
-.token.deleted,
-.language-autohotkey .token.tag {
-  color: #9a050f;
-}
+/*.token.deleted,*/
+/*.language-autohotkey .token.tag {*/
+/*  color: #9a050f;*/
+/*}*/
 
-.token.selector,
-.language-autohotkey .token.keyword {
-  color: #00009f;
-}
+/*.token.selector,*/
+/*.language-autohotkey .token.keyword {*/
+/*  color: #00009f;*/
+/*}*/
 
-.token.important {
-  color: #e90;
-}
+/*.token.important {*/
+/*  color: #e90;*/
+/*}*/
 
-.token.important,
-.token.bold {
-  font-weight: bold;
-}
+/*.token.important,*/
+/*.token.bold {*/
+/*  font-weight: bold;*/
+/*}*/
 
-.token.italic {
-  font-style: italic;
-}
+/*.token.italic {*/
+/*  font-style: italic;*/
+/*}*/
 
-.token.class-name,
-.language-json .token.property {
-  color: #2b91af;
-}
+/*.token.class-name,*/
+/*.language-json .token.property {*/
+/*  color: #2b91af;*/
+/*}*/
 
-.token.tag,
-.token.selector {
-  color: #800000;
-}
+/*.token.tag,*/
+/*.token.selector {*/
+/*  color: #800000;*/
+/*}*/
 
-.token.attr-name,
-.token.property,
-.token.regex,
-.token.entity {
-  color: #ff0000;
-}
+/*.token.attr-name,*/
+/*.token.property,*/
+/*.token.regex,*/
+/*.token.entity {*/
+/*  color: #ff0000;*/
+/*}*/
 
-.token.directive.tag .tag {
-  background: #ffff00;
-  color: #393a34;
-}
+/*.token.directive.tag .tag {*/
+/*  background: #ffff00;*/
+/*  color: #393a34;*/
+/*}*/
 
-/* overrides color-values for the Line Numbers plugin
- * http://prismjs.com/plugins/line-numbers/
- */
-.line-numbers.line-numbers .line-numbers-rows {
-  border-right-color: #a5a5a5;
-}
+/*!* overrides color-values for the Line Numbers plugin*/
+/* * http://prismjs.com/plugins/line-numbers/*/
+/* *!*/
+/*.line-numbers.line-numbers .line-numbers-rows {*/
+/*  border-right-color: #a5a5a5;*/
+/*}*/
 
-.line-numbers .line-numbers-rows > span:before {
-  color: #2b91af;
-}
+/*.line-numbers .line-numbers-rows > span:before {*/
+/*  color: #2b91af;*/
+/*}*/
 
-/* overrides color-values for the Line Highlight plugin
-* http://prismjs.com/plugins/line-highlight/
-*/
-.line-highlight.line-highlight {
-  background: rgba(193, 222, 241, 0.2);
-  background: -webkit-linear-gradient(left, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));
-  background: linear-gradient(to right, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));
-}
+/*!* overrides color-values for the Line Highlight plugin*/
+/** http://prismjs.com/plugins/line-highlight/*/
+/**!*/
+/*.line-highlight.line-highlight {*/
+/*  background: rgba(193, 222, 241, 0.2);*/
+/*  background: -webkit-linear-gradient(left, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));*/
+/*  background: linear-gradient(to right, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));*/
+/*}*/


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

please see the code block in light theme, all code block style is ugly, even we can't see the content clearly.

I sovled it by commenting a css file.

<img width="722" alt="image" src="https://user-images.githubusercontent.com/20167257/217539811-19ce4c61-2620-43f4-b3c6-544112a4bfc3.png">

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
