### PR TITLE
fix(azure-swa): cleaner handling of responses for Azure Functions

### DIFF
--- a/packages/qwik-city/adapters/azure-swa/vite/index.ts
+++ b/packages/qwik-city/adapters/azure-swa/vite/index.ts
@@ -48,7 +48,7 @@ export function azureSwaAdapter(opts: AzureSwaAdapterOptions = {}): any {
             {
               type: 'http',
               direction: 'out',
-              name: 'response',
+              name: '$return',
             },
           ],
           scriptFile: azureSwaModulePath,

--- a/packages/qwik-city/middleware/azure-swa/index.ts
+++ b/packages/qwik-city/middleware/azure-swa/index.ts
@@ -2,11 +2,15 @@ import type { AzureFunction, Context, HttpRequest } from '@azure/functions';
 import type { RenderOptions } from '@builder.io/qwik';
 import type { Render } from '@builder.io/qwik/server';
 import qwikCityPlan from '@qwik-city-plan';
-import { requestHandler } from '@builder.io/qwik-city/middleware/request-handler';
+import {
+  mergeHeadersCookies,
+  requestHandler,
+} from '@builder.io/qwik-city/middleware/request-handler';
 import type {
   ServerRenderOptions,
   ServerRequestEvent,
 } from '@builder.io/qwik-city/middleware/request-handler';
+import { getNotFound } from '@qwik-city-not-found-paths';
 
 // @builder.io/qwik-city/middleware/azure-swa
 
