### PR TITLE
Update package.json

### DIFF
--- a/packages/qwik-auth/package.json
+++ b/packages/qwik-auth/package.json
@@ -18,7 +18,7 @@
   },
   "exports": {
     ".": {
-      "import": "./lib/index.js",
+      "import": "./lib/index.mjs",
       "require": "./lib/index.cjs",
       "types": "./lib/types/index.d.ts"
     }
@@ -37,7 +37,7 @@
     "url": "https://github.com/BuilderIO/qwik/issues"
   },
   "type": "module",
-  "main": "./lib/index.js",
+  "main": "./lib/index.mjs", 
   "types": "./lib/types/index.d.ts",
   "devDependencies": {
     "@builder.io/qwik": "workspace:*",

--- a/packages/qwik-auth/package.json
+++ b/packages/qwik-auth/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/BuilderIO/qwik/issues"
   },
   "type": "module",
-  "main": "./lib/index.mjs", 
+  "main": "./lib/index.mjs",
   "types": "./lib/types/index.d.ts",
   "devDependencies": {
     "@builder.io/qwik": "workspace:*",


### PR DESCRIPTION
Point to the .mjs file as main and import.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

This change will point to the generated module file instead of the js file. It's also pointing imports to the same generated module file.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
