### PR TITLE
docs: fixed light theme toggle problem

### DIFF
--- a/packages/docs/src/components/theme-toggle/theme-toggle.tsx
+++ b/packages/docs/src/components/theme-toggle/theme-toggle.tsx
@@ -40,6 +40,9 @@ export const ThemeToggle = component$(() => {
   const state = useContext(GlobalStore);
 
   const onClick$ = $(() => {
+    if (state.theme === 'auto') {
+      state.theme = getColorPreference();
+    }
     state.theme = state.theme === 'light' ? 'dark' : 'light';
     setPreference(state.theme);
   });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests

# Description

If you load the website with a light theme and click on the toggle theme, it won't change. The reason for that is the initial value of `state.theme`, which is received in `ThemeToggle` component as `auto`.  So when it's `auto` the following comparison changes the `light` theme to `light`.

```tsx 
  state.theme = state.theme === 'light' ? 'dark' : 'light';
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
