### PR TITLE
Add essential url fields to RouteLocation

### DIFF
--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -322,16 +322,18 @@ routeBundleNames: string[]
 
 // @alpha (undocumented)
 export interface RouteLocation {
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly href: string;
     // (undocumented)
     readonly isNavigating: boolean;
     // (undocumented)
     readonly params: Readonly<Record<string, string>>;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly pathname: string;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly query: URLSearchParams;
+    // (undocumented)
+    readonly url: URL;
 }
 
 // @alpha (undocumented)

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -80,6 +80,7 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
 
   const url = new URL(urlEnv);
   const routeLocation = useStore<MutableRouteLocation>({
+    url,
     href: url.href,
     pathname: url.pathname,
     query: url.searchParams,
@@ -124,7 +125,7 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
       navPath.value = '';
       navPath.value = value;
     }
-    const prefetchURL = new URL(navPath.value, routeLocation.href);
+    const prefetchURL = new URL(navPath.value, routeLocation.url);
     loadClientData(prefetchURL);
     loadRoute(routes, menus, cacheModules, prefetchURL.pathname);
 
@@ -144,7 +145,7 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
     async function run() {
       const [path, action] = track(() => [navPath.value, actionState.value]);
       const locale = getLocale('');
-      let url = new URL(path, routeLocation.href);
+      let url = new URL(path, routeLocation.url);
       let clientPageData: EndpointResponse | ClientPageData | undefined;
       let loadedRoute: LoadedRoute | null = null;
       if (isServer) {
@@ -181,6 +182,7 @@ export const QwikCityProvider = component$<QwikCityProps>(() => {
         const pageModule = contentModules[contentModules.length - 1] as PageModule;
 
         // Update route location
+        routeLocation.url = url;
         routeLocation.href = url.href;
         routeLocation.pathname = url.pathname;
         routeLocation.params = { ...params };
@@ -253,6 +255,7 @@ export const QwikCityMockProvider = component$<QwikCityMockProps>((props) => {
   const urlEnv = props.url ?? 'http://localhost/';
   const url = new URL(urlEnv);
   const routeLocation = useStore<MutableRouteLocation>({
+    url,
     href: url.href,
     pathname: url.pathname,
     query: url.searchParams,

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -55,8 +55,18 @@ export interface MenuModule {
  */
 export interface RouteLocation {
   readonly params: Readonly<Record<string, string>>;
+  readonly url: URL;
+  /**
+   * @deprecated Please use `url` instead of href
+   */
   readonly href: string;
+  /**
+   * @deprecated Please use `url` instead of pathname
+   */
   readonly pathname: string;
+  /**
+   * @deprecated Please use `url` instead of query
+   */
   readonly query: URLSearchParams;
   readonly isNavigating: boolean;
 }


### PR DESCRIPTION
# What is it?
Add essential url fields to RouteLocation

- [√] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
Add `url` to RouteLocation so `useLocation()` can provide access to essential fields.

# Use cases and why
Without easy access to `protocol`, `host`, `port`, etc., the developer is required to write redundant code to extract them from a potentially complex `href` string. This should be easily available. Coincidentally, this also helps resolve the missing fields from `useLocation()` discussed in-part in Issue #2873.

```typescript
  const location = useLocation();
  console.log("location =", location);
```

**BEFORE:**
```console
location = {
  href: 'http://localhost:5173/foo/',
  pathname: '/foo/',
  query: URLSearchParams {},
  params: {},
  isNavigating: false
}
```

**AFTER:**
```console
location = {
  url: URL {
    href: 'http://localhost:5173/foo/',
    origin: 'http://localhost:5173',
    protocol: 'http:',
    username: '',
    password: '',
    host: 'localhost:5173',
    hostname: 'localhost',
    port: '5173',
    pathname: '/foo/',
    search: '',
    searchParams: URLSearchParams {},
    hash: ''
  },
  href: 'http://localhost:5173/foo/',
  pathname: '/foo/',
  query: URLSearchParams {},
  params: {},
  isNavigating: false
}
```

@manucorporat, Would you mind taking a quick look at `goto` line 127 and `useTask$` line 147 changes? Please make any changes you deem necessary to make mergable -- Thank you.

_**Also**, from exploring uses of the location object within the project, it appears there may be opportunities to simplify code once the deprecated fields are removed._

# Checklist:

- [√] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [√] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
