### PR TITLE
Updated loader$() documentation

### DIFF
--- a/packages/docs/src/routes/qwikcity/loader/index.mdx
+++ b/packages/docs/src/routes/qwikcity/loader/index.mdx
@@ -39,7 +39,7 @@ Loaders can be used by any component in the application, as long as the loader i
 import { loader$ } from '@builder.io/qwik-city';
 import { component$ } from '@builder.io/qwik';
 
-export const useGetServerTime = loader$(() => {
+export const getServerTime = loader$(() => {
   return {
     time: Date.now();
   }
@@ -47,7 +47,7 @@ export const useGetServerTime = loader$(() => {
 
 export default component$(() => {
   // Retrieve a reactive signal of the loader data
-  const signal = useGetServerTime(); // Signal<{time: number}>
+  const signal = getServerTime.use(); // Signal<{time: number}>
   return (
     <div>
       Server time: {signal.value.time}
@@ -56,7 +56,7 @@ export default component$(() => {
 });
 ```
 
-> The `useGetServerTime()` retrieves the loader data, but it does not execute the loader multiple times. Loaders execute eagerly\ at the beginning of the request in order to provide low latency. For this reason they are only allowed in the `src/routes` folder, in a `layout.tsx` or `index.tsx` file, and they MUST be exported.
+> The `getServerTime.use()` retrieves the loader data, but it does not execute the loader multiple times. Loaders execute eagerly\ at the beginning of the request in order to provide low latency. For this reason they are only allowed in the `src/routes` folder, in a `layout.tsx` or `index.tsx` file, and they MUST be exported.
 
 ## Multiple loaders
 
@@ -69,14 +69,14 @@ import { component$ } from '@builder.io/qwik';
 import { loader$ } from '@builder.io/qwik-city';
 import { Footer } from '../components/footer.tsx';
 
-export const useGetServerTime = loader$(() => {
+export const getServerTime = loader$(() => {
   return {
     time: Date.now();
   }
 });
 
 export default component$(() => {
-  const signal = useGetServerTime();
+  const signal = getServerTime.use();
   return (
     <main>
       <Slot>
@@ -92,11 +92,11 @@ export default component$(() => {
 import { component$ } from '@builder.io/qwik';
 
 // Import the loader from the layout
-import { useGetServerTime } from '../routes/layout.tsx';
+import { getServerTime } from '../routes/layout.tsx';
 
 export const Footer = component$(() => {
   // Consume the loader data
-  const signal = useGetServerTime();
+  const signal = getServerTime.use();
   return <footer>Server time: {signal.value.time}</footer>;
 });
 ```
@@ -107,21 +107,21 @@ export const Footer = component$(() => {
 import { component$ } from '@builder.io/qwik';
 import { loader$ } from '@builder.io/qwik-city';
 
-export const useIsLogged = loader$(({cookies}) => {
+export const isLogged = loader$(({cookies}) => {
   return {
     logged: checkCookies(cookies);
   }
 });
 
-export const useGetCurrentUser = loader$(({cookies}) => {
+export const getCurrentUser = loader$(({cookies}) => {
   return {
     user: currentUserFromCookies(cookies);
   }
 });
 
 export default component$(() => {
-  const logged = useIsLogged();
-  const user = useGetCurrentUser();
+  const logged = isLogged.use();
+  const user = getCurrentUser.use();
   return (
     <section>
       <h1>Admin</h1>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

An example in docs does not work without a ".use()" when using the loader.
I also changed a few loader names to stay consistent.

# Why

- I got confused while working on a personal project because I was missing .use() and trying just to call the loader.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality