### PR TITLE
fix(qwik-auth): await signout authAction

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -72,7 +72,7 @@ export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikA
   const useAuthSignout = action$(async (_, req) => {
     const auth = await authOptions(req);
     const body = new URLSearchParams();
-    return authAction(body, req, `/api/auth/signout`, auth);
+    await authAction(body, req, `/api/auth/signout`, auth);
   });
 
   const useAuthSession = loader$((req) => {


### PR DESCRIPTION
nothing needs to be returned

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
