### PR TITLE
Change starter to-do demo page title

### DIFF
--- a/packages/docs/src/routes/docs/components/lifecycle/index.mdx
+++ b/packages/docs/src/routes/docs/components/lifecycle/index.mdx
@@ -172,7 +172,7 @@ Under the hood, `useBrowserVisibleTask$()` creates a DOM listener that uses [Int
 However this `strategy` can be changed, and for example, run when the `document` is ready.
 
 ```tsx
-useClientEffect$(() => console.log('runs in the browser'), {
+useBrowserVisibleTask$(() => console.log('runs in the browser'), {
   strategy: 'document-ready', // 'load' | 'visible' | 'idle'
 });
 ```

--- a/packages/docs/src/routes/docs/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/getting-started/index.mdx
@@ -38,7 +38,7 @@ The CLI will guide you through an interactive menu to set the project-name, sele
 After your new app is created, you will see an output like the following in your terminal:
 
 ```shell
-🐰 Let's create a Qwik app 🐇   v0.17.6
+🐰 Let's create a Qwik app 🐇   v0.18.1
 
 ✔ Where would you like to create your new project? … qwik-app
 

--- a/starters/apps/basic/src/routes/todolist/index.tsx
+++ b/starters/apps/basic/src/routes/todolist/index.tsx
@@ -45,5 +45,5 @@ export default component$(() => {
 });
 
 export const head: DocumentHead = {
-  title: 'Qwik Flower',
+  title: 'Qwik To-Do',
 };


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

I found that to-do demo in Qwik Basic starter template had wrong title "Qwik Flower", So, I changed it to "Qwik To-Do"
and changed qwik version in getting starter webpage

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
