### PR TITLE
docs: adjust wording on qwik-city pages nested layout and head

### DIFF
--- a/packages/docs/src/routes/qwikcity/pages/index.mdx
+++ b/packages/docs/src/routes/qwikcity/pages/index.mdx
@@ -163,7 +163,7 @@ export const head: DocumentHead = ({ params, resolveValue }) => {
 
 ### Nested layouts and head
 
-An advanced case is that a [layout](/qwikcity/layout/index.mdx) may want to modify the document title of an already resolved document head. In the example below, the page component returns the title of `Foo`. Next, the containing layout component can read the value of the page's document head and modify it. In this example, the layout component is adding `Bar` to the title, so that when rendered, the title will be `Foo Bar`. Every layout in the stack has the opportunity to return a new value.
+An advanced case is that a [layout](/qwikcity/layout/index.mdx) may want to modify the document title of an already resolved document head. In the example below, the page component returns the title of `Foo`. Next, the containing layout component can read the value of the page's document head and modify it. In this example, the layout component is adding `MyCompany - ` to the title, so that when rendered, the title will be `MyCompany - Foo`. Every layout in the stack has the opportunity to return a new value.
 
 ```
 ──src/


### PR DESCRIPTION
Documentation's incorrect text (Bar) fixed to code example's output text (MyCompany)

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

There was a simple error in description text and code example. It could have created confusion. So, I fixed it.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
