### PR TITLE
docs: replace `Solid Start` to `SolidStart` and add link

### DIFF
--- a/packages/docs/src/routes/qwikcity/routing/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/index.mdx
@@ -11,7 +11,7 @@ contributors:
 
 # Routing
 
-Routing in Qwik City is file-system based like [Next.js](https://nextjs.org/docs/routing/introduction), [SvelteKit](https://kit.svelte.dev/docs/routing), SolidStart or Remix. Files and directories in the `src/routes` have a role in the routing of your application.
+Routing in Qwik City is file-system based like [Next.js](https://nextjs.org/docs/routing/introduction), [SvelteKit](https://kit.svelte.dev/docs/routing), [SolidStart](https://start.solidjs.com/getting-started/what-is-solidstart) or Remix. Files and directories in the `src/routes` have a role in the routing of your application.
 
 - **📂 Directories:** Describe the URL segments to match by the router.
 - **📄 index. files:** Page/endpoint.

--- a/packages/docs/src/routes/qwikcity/routing/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/index.mdx
@@ -11,7 +11,7 @@ contributors:
 
 # Routing
 
-Routing in Qwik City is file-system based like [Next.js](https://nextjs.org/docs/routing/introduction), [SvelteKit](https://kit.svelte.dev/docs/routing), Solid Start or Remix. Files and directories in the `src/routes` have a role in the routing of your application.
+Routing in Qwik City is file-system based like [Next.js](https://nextjs.org/docs/routing/introduction), [SvelteKit](https://kit.svelte.dev/docs/routing), SolidStart or Remix. Files and directories in the `src/routes` have a role in the routing of your application.
 
 - **📂 Directories:** Describe the URL segments to match by the router.
 - **📄 index. files:** Page/endpoint.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

docs: replace `Solid Start` to `SolidStart` and add a link to `SolidStart`

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
