### PR TITLE
fix(docs): add missing import statement of qwik-city menu

### DIFF
--- a/packages/docs/src/routes/qwikcity/action/index.mdx
+++ b/packages/docs/src/routes/qwikcity/action/index.mdx
@@ -12,6 +12,7 @@ Actions are referenced using the `.use()` method from within a Qwik Component. T
 
 ```tsx
 // src/routes/layout.tsx
+import { component$ } from '@builder.io/qwik';
 import { action$ } from '@builder.io/qwik-city';
 export const useAddUser = action$((user) => {
   const userID = db.users.add(user);
@@ -149,7 +150,8 @@ export const addUser = action$(
 When submitting data to an action, the data is validated against the Zod schema. If the data is invalid, the action will put the validation error in the `action.fail` property.
 
 ```tsx
-import { action$, Form } from '@builder.io/qwik-city';
+import { component$ } from '@builder.io/qwik';
+import { action$, Form, zod$, z } from '@builder.io/qwik-city';
 
 export const addUser = action$(
   (user) => {
@@ -185,7 +187,7 @@ Please refer to the [Zod documentation](https://zod.dev/) for more information o
 In order to return non-success values, the action must use the `fail()` method.
 
 ```tsx
-import { action$, Form } from '@builder.io/qwik-city';
+import { action$, zod$, z } from '@builder.io/qwik-city';
 
 export const addUser = action$(
   (user, { fail }) => {
@@ -209,6 +211,9 @@ export const addUser = action$(
 Failures are stored in the `action.value` property, just like the success value. However, the `action.value.failed` property is set to `true` when the action fails.
 
 ```tsx
+import { component$ } from '@builder.io/qwik';
+import { Form } from '@builder.io/qwik-city';
+
 export default component$(() => {
   const action = useAddUser();
   return (
@@ -229,7 +234,8 @@ Thanks to Typescript type discrimination, you can use the `action.value.failed` 
 When an action is triggered, the previous state is stored in the `action.formData` property. This is useful to display a loading state while the action is running.
 
 ```tsx
-import { action$, Form } from '@builder.io/qwik-city';
+import { component$ } from '@builder.io/qwik';
+import { action$, Form, zod$, z } from '@builder.io/qwik-city';
 
 export const useAddUser = action$(
   (user) => {

--- a/packages/docs/src/routes/qwikcity/advanced/menu/index.mdx
+++ b/packages/docs/src/routes/qwikcity/advanced/menu/index.mdx
@@ -94,6 +94,8 @@ The example above will return:
 While [`useContent()`](/qwikcity/api/index.mdx#usecontent) can be invoked from any component that is part of the current route. It is typically used in a layout component (or a component used by layout) to render the menu. An example usage is shown here:
 
 ```tsx
+import { component$ } from '@builder.io/qwik';
+import { useLocation, useContent } from '@builder.io/qwik-city';
 export default component$(() => {
   const { menu } = useContent();
   const { pathname } = useLocation();

--- a/packages/docs/src/routes/qwikcity/advanced/routing/index.mdx
+++ b/packages/docs/src/routes/qwikcity/advanced/routing/index.mdx
@@ -50,6 +50,9 @@ For example, let's say we have a product page with a URL such as `https://exampl
 In this example, `id` is used as a key to load the product data from the database. When the product data is found, great, we'll correctly render data. However, if the product data is not found in the database, we can still handle rendering this page, but instead responding with a 404 HTTP status code.
 
 ```tsx
+import { component$ } from '@builder.io/qwik';
+import { loader$ } from '@builder.io/qwik-city';
+
 export const useProductLoader = loader$(async ({ params, status }) => {
   // Example database call using the id param
   // The database could return null if the product is not found
@@ -185,6 +188,8 @@ In this case, the layouts will nest each other with the page within each of them
 
 ```tsx
 // File: src/routes/layout.tsx
+import { component$ } from '@builder.io/qwik';
+
 export default component$(() => {
   return (
     <main>
@@ -196,6 +201,8 @@ export default component$(() => {
 
 ```tsx
 // File: src/routes/about/layout.tsx
+import { component$ } from '@builder.io/qwik';
+
 export default component$(() => {
   return (
     <section>
@@ -207,6 +214,8 @@ export default component$(() => {
 
 ```tsx
 // File: src/routes/about/index.tsx
+import { component$ } from '@builder.io/qwik';
+
 export default component$(() => {
   return <h1>About</h1>;
 });

--- a/packages/docs/src/routes/qwikcity/api/index.mdx
+++ b/packages/docs/src/routes/qwikcity/api/index.mdx
@@ -168,6 +168,9 @@ This component will have a button then when clicked, QwikCity will navigate to `
 The `loader$()` function is used to declare a new Server Loader in the given page/endpoint or layout. QwikCity will execute all the declared loaders for the given route match. Qwik Components can later reference the loaders, by importing them and calling the `.use()` method in order to retrieve the data.
 
 ```tsx
+import { component$ } from '@builder.io/qwik';
+import { loader$ } from '@builder.io/qwik-city';
+
 export const useGetTime = loader$(() => {
   return { time: new Date() }
 });
@@ -259,6 +262,9 @@ The `Link` component works like the `<a>` anchor element, but instead of causing
 Under the hood, the `<Link>` component uses the [`useNavigate()`](/qwikcity/api/index.mdx#usenavigate) API and prevents the default behaviour of the native `<a>`:
 
 ```tsx
+import { component$ } from '@builder.io/qwik';
+import { useNavigate } from '@builder.io/qwik-city';
+
 export const Link = component$<LinkProps>((props) => {
   const nav = useNavigate();
 

--- a/packages/docs/src/routes/qwikcity/guides/static-site-generation/index.mdx
+++ b/packages/docs/src/routes/qwikcity/guides/static-site-generation/index.mdx
@@ -72,6 +72,8 @@ For a Javascript project, it's quite common for the build's runtime to be built 
 ## Dynamic SSG Routes
 
 ```tsx
+import { component$ } from '@builder.io/qwik';
+import { useLocation } from '@builder.io/qwik-city';
 import type { StaticGenerateHandler } from '@builder.io/qwik-city';
 
 export default component$(() => {

--- a/packages/docs/src/routes/qwikcity/layout/index.mdx
+++ b/packages/docs/src/routes/qwikcity/layout/index.mdx
@@ -59,6 +59,8 @@ It will be used for all routes under the `src/routes` directory. It will render 
 
 ```tsx
 // File: src/routes/layout.tsx
+import { component$ } from '@builder.io/qwik';
+
 export default component$(() => {
   return (
     <>
@@ -77,6 +79,8 @@ This is the main route for the site. It will be rendered under the `Slot` compon
 
 ```tsx
 // File: src/routes/index.tsx
+import { component$ } from '@builder.io/qwik';
+
 export default component$(() => {
   return <>Home</>;
 });
@@ -88,6 +92,8 @@ Same as the `src/routes/index.tsx` file, but for the `about` route, similary it 
 
 ```tsx
 // File: src/routes/about/index.tsx
+import { component$ } from '@builder.io/qwik';
+
 export default component$(() => {
   return <>About</>;
 });

--- a/packages/docs/src/routes/qwikcity/loader/index.mdx
+++ b/packages/docs/src/routes/qwikcity/loader/index.mdx
@@ -142,6 +142,8 @@ Just like request handlers such as `onRequest` and `onGet`, loaders have access 
 This information comes in handly when the loader needs to conditionally return data based on the request, or it needs to override the response status, headers or body manually.
 
 ```tsx
+import { loader$ } from '@builder.io/qwik-city';
+
 export const getServerTime = loader$((ev) => {
   console.log('Request headers:', ev.headers);
   console.log('Request cookies:', ev.cookie);

--- a/starters/adapters/express/src/entry.express.tsx
+++ b/starters/adapters/express/src/entry.express.tsx
@@ -1,7 +1,7 @@
 /*
  * WHAT IS THIS FILE?
  *
- * It's the  entry point for the express server when building for production.
+ * It's the entry point for the express server when building for production.
  *
  * Learn more about the cloudflare integration here:
  * - https://qwik.builder.io/integrations/deployments/node/


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

fix(docs): add missing import statement of qwik-city menu

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
