### PR TITLE
fix(qwik-city): remove of logging 'undfined' on every request

### DIFF
--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -67,7 +67,9 @@ export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
       const handledResponse = await requestHandler(serverRequestEv, opts);
       if (handledResponse) {
         handledResponse.completion.then((v) => {
-          console.error(v);
+          if (v) {
+            console.error(v);
+          }
         });
         const response = await handledResponse.response;
         if (response) {

--- a/packages/qwik-city/middleware/netlify-edge/index.ts
+++ b/packages/qwik-city/middleware/netlify-edge/index.ts
@@ -49,7 +49,9 @@ export function createQwikCity(opts: QwikCityNetlifyOptions) {
       const handledResponse = await requestHandler(serverRequestEv, opts);
       if (handledResponse) {
         handledResponse.completion.then((v) => {
-          console.error(v);
+          if (v) {
+            console.error(v);
+          }
         });
         const response = await handledResponse.response;
         if (response) {

--- a/packages/qwik-city/middleware/vercel-edge/index.ts
+++ b/packages/qwik-city/middleware/vercel-edge/index.ts
@@ -54,7 +54,9 @@ export function createQwikCity(opts: QwikCityVercelEdgeOptions) {
       const handledResponse = await requestHandler(serverRequestEv, opts);
       if (handledResponse) {
         handledResponse.completion.then((v) => {
-          console.error(v);
+          if (v) {
+            console.error(v);
+          }
         });
         const response = await handledResponse.response;
         if (response) {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently, the adapters for all cloud providers log `undefined` on every request:
```
GET /build/q-3b0826ee.js 200 OK (2.32ms)
undefined        <- this is logged with every handled request
GET /q-data.json 200 OK (3.08ms)
GET /build/q-6d5bf18c.js 200 OK (2.74ms)
undefined        <- this is logged with every handled request
GET /static/idk/q-data.json 404 Not Found (2.84ms)
```` 

This is because the `handledResponse.completion` is resolved with `undefined` when no error occurs.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
