### PR TITLE
fix(azure-swa): handling of non-GET requests in Azure adapter

### DIFF
--- a/packages/qwik-city/middleware/azure-swa/index.ts
+++ b/packages/qwik-city/middleware/azure-swa/index.ts
@@ -26,17 +26,11 @@ interface AzureResponse {
 export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
   async function onAzureSwaRequest(context: Context, req: HttpRequest): Promise<AzureResponse> {
     try {
-      const getRequestBody = async function* () {
-        for await (const chunk of req as any) {
-          yield chunk;
-        }
-      };
-      const body = req.method === 'HEAD' || req.method === 'GET' ? undefined : getRequestBody();
       const url = new URL(req.headers['x-ms-original-url']!);
       const options = {
         method: req.method,
         headers: req.headers,
-        body: body as any,
+        body: req.body,
         duplex: 'half' as any,
       };
 

--- a/starters/adapters/azure-swa/public/staticwebapp.config.json
+++ b/starters/adapters/azure-swa/public/staticwebapp.config.json
@@ -1,6 +1,11 @@
 {
   "routes": [
     {
+      "route": "*",
+      "methods": ["POST", "PUT", "DELETE"],
+      "rewrite": "/api/render"
+    },
+    {
       "route": "/",
       "rewrite": "/api/render"
     },


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

The Azure adapter needed an additional route for non-GET requests.

Another issue was the body handling - this was copied from the Node.js middleware and this implementation was not compatible with Azure.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
