### PR TITLE
docs: fix some errors in docs

### DIFF
--- a/packages/docs/src/routes/docs/advanced/containers/index.mdx
+++ b/packages/docs/src/routes/docs/advanced/containers/index.mdx
@@ -38,7 +38,7 @@ The code above will render the following HTML:
 
 In the example above, the `lang` attribute is added to the `<html>` container element.
 
-> Note that this attribute will not be reactive, if the app needs to change this value dynamically, it will need to do though manual DOM manipulation.
+> Note that this attribute will not be reactive, if the app needs to change this value dynamically, it will need to do through manual DOM manipulation.
 
 Along with the custom attributes, Qwik will automatically render the `q:container`, `q:version`, `q:render` and `q:base` attributes.
 

--- a/packages/docs/src/routes/docs/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/getting-started/index.mdx
@@ -25,7 +25,7 @@ The first step is to create an application. Qwik comes with a CLI that allows yo
 
 ### Run the Qwik CLI in your shell
 
-Choose the package manager you prefer and run the following command:
+Choose the package manager you prefer and run one of the following command:
 
 ```shell
 npm create qwik@latest

--- a/packages/docs/src/routes/qwikcity/action/index.mdx
+++ b/packages/docs/src/routes/qwikcity/action/index.mdx
@@ -113,7 +113,7 @@ When submitting data to an action by default, the data is not validated.
 ```tsx
 // src/routes/index.tsx
 
-import { action$, Form } from '@builder.io/qwik-city';
+import { action$ } from '@builder.io/qwik-city';
 
 export const addUser = action$((user) => {
   // `user` is typed Record<string, any>

--- a/packages/docs/src/routes/qwikcity/api/index.mdx
+++ b/packages/docs/src/routes/qwikcity/api/index.mdx
@@ -45,6 +45,7 @@ export interface RouteLocation {
   readonly href: string;
   readonly pathname: string;
   readonly query: Record<string, string>;
+  readonly isNavigating: boolean;
 }
 ```
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

dosc: fix some errors.

* though => through
* add isNavigating to interface RouteLocation
* add `one of` to make the statement smooth
* remove unused `Form` api in an example


