### PR TITLE
docs: Fix the href link - Cloudflare Page's function-invocation-routes config

### DIFF
--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -107,7 +107,7 @@ Within the projects "Settings" for "Build and deployments", the "Build command" 
 
 ### Function Invocation Routes
 
-Cloudflare Page's [function-invocation-routes config](https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/) can be used to include, or exclude, certain paths to be used by the worker functions. Having a `_routes.json` file gives developers more granular control over when your Function is invoked.
+Cloudflare Page's [function-invocation-routes config](https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes) can be used to include, or exclude, certain paths to be used by the worker functions. Having a `_routes.json` file gives developers more granular control over when your Function is invoked.
 This is useful to determine if a page response should be Server-Side Rendered (SSR) or if the response should use a static-site generated (SSG) `index.html` file.
 
 By default, the Cloudflare pages adaptor _does not_ include a `public/_routes.json` config, but rather it is auto-generated from the build by the Cloudflare adaptor. An example of an auto-generate `dist/_routes.json` would be:

--- a/packages/docs/src/routes/integrations/deployments/cloudflare-pages/index.mdx
+++ b/packages/docs/src/routes/integrations/deployments/cloudflare-pages/index.mdx
@@ -74,11 +74,11 @@ export { onRequest } from '../server/entry.cloudflare-pages';
 
 - [Cloudflare Pages Middleware Source](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/middleware/cloudflare-pages/index.ts)
 - [Cloudflare Pages Functions](https://developers.cloudflare.com/pages/platform/functions/)
-- [Function Invocation Route Config](https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/)
+- [Function Invocation Route Config](https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes)
 
 ### Cloudflare Pages Function Invocation Routes
 
-Cloudflare Page's [function-invocation-routes config](https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/) can be used to include, or exclude, certain paths to be used by the worker functions. Having a `_routes.json` file gives developers more granular control over when your Function is invoked.
+Cloudflare Page's [function-invocation-routes config](https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes) can be used to include, or exclude, certain paths to be used by the worker functions. Having a `_routes.json` file gives developers more granular control over when your Function is invoked.
 
 This is useful to determine if a page response should be Server-Side Rendered (SSR) or if the response should use a static-site generated (SSG) `index.html` file instead.
 

--- a/packages/qwik-city/adapters/cloudflare-pages/vite/index.ts
+++ b/packages/qwik-city/adapters/cloudflare-pages/vite/index.ts
@@ -65,7 +65,7 @@ export interface CloudflarePagesAdapterOptions extends ServerAdapterOptions {
   /**
    * Determines if the build should generate the function invocation routes `_routes.json` file.
    *
-   * https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/
+   * https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes
    *
    * Defaults to `true`.
    */

--- a/starters/adapters/cloudflare-pages/README.md
+++ b/starters/adapters/cloudflare-pages/README.md
@@ -18,7 +18,7 @@ Within the projects "Settings" for "Build and deployments", the "Build command" 
 
 ### Function Invocation Routes
 
-Cloudflare Page's [function-invocation-routes config](https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/) can be used to include, or exclude, certain paths to be used by the worker functions. Having a `_routes.json` file gives developers more granular control over when your Function is invoked.
+Cloudflare Page's [function-invocation-routes config](https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes) can be used to include, or exclude, certain paths to be used by the worker functions. Having a `_routes.json` file gives developers more granular control over when your Function is invoked.
 This is useful to determine if a page response should be Server-Side Rendered (SSR) or if the response should use a static-site generated (SSG) `index.html` file.
 
 By default, the Cloudflare pages adaptor _does not_ include a `public/_routes.json` config, but rather it is auto-generated from the build by the Cloudflare adaptor. An example of an auto-generate `dist/_routes.json` would be:


### PR DESCRIPTION
Fix the href links for the Cloudflare page's function-invocation-routes config.

https://developers.cloudflare.com/pages/platform/functions/function-invocation-routes/
->
https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
