### PR TITLE
refactor(starters): don't use deprecated `href` of `RouteLocation`

### DIFF
--- a/starters/apps/basic/src/components/router-head/router-head.tsx
+++ b/starters/apps/basic/src/components/router-head/router-head.tsx
@@ -12,7 +12,7 @@ export const RouterHead = component$(() => {
     <>
       <title>{head.title}</title>
 
-      <link rel="canonical" href={loc.href} />
+      <link rel="canonical" href={loc.url.href} />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 

--- a/starters/apps/documentation-site/src/components/router-head/router-head.tsx
+++ b/starters/apps/documentation-site/src/components/router-head/router-head.tsx
@@ -12,7 +12,7 @@ export const RouterHead = component$(() => {
     <>
       <title>{head.title}</title>
 
-      <link rel="canonical" href={loc.href} />
+      <link rel="canonical" href={loc.url.href} />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 

--- a/starters/apps/qwikcity-test/src/components/router-head/router-head.tsx
+++ b/starters/apps/qwikcity-test/src/components/router-head/router-head.tsx
@@ -11,7 +11,7 @@ export const RouterHead = component$(() => {
   return (
     <>
       <title>{title}</title>
-      <link rel="canonical" href={loc.href} />
+      <link rel="canonical" href={loc.url.href} />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       <meta name="viewport" content="width=device-width" />
 

--- a/starters/apps/qwikcity-test/src/components/router-head/social.tsx
+++ b/starters/apps/qwikcity-test/src/components/router-head/social.tsx
@@ -4,7 +4,7 @@ export const Social = ({ head, loc }: SocialProps) => {
   return (
     <>
       {/*  Open Graph: https://ogp.me/  */}
-      <meta property="og:url" content={loc.href} />
+      <meta property="og:url" content={loc.url.href} />
       <meta property="og:title" content={head.title} />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Qwik" />


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

According to the documented message, usage of `href` has been deprecated (as well as some others surrounding it) with a suggestion to instead use `url`. However, this hasn't been reflected in the starter templates. This PR attempts to address that. 

Sidenote: this is my very first PR attempting to contribute to an open-source project. I was going to try out Qwik and came across this depreciation warning. Hope this fix might helpful, if there is anything I could improve or missed, please suggest.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

None

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
