### PR TITLE
Update index.ts

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -38,14 +38,11 @@ export async function authAction(
   });
   fixCookies(req);
 
-  let parsedRes;
   try {
-    parsedRes = await res.json();
+    return await res.json();
   } catch (error) {
-    parsedRes = await res.text();
+    return await res.text();
   }
-
-  return parsedRes;
 }
 
 export const fixCookies = (req: RequestEventCommon) => {

--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -38,7 +38,14 @@ export async function authAction(
   });
   fixCookies(req);
 
-  return await res.json();
+  let parsedRes;
+  try {
+    parsedRes = await res.json();
+  } catch (error) {
+    parsedRes = await res.text();
+  }
+
+  return parsedRes;
 }
 
 export const fixCookies = (req: RequestEventCommon) => {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Updated the authAction function to be able to run with credentials, which aren't returning json but text.  Removes the error:
`[vite] Internal server error: Unexpected end of JSON input
      at JSON.parse (<anonymous>)
      at Response.json (node:internal/deps/undici/undici:6160:23)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async authAction (C:\sparXysProjects\qwik-workshop-checkout\node_modules\.pnpm\@builder.io+qwik-auth@0.0.2_bglh2a4lfprj64z3sx3otiimom\node_modules\@builder.io
\qwik-auth\lib\index.qwik.mjs:195:9)`

# Use cases and why

Expected to be able to run with credentials without failing with a json parsing error.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
