### PR TITLE
Updated action$() documentation

### DIFF
--- a/packages/docs/src/routes/qwikcity/action/index.mdx
+++ b/packages/docs/src/routes/qwikcity/action/index.mdx
@@ -13,7 +13,7 @@ Actions are referenced using the `.use()` method from within a Qwik Component. T
 ```tsx
 // src/routes/layout.tsx
 import { action$ } from '@builder.io/qwik';
-export const useAddUser = action$((user) => {
+export const addUser = action$((user) => {
   const userID = db.users.add(user);
   return {
     success: true,
@@ -22,7 +22,7 @@ export const useAddUser = action$((user) => {
 });
 
 export default component$(() => {
-  const action = useAddUser();
+  const action = addUser.use();
   // action.actionPath: string;
   // action.isRunning: boolean;
   // action.status?: number;
@@ -46,7 +46,7 @@ The best way to trigger an action is by using the `<Form/>` component exported i
 import { action$, Form } from '@builder.io/qwik-city';
 import { component$ } from '@builder.io/qwik';
 
-export const useAddUser = action$((user) => {
+export const addUser = action$((user) => {
   const userID = db.users.add(user);
   return {
     success: true,
@@ -55,7 +55,7 @@ export const useAddUser = action$((user) => {
 });
 
 export default component$(() => {
-  const action = useAddUser();
+  const action = addUser.use();
   return (
     <Form action={action}>
       <input name="name" />
@@ -78,7 +78,7 @@ Actions can also be triggered programatically using the `action.run()` method, i
 import { action$ } from '@builder.io/qwik-city';
 import { component$ } from '@builder.io/qwik';
 
-export const useAddUser = action$((user) => {
+export const addUser = action$((user) => {
   const userID = db.users.add(user);
   return {
     success: true,
@@ -87,7 +87,7 @@ export const useAddUser = action$((user) => {
 });
 
 export default component$(() => {
-  const action = useAddUser();
+  const action = addUser.use();
   return (
     <div>
       <button
@@ -167,7 +167,7 @@ export const addUser = action$(
 );
 
 export default component$(() => {
-  const action = useAddUser();
+  const action = addUser.use();
   return (
     <Form action={action}>
       <input name="name" />
@@ -211,7 +211,7 @@ Failures are stored in the `action.value` property, just like the success value.
 
 ```tsx
 export default component$(() => {
-  const action = useAddUser();
+  const action = addUser.use();
   return (
     <Form action={action}>
       <input name="name" />
@@ -232,7 +232,7 @@ When an action is triggered, the previous state is stored in the `action.formDat
 ```tsx
 import { action$, Form } from '@builder.io/qwik-city';
 
-export const useAddUser = action$(
+export const addUser = action$(
   (user) => {
     // `user` is typed { name: string }
     const userID = db.users.add(user);
@@ -246,7 +246,7 @@ export const useAddUser = action$(
 );
 
 export default component$(() => {
-  const action = useAddUser();
+  const action = addUser.use();
   return (
     <Form action={action}>
       <input name="name" value={action.formData?.get('name')} />


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

An example in docs does not work without a ".use()" when using the action.
I also changed a few action names to stay consistent.

# Why

- I got confused while working on a personal project because I was missing .use() and trying just to call the action.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality