### PR TITLE
fix(qwik-auth): use authjs convention of signout

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -69,10 +69,10 @@ export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikA
     })
   );
 
-  const useAuthLogout = action$(async (_, req) => {
+  const useAuthSignout = action$(async (_, req) => {
     const auth = await authOptions(req);
     const body = new URLSearchParams();
-    return authAction(body, req, `/api/auth/logout`, auth);
+    return authAction(body, req, `/api/auth/signout`, auth);
   });
 
   const useAuthSession = loader$((req) => {
@@ -103,7 +103,7 @@ export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikA
 
   return {
     useAuthSignup,
-    useAuthLogout,
+    useAuthSignout,
     useAuthSession,
     onRequest,
   };


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Fix issue with not finding an allowed action "logout" and rename to Signout for consistancy

# Use cases and why

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
