### PR TITLE
docs: updates State Page useStore option 'recursive' to 'deep'

### DIFF
--- a/packages/docs/src/routes/docs/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/components/state/index.mdx
@@ -113,7 +113,7 @@ export default component$(() => {
     {
       nested: { fields: { are: 'not tracked' } },
     },
-    { recursive: true }
+    { deep: true }
   );
 
   return (
@@ -135,7 +135,7 @@ export default component$(() => {
     {
       letters: ['A', 'B', 'C'],
     },
-    { recursive: true }
+    { deep: true }
   );
 
   return (


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Update the State page useStore code examples to use 'deep' instead of the depreciated 'recursive' option.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
