### PR TITLE
fix: removed old hooks in warning

### DIFF
--- a/packages/qwik/src/core/state/signal.ts
+++ b/packages/qwik/src/core/state/signal.ts
@@ -73,7 +73,7 @@ export class SignalImpl<T> implements Signal<T> {
       const invokeCtx = tryGetInvokeContext();
       if (invokeCtx && invokeCtx.$event$ === RenderEvent) {
         logWarn(
-          'State mutation inside render function. Move mutation to useWatch(), useBrowserVisibleTask() or useServerMount()',
+          'State mutation inside render function. Move mutation to useTask$() or useBrowserVisibleTask$()',
           invokeCtx.$hostElement$
         );
       }

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -152,7 +152,7 @@ class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
       const invokeCtx = tryGetInvokeContext();
       if (invokeCtx && invokeCtx.$event$ === RenderEvent) {
         logError(
-          'State mutation inside render function. Move mutation to useWatch(), useBrowserVisibleTask() or useServerMount()',
+          'State mutation inside render function. Move mutation to useTask$() or useBrowserVisibleTask$()',
           prop
         );
       }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Removed leftovers from the old days :)

not sure why the $ wasn't there (does it break the optimizing process if it's in a string?)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
