### PR TITLE
fix(qwik-city): type error

### DIFF
--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -343,7 +343,7 @@ type StrictUnion<T> = Prettify<StrictUnionHelper<T, T>>;
 
 type Prettify<T> = {
   [K in keyof T]?: T[K];
-} & {};
+} | {};
 
 /**
  * @alpha

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -341,9 +341,9 @@ type StrictUnionHelper<T, TAll> = T extends any
 
 type StrictUnion<T> = Prettify<StrictUnionHelper<T, T>>;
 
-type Prettify<T> = {
+type Prettify<T> = {} & {
   [K in keyof T]?: T[K];
-} | {};
+};
 
 /**
  * @alpha


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

in new version0.20.0, when you `npm run preview`, an error happen.

`node_modules/@builder.io/qwik-city/index.d.ts(499,8): error TS1005: ';' expected.`

the error line in node_modules is:

```
declare type Prettify<T> = {
    [K in keyof T]?: T[K];
} & 
```

the raw code is: 
```
type Prettify<T> = {
  [K in keyof T]?: T[K];
} & {};
```

so maybe we should put `{}` in front ?

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
