### PR TITLE
allow `OnRenderFn` be async and use `Promise`s

### DIFF
--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -373,7 +373,7 @@ export type NoSerialize<T> = (T & {
 export const noSerialize: <T extends object | undefined>(input: T) => NoSerialize<T>;
 
 // @public (undocumented)
-export type OnRenderFn<PROPS> = (props: PROPS) => JSXNode<any> | null;
+export type OnRenderFn<PROPS> = (props: PROPS) => ValueOrPromise<JSXNode<any> | null>;
 
 // @public (undocumented)
 export interface OnVisibleTaskOptions {

--- a/packages/qwik/src/core/component/component.public.ts
+++ b/packages/qwik/src/core/component/component.public.ts
@@ -221,7 +221,7 @@ export const component$ = <PROPS extends {}>(onMount: OnRenderFn<PROPS>): Compon
 /**
  * @public
  */
-export type OnRenderFn<PROPS> = (props: PROPS) => JSXNode<any> | null;
+export type OnRenderFn<PROPS> = (props: PROPS) => ValueOrPromise<JSXNode<any> | null>
 
 export interface RenderFactoryOutput<PROPS> {
   renderQRL: QRL<OnRenderFn<PROPS>>;

--- a/packages/qwik/src/core/component/component.public.ts
+++ b/packages/qwik/src/core/component/component.public.ts
@@ -221,7 +221,7 @@ export const component$ = <PROPS extends {}>(onMount: OnRenderFn<PROPS>): Compon
 /**
  * @public
  */
-export type OnRenderFn<PROPS> = (props: PROPS) => ValueOrPromise<JSXNode<any> | null>
+export type OnRenderFn<PROPS> = (props: PROPS) => ValueOrPromise<JSXNode<any> | null>;
 
 export interface RenderFactoryOutput<PROPS> {
   renderQRL: QRL<OnRenderFn<PROPS>>;


### PR DESCRIPTION
allow `component$(...)` to use async functions as callback, thus simplifying server code
this would also align its signature more with `useBrowserVisibleTask$(...)`(originally `useClientEffect$(...)`

# What is it?

- [X] Feature / enhancement

# Description

fixes https://github.com/BuilderIO/qwik/issues/2765

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality -- only changes function signature, in a backward compatible way
