### PR TITLE
docs: remove builder bar from examples/tutorial/playground

### DIFF
--- a/packages/docs/src/components/header/header.css
+++ b/packages/docs/src/components/header/header.css
@@ -1,9 +1,13 @@
 .header-container {
-  height: calc(var(--header-height) + var(--builder-bar-height));
+  height: var(--header-height);
   margin-bottom: 6px;
   background: var(--bg-color);
   position: relative;
   z-index: 100;
+}
+
+.header-container.builder-bar {
+  height: calc(var(--header-height) + var(--builder-bar-height));
 }
 
 @media (min-width: 1024px) {

--- a/packages/docs/src/components/header/header.tsx
+++ b/packages/docs/src/components/header/header.tsx
@@ -21,7 +21,7 @@ import { BUILDER_MODEL, BUILDER_PUBLIC_API_KEY } from '../../constants';
 export const Header = component$(() => {
   useStyles$(styles);
   const globalStore = useContext(GlobalStore);
-  const pathname = useLocation().pathname;
+  const pathname = new URL(useLocation().url).pathname;
 
   useBrowserVisibleTask$(() => {
     globalStore.theme = getColorPreference();
@@ -31,9 +31,17 @@ export const Header = component$(() => {
     });
   });
 
+  const hasBuilderBar = !(
+    pathname.startsWith('/examples') ||
+    pathname.startsWith('/tutorial') ||
+    pathname.startsWith('/playground')
+  );
+
   return (
-    <header class="header-container">
-      <BuilderContentComp apiKey={BUILDER_PUBLIC_API_KEY} model={BUILDER_MODEL} tag="div" />
+    <header class={['header-container', ...(hasBuilderBar ? ['builder-bar'] : [])]}>
+      {hasBuilderBar && (
+        <BuilderContentComp apiKey={BUILDER_PUBLIC_API_KEY} model={BUILDER_MODEL} tag="div" />
+      )}
       <div class="header-inner">
         <div class="header-logo">
           <a href="/">

--- a/packages/docs/src/routes/examples/[...id]/examples.css
+++ b/packages/docs/src/routes/examples/[...id]/examples.css
@@ -1,6 +1,6 @@
 .examples {
   position: fixed;
-  top: calc(var(--header-height) + var(--builder-bar-height));
+  top: var(--header-height);
   bottom: 0;
   left: 0;
   right: 0;
@@ -11,7 +11,7 @@
   grid-template-rows: 100%;
   grid-template-columns: 100vw 100vw;
   grid-template-areas: 'example-content-panel example-repl-panel';
-  height: calc(100% - var(--header-height) - var(--builder-bar-height));
+  height: calc(100% - var(--header-height));
   transform: translate3d(0, 0, 0);
   transition: transform 500ms;
   height: 100%;

--- a/packages/docs/src/routes/playground/playground.css
+++ b/packages/docs/src/routes/playground/playground.css
@@ -1,6 +1,6 @@
 .playground {
   position: fixed;
-  top: calc(var(--header-height) + var(--builder-bar-height));
+  top: calc(var(--header-height));
   width: 100%;
   height: cal(100vh - var(--header-height));
 

--- a/packages/docs/src/routes/tutorial/tutorial.css
+++ b/packages/docs/src/routes/tutorial/tutorial.css
@@ -1,8 +1,8 @@
 .tutorial {
   position: fixed;
-  top: calc(var(--header-height) + var(--builder-bar-height));
+  top: var(--header-height);
   width: 100%;
-  height: calc(100vh - var(--header-height) - var(--builder-bar-height));
+  height: calc(100vh - var(--header-height));
 }
 
 .tutorial .repl {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
