### PR TITLE
chore: delete unnecessary eslint disable

### DIFF
--- a/packages/qwik/src/core/util/log.ts
+++ b/packages/qwik/src/core/util/log.ts
@@ -9,7 +9,6 @@ const STYLE = qDev
 
 export const logError = (message?: any, ...optionalParams: any[]) => {
   const err = message instanceof Error ? message : createError(message);
-  // eslint-disable-next-line no-console
   const messageStr = err.stack || err.message;
   console.error('%cQWIK ERROR', STYLE, messageStr, ...printParams(optionalParams));
   return err;
@@ -28,7 +27,6 @@ export const logErrorAndStop = (message?: any, ...optionalParams: any[]) => {
 };
 
 export const logWarn = (message?: any, ...optionalParams: any[]) => {
-  // eslint-disable-next-line no-console
   if (qDev) {
     console.warn('%cQWIK WARN', STYLE, message, ...printParams(optionalParams));
   }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

delete unnecessary eslint disable in two places, because we have config `warn` and `error` allowed in .eslintrc.js.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
