### PR TITLE
fix: code allows sitemapOutFile to be null but type is wrong

### DIFF
--- a/packages/qwik-city/static/api.md
+++ b/packages/qwik-city/static/api.md
@@ -32,7 +32,7 @@ export interface StaticGenerateRenderOptions extends RenderOptions {
     maxWorkers?: number;
     origin: string;
     outDir: string;
-    sitemapOutFile?: string;
+    sitemapOutFile?: string | null;
 }
 
 // @alpha (undocumented)

--- a/packages/qwik-city/static/types.ts
+++ b/packages/qwik-city/static/types.ts
@@ -72,7 +72,7 @@ export interface StaticGenerateRenderOptions extends RenderOptions {
    * and written to the root of the `outDir`. Setting to `null` will prevent
    * the sitemap from being created.
    */
-  sitemapOutFile?: string;
+  sitemapOutFile?: string | null;
   /**
    * Log level.
    */


### PR DESCRIPTION
Fix #2872

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

See #2872

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
