### PR TITLE
docs: fix a broken link in the Qwik City data loader docs

### DIFF
--- a/packages/docs/src/routes/qwikcity/loader/index.mdx
+++ b/packages/docs/src/routes/qwikcity/loader/index.mdx
@@ -161,4 +161,4 @@ export const getServerTime = loader$((ev) => {
 
 A loader should be used when you need to provide some server-side data to your Qwik Components. For example, if you need to fetch some data from a database or an API, you can use a loader to do that.
 
-You should not use a loader to create a REST API, for that you’d be better off using an [Endpoint](/qwik-city/), which allows you to have tight control over the response headers and body.
+You should not use a loader to create a REST API, for that you’d be better off using an [Endpoint](/qwikcity/endpoints/index.mdx), which allows you to have tight control over the response headers and body.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The link shown below was broken, this points it at the Endpoints path.

![image](https://user-images.githubusercontent.com/329184/218256496-273352ba-1a98-48fd-9814-307e76c902fd.png)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
