### PR TITLE
docs: add specific type to Context example

### DIFF
--- a/packages/docs/src/routes/docs/components/context/index.mdx
+++ b/packages/docs/src/routes/docs/components/context/index.mdx
@@ -32,8 +32,12 @@ import {
   createContextId,
 } from '@builder.io/qwik';
 
+export interface IMyContext {
+    count: number
+}
+
 // Create a new context descriptor
-export const MyContext = createContextId('my-context');
+export const MyContext = createContextId<IMyContext>('my-context');
 
 export const Parent = component$(() => {
   // Create some reactive storage
@@ -53,7 +57,7 @@ export const Parent = component$(() => {
 
 export const Child = component$(() => {
   // Get reference to state using MyContext
-  const state = useContext(MyContext);
+  const state = useContext<IMyContext>(MyContext);
   return (
     <>
       <button onClick$={() => state.count++}>Increment</button>

--- a/packages/docs/src/routes/docs/components/context/index.mdx
+++ b/packages/docs/src/routes/docs/components/context/index.mdx
@@ -57,7 +57,7 @@ export const Parent = component$(() => {
 
 export const Child = component$(() => {
   // Get reference to state using MyContext
-  const state = useContext<IMyContext>(MyContext);
+  const state = useContext(MyContext);
   return (
     <>
       <button onClick$={() => state.count++}>Increment</button>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Example in docs does not work without a specific type cast for `createContext`. I think that updating the docs with my changes will save some time for less experienced TS developers in the future (such as my self).

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
