### PR TITLE
Update path in SSG docs for generated vite.config.ts file

### DIFF
--- a/packages/docs/src/routes/qwikcity/guides/static-site-generation/index.mdx
+++ b/packages/docs/src/routes/qwikcity/guides/static-site-generation/index.mdx
@@ -32,14 +32,14 @@ Static site generation is created from the built in adapter, to create an adapte
 npm run qwik add
 ```
 
-Select `Adaptor: Static site (.html files)`. Done!
+Select `Adapter: Static site (.html files)`. Done!
 
 ### Changes
 
 Running the above command will make the following changes to your project:
 
 - A `build.server` script will be automatically added to your `package.json` file.
-- A `adapters/vite.config.ts` file will be created.
+- A `adapters/static/vite.config.ts` file will be created.
 
 In node you can run the generation after building using:
 
@@ -51,7 +51,7 @@ Your build files will be generated into the `dist` folder.
 
 ### SSG Config
 
-The `adapters/vite.config.ts` file also includes the SSG config, which would be custom for each implementation.
+The `adapters/static/vite.config.ts` file also includes the SSG config, which would be custom for each implementation.
 
 #### `origin`
 


### PR DESCRIPTION
When running `npm run qwik add` and selecting the SSG adapter, the new `vite.config.ts` file is created in `adapters/static/`, not `adapters/`.

Also fix a typo in the adapter selection text: `Adaptor` -> `Adapter`

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Minor fixes to the documentation based on what I see by running the commands.

# Use cases and why

Ensure clarity on what should happen.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
