### PR TITLE
feat(global): kleur/colors for treeshaking

### DIFF
--- a/packages/create-qwik/create-app.ts
+++ b/packages/create-qwik/create-app.ts
@@ -1,6 +1,6 @@
 import type { CreateAppOptions, CreateAppResult, IntegrationData } from '../qwik/src/cli/types';
 import fs from 'node:fs';
-import color from 'kleur';
+import { bgMagenta, magenta, cyan, bold } from 'kleur/colors';
 import { isAbsolute, join, relative, resolve } from 'node:path';
 import {
   cleanPackageJson,
@@ -50,17 +50,17 @@ export function logCreateAppResult(
   const outString = [];
 
   if (isCwdDir) {
-    outString.push(`🦄 ${color.bgMagenta(' Success! ')}`);
+    outString.push(`🦄 ${bgMagenta(' Success! ')}`);
   } else {
     outString.push(
-      `🦄 ${color.bgMagenta(' Success! ')} ${color.cyan(`Project created in`)} ${color.bold(
-        color.magenta(relativeProjectPath)
-      )} ${color.cyan(`directory`)}`
+      `🦄 ${bgMagenta(' Success! ')} ${cyan(`Project created in`)} ${bold(
+        magenta(relativeProjectPath)
+      )} ${cyan(`directory`)}`
     );
   }
   outString.push(``);
 
-  outString.push(`🐰 ${color.cyan(`Next steps:`)}`);
+  outString.push(`🐰 ${cyan(`Next steps:`)}`);
   if (!isCwdDir) {
     outString.push(`   cd ${relativeProjectPath}`);
   }
@@ -71,13 +71,13 @@ export function logCreateAppResult(
   outString.push(``);
 
   const qwikAdd = pkgManager !== 'npm' ? `${pkgManager} qwik add` : `npm run qwik add`;
-  outString.push(`🤍 ${color.cyan('Integrations? Add Netlify, Cloudflare, Tailwind...')}`);
+  outString.push(`🤍 ${cyan('Integrations? Add Netlify, Cloudflare, Tailwind...')}`);
   outString.push(`   ${qwikAdd}`);
   outString.push(``);
 
   outString.push(logSuccessFooter(result.docs));
 
-  outString.push(`👀 ${color.cyan('Presentations, Podcasts and Videos:')}`);
+  outString.push(`👀 ${cyan('Presentations, Podcasts and Videos:')}`);
   outString.push(`   https://qwik.builder.io/media/`);
   outString.push(``);
 

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { relative } from 'node:path';
 import { text, select, confirm, intro, outro, cancel, spinner, isCancel } from '@clack/prompts';
-import color from 'kleur';
+import { gray, white, green, reset, bgBlue } from 'kleur/colors';
 import type { CreateAppOptions } from '../qwik/src/cli/types';
 import { backgroundInstallDeps } from '../qwik/src/cli/utils/install-deps';
 import { createApp, getOutDir, logCreateAppResult } from './create-app';
@@ -30,21 +30,21 @@ const note = (message = '', title = '') => {
   const msg = lines
     .map(
       (ln) =>
-        `${color.gray(bar)}  ${color.white(ln)}${' '.repeat(len - strip(ln).length)}${color.gray(
+        `${gray(bar)}  ${white(ln)}${' '.repeat(len - strip(ln).length)}${gray(
           bar
         )}`
     )
     .join('\n');
   process.stdout.write(
-    `${color.gray(bar)}\n${color.green('○')}  ${color.reset(title)} ${color.gray(
+    `${gray(bar)}\n${green('○')}  ${reset(title)} ${gray(
       '─'.repeat(len - title.length - 1) + '╮'
-    )}\n${msg}\n${color.gray('├' + '─'.repeat(len + 2) + '╯')}\n`
+    )}\n${msg}\n${gray('├' + '─'.repeat(len + 2) + '╯')}\n`
   );
 };
 // End of used code from clack
 
 export async function runCreateInteractiveCli() {
-  intro(`Let's create a ${color.bgBlue(' Qwik App ')} ✨ (v${(globalThis as any).QWIK_VERSION})`);
+  intro(`Let's create a ${bgBlue(' Qwik App ')} ✨ (v${(globalThis as any).QWIK_VERSION})`);
 
   const defaultProjectName = './qwik-app';
   const projectNameAnswer =

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -28,12 +28,7 @@ const note = (message = '', title = '') => {
       return ln.length > sum ? ln.length : sum;
     }, 0) + 2;
   const msg = lines
-    .map(
-      (ln) =>
-        `${gray(bar)}  ${white(ln)}${' '.repeat(len - strip(ln).length)}${gray(
-          bar
-        )}`
-    )
+    .map((ln) => `${gray(bar)}  ${white(ln)}${' '.repeat(len - strip(ln).length)}${gray(bar)}`)
     .join('\n');
   process.stdout.write(
     `${gray(bar)}\n${green('○')}  ${reset(title)} ${gray(

--- a/packages/create-qwik/index.ts
+++ b/packages/create-qwik/index.ts
@@ -2,7 +2,7 @@
 import { createApp, runCreateCli } from './create-app';
 import { panic } from '../qwik/src/cli/utils/utils';
 import { runCreateInteractiveCli } from './create-interactive';
-import color from 'kleur';
+import { red, yellow, blue, magenta } from 'kleur/colors';
 
 export async function runCli() {
   console.clear();
@@ -31,7 +31,7 @@ function checkNodeVersion() {
   const [majorVersion, minorVersion] = version.replace('v', '').split('.');
   if (Number(majorVersion) < 16) {
     console.error(
-      color.red(
+      red(
         `Qwik requires Node.js 16.8 or higher. You are currently running Node.js ${version}.`
       )
     );
@@ -39,7 +39,7 @@ function checkNodeVersion() {
   } else if (Number(majorVersion) === 16) {
     if (Number(minorVersion) < 8) {
       console.warn(
-        color.yellow(
+        yellow(
           `Node.js 16.8 or higher is recommended. You are currently running Node.js ${version}.`
         )
       );
@@ -47,7 +47,7 @@ function checkNodeVersion() {
   } else if (Number(majorVersion) === 18) {
     if (Number(minorVersion) < 11) {
       console.error(
-        color.red(
+        red(
           `Node.js 18.11 or higher is REQUIRED. From Node 18.0.0 to 18.11.0, there is a bug preventing correct behaviour of Qwik. You are currently running Node.js ${version}. https://github.com/BuilderIO/qwik/issues/3035`
         )
       );
@@ -58,17 +58,17 @@ function checkNodeVersion() {
 function printHeader() {
   // const qwikGradient = gradient(["rgb(24, 182, 246)", "rgb(172, 127, 244)"]);
   console.log(
-    color.blue(`
-      ${color.magenta('............')}
-    .::: ${color.magenta(':--------:.')}
-   .::::  ${color.magenta('.:-------:.')}
-  .:::::.   ${color.magenta('.:-------.')}
-  ::::::.     ${color.magenta('.:------.')}
- ::::::.        ${color.magenta(':-----:')}
- ::::::.       ${color.magenta('.:-----.')}
-  :::::::.     ${color.magenta('.-----.')}
-   ::::::::..   ${color.magenta('---:.')}
-    .:::::::::. ${color.magenta(':-:.')}
+    blue(`
+      ${magenta('............')}
+    .::: ${magenta(':--------:.')}
+   .::::  ${magenta('.:-------:.')}
+  .:::::.   ${magenta('.:-------.')}
+  ::::::.     ${magenta('.:------.')}
+ ::::::.        ${magenta(':-----:')}
+ ::::::.       ${magenta('.:-----.')}
+  :::::::.     ${magenta('.-----.')}
+   ::::::::..   ${magenta('---:.')}
+    .:::::::::. ${magenta(':-:.')}
      ..::::::::::::
              ...::::
     `),

--- a/packages/create-qwik/index.ts
+++ b/packages/create-qwik/index.ts
@@ -31,9 +31,7 @@ function checkNodeVersion() {
   const [majorVersion, minorVersion] = version.replace('v', '').split('.');
   if (Number(majorVersion) < 16) {
     console.error(
-      red(
-        `Qwik requires Node.js 16.8 or higher. You are currently running Node.js ${version}.`
-      )
+      red(`Qwik requires Node.js 16.8 or higher. You are currently running Node.js ${version}.`)
     );
     process.exit(1);
   } else if (Number(majorVersion) === 16) {

--- a/packages/qwik-city/static/main-thread.ts
+++ b/packages/qwik-city/static/main-thread.ts
@@ -6,7 +6,7 @@ import { getPathnameForDynamicRoute } from '../utils/pathname';
 import { msToString } from '../utils/format';
 import { pathToFileURL } from 'node:url';
 import { relative } from 'node:path';
-import color from 'kleur';
+import { bold, green, dim, red, magenta } from 'kleur/colors';
 import { formatError } from '../buildtime/vite/format-error';
 import { buildErrorMessage } from 'vite';
 
@@ -16,7 +16,7 @@ export async function mainThread(sys: System) {
 
   const main = await sys.createMainProcess!();
   const log = await sys.createLogger();
-  log.info('\n' + color.bold().green('Starting Qwik City SSG...'));
+  log.info('\n' + bold(green('Starting Qwik City SSG...')));
 
   const qwikCityPlan: QwikCityPlan = (await import(pathToFileURL(opts.qwikCityPlanModulePath).href))
     .default;
@@ -48,21 +48,21 @@ export async function mainThread(sys: System) {
         generatorResult.duration = timer();
 
         if (generatorResult.errors === 0) {
-          log.info(`\n${color.green('SSG results')}`);
+          log.info(`\n${green('SSG results')}`);
           if (generatorResult.rendered > 0) {
             log.info(
-              `- Generated: ${color.dim(
+              `- Generated: ${dim(
                 `${generatorResult.rendered} page${generatorResult.rendered === 1 ? '' : 's'}`
               )}`
             );
           }
 
-          log.info(`- Duration: ${color.dim(msToString(generatorResult.duration))}`);
+          log.info(`- Duration: ${dim(msToString(generatorResult.duration))}`);
 
           const total = generatorResult.rendered + generatorResult.errors;
           if (total > 0) {
             log.info(
-              `- Average: ${color.dim(msToString(generatorResult.duration / total) + ' per page')}`
+              `- Average: ${dim(msToString(generatorResult.duration / total) + ' per page')}`
             );
           }
           log.info(``);
@@ -111,9 +111,9 @@ export async function mainThread(sys: System) {
           if (result.error) {
             const err = new Error(result.error.message);
             err.stack = result.error.stack;
-            log.error(`\n${color.bold().red('Error during SSG')}`);
-            log.error(color.red(err.message));
-            log.error(`  Pathname: ${color.magenta(staticRoute.pathname)}`);
+            log.error(`\n${bold(red('Error during SSG'))}`);
+            log.error(red(err.message));
+            log.error(`  Pathname: ${magenta(staticRoute.pathname)}`);
             Object.assign(formatError(err), {
               plugin: 'qwik-ssg',
             });
@@ -128,7 +128,7 @@ export async function mainThread(sys: System) {
             const base = opts.rootDir ?? opts.outDir;
             const path = relative(base, result.filePath);
             const lastSlash = path.lastIndexOf('/');
-            log.info(`${color.dim(path.slice(0, lastSlash + 1))}${path.slice(lastSlash + 1)}`);
+            log.info(`${dim(path.slice(0, lastSlash + 1))}${path.slice(lastSlash + 1)}`);
           }
 
           flushQueue();

--- a/packages/qwik/src/cli/add/print-add-help.ts
+++ b/packages/qwik/src/cli/add/print-add-help.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import color from 'kleur';
+import { magenta, cyan, dim } from 'kleur/colors';
 import { loadIntegrations } from '../utils/integrations';
 import { pmRunCmd } from '../utils/utils';
 
@@ -10,18 +10,18 @@ export async function printAddHelp() {
   const pmRun = pmRunCmd();
 
   console.log(``);
-  console.log(`${pmRun} qwik ${color.magenta(`add`)} [integration]`);
+  console.log(`${pmRun} qwik ${magenta(`add`)} [integration]`);
   console.log(``);
 
-  console.log(`  ${color.cyan('Adapters')}`);
+  console.log(`  ${cyan('Adapters')}`);
   for (const s of adapters) {
-    console.log(`    ${s.id}  ${color.dim(s.pkgJson.description)}`);
+    console.log(`    ${s.id}  ${dim(s.pkgJson.description)}`);
   }
   console.log(``);
 
-  console.log(`  ${color.cyan('Features')}`);
+  console.log(`  ${cyan('Features')}`);
   for (const s of features) {
-    console.log(`    ${s.id}  ${color.dim(s.pkgJson.description)}`);
+    console.log(`    ${s.id}  ${dim(s.pkgJson.description)}`);
   }
   console.log(``);
 }

--- a/packages/qwik/src/cli/add/run-add-command.ts
+++ b/packages/qwik/src/cli/add/run-add-command.ts
@@ -1,5 +1,5 @@
 import type { AppCommand } from '../utils/app-command';
-import color from 'kleur';
+import { red } from 'kleur/colors';
 import { runAddInteractive } from './run-add-interactive';
 import { printAddHelp } from './print-add-help';
 
@@ -12,7 +12,7 @@ export async function runAddCommand(app: AppCommand) {
       await runAddInteractive(app, id);
     }
   } catch (e) {
-    console.error(`\n❌ ${color.red(String(e))}\n`);
+    console.error(`\n❌ ${red(String(e))}\n`);
     await printAddHelp();
     process.exit(1);
   }

--- a/packages/qwik/src/cli/add/run-add-interactive.ts
+++ b/packages/qwik/src/cli/add/run-add-interactive.ts
@@ -2,7 +2,7 @@
 import type { AppCommand } from '../utils/app-command';
 import { loadIntegrations } from '../utils/integrations';
 import prompts from 'prompts';
-import color from 'kleur';
+import { bgCyan, bold, magenta, cyan, bgMagenta } from 'kleur/colors';
 import { getPackageManager, panic } from '../utils/utils';
 import { updateApp } from './update-app';
 import type { IntegrationData, UpdateAppResult } from '../types';
@@ -27,12 +27,12 @@ export async function runAddInteractive(app: AppCommand, id: string | undefined)
     }
 
     console.log(
-      `🦋 ${color.bgCyan(` Add Integration `)} ${color.bold(color.magenta(integration.id))}`
+      `🦋 ${bgCyan(` Add Integration `)} ${bold(magenta(integration.id))}`
     );
     console.log(``);
   } else {
     // use interactive cli to choose which integration to add
-    console.log(`🦋 ${color.bgCyan(` Add Integration `)}`);
+    console.log(`🦋 ${bgCyan(` Add Integration `)}`);
     console.log(``);
 
     const integrationChoices = [
@@ -117,14 +117,14 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
   console.log(``);
 
   console.log(
-    `👻 ${color.bgCyan(` Ready? `)} Add ${color.bold(
-      color.magenta(result.integration.id)
+    `👻 ${bgCyan(` Ready? `)} Add ${bold(
+      magenta(result.integration.id)
     )} to your app?`
   );
   console.log(``);
 
   if (modifyFiles.length > 0) {
-    console.log(`🐬 ${color.cyan(`Modify`)}`);
+    console.log(`🐬 ${cyan(`Modify`)}`);
     for (const f of modifyFiles) {
       console.log(`   - ${relative(process.cwd(), f.path)}`);
     }
@@ -132,7 +132,7 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
   }
 
   if (createFiles.length > 0) {
-    console.log(`🌟 ${color.cyan(`Create`)}`);
+    console.log(`🌟 ${cyan(`Create`)}`);
     for (const f of createFiles) {
       console.log(`   - ${relative(process.cwd(), f.path)}`);
     }
@@ -140,7 +140,7 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
   }
 
   if (overwriteFiles.length > 0) {
-    console.log(`🐳 ${color.cyan(`Overwrite`)}`);
+    console.log(`🐳 ${cyan(`Overwrite`)}`);
     for (const f of overwriteFiles) {
       console.log(`   - ${relative(process.cwd(), f.path)}`);
     }
@@ -149,7 +149,7 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
 
   if (installDeps) {
     console.log(
-      `💾 ${color.cyan(
+      `💾 ${cyan(
         `Install ${pkgManager} dependenc${installDepNames.length > 1 ? 'ies' : 'y'}:`
       )}`
     );
@@ -163,8 +163,8 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
     {
       type: 'select',
       name: 'commit',
-      message: `Ready to apply the ${color.bold(
-        color.magenta(result.integration.id)
+      message: `Ready to apply the ${bold(
+        magenta(result.integration.id)
       )} updates to your app?`,
       choices: [
         { title: 'Yes looks good, finish update!', value: true },
@@ -186,8 +186,8 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
 
 function logUpdateAppCommitResult(result: UpdateAppResult) {
   console.log(
-    `🦄 ${color.bgMagenta(` Success! `)} Added ${color.bold(
-      color.cyan(result.integration.id)
+    `🦄 ${bgMagenta(` Success! `)} Added ${bold(
+      cyan(result.integration.id)
     )} to your app`
   );
   console.log(``);

--- a/packages/qwik/src/cli/add/run-add-interactive.ts
+++ b/packages/qwik/src/cli/add/run-add-interactive.ts
@@ -26,9 +26,7 @@ export async function runAddInteractive(app: AppCommand, id: string | undefined)
       throw new Error(`Invalid integration: ${id}`);
     }
 
-    console.log(
-      `🦋 ${bgCyan(` Add Integration `)} ${bold(magenta(integration.id))}`
-    );
+    console.log(`🦋 ${bgCyan(` Add Integration `)} ${bold(magenta(integration.id))}`);
     console.log(``);
   } else {
     // use interactive cli to choose which integration to add
@@ -116,11 +114,7 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
   console.clear();
   console.log(``);
 
-  console.log(
-    `👻 ${bgCyan(` Ready? `)} Add ${bold(
-      magenta(result.integration.id)
-    )} to your app?`
-  );
+  console.log(`👻 ${bgCyan(` Ready? `)} Add ${bold(magenta(result.integration.id))} to your app?`);
   console.log(``);
 
   if (modifyFiles.length > 0) {
@@ -149,9 +143,7 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
 
   if (installDeps) {
     console.log(
-      `💾 ${cyan(
-        `Install ${pkgManager} dependenc${installDepNames.length > 1 ? 'ies' : 'y'}:`
-      )}`
+      `💾 ${cyan(`Install ${pkgManager} dependenc${installDepNames.length > 1 ? 'ies' : 'y'}:`)}`
     );
     installDepNames.forEach((depName) => {
       console.log(`   - ${depName} ${result.updates.installedDeps[depName]}`);
@@ -163,9 +155,7 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
     {
       type: 'select',
       name: 'commit',
-      message: `Ready to apply the ${bold(
-        magenta(result.integration.id)
-      )} updates to your app?`,
+      message: `Ready to apply the ${bold(magenta(result.integration.id))} updates to your app?`,
       choices: [
         { title: 'Yes looks good, finish update!', value: true },
         { title: 'Nope, cancel update', value: false },
@@ -186,9 +176,7 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
 
 function logUpdateAppCommitResult(result: UpdateAppResult) {
   console.log(
-    `🦄 ${bgMagenta(` Success! `)} Added ${bold(
-      cyan(result.integration.id)
-    )} to your app`
+    `🦄 ${bgMagenta(` Success! `)} Added ${bold(cyan(result.integration.id))} to your app`
   );
   console.log(``);
   logSuccessFooter(result.integration.docs);

--- a/packages/qwik/src/cli/add/update-app.ts
+++ b/packages/qwik/src/cli/add/update-app.ts
@@ -6,7 +6,7 @@ import { loadIntegrations } from '../utils/integrations';
 import { installDeps, startSpinner } from '../utils/install-deps';
 import { mergeIntegrationDir } from './update-files';
 import { updateViteConfigs } from './update-vite-config';
-import color from 'kleur';
+import { bgRed, green } from 'kleur/colors';
 
 export async function updateApp(pkgManager: string, opts: UpdateAppOptions) {
   const integrations = await loadIntegrations();
@@ -65,9 +65,9 @@ export async function updateApp(pkgManager: string, opts: UpdateAppOptions) {
       await fsWrites;
       spinner && spinner.succeed();
       if (!passed) {
-        const errorMessage = `\n\n❌ ${color.bgRed(
+        const errorMessage = `\n\n❌ ${bgRed(
           `  ${pkgManager} install failed  `
-        )}\n\n   You might need to run "${color.green(
+        )}\n\n   You might need to run "${green(
           `${pkgManager} install`
         )}" manually inside the root of the project.\n\n`;
 

--- a/packages/qwik/src/cli/build/run-build-command.ts
+++ b/packages/qwik/src/cli/build/run-build-command.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import color from 'kleur';
+import { dim, cyan, bgMagenta, magenta, } from 'kleur/colors';
 import type { AppCommand } from '../utils/app-command';
 import { execaCommand } from 'execa';
 import { getPackageManager, pmRunCmd } from '../utils/utils';
@@ -55,7 +55,7 @@ export async function runBuildCommand(app: AppCommand) {
 
   console.log(``);
   for (const script of scripts) {
-    console.log(color.dim(script!));
+    console.log(dim(script!));
   }
   console.log(``);
 
@@ -92,7 +92,7 @@ export async function runBuildCommand(app: AppCommand) {
     });
 
     console.log(``);
-    console.log(`${color.cyan('✓')} Built client modules`);
+    console.log(`${cyan('✓')} Built client modules`);
   }
 
   const step2: Promise<Step>[] = [];
@@ -227,16 +227,16 @@ export async function runBuildCommand(app: AppCommand) {
           console.log('');
           console.log(step.stdout);
         }
-        console.log(`${color.cyan('✓')} ${step.title}`);
+        console.log(`${cyan('✓')} ${step.title}`);
       });
 
       if (!isPreviewBuild && !buildServerScript && !buildStaticScript && !isLibraryBuild) {
         const pmRun = pmRunCmd()
         console.log(``);
-        console.log(`${color.bgMagenta(' Missing an integration ')}`);
+        console.log(`${bgMagenta(' Missing an integration ')}`);
         console.log(``);
-        console.log(`${color.magenta('・')} Use ${color.magenta(pmRun + ' qwik add')} to add an integration`);
-        console.log(`${color.magenta('・')} Use ${color.magenta(pmRun + ' preview')} to preview the build`);
+        console.log(`${magenta('・')} Use ${magenta(pmRun + ' qwik add')} to add an integration`);
+        console.log(`${magenta('・')} Use ${magenta(pmRun + ' preview')} to preview the build`);
       }
 
       if (isPreviewBuild && buildStaticScript && runSsgScript) {

--- a/packages/qwik/src/cli/run.ts
+++ b/packages/qwik/src/cli/run.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import color from 'kleur';
+import { red, bgMagenta, cyan, dim } from 'kleur/colors';
 import { AppCommand } from './utils/app-command';
 import { runAddCommand } from './add/run-add-command';
 import { panic, pmRunCmd } from './utils/utils';
@@ -39,7 +39,7 @@ async function runCommand(app: AppCommand) {
   }
 
   if (typeof app.task === 'string') {
-    console.log(color.red(`Unrecognized qwik command: ${app.task}`) + '\n');
+    console.log(red(`Unrecognized qwik command: ${app.task}`) + '\n');
   }
 
   await printHelp();
@@ -49,18 +49,18 @@ async function runCommand(app: AppCommand) {
 async function printHelp() {
   const pmRun = pmRunCmd();
   console.log(``);
-  console.log(color.bgMagenta(` Qwik Help `));
+  console.log(bgMagenta(` Qwik Help `));
   console.log(``);
   console.log(
-    `  ${pmRun} qwik ${color.cyan(`add`)}            ${color.dim(`Add an integration to this app`)}`
+    `  ${pmRun} qwik ${cyan(`add`)}            ${dim(`Add an integration to this app`)}`
   );
   console.log(
-    `  ${pmRun} qwik ${color.cyan(`build`)}          ${color.dim(
+    `  ${pmRun} qwik ${cyan(`build`)}          ${dim(
       `Parallelize builds and type checking`
     )}`
   );
   console.log(
-    `  ${pmRun} qwik ${color.cyan(`build preview`)}  ${color.dim(
+    `  ${pmRun} qwik ${cyan(`build preview`)}  ${dim(
       `Same as "build", but for preview server`
     )}`
   );

--- a/packages/qwik/src/cli/run.ts
+++ b/packages/qwik/src/cli/run.ts
@@ -51,18 +51,12 @@ async function printHelp() {
   console.log(``);
   console.log(bgMagenta(` Qwik Help `));
   console.log(``);
+  console.log(`  ${pmRun} qwik ${cyan(`add`)}            ${dim(`Add an integration to this app`)}`);
   console.log(
-    `  ${pmRun} qwik ${cyan(`add`)}            ${dim(`Add an integration to this app`)}`
+    `  ${pmRun} qwik ${cyan(`build`)}          ${dim(`Parallelize builds and type checking`)}`
   );
   console.log(
-    `  ${pmRun} qwik ${cyan(`build`)}          ${dim(
-      `Parallelize builds and type checking`
-    )}`
-  );
-  console.log(
-    `  ${pmRun} qwik ${cyan(`build preview`)}  ${dim(
-      `Same as "build", but for preview server`
-    )}`
+    `  ${pmRun} qwik ${cyan(`build preview`)}  ${dim(`Same as "build", but for preview server`)}`
   );
   console.log(``);
 }

--- a/packages/qwik/src/cli/utils/install-deps.ts
+++ b/packages/qwik/src/cli/utils/install-deps.ts
@@ -1,4 +1,4 @@
-import color from 'kleur';
+import { bgRed, green, red } from 'kleur/colors';
 import fs from 'node:fs';
 import ora from 'ora';
 import os from 'node:os';
@@ -105,9 +105,9 @@ export function backgroundInstallDeps(
           spinner.succeed();
           success = true;
         } else {
-          const errorMessage = `\n\n${color.bgRed(
+          const errorMessage = `\n\n${bgRed(
             `  ${pkgManager} install failed  `
-          )}\n  Automatic install failed. "${color.green(
+          )}\n  Automatic install failed. "${green(
             `${pkgManager} install`
           )}" must be manually executed to install deps.\n`;
 
@@ -138,7 +138,7 @@ function setupTmpInstall(baseApp: IntegrationData) {
   try {
     fs.mkdirSync(tmpInstallDir);
   } catch (e) {
-    console.error(`\n❌ ${color.red(String(e))}\n`);
+    console.error(`\n❌ ${red(String(e))}\n`);
   }
 
   const basePkgJson = path.join(baseApp.dir, 'package.json');

--- a/packages/qwik/src/cli/utils/log.ts
+++ b/packages/qwik/src/cli/utils/log.ts
@@ -1,17 +1,17 @@
-import color from 'kleur';
+import { cyan, bgMagenta } from 'kleur/colors';
 import type { NextSteps } from '../types';
 
 export function logSuccessFooter(docs: string[]) {
   const outString = [];
 
   if (docs.length > 0) {
-    outString.push(`📄 ${color.cyan('Relevant docs:')}`);
+    outString.push(`📄 ${cyan('Relevant docs:')}`);
     docs.forEach((link) => {
       outString.push(`   ${link}`);
     });
   }
   outString.push(``);
-  outString.push(`💬 ${color.cyan('Questions? Start the conversation at:')}`);
+  outString.push(`💬 ${cyan('Questions? Start the conversation at:')}`);
   outString.push(`   https://qwik.builder.io/chat`);
   outString.push(`   https://twitter.com/QwikDev`);
   outString.push(``);
@@ -25,7 +25,7 @@ export function logSuccessFooter(docs: string[]) {
 export function logNextStep(nextSteps: NextSteps | undefined) {
   const outString = [];
   if (nextSteps) {
-    outString.push(`🟣 ${color.bgMagenta(` ${nextSteps.title ?? 'Action Required!'} `)}`);
+    outString.push(`🟣 ${bgMagenta(` ${nextSteps.title ?? 'Action Required!'} `)}`);
     nextSteps.lines.forEach((step) => outString.push(`   ${step}`));
     outString.push(``);
   }

--- a/packages/qwik/src/cli/utils/utils.ts
+++ b/packages/qwik/src/cli/utils/utils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import color from 'kleur';
+import { red } from 'kleur/colors';
 import detectPackageManager from 'which-pm-runs';
 import type { IntegrationPackageJson } from '../types';
 
@@ -72,6 +72,6 @@ export function pmRunCmd() {
 }
 
 export function panic(msg: string) {
-  console.error(`\n❌ ${color.red(msg)}\n`);
+  console.error(`\n❌ ${red(msg)}\n`);
   process.exit(1);
 }


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

For better treeshaking, use `kleur/colors` instead of `kleur`.

This is also what **Astro** does. 
You can't find any `import color from 'kleur'` in Astro.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
