### PR TITLE
feat: add comment into the starter template for required `title` element editor hint

### DIFF
--- a/starters/apps/basic/src/root.tsx
+++ b/starters/apps/basic/src/root.tsx
@@ -15,9 +15,9 @@ export default component$(() => {
   return (
     <QwikCityProvider>
       <head>
-        <title>Qwik app</title>
         <meta charSet="utf-8" />
         <link rel="manifest" href="/manifest.json" />
+        {/* <RouterHead> contains <title> element, please ignore the editor hint */}
         <RouterHead />
       </head>
       <body lang="en">

--- a/starters/apps/basic/src/root.tsx
+++ b/starters/apps/basic/src/root.tsx
@@ -15,6 +15,7 @@ export default component$(() => {
   return (
     <QwikCityProvider>
       <head>
+        <title>Qwik app</title>
         <meta charSet="utf-8" />
         <link rel="manifest" href="/manifest.json" />
         <RouterHead />


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

add required `title` element into the starter template, for better SEO. 

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
