### PR TITLE
refactor: useClientEffect to useOnVisibleTask

### DIFF
--- a/.vscode/qwik.code-snippets
+++ b/.vscode/qwik.code-snippets
@@ -49,12 +49,12 @@
 			""
 		]
 	},
-	"useOnVisibleTask": {
+	"useBrowserVisibleTask": {
 		"scope": "javascriptreact,typescriptreact",
-		"prefix": "q:useOnVisibleTask",
-		"description": "useOnVisibleTask$() function hook",
+		"prefix": "q:useBrowserVisibleTask",
+		"description": "useBrowserVisibleTask$() function hook",
 		"body": [
-			"useOnVisibleTask$(({ track }) => {",
+			"useBrowserVisibleTask$(({ track }) => {",
 			"  $0",
 			"});",
 			""

--- a/.vscode/qwik.code-snippets
+++ b/.vscode/qwik.code-snippets
@@ -49,12 +49,12 @@
 			""
 		]
 	},
-	"useClientEffect": {
+	"useOnVisibleTask": {
 		"scope": "javascriptreact,typescriptreact",
-		"prefix": "q:useClientEffect",
-		"description": "useClientEffect$() function hook",
+		"prefix": "q:useOnVisibleTask",
+		"description": "useOnVisibleTask$() function hook",
 		"body": [
-			"useClientEffect$(({ track }) => {",
+			"useOnVisibleTask$(({ track }) => {",
 			"  $0",
 			"});",
 			""

--- a/packages/docs/src/routes/docs/components/lifecycle/index.mdx
+++ b/packages/docs/src/routes/docs/components/lifecycle/index.mdx
@@ -13,24 +13,30 @@ import diagram from './diagram2.svg';
 
 Thanks to [Resumability](/docs/concepts/resumable/index.mdx), components life and its lifecycle extend across server and browser. Sometimes the component will be first rendered in the server, sometimes it could be in the browser, however, in both cases the lifecycle will be the same, only its execution happens in different environments.
 
-Usually **the life of a component starts on the server** (during SSR or SSG), in that case, the hooks will run like this:
+**In Qwik, there is only 3 lifecycles stages:**
+
+- `Task` - runs before rendering and when tracked state changes
+- `Render` - runs after `TASK` and before `VisibleTask`
+- `VisibleTask` - runs after `Render` and when the component becomes visible
 
 ```
-  useTask$ --> RENDER --> useClientEffect$
-                       |
-| ------ SERVER ------ | ---- BROWSER ---- |
-                       |
-                  pause|resume
+  useTask$ ------> RENDER -----> useOnVisibleTask$
+                            |
+| --- SERVER or BROWSER --- | ----- BROWSER ----- |
+                            |
+                       pause|resume
 ```
+
+**SERVER**: Usually **the life of a component starts on the server** (during SSR or SSG), in that case, the `useTask$` and `RENDER` will run in the server, and then the `VisibleTask` will run in the browser, after the component is visible.
 
 > **Notice** that because the component was mounted in the server, **only useClientEffect$() runs in the browser**. This is because the browser continues the same lifecycle, that was paused in the server right after the render and resumed in the browser.
 
-Sometimes a component will be first mounted/rendered in the browser, for example when the user SPA navigates to a new page, or a "modal" component first appears in the page. In that case, the lifecycle will run like this:
+**BROWSER**: Sometimes a component will be first mounted/rendered in the browser, for example when the user SPA navigates to a new page, or a "modal" component first appears in the page. In that case, the lifecycle will run like this:
 
 ```
-  useTask$ --> RENDER --> useClientEffect$
+  useTask$ --> RENDER --> useOnVisibleTask$
 
-| --------------- BROWSER --------------- |
+| ---------------- BROWSER --------------- |
 ```
 
 > **Notice** that the lifecycle is exactly the same, but this time all the hooks run in the browser, and non in the server.
@@ -145,25 +151,37 @@ export const Cmp = component$(() => {
 
 > But as mentioned above - for data fetching, consider using [`useResource$()`](/docs/components/resource/index.mdx) instead.
 
-## `useClientEffect$()`
+## `useOnVisibleTask$()`
 
-- **When:** AFTER component's first render and on tracked state changes
+- **When:** once the component becomes visible on the browser, and when tracked state changes
 - **Times:** at least once
 - **Platform:** browser only
 
-For all components that got mounted during SSR (in the server), the `useClientEffect$()` will run eagerly\, that means, without user interaction, but the eagerness can be configured!
+`useOnVisibleTask$()` registers a hook to be executed when the component becomes visible in the viewport, it will run at least once in the browser, and it can be reactive and re-execute when some **tracked** [signal or store](/docs/components/state/index.mdx) changes, like this:
+
+```tsx
+useOnVisibleTask$(({ track }) => {
+  track(() => store.count);
+  // will run when the component becomes visible and every time "store.count" changes
+  console.log('runs in the browser');
+});
+```
+
+Under the hood, `useOnVisibleTask$()` creates a DOM listener that uses [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to detect when the component becomes visible in the viewport.
+
+However this `strategy` can be changed, and for example, run when the `document` is ready.
 
 ```tsx
 useClientEffect$(() => console.log('runs in the browser'), {
-  eagerness: 'visible', // 'load' | 'visible' | 'idle'
+  strategy: 'document-ready', // 'load' | 'visible' | 'idle'
 });
 ```
 
 This is a unique feature of Qwik, any other frameworks would execute this and other code as part of hydration, but in Qwik, you can actually specify when it happens:
 
-- `"visible"`: (this is the default) when the component becomes visible in the viewport (uses [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) under the hood).
-- `"load"`: when the documents finish loading (the document's "load" event)
-- `"idle"`: after load the first moment the site becomes idle. It uses [`requestIdleCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) under the hood.
+- `"intersection-observer"`: (this is the default) when the component becomes visible in the viewport (uses [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) under the hood).
+- `"document-ready"`: when the documents finish loading (the document's "load" event)
+- `"document-idle"`: after load the first moment the site becomes idle. It uses [`requestIdleCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) under the hood.
 
 ### Example
 
@@ -172,7 +190,7 @@ export const Timer = component$(() => {
   const store = useStore({
     count: 0,
   });
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     // Only runs in the client
     const timer = setInterval(() => {
       store.count++;
@@ -185,23 +203,18 @@ export const Timer = component$(() => {
 });
 ```
 
-> **NOTE:** Don't abuse `useClientEffect$()` when the same logic can be achieved using `useTask$()` or other means. Ask to yourself: Does this code really need to run at the beginning in the browser? If the answer is no, `useClientEffect$()` is probably not the right answer.
+> **NOTE:** Don't abuse `useOnVisibleTask$()` when the same logic can be achieved using `useTask$()` or other means. Ask to yourself: Does this code really need to run at the beginning in the browser? If the answer is no, `useOnVisibleTask$()` is probably not the right answer.
 
-### When to use `useClientEffect$()`
+### When to use `useOnVisibleTask$()`
 
-Use this hook when you need to run JS right at loading time of the page, even if the user never interacts with the page.
+> **NOTE:** Don't abuse `useOnVisibleTask$()` when the same logic can be achieved using `useTask$()` or other means. Ask to yourself: Does this code really need to run at the beginning in the browser? If the answer is no, `useOnVisibleTask$()` is probably not the right answer.
 
-For example:
+As the name implies, `useOnVisibleTask$()` is useful when you need to run some code when the component becomes visible in the viewport. This is useful for:
 
+- Run code BEFORE user interaction, like animations, or other logic that needs to run before user interaction.
 - Read the DOM after rendering
 - Initialize some animations
 - WebGL logic
-- Use DOM APIs like `localStorage`
-- Run some code without user interaction, like a setInterval()
-
-#### How does it compare with React's `useEffect()`?
-
-Both APIs share a lot of semantics, but while both run AFTER rendering, `useClientEffect$()` can run also independently from rendering.
 
 ## Use Method Rules
 

--- a/packages/docs/src/routes/docs/components/lifecycle/index.mdx
+++ b/packages/docs/src/routes/docs/components/lifecycle/index.mdx
@@ -20,7 +20,7 @@ Thanks to [Resumability](/docs/concepts/resumable/index.mdx), components life an
 - `VisibleTask` - runs after `Render` and when the component becomes visible
 
 ```
-  useTask$ ------> RENDER -----> useOnVisibleTask$
+  useTask$ ------> RENDER -----> useBrowserVisibleTask$
                             |
 | --- SERVER or BROWSER --- | ----- BROWSER ----- |
                             |
@@ -34,7 +34,7 @@ Thanks to [Resumability](/docs/concepts/resumable/index.mdx), components life an
 **BROWSER**: Sometimes a component will be first mounted/rendered in the browser, for example when the user SPA navigates to a new page, or a "modal" component first appears in the page. In that case, the lifecycle will run like this:
 
 ```
-  useTask$ --> RENDER --> useOnVisibleTask$
+  useTask$ --> RENDER --> useBrowserVisibleTask$
 
 | ---------------- BROWSER --------------- |
 ```
@@ -151,23 +151,23 @@ export const Cmp = component$(() => {
 
 > But as mentioned above - for data fetching, consider using [`useResource$()`](/docs/components/resource/index.mdx) instead.
 
-## `useOnVisibleTask$()`
+## `useBrowserVisibleTask$()`
 
 - **When:** once the component becomes visible on the browser, and when tracked state changes
 - **Times:** at least once
 - **Platform:** browser only
 
-`useOnVisibleTask$()` registers a hook to be executed when the component becomes visible in the viewport, it will run at least once in the browser, and it can be reactive and re-execute when some **tracked** [signal or store](/docs/components/state/index.mdx) changes, like this:
+`useBrowserVisibleTask$()` registers a hook to be executed when the component becomes visible in the viewport, it will run at least once in the browser, and it can be reactive and re-execute when some **tracked** [signal or store](/docs/components/state/index.mdx) changes, like this:
 
 ```tsx
-useOnVisibleTask$(({ track }) => {
+useBrowserVisibleTask$(({ track }) => {
   track(() => store.count);
   // will run when the component becomes visible and every time "store.count" changes
   console.log('runs in the browser');
 });
 ```
 
-Under the hood, `useOnVisibleTask$()` creates a DOM listener that uses [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to detect when the component becomes visible in the viewport.
+Under the hood, `useBrowserVisibleTask$()` creates a DOM listener that uses [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to detect when the component becomes visible in the viewport.
 
 However this `strategy` can be changed, and for example, run when the `document` is ready.
 
@@ -190,7 +190,7 @@ export const Timer = component$(() => {
   const store = useStore({
     count: 0,
   });
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     // Only runs in the client
     const timer = setInterval(() => {
       store.count++;
@@ -203,13 +203,13 @@ export const Timer = component$(() => {
 });
 ```
 
-> **NOTE:** Don't abuse `useOnVisibleTask$()` when the same logic can be achieved using `useTask$()` or other means. Ask to yourself: Does this code really need to run at the beginning in the browser? If the answer is no, `useOnVisibleTask$()` is probably not the right answer.
+> **NOTE:** Don't abuse `useBrowserVisibleTask$()` when the same logic can be achieved using `useTask$()` or other means. Ask to yourself: Does this code really need to run at the beginning in the browser? If the answer is no, `useBrowserVisibleTask$()` is probably not the right answer.
 
-### When to use `useOnVisibleTask$()`
+### When to use `useBrowserVisibleTask$()`
 
-> **NOTE:** Don't abuse `useOnVisibleTask$()` when the same logic can be achieved using `useTask$()` or other means. Ask to yourself: Does this code really need to run at the beginning in the browser? If the answer is no, `useOnVisibleTask$()` is probably not the right answer.
+> **NOTE:** Don't abuse `useBrowserVisibleTask$()` when the same logic can be achieved using `useTask$()` or other means. Ask to yourself: Does this code really need to run at the beginning in the browser? If the answer is no, `useBrowserVisibleTask$()` is probably not the right answer.
 
-As the name implies, `useOnVisibleTask$()` is useful when you need to run some code when the component becomes visible in the viewport. This is useful for:
+As the name implies, `useBrowserVisibleTask$()` is useful when you need to run some code when the component becomes visible in the viewport. This is useful for:
 
 - Run code BEFORE user interaction, like animations, or other logic that needs to run before user interaction.
 - Read the DOM after rendering

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -899,6 +899,12 @@ export interface Tracker {
 // @alpha (undocumented)
 export const untrack: <T>(fn: () => T) => T;
 
+// @public
+export const useBrowserVisibleTask$: (first: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void;
+
+// @public
+export const useBrowserVisibleTaskQrl: (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOptions) => void;
+
 // @alpha @deprecated
 export const useCleanup$: (first: () => void) => void;
 
@@ -950,12 +956,6 @@ export const useOn: (event: string | string[], eventQrl: QRL<(ev: Event) => void
 
 // @alpha
 export const useOnDocument: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;
-
-// @public
-export const useOnVisibleTask$: (first: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void;
-
-// @public
-export const useOnVisibleTaskQrl: (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOptions) => void;
 
 // @alpha
 export const useOnWindow: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -368,6 +368,13 @@ export const noSerialize: <T extends object | undefined>(input: T) => NoSerializ
 // @public (undocumented)
 export type OnRenderFn<PROPS> = (props: PROPS) => JSXNode<any> | null;
 
+// @public (undocumented)
+export interface OnVisibleTaskOptions {
+    // @deprecated (undocumented)
+    eagerness?: EagernessOptions;
+    strategy?: VisibleTaskStrategy;
+}
+
 // Warning: (ae-forgotten-export) The symbol "QContext" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ContainerState" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "GetObjID" needs to be exported by the entry point index.d.ts
@@ -891,6 +898,12 @@ export const useCleanup$: (first: () => void) => void;
 // @alpha @deprecated
 export const useCleanupQrl: (unmountFn: QRL<() => void>) => void;
 
+// @alpha @deprecated (undocumented)
+export const useClientEffect$: (first: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void;
+
+// @alpha @deprecated (undocumented)
+export const useClientEffectQrl: (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOptions) => void;
+
 // @public @deprecated
 export const useClientMount$: <T>(first: MountFn<T>) => void;
 
@@ -904,11 +917,6 @@ export const useContext: UseContext;
 
 // @public
 export const useContextProvider: <STATE extends object>(context: Context<STATE>, newValue: STATE) => void;
-
-// @public (undocumented)
-export interface UseEffectOptions {
-    eagerness?: EagernessOptions;
-}
 
 // @alpha @deprecated (undocumented)
 export const useEnvData: typeof useServerData;
@@ -937,10 +945,10 @@ export const useOn: (event: string | string[], eventQrl: QRL<(ev: Event) => void
 export const useOnDocument: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;
 
 // @public
-export const useOnVisibleTask$: (first: TaskFn, opts?: UseEffectOptions | undefined) => void;
+export const useOnVisibleTask$: (first: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void;
 
 // @public
-export const useOnVisibleTaskQrl: (qrl: QRL<TaskFn>, opts?: UseEffectOptions) => void;
+export const useOnVisibleTaskQrl: (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOptions) => void;
 
 // @alpha
 export const useOnWindow: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;
@@ -1034,6 +1042,9 @@ export const _verifySerializable: <T>(value: T, preMessage?: string) => T;
 
 // @public
 export const version: string;
+
+// @public (undocumented)
+export type VisibleTaskStrategy = 'intersection-observer' | 'document-ready' | 'document-idle';
 
 // @internal (undocumented)
 export const _weakSerialize: <T extends Record<string, any>>(input: T) => Partial<T>;

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -891,12 +891,6 @@ export const useCleanup$: (first: () => void) => void;
 // @alpha @deprecated
 export const useCleanupQrl: (unmountFn: QRL<() => void>) => void;
 
-// @public
-export const useClientEffect$: (first: TaskFn, opts?: UseEffectOptions | undefined) => void;
-
-// @public
-export const useClientEffectQrl: (qrl: QRL<TaskFn>, opts?: UseEffectOptions) => void;
-
 // @public @deprecated
 export const useClientMount$: <T>(first: MountFn<T>) => void;
 
@@ -941,6 +935,12 @@ export const useOn: (event: string | string[], eventQrl: QRL<(ev: Event) => void
 
 // @alpha
 export const useOnDocument: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;
+
+// @public
+export const useOnVisibleTask$: (first: TaskFn, opts?: UseEffectOptions | undefined) => void;
+
+// @public
+export const useOnVisibleTaskQrl: (qrl: QRL<TaskFn>, opts?: UseEffectOptions) => void;
 
 // @alpha
 export const useOnWindow: (event: string | string[], eventQrl: QRL<(ev: Event) => void>) => void;

--- a/packages/qwik/src/core/examples.tsx
+++ b/packages/qwik/src/core/examples.tsx
@@ -12,7 +12,7 @@ import { $, QRL } from './qrl/qrl.public';
 import { useOn, useOnDocument, useOnWindow } from './use/use-on';
 import { useStore } from './use/use-store.public';
 import { useStyles$, useStylesScoped$ } from './use/use-styles';
-import { useClientEffect$, useTask$ } from './use/use-task';
+import { useOnVisibleTask$, useTask$ } from './use/use-task';
 import { implicit$FirstArg } from './util/implicit_dollar';
 
 //////////////////////////////////////////////////////////
@@ -309,7 +309,7 @@ export const CmpInline = component$(() => {
       count: 0,
     });
 
-    useClientEffect$(() => {
+    useOnVisibleTask$(() => {
       // Only runs in the client
       const timer = setInterval(() => {
         store.count++;
@@ -360,7 +360,7 @@ export const CmpInline = component$(() => {
     const counterStore = useStore({
       value: 0,
     });
-    useClientEffect$(() => {
+    useOnVisibleTask$(() => {
       // Only runs in the client
       const timer = setInterval(() => {
         counterStore.value += step;
@@ -388,7 +388,7 @@ export const CmpInline = component$(() => {
   const Cmp = component$(() => {
     const input = useRef<HTMLInputElement>();
 
-    useClientEffect$(({ track }) => {
+    useOnVisibleTask$(({ track }) => {
       const el = track(() => input.current)!;
       el.focus();
     });

--- a/packages/qwik/src/core/examples.tsx
+++ b/packages/qwik/src/core/examples.tsx
@@ -12,7 +12,7 @@ import { $, QRL } from './qrl/qrl.public';
 import { useOn, useOnDocument, useOnWindow } from './use/use-on';
 import { useStore } from './use/use-store.public';
 import { useStyles$, useStylesScoped$ } from './use/use-styles';
-import { useOnVisibleTask$, useTask$ } from './use/use-task';
+import { useBrowserVisibleTask$, useTask$ } from './use/use-task';
 import { implicit$FirstArg } from './util/implicit_dollar';
 
 //////////////////////////////////////////////////////////
@@ -309,7 +309,7 @@ export const CmpInline = component$(() => {
       count: 0,
     });
 
-    useOnVisibleTask$(() => {
+    useBrowserVisibleTask$(() => {
       // Only runs in the client
       const timer = setInterval(() => {
         store.count++;
@@ -360,7 +360,7 @@ export const CmpInline = component$(() => {
     const counterStore = useStore({
       value: 0,
     });
-    useOnVisibleTask$(() => {
+    useBrowserVisibleTask$(() => {
       // Only runs in the client
       const timer = setInterval(() => {
         counterStore.value += step;
@@ -388,7 +388,7 @@ export const CmpInline = component$(() => {
   const Cmp = component$(() => {
     const input = useRef<HTMLInputElement>();
 
-    useOnVisibleTask$(({ track }) => {
+    useBrowserVisibleTask$(({ track }) => {
       const el = track(() => input.current)!;
       el.focus();
     });

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -83,7 +83,8 @@ export type { UseStoreOptions } from './use/use-store.public';
 export type {
   Tracker,
   TaskFn,
-  UseEffectOptions,
+  OnVisibleTaskOptions,
+  VisibleTaskStrategy,
   EagernessOptions,
   ResourceReturn,
   ResourceCtx,
@@ -100,6 +101,7 @@ export type { ResourceProps, ResourceOptions } from './use/use-resource';
 export { useResource$, useResourceQrl, Resource } from './use/use-resource';
 export { useTask$, useTaskQrl } from './use/use-task';
 export { useOnVisibleTask$, useOnVisibleTaskQrl } from './use/use-task';
+export { useClientEffect$, useClientEffectQrl } from './use/use-task';
 export { useMount$, useMountQrl } from './use/use-mount';
 export { useServerMount$, useServerMountQrl } from './use/use-mount';
 export { useClientMount$, useClientMountQrl } from './use/use-mount';

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -99,7 +99,7 @@ export { useWatch$, useWatchQrl } from './use/use-task';
 export type { ResourceProps, ResourceOptions } from './use/use-resource';
 export { useResource$, useResourceQrl, Resource } from './use/use-resource';
 export { useTask$, useTaskQrl } from './use/use-task';
-export { useClientEffect$, useClientEffectQrl } from './use/use-task';
+export { useOnVisibleTask$, useOnVisibleTaskQrl } from './use/use-task';
 export { useMount$, useMountQrl } from './use/use-mount';
 export { useServerMount$, useServerMountQrl } from './use/use-mount';
 export { useClientMount$, useClientMountQrl } from './use/use-mount';

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -100,7 +100,7 @@ export { useWatch$, useWatchQrl } from './use/use-task';
 export type { ResourceProps, ResourceOptions } from './use/use-resource';
 export { useResource$, useResourceQrl, Resource } from './use/use-resource';
 export { useTask$, useTaskQrl } from './use/use-task';
-export { useOnVisibleTask$, useOnVisibleTaskQrl } from './use/use-task';
+export { useBrowserVisibleTask$, useBrowserVisibleTaskQrl } from './use/use-task';
 export { useClientEffect$, useClientEffectQrl } from './use/use-task';
 export { useMount$, useMountQrl } from './use/use-mount';
 export { useServerMount$, useServerMountQrl } from './use/use-mount';

--- a/packages/qwik/src/core/readme.md
+++ b/packages/qwik/src/core/readme.md
@@ -121,7 +121,7 @@ The `obs` passed into the `taskFn` is used to mark `state.count` as a property o
 
 @public
 
-# `useClientEffect`
+# `useOnVisibleTask`
 
 <docs code="./examples.tsx#use-client-effect"/>
 
@@ -206,7 +206,7 @@ Component styles allow Qwik to lazy load the style information for the component
 It can be used to release resources, abort network requests, stop timers...
 
 @alpha
-@deprecated Use the cleanup() function of `useTask$()`, `useResource$()` or `useClientEffect$()` instead.
+@deprecated Use the cleanup() function of `useTask$()`, `useResource$()` or `useOnVisibleTask$()` instead.
 
 # `useOn`
 

--- a/packages/qwik/src/core/readme.md
+++ b/packages/qwik/src/core/readme.md
@@ -121,7 +121,7 @@ The `obs` passed into the `taskFn` is used to mark `state.count` as a property o
 
 @public
 
-# `useOnVisibleTask`
+# `useBrowserVisibleTask`
 
 <docs code="./examples.tsx#use-client-effect"/>
 
@@ -206,7 +206,7 @@ Component styles allow Qwik to lazy load the style information for the component
 It can be used to release resources, abort network requests, stop timers...
 
 @alpha
-@deprecated Use the cleanup() function of `useTask$()`, `useResource$()` or `useOnVisibleTask$()` instead.
+@deprecated Use the cleanup() function of `useTask$()`, `useResource$()` or `useBrowserVisibleTask$()` instead.
 
 # `useOn`
 

--- a/packages/qwik/src/core/render/dom/render.unit.tsx
+++ b/packages/qwik/src/core/render/dom/render.unit.tsx
@@ -4,7 +4,7 @@ import { component$ } from '../../component/component.public';
 import { inlinedQrl } from '../../qrl/qrl';
 import { useLexicalScope } from '../../use/use-lexical-scope.public';
 import { useStore } from '../../use/use-store.public';
-import { useClientEffect$, useTask$ } from '../../use/use-task';
+import { useOnVisibleTask$, useTask$ } from '../../use/use-task';
 import { useCleanup$, useOn } from '../../use/use-on';
 import { Slot } from '../jsx/slot.public';
 import { render } from './render.public';
@@ -971,7 +971,7 @@ export const Transparent = component$(() => {
 });
 
 export const UseEvents = component$(() => {
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.warn('hello');
   });
   useOn(
@@ -1012,7 +1012,7 @@ export const Hooks = component$(() => {
     };
   });
 
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     effectDiv.current!.textContent = 'true';
     return () => {
       effectDestroyDiv.current!.textContent = 'true';

--- a/packages/qwik/src/core/render/dom/render.unit.tsx
+++ b/packages/qwik/src/core/render/dom/render.unit.tsx
@@ -4,7 +4,7 @@ import { component$ } from '../../component/component.public';
 import { inlinedQrl } from '../../qrl/qrl';
 import { useLexicalScope } from '../../use/use-lexical-scope.public';
 import { useStore } from '../../use/use-store.public';
-import { useOnVisibleTask$, useTask$ } from '../../use/use-task';
+import { useBrowserVisibleTask$, useTask$ } from '../../use/use-task';
 import { useCleanup$, useOn } from '../../use/use-on';
 import { Slot } from '../jsx/slot.public';
 import { render } from './render.public';
@@ -971,7 +971,7 @@ export const Transparent = component$(() => {
 });
 
 export const UseEvents = component$(() => {
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.warn('hello');
   });
   useOn(
@@ -1012,7 +1012,7 @@ export const Hooks = component$(() => {
     };
   });
 
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     effectDiv.current!.textContent = 'true';
     return () => {
       effectDestroyDiv.current!.textContent = 'true';

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -425,7 +425,7 @@ const renderSSRComponent = (
           }
           renderNodeElementSync('script', attributes, stream);
           logWarn(`Component has listeners attached, but it does not render any elements, injecting a new <script> element to attach listeners.
-          This is likely to the usage of useOnVisibleTask$() in a component that renders no elements.`);
+          This is likely to the usage of useBrowserVisibleTask$() in a component that renders no elements.`);
         }
         if (beforeClose) {
           return then(renderQTemplates(rCtx, newSSrContext, stream), () => beforeClose(stream));

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -425,7 +425,7 @@ const renderSSRComponent = (
           }
           renderNodeElementSync('script', attributes, stream);
           logWarn(`Component has listeners attached, but it does not render any elements, injecting a new <script> element to attach listeners.
-          This is likely to the usage of useClientEffect$() in a component that renders no elements.`);
+          This is likely to the usage of useOnVisibleTask$() in a component that renders no elements.`);
         }
         if (beforeClose) {
           return then(renderQTemplates(rCtx, newSSrContext, stream), () => beforeClose(stream));

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -12,7 +12,7 @@ import { useOn, useOnDocument, useOnWindow } from '../../use/use-on';
 import { Ref, useRef } from '../../use/use-ref';
 import { Resource, useResource$ } from '../../use/use-resource';
 import { useStylesScopedQrl, useStylesQrl } from '../../use/use-styles';
-import { useClientEffect$, useTask$ } from '../../use/use-task';
+import { useOnVisibleTask$, useTask$ } from '../../use/use-task';
 import { delay } from '../../util/promises';
 import { SSRComment } from '../jsx/utils.public';
 import { Slot } from '../jsx/slot.public';
@@ -1045,7 +1045,7 @@ renderSSRSuite('component useStylesScoped() + slot', async () => {
   );
 });
 
-renderSSRSuite('component useClientEffect()', async () => {
+renderSSRSuite('component useOnVisibleTask()', async () => {
   await testSSR(
     <UseClientEffect />,
     `<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
@@ -1060,7 +1060,7 @@ renderSSRSuite('component useClientEffect()', async () => {
   );
 });
 
-renderSSRSuite('component useClientEffect() without elements', async () => {
+renderSSRSuite('component useOnVisibleTask() without elements', async () => {
   await testSSR(
     <body>
       <UseEmptyClientEffect />
@@ -1078,7 +1078,7 @@ renderSSRSuite('component useClientEffect() without elements', async () => {
   );
 });
 
-renderSSRSuite('component useClientEffect() inside <head>', async () => {
+renderSSRSuite('component useOnVisibleTask() inside <head>', async () => {
   await testSSR(
     <head>
       <UseEmptyClientEffect />
@@ -1536,10 +1536,10 @@ export const ContextConsumer = component$(() => {
 });
 
 export const UseClientEffect = component$((props: any) => {
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.warn('client effect');
   });
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.warn('second client effect');
   });
   useTask$(async () => {
@@ -1551,10 +1551,10 @@ export const UseClientEffect = component$((props: any) => {
 });
 
 export const UseEmptyClientEffect = component$(() => {
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.warn('client effect');
   });
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.warn('second client effect');
   });
   useTask$(async () => {
@@ -1565,7 +1565,7 @@ export const UseEmptyClientEffect = component$(() => {
 });
 
 export const HeadCmp = component$(() => {
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.warn('client effect');
   });
   return (
@@ -1645,14 +1645,14 @@ export const NullCmp = component$(() => {
 });
 
 export const EffectTransparent = component$(() => {
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.warn('log');
   });
   return <Slot />;
 });
 
 export const EffectTransparentRoot = component$(() => {
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.warn('log');
   });
   return (

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -12,7 +12,7 @@ import { useOn, useOnDocument, useOnWindow } from '../../use/use-on';
 import { Ref, useRef } from '../../use/use-ref';
 import { Resource, useResource$ } from '../../use/use-resource';
 import { useStylesScopedQrl, useStylesQrl } from '../../use/use-styles';
-import { useOnVisibleTask$, useTask$ } from '../../use/use-task';
+import { useBrowserVisibleTask$, useTask$ } from '../../use/use-task';
 import { delay } from '../../util/promises';
 import { SSRComment } from '../jsx/utils.public';
 import { Slot } from '../jsx/slot.public';
@@ -1045,7 +1045,7 @@ renderSSRSuite('component useStylesScoped() + slot', async () => {
   );
 });
 
-renderSSRSuite('component useOnVisibleTask()', async () => {
+renderSSRSuite('component useBrowserVisibleTask()', async () => {
   await testSSR(
     <UseClientEffect />,
     `<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
@@ -1060,7 +1060,7 @@ renderSSRSuite('component useOnVisibleTask()', async () => {
   );
 });
 
-renderSSRSuite('component useOnVisibleTask() without elements', async () => {
+renderSSRSuite('component useBrowserVisibleTask() without elements', async () => {
   await testSSR(
     <body>
       <UseEmptyClientEffect />
@@ -1078,7 +1078,7 @@ renderSSRSuite('component useOnVisibleTask() without elements', async () => {
   );
 });
 
-renderSSRSuite('component useOnVisibleTask() inside <head>', async () => {
+renderSSRSuite('component useBrowserVisibleTask() inside <head>', async () => {
   await testSSR(
     <head>
       <UseEmptyClientEffect />
@@ -1536,10 +1536,10 @@ export const ContextConsumer = component$(() => {
 });
 
 export const UseClientEffect = component$((props: any) => {
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.warn('client effect');
   });
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.warn('second client effect');
   });
   useTask$(async () => {
@@ -1551,10 +1551,10 @@ export const UseClientEffect = component$((props: any) => {
 });
 
 export const UseEmptyClientEffect = component$(() => {
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.warn('client effect');
   });
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.warn('second client effect');
   });
   useTask$(async () => {
@@ -1565,7 +1565,7 @@ export const UseEmptyClientEffect = component$(() => {
 });
 
 export const HeadCmp = component$(() => {
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.warn('client effect');
   });
   return (
@@ -1645,14 +1645,14 @@ export const NullCmp = component$(() => {
 });
 
 export const EffectTransparent = component$(() => {
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.warn('log');
   });
   return <Slot />;
 });
 
 export const EffectTransparentRoot = component$(() => {
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.warn('log');
   });
   return (

--- a/packages/qwik/src/core/state/signal.ts
+++ b/packages/qwik/src/core/state/signal.ts
@@ -73,7 +73,7 @@ export class SignalImpl<T> implements Signal<T> {
       const invokeCtx = tryGetInvokeContext();
       if (invokeCtx && invokeCtx.$event$ === RenderEvent) {
         logWarn(
-          'State mutation inside render function. Move mutation to useWatch(), useOnVisibleTask() or useServerMount()',
+          'State mutation inside render function. Move mutation to useWatch(), useBrowserVisibleTask() or useServerMount()',
           invokeCtx.$hostElement$
         );
       }

--- a/packages/qwik/src/core/state/signal.ts
+++ b/packages/qwik/src/core/state/signal.ts
@@ -73,7 +73,7 @@ export class SignalImpl<T> implements Signal<T> {
       const invokeCtx = tryGetInvokeContext();
       if (invokeCtx && invokeCtx.$event$ === RenderEvent) {
         logWarn(
-          'State mutation inside render function. Move mutation to useWatch(), useClientEffect() or useServerMount()',
+          'State mutation inside render function. Move mutation to useWatch(), useOnVisibleTask() or useServerMount()',
           invokeCtx.$hostElement$
         );
       }

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -152,7 +152,7 @@ class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
       const invokeCtx = tryGetInvokeContext();
       if (invokeCtx && invokeCtx.$event$ === RenderEvent) {
         logError(
-          'State mutation inside render function. Move mutation to useWatch(), useOnVisibleTask() or useServerMount()',
+          'State mutation inside render function. Move mutation to useWatch(), useBrowserVisibleTask() or useServerMount()',
           prop
         );
       }

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -152,7 +152,7 @@ class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
       const invokeCtx = tryGetInvokeContext();
       if (invokeCtx && invokeCtx.$event$ === RenderEvent) {
         logError(
-          'State mutation inside render function. Move mutation to useWatch(), useClientEffect() or useServerMount()',
+          'State mutation inside render function. Move mutation to useWatch(), useOnVisibleTask() or useServerMount()',
           prop
         );
       }

--- a/packages/qwik/src/core/use/use-on.ts
+++ b/packages/qwik/src/core/use/use-on.ts
@@ -15,7 +15,7 @@ import { Task, WatchFlagsIsCleanup } from './use-task';
  *
  * @alpha
  * @deprecated Use the cleanup() function of `useTask$()`, `useResource$()` or
- * `useOnVisibleTask$()` instead.
+ * `useBrowserVisibleTask$()` instead.
  */
 // </docs>
 export const useCleanupQrl = (unmountFn: QRL<() => void>): void => {
@@ -39,7 +39,7 @@ export const useCleanupQrl = (unmountFn: QRL<() => void>): void => {
  *
  * @alpha
  * @deprecated Use the cleanup() function of `useTask$()`, `useResource$()` or
- * `useOnVisibleTask$()` instead.
+ * `useBrowserVisibleTask$()` instead.
  */
 // </docs>
 export const useCleanup$ = /*#__PURE__*/ implicit$FirstArg(useCleanupQrl);

--- a/packages/qwik/src/core/use/use-on.ts
+++ b/packages/qwik/src/core/use/use-on.ts
@@ -15,7 +15,7 @@ import { Task, WatchFlagsIsCleanup } from './use-task';
  *
  * @alpha
  * @deprecated Use the cleanup() function of `useTask$()`, `useResource$()` or
- * `useClientEffect$()` instead.
+ * `useOnVisibleTask$()` instead.
  */
 // </docs>
 export const useCleanupQrl = (unmountFn: QRL<() => void>): void => {
@@ -39,7 +39,7 @@ export const useCleanupQrl = (unmountFn: QRL<() => void>): void => {
  *
  * @alpha
  * @deprecated Use the cleanup() function of `useTask$()`, `useResource$()` or
- * `useClientEffect$()` instead.
+ * `useOnVisibleTask$()` instead.
  */
 // </docs>
 export const useCleanup$ = /*#__PURE__*/ implicit$FirstArg(useCleanupQrl);

--- a/packages/qwik/src/core/use/use-ref.ts
+++ b/packages/qwik/src/core/use/use-ref.ts
@@ -28,7 +28,7 @@ export interface Ref<T = Element> {
  * const Cmp = component$(() => {
  *   const input = useRef<HTMLInputElement>();
  *
- *   useClientEffect$(({ track }) => {
+ *   useOnVisibleTask$(({ track }) => {
  *     const el = track(() => input.current)!;
  *     el.focus();
  *   });

--- a/packages/qwik/src/core/use/use-ref.ts
+++ b/packages/qwik/src/core/use/use-ref.ts
@@ -28,7 +28,7 @@ export interface Ref<T = Element> {
  * const Cmp = component$(() => {
  *   const input = useRef<HTMLInputElement>();
  *
- *   useOnVisibleTask$(({ track }) => {
+ *   useBrowserVisibleTask$(({ track }) => {
  *     const el = track(() => input.current)!;
  *     el.focus();
  *   });

--- a/packages/qwik/src/core/use/use-store.public.ts
+++ b/packages/qwik/src/core/use/use-store.public.ts
@@ -73,7 +73,7 @@ export interface UseStoreOptions {
  *   const counterStore = useStore({
  *     value: 0,
  *   });
- *   useOnVisibleTask$(() => {
+ *   useBrowserVisibleTask$(() => {
  *     // Only runs in the client
  *     const timer = setInterval(() => {
  *       counterStore.value += step;

--- a/packages/qwik/src/core/use/use-store.public.ts
+++ b/packages/qwik/src/core/use/use-store.public.ts
@@ -73,7 +73,7 @@ export interface UseStoreOptions {
  *   const counterStore = useStore({
  *     value: 0,
  *   });
- *   useClientEffect$(() => {
+ *   useOnVisibleTask$(() => {
  *     // Only runs in the client
  *     const timer = setInterval(() => {
  *       counterStore.value += step;

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -368,9 +368,9 @@ export const useWatch$ = /*#__PURE__*/ useTask$;
  */
 export const useWatchQrl = /*#__PURE__*/ useTaskQrl;
 
-// <docs markdown="../readme.md#useOnVisibleTask">
+// <docs markdown="../readme.md#useBrowserVisibleTask">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#useOnVisibleTask instead)
+// (edit ../readme.md#useBrowserVisibleTask instead)
 /**
  * ```tsx
  * const Timer = component$(() => {
@@ -378,7 +378,7 @@ export const useWatchQrl = /*#__PURE__*/ useTaskQrl;
  *     count: 0,
  *   });
  *
- *   useOnVisibleTask$(() => {
+ *   useBrowserVisibleTask$(() => {
  *     // Only runs in the client
  *     const timer = setInterval(() => {
  *       store.count++;
@@ -395,7 +395,7 @@ export const useWatchQrl = /*#__PURE__*/ useTaskQrl;
  * @public
  */
 // </docs>
-export const useOnVisibleTaskQrl = (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOptions): void => {
+export const useBrowserVisibleTaskQrl = (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOptions): void => {
   const { get, set, i, iCtx, elCtx } = useSequentialScope<Task>();
   const eagerness = opts?.strategy ?? opts?.eagerness ?? 'intersection-observer';
   if (get) {
@@ -419,9 +419,9 @@ export const useOnVisibleTaskQrl = (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOption
   }
 };
 
-// <docs markdown="../readme.md#useOnVisibleTask">
+// <docs markdown="../readme.md#useBrowserVisibleTask">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#useOnVisibleTask instead)
+// (edit ../readme.md#useBrowserVisibleTask instead)
 /**
  * ```tsx
  * const Timer = component$(() => {
@@ -429,7 +429,7 @@ export const useOnVisibleTaskQrl = (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOption
  *     count: 0,
  *   });
  *
- *   useOnVisibleTask$(() => {
+ *   useBrowserVisibleTask$(() => {
  *     // Only runs in the client
  *     const timer = setInterval(() => {
  *       store.count++;
@@ -446,19 +446,19 @@ export const useOnVisibleTaskQrl = (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOption
  * @public
  */
 // </docs>
-export const useOnVisibleTask$ = /*#__PURE__*/ implicit$FirstArg(useOnVisibleTaskQrl);
+export const useBrowserVisibleTask$ = /*#__PURE__*/ implicit$FirstArg(useBrowserVisibleTaskQrl);
 
 /**
  * @alpha
- * @deprecated - use `useOnVisibleTask$()` instead
+ * @deprecated - use `useBrowserVisibleTask$()` instead
  */
-export const useClientEffectQrl = useOnVisibleTaskQrl;
+export const useClientEffectQrl = useBrowserVisibleTaskQrl;
 
 /**
  * @alpha
- * @deprecated - use `useOnVisibleTask$()` instead
+ * @deprecated - use `useBrowserVisibleTask$()` instead
  */
-export const useClientEffect$ = useOnVisibleTask$;
+export const useClientEffect$ = useBrowserVisibleTask$;
 
 export type WatchDescriptor = DescriptorBase<TaskFn>;
 

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -449,11 +449,13 @@ export const useOnVisibleTaskQrl = (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOption
 export const useOnVisibleTask$ = /*#__PURE__*/ implicit$FirstArg(useOnVisibleTaskQrl);
 
 /**
+ * @alpha
  * @deprecated - use `useOnVisibleTask$()` instead
  */
 export const useClientEffectQrl = useOnVisibleTaskQrl;
 
 /**
+ * @alpha
  * @deprecated - use `useOnVisibleTask$()` instead
  */
 export const useClientEffect$ = useOnVisibleTask$;

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -355,9 +355,9 @@ export const useWatch$ = /*#__PURE__*/ useTask$;
  */
 export const useWatchQrl = /*#__PURE__*/ useTaskQrl;
 
-// <docs markdown="../readme.md#useClientEffect">
+// <docs markdown="../readme.md#useOnVisibleTask">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#useClientEffect instead)
+// (edit ../readme.md#useOnVisibleTask instead)
 /**
  * ```tsx
  * const Timer = component$(() => {
@@ -365,7 +365,7 @@ export const useWatchQrl = /*#__PURE__*/ useTaskQrl;
  *     count: 0,
  *   });
  *
- *   useClientEffect$(() => {
+ *   useOnVisibleTask$(() => {
  *     // Only runs in the client
  *     const timer = setInterval(() => {
  *       store.count++;
@@ -382,7 +382,7 @@ export const useWatchQrl = /*#__PURE__*/ useTaskQrl;
  * @public
  */
 // </docs>
-export const useClientEffectQrl = (qrl: QRL<TaskFn>, opts?: UseEffectOptions): void => {
+export const useOnVisibleTaskQrl = (qrl: QRL<TaskFn>, opts?: UseEffectOptions): void => {
   const { get, set, i, iCtx, elCtx } = useSequentialScope<Task>();
   const eagerness = opts?.eagerness ?? 'visible';
   if (get) {
@@ -406,9 +406,9 @@ export const useClientEffectQrl = (qrl: QRL<TaskFn>, opts?: UseEffectOptions): v
   }
 };
 
-// <docs markdown="../readme.md#useClientEffect">
+// <docs markdown="../readme.md#useOnVisibleTask">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
-// (edit ../readme.md#useClientEffect instead)
+// (edit ../readme.md#useOnVisibleTask instead)
 /**
  * ```tsx
  * const Timer = component$(() => {
@@ -416,7 +416,7 @@ export const useClientEffectQrl = (qrl: QRL<TaskFn>, opts?: UseEffectOptions): v
  *     count: 0,
  *   });
  *
- *   useClientEffect$(() => {
+ *   useOnVisibleTask$(() => {
  *     // Only runs in the client
  *     const timer = setInterval(() => {
  *       store.count++;
@@ -433,7 +433,9 @@ export const useClientEffectQrl = (qrl: QRL<TaskFn>, opts?: UseEffectOptions): v
  * @public
  */
 // </docs>
-export const useClientEffect$ = /*#__PURE__*/ implicit$FirstArg(useClientEffectQrl);
+export const useOnVisibleTask$ = /*#__PURE__*/ implicit$FirstArg(useOnVisibleTaskQrl);
+
+export const useClientEffect$ = /*#__PURE__*/ implicit$FirstArg(useOnVisibleTaskQrl);
 
 export type WatchDescriptor = DescriptorBase<TaskFn>;
 

--- a/packages/qwik/src/optimizer/core/src/parse.rs
+++ b/packages/qwik/src/optimizer/core/src/parse.rs
@@ -679,5 +679,5 @@ pub fn might_need_handle_watch(ctx_kind: &HookKind, ctx_name: &str) -> bool {
     if matches!(ctx_kind, HookKind::Event) {
         return false;
     }
-    matches!(ctx_name, "useTask$" | "useOnVisibleTask$" | "$")
+    matches!(ctx_name, "useTask$" | "useBrowserVisibleTask$" | "$")
 }

--- a/packages/qwik/src/optimizer/core/src/parse.rs
+++ b/packages/qwik/src/optimizer/core/src/parse.rs
@@ -679,5 +679,5 @@ pub fn might_need_handle_watch(ctx_kind: &HookKind, ctx_name: &str) -> bool {
     if matches!(ctx_kind, HookKind::Event) {
         return false;
     }
-    matches!(ctx_name, "useTask$" | "useClientEffect$" | "$")
+    matches!(ctx_name, "useTask$" | "useOnVisibleTask$" | "$")
 }

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_inlined_entry_strategy.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_inlined_entry_strategy.snap
@@ -5,7 +5,7 @@ expression: output
 ==INPUT==
 
 
-import { component$, useOnVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
 import { thing } from './sibling';
 import mongodb from 'mongodb';
 
@@ -17,7 +17,7 @@ export const Child = component$(() => {
     });
 
     // Double count watch
-    useOnVisibleTask$(() => {
+    useBrowserVisibleTask$(() => {
         state.count = thing.doStuff() + import("./sibling");
     });
 
@@ -33,7 +33,7 @@ export const Child = component$(() => {
 import { componentQrl } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 import { inlinedQrl } from "@builder.io/qwik";
-import { useOnVisibleTaskQrl } from "@builder.io/qwik";
+import { useBrowserVisibleTaskQrl } from "@builder.io/qwik";
 import { useLexicalScope } from "@builder.io/qwik";
 import { useStore } from '@builder.io/qwik';
 import { thing } from './sibling';
@@ -44,10 +44,10 @@ export const Child = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
         count: 0
     });
     // Double count watch
-    useOnVisibleTaskQrl(inlinedQrl(()=>{
+    useBrowserVisibleTaskQrl(inlinedQrl(()=>{
         const [state] = useLexicalScope();
         state.count = thing.doStuff() + import("./sibling");
-    }, "Child_component_useOnVisibleTask_nZ6mF0oPCE0", [
+    }, "Child_component_useBrowserVisibleTask_0IGFPOyJmQA", [
         state
     ]));
     return <div onClick$={inlinedQrl(()=>console.log(mongodb), "Child_component_div_onClick_elliVSnAiOQ")}>
@@ -56,7 +56,7 @@ export const Child = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
 }, "Child_component_9GyF01GDKqw"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA;;;;;AAAA,SAAwC,QAAQ,QAAoB,mBAAmB;AACvF,SAAS,KAAK,QAAQ,YAAY;AAClC,OAAO,aAAa,UAAU;AAE9B,OAAO,MAAM,sBAAQ,wBAAW,IAAM;IAElC,wBAAW;IACX,MAAM,QAAQ,SAAS;QACnB,OAAO;IACX;IAEA,qBAAqB;IACrB,+BAAkB;;QACd,MAAM,KAAK,GAAG,MAAM,OAAO,KAAK,MAAM,CAAC;;;;IAG3C,QACK,IAAI,qBAAU,IAAM,QAAQ,GAAG,CAAC,sDAAU;;QAC3C,EAAE;AAEV,mCAAG\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA;;;;;AAAA,SAA6C,QAAQ,QAAoB,mBAAmB;AAC5F,SAAS,KAAK,QAAQ,YAAY;AAClC,OAAO,aAAa,UAAU;AAE9B,OAAO,MAAM,sBAAQ,wBAAW,IAAM;IAElC,wBAAW;IACX,MAAM,QAAQ,SAAS;QACnB,OAAO;IACX;IAEA,qBAAqB;IACrB,oCAAuB;;QACnB,MAAM,KAAK,GAAG,MAAM,OAAO,KAAK,MAAM,CAAC;;;;IAG3C,QACK,IAAI,qBAAU,IAAM,QAAQ,GAAG,CAAC,sDAAU;;QAC3C,EAAE;AAEV,mCAAG\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_inlined_entry_strategy.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_inlined_entry_strategy.snap
@@ -5,7 +5,7 @@ expression: output
 ==INPUT==
 
 
-import { component$, useClientEffect$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
 import { thing } from './sibling';
 import mongodb from 'mongodb';
 
@@ -17,7 +17,7 @@ export const Child = component$(() => {
     });
 
     // Double count watch
-    useClientEffect$(() => {
+    useOnVisibleTask$(() => {
         state.count = thing.doStuff() + import("./sibling");
     });
 
@@ -33,7 +33,7 @@ export const Child = component$(() => {
 import { componentQrl } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 import { inlinedQrl } from "@builder.io/qwik";
-import { useClientEffectQrl } from "@builder.io/qwik";
+import { useOnVisibleTaskQrl } from "@builder.io/qwik";
 import { useLexicalScope } from "@builder.io/qwik";
 import { useStore } from '@builder.io/qwik';
 import { thing } from './sibling';
@@ -44,10 +44,10 @@ export const Child = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
         count: 0
     });
     // Double count watch
-    useClientEffectQrl(inlinedQrl(()=>{
+    useOnVisibleTaskQrl(inlinedQrl(()=>{
         const [state] = useLexicalScope();
         state.count = thing.doStuff() + import("./sibling");
-    }, "Child_component_useClientEffect_kYRT1iERt9g", [
+    }, "Child_component_useOnVisibleTask_kYRT1iERt9g", [
         state
     ]));
     return <div onClick$={inlinedQrl(()=>console.log(mongodb), "Child_component_div_onClick_elliVSnAiOQ")}>

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_inlined_entry_strategy.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_inlined_entry_strategy.snap
@@ -47,7 +47,7 @@ export const Child = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
     useOnVisibleTaskQrl(inlinedQrl(()=>{
         const [state] = useLexicalScope();
         state.count = thing.doStuff() + import("./sibling");
-    }, "Child_component_useOnVisibleTask_kYRT1iERt9g", [
+    }, "Child_component_useOnVisibleTask_nZ6mF0oPCE0", [
         state
     ]));
     return <div onClick$={inlinedQrl(()=>console.log(mongodb), "Child_component_div_onClick_elliVSnAiOQ")}>
@@ -56,7 +56,7 @@ export const Child = /*#__PURE__*/ componentQrl(inlinedQrl(()=>{
 }, "Child_component_9GyF01GDKqw"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA;;;;;AAAA,SAAuC,QAAQ,QAAoB,mBAAmB;AACtF,SAAS,KAAK,QAAQ,YAAY;AAClC,OAAO,aAAa,UAAU;AAE9B,OAAO,MAAM,sBAAQ,wBAAW,IAAM;IAElC,wBAAW;IACX,MAAM,QAAQ,SAAS;QACnB,OAAO;IACX;IAEA,qBAAqB;IACrB,8BAAiB;;QACb,MAAM,KAAK,GAAG,MAAM,OAAO,KAAK,MAAM,CAAC;;;;IAG3C,QACK,IAAI,qBAAU,IAAM,QAAQ,GAAG,CAAC,sDAAU;;QAC3C,EAAE;AAEV,mCAAG\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA;;;;;AAAA,SAAwC,QAAQ,QAAoB,mBAAmB;AACvF,SAAS,KAAK,QAAQ,YAAY;AAClC,OAAO,aAAa,UAAU;AAE9B,OAAO,MAAM,sBAAQ,wBAAW,IAAM;IAElC,wBAAW;IACX,MAAM,QAAQ,SAAS;QACnB,OAAO;IACX;IAEA,qBAAqB;IACrB,+BAAkB;;QACd,MAAM,KAAK,GAAG,MAAM,OAAO,KAAK,MAAM,CAAC;;;;IAG3C,QACK,IAAI,qBAAU,IAAM,QAAQ,GAAG,CAAC,sDAAU;;QAC3C,EAAE;AAEV,mCAAG\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_client_effect.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_client_effect.snap
@@ -5,7 +5,7 @@ expression: output
 ==INPUT==
 
 
-import { component$, useClientEffect$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
 
 export const Child = component$(() => {
     const state = useStore({
@@ -13,7 +13,7 @@ export const Child = component$(() => {
     });
 
     // Double count watch
-    useClientEffect$(() => {
+    useOnVisibleTask$(() => {
         const timer = setInterval(() => {
         state.count++;
         }, 1000);
@@ -43,14 +43,14 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 import { jsx as _jsx } from "@builder.io/qwik/jsx-runtime";
 import { _wrapSignal } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-import { useClientEffectQrl } from "@builder.io/qwik";
+import { useOnVisibleTaskQrl } from "@builder.io/qwik";
 import { useStore } from "@builder.io/qwik";
 export const Child_component_9GyF01GDKqw = ()=>{
     const state = useStore({
         count: 0
     });
     // Double count watch
-    useClientEffectQrl(qrl(()=>import("./child_component_useclienteffect_kyrt1iert9g"), "Child_component_useClientEffect_kYRT1iERt9g", [
+    useOnVisibleTaskQrl(qrl(()=>import("./child_component_useclienteffect_kyrt1iert9g"), "Child_component_useOnVisibleTask_kYRT1iERt9g", [
         state
     ]));
     return /*#__PURE__*/ _jsx("div", {
@@ -82,7 +82,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 ============================= child_component_useclienteffect_kyrt1iert9g.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
-export const Child_component_useClientEffect_kYRT1iERt9g = ()=>{
+export const Child_component_useOnVisibleTask_kYRT1iERt9g = ()=>{
     const [state] = useLexicalScope();
     const timer = setInterval(()=>{
         state.count++;
@@ -98,15 +98,15 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 /*
 {
   "origin": "test.tsx",
-  "name": "Child_component_useClientEffect_kYRT1iERt9g",
+  "name": "Child_component_useOnVisibleTask_kYRT1iERt9g",
   "entry": null,
-  "displayName": "Child_component_useClientEffect",
+  "displayName": "Child_component_useOnVisibleTask",
   "hash": "kYRT1iERt9g",
   "canonicalFilename": "child_component_useclienteffect_kyrt1iert9g",
   "extension": "js",
   "parent": "Child_component_9GyF01GDKqw",
   "ctxKind": "function",
-  "ctxName": "useClientEffect$",
+  "ctxName": "useOnVisibleTask$",
   "captures": true,
   "loc": [
     232,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_client_effect.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_client_effect.snap
@@ -5,7 +5,7 @@ expression: output
 ==INPUT==
 
 
-import { component$, useOnVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
 
 export const Child = component$(() => {
     const state = useStore({
@@ -13,7 +13,7 @@ export const Child = component$(() => {
     });
 
     // Double count watch
-    useOnVisibleTask$(() => {
+    useBrowserVisibleTask$(() => {
         const timer = setInterval(() => {
         state.count++;
         }, 1000);
@@ -30,18 +30,10 @@ export const Child = component$(() => {
 });
 
 
-============================= test.js ==
-
-import { componentQrl } from "@builder.io/qwik";
-import { qrl } from "@builder.io/qwik";
-export const Child = /*#__PURE__*/ componentQrl(qrl(()=>import("./child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
-
-
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA;;AAEA,OAAO,MAAM,sBAAQ,8FAoBlB\"}")
-============================= child_component_useonvisibletask_nz6mf0opce0.js (ENTRY POINT)==
+============================= child_component_usebrowservisibletask_0igfpoyjmqa.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
-export const Child_component_useOnVisibleTask_nZ6mF0oPCE0 = ()=>{
+export const Child_component_useBrowserVisibleTask_0IGFPOyJmQA = ()=>{
     const [state] = useLexicalScope();
     const timer = setInterval(()=>{
         state.count++;
@@ -53,39 +45,47 @@ export const Child_component_useOnVisibleTask_nZ6mF0oPCE0 = ()=>{
 export { _hW } from "@builder.io/qwik";
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";4DASsB;;IACd,MAAM,QAAQ,YAAY,IAAM;QAChC,MAAM,KAAK;IACX,GAAG;IACH,OAAO,IAAM;QACb,cAAc;IACd\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";iEAS2B;;IACnB,MAAM,QAAQ,YAAY,IAAM;QAChC,MAAM,KAAK;IACX,GAAG;IACH,OAAO,IAAM;QACb,cAAc;IACd\"}")
 /*
 {
   "origin": "test.tsx",
-  "name": "Child_component_useOnVisibleTask_nZ6mF0oPCE0",
+  "name": "Child_component_useBrowserVisibleTask_0IGFPOyJmQA",
   "entry": null,
-  "displayName": "Child_component_useOnVisibleTask",
-  "hash": "nZ6mF0oPCE0",
-  "canonicalFilename": "child_component_useonvisibletask_nz6mf0opce0",
+  "displayName": "Child_component_useBrowserVisibleTask",
+  "hash": "0IGFPOyJmQA",
+  "canonicalFilename": "child_component_usebrowservisibletask_0igfpoyjmqa",
   "extension": "js",
   "parent": "Child_component_9GyF01GDKqw",
   "ctxKind": "function",
-  "ctxName": "useOnVisibleTask$",
+  "ctxName": "useBrowserVisibleTask$",
   "captures": true,
   "loc": [
-    234,
-    393
+    244,
+    403
   ]
 }
 */
+============================= test.js ==
+
+import { componentQrl } from "@builder.io/qwik";
+import { qrl } from "@builder.io/qwik";
+export const Child = /*#__PURE__*/ componentQrl(qrl(()=>import("./child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA;;AAEA,OAAO,MAAM,sBAAQ,8FAoBlB\"}")
 ============================= child_component_9gyf01gdkqw.js (ENTRY POINT)==
 
 import { jsx as _jsx } from "@builder.io/qwik/jsx-runtime";
 import { _wrapSignal } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-import { useOnVisibleTaskQrl } from "@builder.io/qwik";
+import { useBrowserVisibleTaskQrl } from "@builder.io/qwik";
 import { useStore } from "@builder.io/qwik";
 export const Child_component_9GyF01GDKqw = ()=>{
     const state = useStore({
         count: 0
     });
     // Double count watch
-    useOnVisibleTaskQrl(qrl(()=>import("./child_component_useonvisibletask_nz6mf0opce0"), "Child_component_useOnVisibleTask_nZ6mF0oPCE0", [
+    useBrowserVisibleTaskQrl(qrl(()=>import("./child_component_usebrowservisibletask_0igfpoyjmqa"), "Child_component_useBrowserVisibleTask_0IGFPOyJmQA", [
         state
     ]));
     return /*#__PURE__*/ _jsx("div", {
@@ -109,8 +109,8 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "ctxName": "component$",
   "captures": false,
   "loc": [
-    123,
-    465
+    128,
+    475
   ]
 }
 */

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_client_effect.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_client_effect.snap
@@ -38,6 +38,41 @@ export const Child = /*#__PURE__*/ componentQrl(qrl(()=>import("./child_componen
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA;;AAEA,OAAO,MAAM,sBAAQ,8FAoBlB\"}")
+============================= child_component_useonvisibletask_nz6mf0opce0.js (ENTRY POINT)==
+
+import { useLexicalScope } from "@builder.io/qwik";
+export const Child_component_useOnVisibleTask_nZ6mF0oPCE0 = ()=>{
+    const [state] = useLexicalScope();
+    const timer = setInterval(()=>{
+        state.count++;
+    }, 1000);
+    return ()=>{
+        clearInterval(timer);
+    };
+};
+export { _hW } from "@builder.io/qwik";
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";4DASsB;;IACd,MAAM,QAAQ,YAAY,IAAM;QAChC,MAAM,KAAK;IACX,GAAG;IACH,OAAO,IAAM;QACb,cAAc;IACd\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Child_component_useOnVisibleTask_nZ6mF0oPCE0",
+  "entry": null,
+  "displayName": "Child_component_useOnVisibleTask",
+  "hash": "nZ6mF0oPCE0",
+  "canonicalFilename": "child_component_useonvisibletask_nz6mf0opce0",
+  "extension": "js",
+  "parent": "Child_component_9GyF01GDKqw",
+  "ctxKind": "function",
+  "ctxName": "useOnVisibleTask$",
+  "captures": true,
+  "loc": [
+    234,
+    393
+  ]
+}
+*/
 ============================= child_component_9gyf01gdkqw.js (ENTRY POINT)==
 
 import { jsx as _jsx } from "@builder.io/qwik/jsx-runtime";
@@ -50,7 +85,7 @@ export const Child_component_9GyF01GDKqw = ()=>{
         count: 0
     });
     // Double count watch
-    useOnVisibleTaskQrl(qrl(()=>import("./child_component_useclienteffect_kyrt1iert9g"), "Child_component_useOnVisibleTask_kYRT1iERt9g", [
+    useOnVisibleTaskQrl(qrl(()=>import("./child_component_useonvisibletask_nz6mf0opce0"), "Child_component_useOnVisibleTask_nZ6mF0oPCE0", [
         state
     ]));
     return /*#__PURE__*/ _jsx("div", {
@@ -74,43 +109,8 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "ctxName": "component$",
   "captures": false,
   "loc": [
-    122,
-    463
-  ]
-}
-*/
-============================= child_component_useclienteffect_kyrt1iert9g.js (ENTRY POINT)==
-
-import { useLexicalScope } from "@builder.io/qwik";
-export const Child_component_useOnVisibleTask_kYRT1iERt9g = ()=>{
-    const [state] = useLexicalScope();
-    const timer = setInterval(()=>{
-        state.count++;
-    }, 1000);
-    return ()=>{
-        clearInterval(timer);
-    };
-};
-export { _hW } from "@builder.io/qwik";
-
-
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";2DASqB;;IACb,MAAM,QAAQ,YAAY,IAAM;QAChC,MAAM,KAAK;IACX,GAAG;IACH,OAAO,IAAM;QACb,cAAc;IACd\"}")
-/*
-{
-  "origin": "test.tsx",
-  "name": "Child_component_useOnVisibleTask_kYRT1iERt9g",
-  "entry": null,
-  "displayName": "Child_component_useOnVisibleTask",
-  "hash": "kYRT1iERt9g",
-  "canonicalFilename": "child_component_useclienteffect_kyrt1iert9g",
-  "extension": "js",
-  "parent": "Child_component_9GyF01GDKqw",
-  "ctxKind": "function",
-  "ctxName": "useOnVisibleTask$",
-  "captures": true,
-  "loc": [
-    232,
-    391
+    123,
+    465
   ]
 }
 */

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -1124,7 +1124,7 @@ export const Foo = component$(() => {
 fn example_use_client_effect() {
     test_input!(TestInput {
         code: r#"
-import { component$, useClientEffect$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
 
 export const Child = component$(() => {
     const state = useStore({
@@ -1132,7 +1132,7 @@ export const Child = component$(() => {
     });
 
     // Double count watch
-    useClientEffect$(() => {
+    useOnVisibleTask$(() => {
         const timer = setInterval(() => {
         state.count++;
         }, 1000);
@@ -1160,7 +1160,7 @@ export const Child = component$(() => {
 fn example_inlined_entry_strategy() {
     test_input!(TestInput {
         code: r#"
-import { component$, useClientEffect$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
 import { thing } from './sibling';
 import mongodb from 'mongodb';
 
@@ -1172,7 +1172,7 @@ export const Child = component$(() => {
     });
 
     // Double count watch
-    useClientEffect$(() => {
+    useOnVisibleTask$(() => {
         state.count = thing.doStuff() + import("./sibling");
     });
 

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -1124,7 +1124,7 @@ export const Foo = component$(() => {
 fn example_use_client_effect() {
     test_input!(TestInput {
         code: r#"
-import { component$, useOnVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
 
 export const Child = component$(() => {
     const state = useStore({
@@ -1132,7 +1132,7 @@ export const Child = component$(() => {
     });
 
     // Double count watch
-    useOnVisibleTask$(() => {
+    useBrowserVisibleTask$(() => {
         const timer = setInterval(() => {
         state.count++;
         }, 1000);
@@ -1160,7 +1160,7 @@ export const Child = component$(() => {
 fn example_inlined_entry_strategy() {
     test_input!(TestInput {
         code: r#"
-import { component$, useOnVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useStore, useStyles$ } from '@builder.io/qwik';
 import { thing } from './sibling';
 import mongodb from 'mongodb';
 
@@ -1172,7 +1172,7 @@ export const Child = component$(() => {
     });
 
     // Double count watch
-    useOnVisibleTask$(() => {
+    useBrowserVisibleTask$(() => {
         state.count = thing.doStuff() + import("./sibling");
     });
 

--- a/packages/qwik/src/optimizer/src/manifest.ts
+++ b/packages/qwik/src/optimizer/src/manifest.ts
@@ -166,7 +166,7 @@ const EVENT_PRIORITY = [
 
 const FUNCTION_PRIORITY = [
   'useTask$',
-  'useOnVisibleTask$',
+  'useBrowserVisibleTask$',
   'useEffect$',
   'component$',
   'useStyles$',

--- a/packages/qwik/src/optimizer/src/manifest.ts
+++ b/packages/qwik/src/optimizer/src/manifest.ts
@@ -166,7 +166,7 @@ const EVENT_PRIORITY = [
 
 const FUNCTION_PRIORITY = [
   'useTask$',
-  'useClientEffect$',
+  'useOnVisibleTask$',
   'useEffect$',
   'component$',
   'useStyles$',

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -343,7 +343,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
         transformOpts.stripExports = SERVER_STRIP_EXPORTS;
         transformOpts.isServer = false;
       } else if (opts.target === 'ssr') {
-        transformOpts.stripCtxName = ['useClient', 'client'];
+        transformOpts.stripCtxName = ['useClient', 'client', 'useOnVisibleTask'];
         transformOpts.stripCtxKind = 'event';
         transformOpts.isServer = true;
       }

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -343,7 +343,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
         transformOpts.stripExports = SERVER_STRIP_EXPORTS;
         transformOpts.isServer = false;
       } else if (opts.target === 'ssr') {
-        transformOpts.stripCtxName = ['useClient', 'client', 'useOnVisibleTask'];
+        transformOpts.stripCtxName = ['useClient', 'client', 'useBrowserVisibleTask'];
         transformOpts.stripCtxKind = 'event';
         transformOpts.isServer = true;
       }

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -343,7 +343,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
         transformOpts.stripExports = SERVER_STRIP_EXPORTS;
         transformOpts.isServer = false;
       } else if (opts.target === 'ssr') {
-        transformOpts.stripCtxName = ['useClient', 'client', 'useBrowserVisibleTask'];
+        transformOpts.stripCtxName = ['useClient', 'client', 'useBrowser', 'browser'];
         transformOpts.stripCtxKind = 'event';
         transformOpts.isServer = true;
       }

--- a/starters/apps/base/.vscode/qwik.code-snippets
+++ b/starters/apps/base/.vscode/qwik.code-snippets
@@ -59,12 +59,12 @@
 			""
 		]
 	},
-	"useOnVisibleTask": {
+	"useBrowserVisibleTask": {
 		"scope": "javascriptreact,typescriptreact",
-		"prefix": "quseOnVisibleTask",
-		"description": "useOnVisibleTask$() function hook",
+		"prefix": "quseBrowserVisibleTask",
+		"description": "useBrowserVisibleTask$() function hook",
 		"body": [
-			"useOnVisibleTask$(({ track }) => {",
+			"useBrowserVisibleTask$(({ track }) => {",
 			"  $0",
 			"});",
 			""

--- a/starters/apps/base/.vscode/qwik.code-snippets
+++ b/starters/apps/base/.vscode/qwik.code-snippets
@@ -59,12 +59,12 @@
 			""
 		]
 	},
-	"useClientEffect": {
+	"useOnVisibleTask": {
 		"scope": "javascriptreact,typescriptreact",
-		"prefix": "quseClientEffect",
-		"description": "useClientEffect$() function hook",
+		"prefix": "quseOnVisibleTask",
+		"description": "useOnVisibleTask$() function hook",
 		"body": [
-			"useClientEffect$(({ track }) => {",
+			"useOnVisibleTask$(({ track }) => {",
 			"  $0",
 			"});",
 			""

--- a/starters/apps/basic/src/routes/flower/index.tsx
+++ b/starters/apps/basic/src/routes/flower/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useOnVisibleTask$, useStore, useStylesScoped$ } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useStore, useStylesScoped$ } from '@builder.io/qwik';
 import { type DocumentHead, useLocation } from '@builder.io/qwik-city';
 import styles from './flower.css?inline';
 
@@ -11,7 +11,7 @@ export default component$(() => {
     number: 20,
   });
 
-  useOnVisibleTask$(({ cleanup }) => {
+  useBrowserVisibleTask$(({ cleanup }) => {
     const timeout = setTimeout(() => (state.count = 1), 500);
     cleanup(() => clearTimeout(timeout));
 

--- a/starters/apps/basic/src/routes/flower/index.tsx
+++ b/starters/apps/basic/src/routes/flower/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useClientEffect$, useStore, useStylesScoped$ } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useStore, useStylesScoped$ } from '@builder.io/qwik';
 import { type DocumentHead, useLocation } from '@builder.io/qwik-city';
 import styles from './flower.css?inline';
 
@@ -11,7 +11,7 @@ export default component$(() => {
     number: 20,
   });
 
-  useClientEffect$(({ cleanup }) => {
+  useOnVisibleTask$(({ cleanup }) => {
     const timeout = setTimeout(() => (state.count = 1), 500);
     cleanup(() => clearTimeout(timeout));
 

--- a/starters/apps/e2e/src/components/context/context.tsx
+++ b/starters/apps/e2e/src/components/context/context.tsx
@@ -6,7 +6,7 @@ import {
   useContext,
   Slot,
   useSignal,
-  useOnVisibleTask$,
+  useBrowserVisibleTask$,
 } from '@builder.io/qwik';
 
 export interface ContextI {
@@ -154,7 +154,7 @@ export const Issue1971Provider = component$(() => {
 
 export const Issue1971Child = component$(() => {
   const show = useSignal(false);
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     show.value = true;
   });
   return (

--- a/starters/apps/e2e/src/components/context/context.tsx
+++ b/starters/apps/e2e/src/components/context/context.tsx
@@ -6,7 +6,7 @@ import {
   useContext,
   Slot,
   useSignal,
-  useClientEffect$,
+  useOnVisibleTask$,
 } from '@builder.io/qwik';
 
 export interface ContextI {
@@ -154,7 +154,7 @@ export const Issue1971Provider = component$(() => {
 
 export const Issue1971Child = component$(() => {
   const show = useSignal(false);
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     show.value = true;
   });
   return (

--- a/starters/apps/e2e/src/components/effect-client/effect-client.tsx
+++ b/starters/apps/e2e/src/components/effect-client/effect-client.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import {
   component$,
-  useClientEffect$,
+  useOnVisibleTask$,
   useRef,
   useStore,
   useStyles$,
@@ -52,13 +52,13 @@ export const Timer = component$(() => {
   });
 
   // Double count watch
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     state.msg = 'run';
     container.current!.setAttribute('data-effect', 'true');
   });
 
   // Double count watch
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     state.count = 10;
     const timer = setInterval(() => {
       state.count++;
@@ -84,7 +84,7 @@ export const Eager = component$(() => {
   });
 
   // Double count watch
-  useClientEffect$(
+  useOnVisibleTask$(
     () => {
       state.msg = 'run';
     },
@@ -110,7 +110,7 @@ export const ClientSide = component$(() => {
     text3: 'empty 3',
   });
 
-  useClientEffect$(
+  useOnVisibleTask$(
     () => {
       state.text1 = 'run';
     },
@@ -119,11 +119,11 @@ export const ClientSide = component$(() => {
     }
   );
 
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     state.text2 = 'run';
   });
 
-  useClientEffect$(
+  useOnVisibleTask$(
     () => {
       state.text3 = 'run';
     },
@@ -143,7 +143,7 @@ export const ClientSide = component$(() => {
 
 export const FancyName = component$(() => {
   console.log('Fancy Name');
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.log('Client effect fancy name');
   });
   return <Slot />;
@@ -152,7 +152,7 @@ export const FancyName = component$(() => {
 export const fancyName = 'Some';
 
 export const Issue1413 = component$(() => {
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     console.log(fancyName);
   });
   console.log('Root route');
@@ -167,7 +167,7 @@ export const Issue1413 = component$(() => {
 
 export function useDelay(value: string) {
   const ready = useSignal('---');
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     ready.value = value;
   });
   return ready;
@@ -204,19 +204,19 @@ export const Issue2015 = component$(() => {
     logs: [] as string[],
   });
 
-  useClientEffect$(async () => {
+  useOnVisibleTask$(async () => {
     state.logs.push('start 1');
     await delay(100);
     state.logs.push('finish 1');
   });
 
-  useClientEffect$(async () => {
+  useOnVisibleTask$(async () => {
     state.logs.push('start 2');
     await delay(100);
     state.logs.push('finish 2');
   });
 
-  useClientEffect$(async () => {
+  useOnVisibleTask$(async () => {
     state.logs.push('start 3');
     await delay(100);
     state.logs.push('finish 3');
@@ -236,7 +236,7 @@ export const Issue1955Helper = component$(() => {
 
 export const Issue1955 = component$(() => {
   const signal = useSignal('empty');
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     debugger;
     signal.value = 'run';
   });

--- a/starters/apps/e2e/src/components/effect-client/effect-client.tsx
+++ b/starters/apps/e2e/src/components/effect-client/effect-client.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import {
   component$,
-  useOnVisibleTask$,
+  useBrowserVisibleTask$,
   useRef,
   useStore,
   useStyles$,
@@ -52,13 +52,13 @@ export const Timer = component$(() => {
   });
 
   // Double count watch
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     state.msg = 'run';
     container.current!.setAttribute('data-effect', 'true');
   });
 
   // Double count watch
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     state.count = 10;
     const timer = setInterval(() => {
       state.count++;
@@ -84,7 +84,7 @@ export const Eager = component$(() => {
   });
 
   // Double count watch
-  useOnVisibleTask$(
+  useBrowserVisibleTask$(
     () => {
       state.msg = 'run';
     },
@@ -110,7 +110,7 @@ export const ClientSide = component$(() => {
     text3: 'empty 3',
   });
 
-  useOnVisibleTask$(
+  useBrowserVisibleTask$(
     () => {
       state.text1 = 'run';
     },
@@ -119,11 +119,11 @@ export const ClientSide = component$(() => {
     }
   );
 
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     state.text2 = 'run';
   });
 
-  useOnVisibleTask$(
+  useBrowserVisibleTask$(
     () => {
       state.text3 = 'run';
     },
@@ -143,7 +143,7 @@ export const ClientSide = component$(() => {
 
 export const FancyName = component$(() => {
   console.log('Fancy Name');
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.log('Client effect fancy name');
   });
   return <Slot />;
@@ -152,7 +152,7 @@ export const FancyName = component$(() => {
 export const fancyName = 'Some';
 
 export const Issue1413 = component$(() => {
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     console.log(fancyName);
   });
   console.log('Root route');
@@ -167,7 +167,7 @@ export const Issue1413 = component$(() => {
 
 export function useDelay(value: string) {
   const ready = useSignal('---');
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     ready.value = value;
   });
   return ready;
@@ -204,19 +204,19 @@ export const Issue2015 = component$(() => {
     logs: [] as string[],
   });
 
-  useOnVisibleTask$(async () => {
+  useBrowserVisibleTask$(async () => {
     state.logs.push('start 1');
     await delay(100);
     state.logs.push('finish 1');
   });
 
-  useOnVisibleTask$(async () => {
+  useBrowserVisibleTask$(async () => {
     state.logs.push('start 2');
     await delay(100);
     state.logs.push('finish 2');
   });
 
-  useOnVisibleTask$(async () => {
+  useBrowserVisibleTask$(async () => {
     state.logs.push('start 3');
     await delay(100);
     state.logs.push('finish 3');
@@ -236,7 +236,7 @@ export const Issue1955Helper = component$(() => {
 
 export const Issue1955 = component$(() => {
   const signal = useSignal('empty');
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     debugger;
     signal.value = 'run';
   });

--- a/starters/apps/e2e/src/components/effect-client/effect-client.tsx
+++ b/starters/apps/e2e/src/components/effect-client/effect-client.tsx
@@ -89,7 +89,7 @@ export const Eager = component$(() => {
       state.msg = 'run';
     },
     {
-      eagerness: 'load',
+      strategy: 'document-ready',
     }
   );
 
@@ -115,7 +115,7 @@ export const ClientSide = component$(() => {
       state.text1 = 'run';
     },
     {
-      eagerness: 'load',
+      strategy: 'document-ready',
     }
   );
 
@@ -128,7 +128,7 @@ export const ClientSide = component$(() => {
       state.text3 = 'run';
     },
     {
-      eagerness: 'idle',
+      strategy: 'document-idle',
     }
   );
 

--- a/starters/apps/e2e/src/components/ref/ref.tsx
+++ b/starters/apps/e2e/src/components/ref/ref.tsx
@@ -1,10 +1,10 @@
-import { component$, useStore, useRef, useOnVisibleTask$, useSignal } from '@builder.io/qwik';
+import { component$, useStore, useRef, useBrowserVisibleTask$, useSignal } from '@builder.io/qwik';
 
 export const RefRoot = component$(() => {
   const state = useStore({
     visible: false,
   });
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     state.visible = true;
   });
 
@@ -23,7 +23,7 @@ export const RefRoot = component$(() => {
 
 export const Ref = component$((props: { id: string }) => {
   const ref = useRef();
-  useOnVisibleTask$(({ track }) => {
+  useBrowserVisibleTask$(({ track }) => {
     const el = track(() => ref.current);
     el!.textContent = `Rendered ${props.id}`;
   });
@@ -36,7 +36,7 @@ export const Ref = component$((props: { id: string }) => {
 
 export const Ref2 = component$((props: { id: string }) => {
   const ref = useSignal<Element>();
-  useOnVisibleTask$(({ track }) => {
+  useBrowserVisibleTask$(({ track }) => {
     const el = track(() => ref.value);
     el!.textContent = `Rendered ${props.id}`;
   });

--- a/starters/apps/e2e/src/components/ref/ref.tsx
+++ b/starters/apps/e2e/src/components/ref/ref.tsx
@@ -1,10 +1,10 @@
-import { component$, useStore, useRef, useClientEffect$, useSignal } from '@builder.io/qwik';
+import { component$, useStore, useRef, useOnVisibleTask$, useSignal } from '@builder.io/qwik';
 
 export const RefRoot = component$(() => {
   const state = useStore({
     visible: false,
   });
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     state.visible = true;
   });
 
@@ -23,7 +23,7 @@ export const RefRoot = component$(() => {
 
 export const Ref = component$((props: { id: string }) => {
   const ref = useRef();
-  useClientEffect$(({ track }) => {
+  useOnVisibleTask$(({ track }) => {
     const el = track(() => ref.current);
     el!.textContent = `Rendered ${props.id}`;
   });
@@ -36,7 +36,7 @@ export const Ref = component$((props: { id: string }) => {
 
 export const Ref2 = component$((props: { id: string }) => {
   const ref = useSignal<Element>();
-  useClientEffect$(({ track }) => {
+  useOnVisibleTask$(({ track }) => {
     const el = track(() => ref.value);
     el!.textContent = `Rendered ${props.id}`;
   });

--- a/starters/apps/e2e/src/components/signals/signals.tsx
+++ b/starters/apps/e2e/src/components/signals/signals.tsx
@@ -5,7 +5,7 @@ import {
   Signal,
   useSignal,
   useStore,
-  useClientEffect$,
+  useOnVisibleTask$,
   useTask$,
   Slot,
   useStyles$,
@@ -42,7 +42,7 @@ export const Signals = component$(() => {
 
   const styles = useSignal('body { background: white}');
 
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     ref.current!.setAttribute('data-set', 'ref');
     ref2.value!.setAttribute('data-set', 'ref2');
   });

--- a/starters/apps/e2e/src/components/signals/signals.tsx
+++ b/starters/apps/e2e/src/components/signals/signals.tsx
@@ -5,7 +5,7 @@ import {
   Signal,
   useSignal,
   useStore,
-  useOnVisibleTask$,
+  useBrowserVisibleTask$,
   useTask$,
   Slot,
   useStyles$,
@@ -42,7 +42,7 @@ export const Signals = component$(() => {
 
   const styles = useSignal('body { background: white}');
 
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     ref.current!.setAttribute('data-set', 'ref');
     ref2.value!.setAttribute('data-set', 'ref2');
   });

--- a/starters/apps/e2e/src/components/useid/useid.tsx
+++ b/starters/apps/e2e/src/components/useid/useid.tsx
@@ -1,4 +1,4 @@
-import { component$, useClientEffect$, useSignal, useId } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useSignal, useId } from '@builder.io/qwik';
 
 export const MIN_CHILDREN = 2;
 export const MAX_CHIDREN = 5;
@@ -37,7 +37,7 @@ export const UseId = component$(() => {
   const collsionsSignal = useSignal<number | null>(null);
   const resultSignal = useSignal<string | null>(null);
 
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     const ids = Array.from(document.querySelectorAll('ul[id]'));
 
     const uniqueIds: Set<string> = [...ids].reduce((prev, value) => {

--- a/starters/apps/e2e/src/components/useid/useid.tsx
+++ b/starters/apps/e2e/src/components/useid/useid.tsx
@@ -1,4 +1,4 @@
-import { component$, useOnVisibleTask$, useSignal, useId } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useSignal, useId } from '@builder.io/qwik';
 
 export const MIN_CHILDREN = 2;
 export const MAX_CHIDREN = 5;
@@ -37,7 +37,7 @@ export const UseId = component$(() => {
   const collsionsSignal = useSignal<number | null>(null);
   const resultSignal = useSignal<string | null>(null);
 
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     const ids = Array.from(document.querySelectorAll('ul[id]'));
 
     const uniqueIds: Set<string> = [...ids].reduce((prev, value) => {

--- a/starters/apps/qwikcity-test/src/routes/(common)/api/index@api.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/api/index@api.tsx
@@ -1,10 +1,10 @@
-import { component$, useOnVisibleTask$, useStore } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useStore } from '@builder.io/qwik';
 import type { RequestHandler } from '@builder.io/qwik-city';
 
 export default component$(() => {
   const store = useStore({ timestamp: '', os: '', arch: '', node: '' });
 
-  useOnVisibleTask$(async () => {
+  useBrowserVisibleTask$(async () => {
     const url = `/qwikcity-test/api/builder.io/oss.json`;
     const rsp = await fetch(url);
     const data: any = await rsp.json();

--- a/starters/apps/qwikcity-test/src/routes/(common)/api/index@api.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/api/index@api.tsx
@@ -1,10 +1,10 @@
-import { component$, useClientEffect$, useStore } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useStore } from '@builder.io/qwik';
 import type { RequestHandler } from '@builder.io/qwik-city';
 
 export default component$(() => {
   const store = useStore({ timestamp: '', os: '', arch: '', node: '' });
 
-  useClientEffect$(async () => {
+  useOnVisibleTask$(async () => {
     const url = `/qwikcity-test/api/builder.io/oss.json`;
     const rsp = await fetch(url);
     const data: any = await rsp.json();

--- a/starters/apps/qwikcity-test/src/routes/issue-loader-serialization/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue-loader-serialization/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useClientEffect$, useSignal, useTask$ } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useSignal, useTask$ } from '@builder.io/qwik';
 import { loader$ } from '@builder.io/qwik-city';
 import { isBrowser } from '@builder.io/qwik/build';
 
@@ -35,7 +35,7 @@ export const useCmp5 = loader$(() => {
 export const Cmp = component$(() => {
   const date = useCmp1();
   const ref = useSignal<HTMLElement>();
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     ref.value!.textContent = date.value.message;
   });
   return (

--- a/starters/apps/qwikcity-test/src/routes/issue-loader-serialization/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue-loader-serialization/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useOnVisibleTask$, useSignal, useTask$ } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useSignal, useTask$ } from '@builder.io/qwik';
 import { loader$ } from '@builder.io/qwik-city';
 import { isBrowser } from '@builder.io/qwik/build';
 
@@ -35,7 +35,7 @@ export const useCmp5 = loader$(() => {
 export const Cmp = component$(() => {
   const date = useCmp1();
   const ref = useSignal<HTMLElement>();
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     ref.value!.textContent = date.value.message;
   });
   return (

--- a/starters/apps/qwikcity-test/src/routes/issue2890/b/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue2890/b/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useOnVisibleTask$, useSignal } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useSignal } from '@builder.io/qwik';
 import { loader$ } from '@builder.io/qwik-city';
 
 export const useGetQuery = loader$(({ query }) => {
@@ -11,7 +11,7 @@ export default component$(() => {
   const signal = useSignal({});
   const data = useGetQuery();
 
-  useOnVisibleTask$(() => {
+  useBrowserVisibleTask$(() => {
     const url = new URL(window.location.href);
     signal.value = {
       query: url.searchParams.get('query') ?? 'NONE',

--- a/starters/apps/qwikcity-test/src/routes/issue2890/b/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue2890/b/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useClientEffect$, useSignal } from '@builder.io/qwik';
+import { component$, useOnVisibleTask$, useSignal } from '@builder.io/qwik';
 import { loader$ } from '@builder.io/qwik-city';
 
 export const useGetQuery = loader$(({ query }) => {
@@ -11,7 +11,7 @@ export default component$(() => {
   const signal = useSignal({});
   const data = useGetQuery();
 
-  useClientEffect$(() => {
+  useOnVisibleTask$(() => {
     const url = new URL(window.location.href);
     signal.value = {
       query: url.searchParams.get('query') ?? 'NONE',

--- a/starters/e2e/e2e.use-id.spec.ts
+++ b/starters/e2e/e2e.use-id.spec.ts
@@ -5,7 +5,7 @@ test.describe('use-id', () => {
     await page.goto('/e2e/use-id');
     page.on('pageerror', (err) => expect(err).toEqual(undefined));
     // await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(500); // Wait for useOnVisibleTask$
+    await page.waitForTimeout(500); // Wait for useBrowserVisibleTask$
   });
 
   test('Creates unique ids and ensure no collisions', async ({ page }) => {

--- a/starters/e2e/e2e.use-id.spec.ts
+++ b/starters/e2e/e2e.use-id.spec.ts
@@ -5,7 +5,7 @@ test.describe('use-id', () => {
     await page.goto('/e2e/use-id');
     page.on('pageerror', (err) => expect(err).toEqual(undefined));
     // await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(500); // Wait for useClientEffect$
+    await page.waitForTimeout(500); // Wait for useOnVisibleTask$
   });
 
   test('Creates unique ids and ensure no collisions', async ({ page }) => {

--- a/starters/e2e/qwikcity/page.spec.ts
+++ b/starters/e2e/qwikcity/page.spec.ts
@@ -141,7 +141,7 @@ function tests() {
     if (javaScriptEnabled) {
       // TODO!!
     } else {
-      // no useClientEffect()
+      // no useOnVisibleTask()
       expect(await nodeVersion.innerText()).toBe('');
     }
 

--- a/starters/e2e/qwikcity/page.spec.ts
+++ b/starters/e2e/qwikcity/page.spec.ts
@@ -141,7 +141,7 @@ function tests() {
     if (javaScriptEnabled) {
       // TODO!!
     } else {
-      // no useOnVisibleTask()
+      // no useBrowserVisibleTask()
       expect(await nodeVersion.innerText()).toBe('');
     }
 

--- a/starters/features/styled-vanilla-extract/src/routes/styled-flower/index.tsx
+++ b/starters/features/styled-vanilla-extract/src/routes/styled-flower/index.tsx
@@ -1,4 +1,4 @@
-import { component$, FunctionComponent, useClientEffect$, useStore } from '@builder.io/qwik';
+import { component$, FunctionComponent, useOnVisibleTask$, useStore } from '@builder.io/qwik';
 import { DocumentHead, useLocation } from '@builder.io/qwik-city';
 import { Host, odd, pride, Range, Square } from './flower.css';
 
@@ -34,7 +34,7 @@ export default component$(() => {
     number: 20,
   });
 
-  useClientEffect$(({ cleanup }) => {
+  useOnVisibleTask$(({ cleanup }) => {
     const timeout = setTimeout(() => (state.count = 1), 500);
     cleanup(() => clearTimeout(timeout));
 

--- a/starters/features/styled-vanilla-extract/src/routes/styled-flower/index.tsx
+++ b/starters/features/styled-vanilla-extract/src/routes/styled-flower/index.tsx
@@ -1,4 +1,4 @@
-import { component$, FunctionComponent, useOnVisibleTask$, useStore } from '@builder.io/qwik';
+import { component$, FunctionComponent, useBrowserVisibleTask$, useStore } from '@builder.io/qwik';
 import { DocumentHead, useLocation } from '@builder.io/qwik-city';
 import { Host, odd, pride, Range, Square } from './flower.css';
 
@@ -34,7 +34,7 @@ export default component$(() => {
     number: 20,
   });
 
-  useOnVisibleTask$(({ cleanup }) => {
+  useBrowserVisibleTask$(({ cleanup }) => {
     const timeout = setTimeout(() => (state.count = 1), 500);
     cleanup(() => clearTimeout(timeout));
 


### PR DESCRIPTION
## There are many problems with useClientEffect$():

- people have pre-conceived notions of what it is and they abuse it.
- They tend to put event listeners in there instead of putting it in useOn().
- a lot of community feedback that it is confusing.
- implies that useTask$() and useClientEffect$() are way different things.
- It is valuable to have a well named "dangerous" method which causes slowness as it is easy to search for. 
- useEffect is already being abused by React developers, in Qwik the same problems can be solved more efficiently with `useTask` or `useResource`

## Design constrains

- It's a different type of Task (happens at the different stage of the rendering pipeline), not just a Task but in the browser
- Should be clear that it's costly
- Should be clear that it's browser only
- Should be clear that happens after the component is rendered, and it's available in the DOM
- Should be clear that the DOM is there, and it's safe to use DOM APIs, without `window` check
- Should be clear that it's not only about rendering, Tasks can be executed independently, so PostRender is not a good fit.
- Should not contain the word `Effect`

## Why `useOnVisibleTask`

- `use`: like other APIs, it's a `use` method, meaning it creates some internals state and needs to be declared at the root level of a component$
- `On`: under the hood, `useOnVisibleTask` creates a event handler, similar to `onClick`, but the event is is triggered automaticlaly, like document-load or IntersectionObserver. `on` also implies that it's a browser only thing, since events only happen in the browser. Also signals the `cost` of this API.
- `VisibleTask:` One word, it's a different type of Task that happens after the component is rendered, there the `Visible` part. Also can behave like a Task, using the `track` API to reexecute when tracked state changes. Also `Visible` also implies that only happens happens in the browser, things are not visible in the server, there is no DOM in the server.

### But, it's so long

This is on purpose, this is an API that usually should not be used by developers, most of the time, the same can be achieved without eagarly running JS in the browser, using useTask.

The wordy name introduces a little bit of friction to favor `useTask`

