### PR TITLE
Add Playground as bug category

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -19,6 +19,7 @@ body:
         - Qwik React
         - Qwik City (routing)
         - Starters / CLI
+        - Qwik Playground
     validations:
       required: true
 


### PR DESCRIPTION
# What is it?

Add the playground as a bug category, as its currently not represented by any of the existing ones.