### PR TITLE
fix(azure-swa): issue with ssg of '/' for Azure SWA

### DIFF
--- a/packages/qwik-city/adapters/azure-swa/vite/index.ts
+++ b/packages/qwik-city/adapters/azure-swa/vite/index.ts
@@ -14,7 +14,7 @@ export function azureSwaAdapter(opts: AzureSwaAdapterOptions = {}): any {
     ssg: opts.ssg,
     cleanStaticGenerated: true,
 
-    async generate({ outputEntries, serverOutDir }) {
+    async generate({ outputEntries, serverOutDir, clientOutDir }) {
       const serverPackageJsonPath = join(serverOutDir!, 'package.json');
       const serverPackageJsonCode = `{"type":"module"}`;
       await fs.promises.mkdir(serverOutDir!, { recursive: true });
@@ -57,6 +57,11 @@ export function azureSwaAdapter(opts: AzureSwaAdapterOptions = {}): any {
         2
       );
       await fs.promises.writeFile(funcJsonPath, funcJson);
+
+      // Azure SWA needs an index.html in the dist folder (otherwise it won't deploy)
+      if (!fs.existsSync(join(clientOutDir, 'index.html'))) {
+        await fs.promises.writeFile(join(clientOutDir, 'index.html'), '');
+      }
     },
   });
 }

--- a/starters/adapters/azure-swa/adapters/azure-swa/vite.config.ts
+++ b/starters/adapters/azure-swa/adapters/azure-swa/vite.config.ts
@@ -19,12 +19,6 @@ export default extendConfig(baseConfig, () => {
       target: 'webworker',
       noExternal: true,
     },
-    plugins: [
-      azureSwaAdapter({
-        ssg: {
-          include: ['/'],
-        },
-      }),
-    ],
+    plugins: [azureSwaAdapter()],
   };
 });


### PR DESCRIPTION
Closes #2955

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Azure Static Web Apps require an `index.html` file in the `dist` folder for successful deployment. The current implementation used `ssg` Vite configuration to create this file. The issue with that is that the router will also use the static file for the `/` route now which might not be intended. 

The fixed version creates an empty `index.html` after the build (if not created by `ssg`).

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