@@ -21,10 +25,6 @@ interface AzureResponse {
  */
 export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
   async function onAzureSwaRequest(context: Context, req: HttpRequest): Promise<AzureResponse> {
-    const res: AzureResponse = (context.res = {
-      status: 200,
-      headers: {},
-    });
     try {
       const getRequestBody = async function* () {
         for await (const chunk of req as any) {
@@ -32,17 +32,18 @@ export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
         }
       };
       const body = req.method === 'HEAD' || req.method === 'GET' ? undefined : getRequestBody();
-      const url = req.headers['x-ms-original-url']!;
+      const url = new URL(req.headers['x-ms-original-url']!);
       const options = {
         method: req.method,
         headers: req.headers,
         body: body as any,
         duplex: 'half' as any,
       };
+
       const serverRequestEv: ServerRequestEvent<AzureResponse> = {
         mode: 'server',
         locale: undefined,
-        url: new URL(url),
+        url,
         platform: context,
         env: {
           get(key) {
@@ -50,18 +51,38 @@ export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
           },
         },
         request: new Request(url, options as any),
-        getWritableStream: (status, headers, _cookies) => {
-          res.status = status;
-          headers.forEach((value, key) => (res.headers[key] = value));
-          return new WritableStream(new AzureWritableStreamSink(res));
+        getWritableStream: (status, headers, cookies, resolve) => {
+          const response: AzureResponse = {
+            status,
+            body: new Uint8Array(),
+            headers: {},
+          };
+          mergeHeadersCookies(headers, cookies).forEach(
+            (value, key) => (response.headers[key] = value)
+          );
+          return new WritableStream({
+            write(chunk: Uint8Array) {
+              if (response.body instanceof Uint8Array) {
+                const newBuffer = new Uint8Array(response.body.length + chunk.length);
+                newBuffer.set(response.body);
+                newBuffer.set(chunk, response.body.length);
+                response.body = newBuffer;
+              }
+            },
+            close() {
+              resolve(response);
+            },
+          });
         },
       };
 
       // send request to qwik city request handler
       const handledResponse = await requestHandler(serverRequestEv, opts);
       if (handledResponse) {
-        handledResponse.completion.then((v) => {
-          console.error(v);
+        handledResponse.completion.then((err) => {
+          if (err) {
+            console.error(err);
+          }
         });
         const response = await handledResponse.response;
         if (response) {
@@ -70,17 +91,19 @@ export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
       }
 
       // qwik city did not have a route for this request
-      // respond with qwik city's 404 handler
-      // const notFoundResponse = await notFoundHandler<void>(serverRequestEv);
-      // return notFoundResponse;
-      return res;
+      // response with 404 for this pathname
+      const notFoundHtml = getNotFound(url.pathname);
+      return {
+        status: 404,
+        headers: { 'Content-Type': 'text/html; charset=utf-8', 'X-Not-Found': url.pathname },
+        body: notFoundHtml,
+      };
     } catch (e: any) {
       console.error(e);
-      context.res = {
+      return {
         status: 500,
         headers: { 'Content-Type': 'text/plain; charset=utf-8' },
       };
-      return res;
     }
   }
 
@@ -113,24 +136,4 @@ export interface EventPluginContext extends Context {}
  */
 export function qwikCity(render: Render, opts?: RenderOptions) {
   return createQwikCity({ render, qwikCityPlan, ...opts });
-}
-
-/**
- * Aggregates the response to a `Uint8Array` and writes it to the Azure response.
- */
-class AzureWritableStreamSink implements UnderlyingSink<Uint8Array> {
-  private buffer!: Uint8Array;
-  constructor(private res: AzureResponse) {}
-  start() {
-    this.buffer = new Uint8Array();
-  }
-  write(chunk: Uint8Array) {
-    const newBuffer = new Uint8Array(this.buffer.length + chunk.length);
-    newBuffer.set(this.buffer);
-    newBuffer.set(chunk, this.buffer.length);
-    this.buffer = newBuffer;
-  }
-  close() {
-    this.res.body = this.buffer;
-  }
 }

--- a/packages/qwik-city/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/middleware/request-handler/request-event.ts
@@ -202,6 +202,10 @@ export function createRequestEvent(
 
     send: send as any,
 
+    isDirty: () => {
+      return writableStream !== null;
+    },
+
     getWritableStream: () => {
       if (writableStream === null) {
         writableStream = serverRequestEv.getWritableStream(
@@ -227,6 +231,12 @@ export interface RequestEventInternal extends RequestEvent, RequestEventLoader {
   [RequestEvTrailingSlash]: boolean;
   [RequestEvBasePathname]: string;
   [RequestEvRoute]: LoadedRoute | null;
+  /**
+   * Check if this request is already written to.
+   *
+   * @returns true, if `getWritableStream()` has already been called.
+   */
+  isDirty(): boolean;
 }
 
 export function getRequestLoaders(requestEv: RequestEventCommon) {

--- a/packages/qwik-city/middleware/request-handler/user-response.ts
+++ b/packages/qwik-city/middleware/request-handler/user-response.ts
@@ -1,6 +1,6 @@
 import type { ServerRequestEvent } from './types';
 import type { RequestEvent, RequestHandler } from '@builder.io/qwik-city';
-import { createRequestEvent } from './request-event';
+import { createRequestEvent, RequestEventInternal } from './request-event';
 import { ErrorResponse, getErrorHtml } from './error-handler';
 import { AbortMessage, RedirectMessage } from './redirect-handler';
 import type { LoadedRoute } from '../../runtime/src/types';
@@ -35,7 +35,7 @@ export function runQwikCity<T>(
   };
 }
 
-async function runNext(requestEv: RequestEvent, resolve: (value: any) => void) {
+async function runNext(requestEv: RequestEventInternal, resolve: (value: any) => void) {
   try {
     await requestEv.next();
   } catch (e) {
@@ -51,7 +51,9 @@ async function runNext(requestEv: RequestEvent, resolve: (value: any) => void) {
       return e;
     }
   } finally {
-    resolve(null);
+    if (!requestEv.isDirty()) {
+      resolve(null);
+    }
   }
   return undefined;
 }

--- a/starters/adapters/azure-swa/adapters/azure-swa/vite.config.ts
+++ b/starters/adapters/azure-swa/adapters/azure-swa/vite.config.ts
@@ -19,6 +19,12 @@ export default extendConfig(baseConfig, () => {
       target: 'webworker',
       noExternal: true,
     },
-    plugins: [azureSwaAdapter()],
+    plugins: [
+      azureSwaAdapter({
+        ssg: {
+          include: ['/'],
+        },
+      }),
+    ],
   };
 });

--- a/starters/adapters/azure-swa/public/staticwebapp.config.json
+++ b/starters/adapters/azure-swa/public/staticwebapp.config.json
@@ -1,22 +1,11 @@
 {
   "routes": [
     {
-      "route": "/build/*"
+      "route": "/",
+      "rewrite": "/api/render"
     },
     {
-      "route": "/favicon.svg"
-    },
-    {
-      "route": "/manifest.json"
-    },
-    {
-      "route": "/service-worker.js"
-    },
-    {
-      "route": "/.auth/*"
-    },
-    {
-      "route": "/*",
+      "route": "/index.html",
       "rewrite": "/api/render"
     }
   ],


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

This is based on #2908 

This changes the handling of Azure Static Web Apps:
- The Azure function now returns the response directly ('$return')
- Route handling is now simple - we mostly use navigationFallback
- '/' and '/index.html' have to be rewritten because Azure will not accept a dist folder without index.html. The build also generates  a static index.html for the same reason.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
