### PR TITLE
Fix linting errors and warnings in starters.

### DIFF
--- a/starters/apps/basic/src/routes/flower/index.tsx
+++ b/starters/apps/basic/src/routes/flower/index.tsx
@@ -1,5 +1,5 @@
 import { component$, useClientEffect$, useStore, useStylesScoped$ } from '@builder.io/qwik';
-import { DocumentHead, useLocation } from '@builder.io/qwik-city';
+import { type DocumentHead, useLocation } from '@builder.io/qwik-city';
 import styles from './flower.css?inline';
 
 export default component$(() => {
@@ -35,7 +35,7 @@ export default component$(() => {
         }}
         class={{
           host: true,
-          pride: loc.query['pride'] === 'true',
+          pride: loc.query.get('pride') === 'true',
         }}
       >
         {Array.from({ length: state.number }, (_, i) => (

--- a/starters/apps/basic/src/routes/todolist/index.tsx
+++ b/starters/apps/basic/src/routes/todolist/index.tsx
@@ -1,5 +1,5 @@
 import { component$ } from '@builder.io/qwik';
-import { DocumentHead, loader$, action$, zod$, z, Form } from '@builder.io/qwik-city';
+import { type DocumentHead, loader$, action$, zod$, z, Form } from '@builder.io/qwik-city';
 
 interface ListItem {
   text: string;

--- a/starters/apps/qwikcity-test/src/routes/(common)/products/404.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/products/404.tsx
@@ -1,5 +1,5 @@
 import { component$ } from '@builder.io/qwik';
-import { useLocation, DocumentHead } from '@builder.io/qwik-city';
+import { useLocation, type DocumentHead } from '@builder.io/qwik-city';
 
 export default component$(() => {
   const { params } = useLocation();

--- a/starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx
@@ -1,5 +1,5 @@
 import { component$ } from '@builder.io/qwik';
-import { useLocation, DocumentHead } from '@builder.io/qwik-city';
+import { useLocation, type DocumentHead } from '@builder.io/qwik-city';
 
 export default component$(() => {
   const { pathname, params } = useLocation();


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently, creating a new project in the CLI will have warnings and errors before you've even changed a file. 

Explicitly sets adds the type keyword to imported types and fixes a URLSearchParams access that throws a typescript error.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
