### PR TITLE
fix: buildTypes never startsWith tsc

### DIFF
--- a/packages/qwik/src/cli/build/run-build-command.ts
+++ b/packages/qwik/src/cli/build/run-build-command.ts
@@ -61,7 +61,7 @@ export async function runBuildCommand(app: AppCommand) {
 
   let typecheck: Promise<Step> | null = null;
 
-  if (buildTypes && buildTypes.startsWith('tsc')) {
+  if (buildTypes) {
     let copyScript = buildTypes;
     if (!copyScript.includes('--pretty')) {
       // ensures colors flow throw when we console log the stdout


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

buildTypes never startswith tsc,  so the code `  if (buildTypes) {}` in line 64 never run.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
