### PR TITLE
fix(qwik-auth): optional signin provider

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -54,7 +54,7 @@ export const fixCookies = (req: RequestEventCommon) => {
 };
 
 export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikAuthConfig>) {
-  const useAuthSignup = action$(
+  const useAuthSignin = action$(
     async ({ providerId, ...rest }, req) => {
       const auth = await authOptions(req);
       const body = new URLSearchParams();

--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -105,7 +105,7 @@ export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikA
   };
 
   return {
-    useAuthSignup,
+    useAuthSignin,
     useAuthSignout,
     useAuthSession,
     onRequest,

--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -4,7 +4,9 @@ import { implicit$FirstArg, QRL } from '@builder.io/qwik';
 import { action$, loader$, RequestEvent, RequestEventCommon, z, zod$ } from '@builder.io/qwik-city';
 import { isServer } from '@builder.io/qwik/build';
 import { parseString, splitCookiesString } from 'set-cookie-parser';
+
 export interface QwikAuthConfig extends AuthConfig {}
+
 const actions: AuthAction[] = [
   'providers',
   'session',
@@ -53,19 +55,20 @@ export const fixCookies = (req: RequestEventCommon) => {
 
 export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikAuthConfig>) {
   const useAuthSignup = action$(
-    async ({ provider, ...rest }, req) => {
+    async ({ providerId, ...rest }, req) => {
       const auth = await authOptions(req);
       const body = new URLSearchParams();
       Object.entries(rest).forEach(([key, value]) => {
         body.set(key, String(value));
       });
-      const data = await authAction(body, req, `/api/auth/signin/${provider}`, auth);
+      const pathname = '/api/auth/signin' + (providerId ? `/${providerId}` : '');
+      const data = await authAction(body, req, pathname, auth);
       if (data.url) {
         throw req.redirect(301, data.url);
       }
     },
     zod$({
-      provider: z.string(),
+      providerId: z.string().optional(),
     })
   );
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

provider should be optional and redirect to the signin page when not provided.
Rename function

Both changes were made for consistency with other authjs packages.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
