### PR TITLE
fix: set `@builder.io/qwik` to be >=0.18.0 for `qwik-city`

### DIFF
--- a/packages/qwik-city/package.json
+++ b/packages/qwik-city/package.json
@@ -145,7 +145,7 @@
     "yaml": "2.2.1"
   },
   "peerDependencies": {
-    "@builder.io/qwik": ">=0.17.0"
+    "@builder.io/qwik": ">=0.18.0"
   },
   "license": "MIT",
   "homepage": "https://qwik.builder.io/",


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

`qwik-city` 0.2.x uses renamed APIs of `@builder.io/qwik` and those APIs are only available in >=0.18.0 of `@builder.io/qwik`. For example, `createContextId`.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

When using `qwik-city` **0.2.x** with `qwik` **0.17.x**, the application doesn't start. 

Switching to `qwik` **0.18.x** solved the issue.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
