### PR TITLE
feat(qwik-city): add a scripts key to head

### DIFF
--- a/packages/qwik-city/buildtime/markdown/frontmatter.ts
+++ b/packages/qwik-city/buildtime/markdown/frontmatter.ts
@@ -58,6 +58,7 @@ export function frontmatterAttrsToDocumentHead(attrs: FrontmatterAttrs | undefin
         styles: [],
         links: [],
         frontmatter: {},
+        scripts: [],
       };
 
       for (const attrName of attrNames) {

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -199,6 +199,10 @@ export interface DocumentHeadValue {
    * meta names (such as title, description, author, etc...), are stored in this property.
    */
   readonly frontmatter?: Readonly<Record<string, any>>;
+  /**
+   *  Used to manually append `<script>` elements to the `<head>`.
+   */
+  readonly scripts?: DocumentScript[];
 }
 
 /**
@@ -239,6 +243,25 @@ export interface DocumentLink {
   title?: string;
   type?: string;
   key?: string;
+}
+
+/**
+ * @alpha
+ */
+export interface DocumentScript {
+  async?: string;
+  crossorigin?: string;
+  defer?: string;
+  fectpriority?: string;
+  integrity?: string;
+  nomodule?: string;
+  nonce?: string;
+  referrerpolicy?: string;
+  src?: string;
+  type?: string;
+  importmap?: string;
+  blocking?: string;
+  id?: string;
 }
 
 /**


### PR DESCRIPTION
Allow for injecting custom scripts

2593

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Added a scripts key to head to allow for injecting custom scripts. 

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
