### PR TITLE
BUGFIX GH#2948 `useLocation().params` should have their values decoded using `decodeURIComponent(...)`

### DIFF
--- a/packages/qwik-city/runtime/src/routing.ts
+++ b/packages/qwik-city/runtime/src/routing.ts
@@ -104,7 +104,9 @@ export const getPathParams = (paramNames: string[] | undefined, match: RegExpExe
   if (paramNames) {
     for (let i = 0; i < paramNames.length; i++) {
       const param = match?.[i + 1] ?? '';
-      params[paramNames[i]] = param.endsWith('/') ? param.slice(0, -1) : param;
+      let v = param.endsWith('/') ? param.slice(0, -1) : param;
+      try { v = decodeURIComponent(v); } catch (e) { }
+      params[paramNames[i]] = v;
     }
   }
   return params;

--- a/packages/qwik-city/runtime/src/routing.ts
+++ b/packages/qwik-city/runtime/src/routing.ts
@@ -104,9 +104,9 @@ export const getPathParams = (paramNames: string[] | undefined, match: RegExpExe
   if (paramNames) {
     for (let i = 0; i < paramNames.length; i++) {
       const param = match?.[i + 1] ?? '';
-      let v = param.endsWith('/') ? param.slice(0, -1) : param;
-      try { v = decodeURIComponent(v); } catch (e) { }
-      params[paramNames[i]] = v;
+      const v = param.endsWith('/') ? param.slice(0, -1) : param;
+      // `decodeURIComponent(...)` should not throw here
+      params[paramNames[i]] = decodeURIComponent(v);
     }
   }
   return params;


### PR DESCRIPTION
# What is it?

- [x] Bug

# Description

if the uri is ill-formed, leave it as is

# Use cases and why

this fixes https://github.com/BuilderIO/qwik/issues/2948

# Checklist:

- no documentation change required
- TODO add tests
