### PR TITLE
docs: replace useClientEffects to useBrowserVisibleTask

### DIFF
--- a/packages/docs/src/routes/tutorial/events/synchronous/index.mdx
+++ b/packages/docs/src/routes/tutorial/events/synchronous/index.mdx
@@ -9,4 +9,4 @@ While not a common use case, you may occasionally need to process events synchro
 
 Since Qwik processes asynchronously by default, your code must be explicitly configured for synchronous calls. This example shows how to eagerly load an event handler that processes a synchronous event.
 
-> **Your task:** Convert the `onClick$` from asynchronous event to synchronous event by using [`useClientEffect`](https://qwik.builder.io/docs/components/lifecycle/#useclienteffect) lifecycle and [normal event registration](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).
+> **Your task:** Convert the `onClick$` from asynchronous event to synchronous event by using [`useBrowserVisibleTask$`](https://qwik.builder.io/docs/components/lifecycle/#usebrowservisibletask) lifecycle and [normal event registration](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).

--- a/packages/docs/src/routes/tutorial/events/synchronous/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/events/synchronous/solution/app.tsx
@@ -1,8 +1,8 @@
-import { component$, useClientEffect$, useSignal } from '@builder.io/qwik';
+import { component$, useBrowserVisibleTask$, useSignal } from '@builder.io/qwik';
 
 export default component$(() => {
   const aHref = useSignal<Element>();
-  useClientEffect$(() => {
+  useBrowserVisibleTask$(() => {
     const handler = (event: Event) => {
       event.preventDefault();
       window.open('http://qwik.builder.io');


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

docs: replace useClientEffects to useBrowserVisibleTask

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
