### PR TITLE
Fix typo with useOnWindow and useOnDocument

### DIFF
--- a/packages/docs/src/routes/docs/cheat/best-practices/index.mdx
+++ b/packages/docs/src/routes/docs/cheat/best-practices/index.mdx
@@ -48,7 +48,7 @@ useOnDocument('mousemove', $((event)=> {
 > NOTE: Similar hooks exist for window and individual components.  
 > `window` -> `useOnWindow` , component -> `useOn`
 >
-> - [useOn / useDocument / useWindow docs](https://qwik.builder.io/tutorial/hooks/use-on/)
+> - [useOn / useOnDocument / useOnWindow docs](https://qwik.builder.io/tutorial/hooks/use-on/)
 > - [Example](https://qwik.builder.io/tutorial/hooks/use-on/#example)
 > - [Tutorial](https://qwik.builder.io/tutorial/events/programmatic/)
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
Use correct hook names for the link text (useOnWindow and useOnDocument hooks) on the best practices page

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
