### PR TITLE
Update RequestHandler types in Cloudflare Pages example

### DIFF
--- a/packages/docs/src/routes/integrations/deployments/cloudflare-pages/index.mdx
+++ b/packages/docs/src/routes/integrations/deployments/cloudflare-pages/index.mdx
@@ -114,12 +114,13 @@ export const onRequest = async ({ platform }) => {
 };
 ```
 
-Additionally, you may import the `RequestHandlerCloudflarePages` type to have have type completions in your editor.
+Additionally, you may import the `RequestHandler` and `PlatformCloudflarePages` types to have have type completions in your editor.
 
 ```tsx
-import { type RequestHandlerCloudflarePages } from '@builder.io/qwik-city/middleware/cloudflare-pages';
+import { type RequestHandler } from "@builder.io/qwik-city";
+import { type PlatformCloudflarePages } from "@builder.io/qwik-city/middleware/cloudflare-pages";
 
-export const onGet: RequestHandlerCloudflarePages = ({ platform }) => {
+export const onGet: RequestHandler<PlatformCloudflarePages> = ({ platform }) => {
   //...
 };
 ```


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

Update RequestHandler types in Cloudflare Pages example. The type seems to have been updated to be a generic and the example import no longer exists.

I'm running:
```
"@builder.io/qwik": "0.18.1",
"@builder.io/qwik-city": "0.2.1",
```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Accessing platform data in endpoint with TS types


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
