### PR TITLE
fix: fixed a broken gitignore file negation pattern in basic starter app

### DIFF
--- a/starters/apps/base/gitignore
+++ b/starters/apps/base/gitignore
@@ -10,7 +10,6 @@ node_modules
 # Cache
 .cache
 .mf
-.vscode
 .rollup.cache
 tsconfig.tsbuildinfo
 
@@ -24,6 +23,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 # Editor
+.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store


### PR DESCRIPTION
The '.vscode/extensions.json' file is intended to be tracked as it is listed for exclusion in gitignore file but even then git was ignoring it.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
