### PR TITLE
docs: fix signal tutorial page typos

### DIFF
--- a/packages/docs/src/routes/tutorial/hooks/use-signal/index.mdx
+++ b/packages/docs/src/routes/tutorial/hooks/use-signal/index.mdx
@@ -5,7 +5,7 @@ contributors:
   - adamdbradley
 ---
 
-Use `useSignal()` to store any single value similar to `useStore()`. `useSignal` is heavely optimized when it comes to re-rendering components. It is able to skip re-renderings of parent components even when the signal itself is defined in the parent. `useSignal` works with all [primitve types](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) as well as with not nested / flat objects. If you need to store arrays or complex objects use [useStore](../../../docs/components/state/index.mdx) instead with the `{deep: true}` option.
+Use `useSignal()` to store any single value similar to `useStore()`. `useSignal` is heavily optimized when it comes to re-rendering components. It is able to skip re-renderings of parent components even when the signal itself is defined in the parent. `useSignal` works with all [primitive types](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) as well as with not nested / flat objects. If you need to store arrays or complex objects use [useStore](../../../docs/components/state/index.mdx) instead with the `{deep: true}` option.
 
 Some examples would be:
 


### PR DESCRIPTION
Fix a few typos

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fix 2 typos in the [`useSignal`](https://qwik.builder.io/tutorial/hooks/use-signal/) section of the tutorial.

# Use cases and why

N/A

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
