### PR TITLE
fix: q:key containing double quotes does not break elements on server side render

### DIFF
--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -655,7 +655,7 @@ This goes against the HTML spec: https://html.spec.whatwg.org/multipage/dom.html
       }
     }
     if (key != null) {
-openingElement += ' q:key="' + escapeAttr(key) + '"';
+      openingElement += ' q:key="' + escapeAttr(key) + '"';
     }
     if ('ref' in props || useSignal || listeners.length > 0) {
       if ('ref' in props || useSignal || listenersNeedId(listeners)) {

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -655,7 +655,7 @@ This goes against the HTML spec: https://html.spec.whatwg.org/multipage/dom.html
       }
     }
     if (key != null) {
-      openingElement += ' q:key="' + key.replace(/"/g, '&quot;') + '"';
+openingElement += ' q:key="' + escapeAttr(key) + '"';
     }
     if ('ref' in props || useSignal || listeners.length > 0) {
       if ('ref' in props || useSignal || listenersNeedId(listeners)) {

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -655,7 +655,7 @@ This goes against the HTML spec: https://html.spec.whatwg.org/multipage/dom.html
       }
     }
     if (key != null) {
-      openingElement += ' q:key="' + key + '"';
+      openingElement += ' q:key="' + key.replace(/"/g, '&quot;') + '"';
     }
     if ('ref' in props || useSignal || listeners.length > 0) {
       if ('ref' in props || useSignal || listenersNeedId(listeners)) {

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -632,6 +632,32 @@ renderSSRSuite('using component with key', async () => {
   );
 });
 
+renderSSRSuite('using element with key', async () => {
+  await testSSR(
+    <body>
+      <div key="hola" />
+    </body>,
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+      <body>
+        <div q:key="hola"></div>
+      </body>
+    </html>`
+  );
+});
+
+renderSSRSuite('using element with key containing double quotes', async () => {
+  await testSSR(
+    <body>
+      <div key={'"hola"'} />
+    </body>,
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+      <body>
+        <div q:key="&quot;hola&quot;"></div>
+      </body>
+    </html>`
+  );
+});
+
 renderSSRSuite('using component props', async () => {
   await testSSR(
     <MyCmp


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Fixes: https://github.com/BuilderIO/qwik/issues/3091

Using strings that contain double quotes as the key for elements breaks on server-side render. Expect a string with double quotes to still work as a valid q:key.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
