### PR TITLE
fix(qwik-city): prevent duplicate call of resolve for response

### DIFF
--- a/packages/qwik-city/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/middleware/request-handler/request-event.ts
@@ -202,6 +202,10 @@ export function createRequestEvent(
 
     send: send as any,
 
+    isDirty: () => {
+      return writableStream !== null;
+    },
+
     getWritableStream: () => {
       if (writableStream === null) {
         writableStream = serverRequestEv.getWritableStream(
@@ -227,6 +231,12 @@ export interface RequestEventInternal extends RequestEvent, RequestEventLoader {
   [RequestEvTrailingSlash]: boolean;
   [RequestEvBasePathname]: string;
   [RequestEvRoute]: LoadedRoute | null;
+  /**
+   * Check if this request is already written to.
+   *
+   * @returns true, if `getWritableStream()` has already been called.
+   */
+  isDirty(): boolean;
 }
 
 export function getRequestLoaders(requestEv: RequestEventCommon) {

--- a/packages/qwik-city/middleware/request-handler/user-response.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.ts
@@ -1,6 +1,6 @@
 import type { ServerRequestEvent } from './types';
 import type { RequestEvent, RequestHandler } from '@builder.io/qwik-city';
-import { createRequestEvent } from './request-event';
+import { createRequestEvent, RequestEventInternal } from './request-event';
 import { ErrorResponse, getErrorHtml } from './error-handler';
 import { AbortMessage, RedirectMessage } from './redirect-handler';
 import type { LoadedRoute } from '../../runtime/src/types';
@@ -35,7 +35,7 @@ export function runQwikCity<T>(
   };
 }
 
-async function runNext(requestEv: RequestEvent, resolve: (value: any) => void) {
+async function runNext(requestEv: RequestEventInternal, resolve: (value: any) => void) {
   try {
     await requestEv.next();
   } catch (e) {
@@ -51,7 +51,9 @@ async function runNext(requestEv: RequestEvent, resolve: (value: any) => void) {
       return e;
     }
   } finally {
-    resolve(null);
+    if (!requestEv.isDirty()) {
+      resolve(null);
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently, for each request that is handled by Quik City the response promise is additionally resolved with a null value. This addresses this issue by checking if the request has been handled already.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
