### PR TITLE
docs: fix to GroupLink scoped styles

### DIFF
--- a/packages/docs/src/routes/community/components/group-link.tsx
+++ b/packages/docs/src/routes/community/components/group-link.tsx
@@ -4,14 +4,11 @@ export interface GroupLinkProps {
   link: string;
 }
 
-export const CSS = `
-  .docs article a {
-    color: var(--secondary-text-color);
-  }
-`;
-
 export const GroupLink = component$((props: GroupLinkProps) => {
-  useStylesScoped$(CSS);
+  useStylesScoped$(`
+    :global(.docs article) a {
+      color: var(--secondary-text-color);
+    }`);
   return (
     <a href={props.link} target="_blank" rel="noopener">
       <Slot />


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fix to GroupLink scoped styles, I had not properly referenced the element and so the styles were being ignored.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code