### PR TITLE
docs(docs/src/routes/examples/[...id]/examples.css): fix scrolling an…

### DIFF
--- a/packages/docs/src/routes/examples/[...id]/examples.css
+++ b/packages/docs/src/routes/examples/[...id]/examples.css
@@ -1,8 +1,9 @@
 .examples {
   position: fixed;
   top: calc(var(--header-height) + var(--builder-bar-height));
-  width: 100%;
-  height: calc(100% - var(--header-height)-var(--builder-bar-height));
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 
 .examples-menu-container {
@@ -56,7 +57,7 @@
 
   .examples .repl {
     grid-template-rows: 1fr 1fr 1fr;
-    grid-template-columns: auto;
+    grid-template-columns: minmax(auto, 100%);
     grid-template-areas:
       'repl-input-panel'
       'repl-output-panel'


### PR DESCRIPTION
…d overflow

On the examples page there the left side menu didnt no have a scroll on small screen sizes and on 768-1033 the code panel extended beyond the screen.

fix #3040

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x ] Docs / tests

# Description

altered css  docs/src/routes/examples/[...id]/examples.css, to prevent overflowing outside the screen and added scrolling on the left side menu

# Use cases and why

1. On small screen sizes the left size menu didnt have scrolling and content was outside the screen. 
2. 738-1033px sizes the right side "repl" was overflowing outside the screen. 


# Checklist:

- [x ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
