### PR TITLE
fix(doc-search): unable to prevent default

### DIFF
--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -1,5 +1,11 @@
 import type { SearchClient } from 'algoliasearch/lite';
-import { component$, useStore, useStyles$, useSignal } from '@builder.io/qwik';
+import {
+  component$,
+  useStore,
+  useStyles$,
+  useSignal,
+  useBrowserVisibleTask$,
+} from '@builder.io/qwik';
 import type { DocSearchHit, InternalDocSearchHit, StoredDocSearchHit } from './types';
 import { ButtonTranslations, DocSearchButton } from './doc-search-button';
 import { DocSearchModal, ModalTranslations } from './doc-search-modal';
@@ -66,43 +72,43 @@ export const DocSearch = component$((props: DocSearchProps) => {
 
   const searchButtonRef = useSignal();
 
+  useBrowserVisibleTask$(() => {
+    window.addEventListener('keydown', (event) => {
+      function open() {
+        // We check that no other DocSearch modal is showing before opening
+        // another one.
+        if (!document.body.classList.contains('DocSearch--active')) {
+          state.isOpen = true;
+        }
+      }
+      if (
+        (event.key === 'Escape' && state.isOpen) ||
+        // The `Cmd+K` shortcut both opens and closes the modal.
+        (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
+        // The `/` shortcut opens but doesn't close the modal because it's
+        // a character.
+        (!isEditingContent(event) && event.key === '/' && !state.isOpen)
+      ) {
+        event.preventDefault();
+
+        if (state.isOpen) {
+          state.isOpen = false;
+        } else if (!document.body.classList.contains('DocSearch--active')) {
+          open();
+        }
+      }
+
+      if (searchButtonRef && searchButtonRef.current === document.activeElement) {
+        if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
+          state.isOpen = true;
+          state.initialQuery = event.key;
+        }
+      }
+    });
+  });
+
   return (
-    <div
-      class="docsearch"
-      window:onKeyDown$={(event) => {
-        function open() {
-          // We check that no other DocSearch modal is showing before opening
-          // another one.
-          if (!document.body.classList.contains('DocSearch--active')) {
-            state.isOpen = true;
-          }
-        }
-        if (
-          (event.key === 'Escape' && state.isOpen) ||
-          // The `Cmd+K` shortcut both opens and closes the modal.
-          (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
-          // The `/` shortcut opens but doesn't close the modal because it's
-          // a character.
-          (!isEditingContent(event) && event.key === '/' && !state.isOpen)
-        ) {
-          // FIXME: not able to prevent
-          // event.preventDefault();
-
-          if (state.isOpen) {
-            state.isOpen = false;
-          } else if (!document.body.classList.contains('DocSearch--active')) {
-            open();
-          }
-        }
-
-        if (searchButtonRef && searchButtonRef.current === document.activeElement) {
-          if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
-            state.isOpen = true;
-            state.initialQuery = event.key;
-          }
-        }
-      }}
-    >
+    <div class="docsearch">
       <DocSearchButton
         ref={searchButtonRef}
         onClick$={() => {

--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -1,11 +1,5 @@
 import type { SearchClient } from 'algoliasearch/lite';
-import {
-  component$,
-  useStore,
-  useStyles$,
-  useSignal,
-  useBrowserVisibleTask$,
-} from '@builder.io/qwik';
+import { component$, useStore, useStyles$, useSignal } from '@builder.io/qwik';
 import type { DocSearchHit, InternalDocSearchHit, StoredDocSearchHit } from './types';
 import { ButtonTranslations, DocSearchButton } from './doc-search-button';
 import { DocSearchModal, ModalTranslations } from './doc-search-modal';
@@ -72,43 +66,45 @@ export const DocSearch = component$((props: DocSearchProps) => {
 
   const searchButtonRef = useSignal();
 
-  useBrowserVisibleTask$(() => {
-    window.addEventListener('keydown', (event) => {
-      function open() {
-        // We check that no other DocSearch modal is showing before opening
-        // another one.
-        if (!document.body.classList.contains('DocSearch--active')) {
-          state.isOpen = true;
-        }
-      }
-      if (
-        (event.key === 'Escape' && state.isOpen) ||
-        // The `Cmd+K` shortcut both opens and closes the modal.
-        (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
-        // The `/` shortcut opens but doesn't close the modal because it's
-        // a character.
-        (!isEditingContent(event) && event.key === '/' && !state.isOpen)
-      ) {
-        event.preventDefault();
-
-        if (state.isOpen) {
-          state.isOpen = false;
-        } else if (!document.body.classList.contains('DocSearch--active')) {
-          open();
-        }
-      }
-
-      if (searchButtonRef && searchButtonRef.current === document.activeElement) {
-        if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
-          state.isOpen = true;
-          state.initialQuery = event.key;
-        }
-      }
-    });
-  });
-
   return (
-    <div class="docsearch">
+    <div
+      class="docsearch"
+      preventdefault:keyDown={!state.isOpen}
+      window:onKeyDown$={(event) => {
+        window.addEventListener('keydown', (event) => {
+          function open() {
+            // We check that no other DocSearch modal is showing before opening
+            // another one.
+            if (!document.body.classList.contains('DocSearch--active')) {
+              state.isOpen = true;
+            }
+          }
+          if (
+            (event.key === 'Escape' && state.isOpen) ||
+            // The `Cmd+K` shortcut both opens and closes the modal.
+            (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
+            // The `/` shortcut opens but doesn't close the modal because it's
+            // a character.
+            (!isEditingContent(event) && event.key === '/' && !state.isOpen)
+          ) {
+            event.preventDefault();
+
+            if (state.isOpen) {
+              state.isOpen = false;
+            } else if (!document.body.classList.contains('DocSearch--active')) {
+              open();
+            }
+          }
+
+          if (searchButtonRef && searchButtonRef.current === document.activeElement) {
+            if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
+              state.isOpen = true;
+              state.initialQuery = event.key;
+            }
+          }
+        });
+      }}
+    >
       <DocSearchButton
         ref={searchButtonRef}
         onClick$={() => {

--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -71,38 +71,34 @@ export const DocSearch = component$((props: DocSearchProps) => {
       class="docsearch"
       preventdefault:keyDown={!state.isOpen}
       window:onKeyDown$={(event) => {
-        window.addEventListener('keydown', (event) => {
-          function open() {
-            // We check that no other DocSearch modal is showing before opening
-            // another one.
-            if (!document.body.classList.contains('DocSearch--active')) {
-              state.isOpen = true;
-            }
+        function open() {
+          // We check that no other DocSearch modal is showing before opening
+          // another one.
+          if (!document.body.classList.contains('DocSearch--active')) {
+            state.isOpen = true;
           }
-          if (
-            (event.key === 'Escape' && state.isOpen) ||
-            // The `Cmd+K` shortcut both opens and closes the modal.
-            (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
-            // The `/` shortcut opens but doesn't close the modal because it's
-            // a character.
-            (!isEditingContent(event) && event.key === '/' && !state.isOpen)
-          ) {
-            event.preventDefault();
+        }
+        if (
+          (event.key === 'Escape' && state.isOpen) ||
+          // The `Cmd+K` shortcut both opens and closes the modal.
+          (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
+          // The `/` shortcut opens but doesn't close the modal because it's
+          // a character.
+          (!isEditingContent(event) && event.key === '/' && !state.isOpen)
+        ) {
+          if (state.isOpen) {
+            state.isOpen = false;
+          } else if (!document.body.classList.contains('DocSearch--active')) {
+            open();
+          }
+        }
 
-            if (state.isOpen) {
-              state.isOpen = false;
-            } else if (!document.body.classList.contains('DocSearch--active')) {
-              open();
-            }
+        if (searchButtonRef && searchButtonRef.current === document.activeElement) {
+          if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
+            state.isOpen = true;
+            state.initialQuery = event.key;
           }
-
-          if (searchButtonRef && searchButtonRef.current === document.activeElement) {
-            if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
-              state.isOpen = true;
-              state.initialQuery = event.key;
-            }
-          }
-        });
+        }
       }}
     >
       <DocSearchButton

--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -68,8 +68,6 @@ export const DocSearch = component$((props: DocSearchProps) => {
 
   useBrowserVisibleTask$(() => {
     window.addEventListener('keydown', (event) => {
-      event.preventDefault();
-
       function open() {
         // We check that no other DocSearch modal is showing before opening
         // another one.
@@ -85,6 +83,8 @@ export const DocSearch = component$((props: DocSearchProps) => {
         // a character.
         (!isEditingContent(event) && event.key === '/' && !state.isOpen)
       ) {
+        event.preventDefault();
+
         if (state.isOpen) {
           state.isOpen = false;
         } else if (!document.body.classList.contains('DocSearch--active')) {

--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -1,5 +1,5 @@
 import type { SearchClient } from 'algoliasearch/lite';
-import { component$, useStore, useStyles$, useRef, useBrowserVisibleTask$ } from '@builder.io/qwik';
+import { component$, useStore, useStyles$, useSignal, useBrowserVisibleTask$ } from '@builder.io/qwik';
 import type { DocSearchHit, InternalDocSearchHit, StoredDocSearchHit } from './types';
 import { ButtonTranslations, DocSearchButton } from './doc-search-button';
 import { DocSearchModal, ModalTranslations } from './doc-search-modal';
@@ -64,7 +64,7 @@ export const DocSearch = component$((props: DocSearchProps) => {
     snippetLength: 10,
   });
 
-  const searchButtonRef = useRef();
+  const searchButtonRef = useSignal();
 
   useBrowserVisibleTask$(() => {
     window.addEventListener('keydown', (event) => {

--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -1,5 +1,5 @@
 import type { SearchClient } from 'algoliasearch/lite';
-import { component$, useStore, useStyles$, useSignal, useBrowserVisibleTask$ } from '@builder.io/qwik';
+import { component$, useStore, useStyles$, useSignal } from '@builder.io/qwik';
 import type { DocSearchHit, InternalDocSearchHit, StoredDocSearchHit } from './types';
 import { ButtonTranslations, DocSearchButton } from './doc-search-button';
 import { DocSearchModal, ModalTranslations } from './doc-search-modal';
@@ -66,43 +66,43 @@ export const DocSearch = component$((props: DocSearchProps) => {
 
   const searchButtonRef = useSignal();
 
-  useBrowserVisibleTask$(() => {
-    window.addEventListener('keydown', (event) => {
-      function open() {
-        // We check that no other DocSearch modal is showing before opening
-        // another one.
-        if (!document.body.classList.contains('DocSearch--active')) {
-          state.isOpen = true;
-        }
-      }
-      if (
-        (event.key === 'Escape' && state.isOpen) ||
-        // The `Cmd+K` shortcut both opens and closes the modal.
-        (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
-        // The `/` shortcut opens but doesn't close the modal because it's
-        // a character.
-        (!isEditingContent(event) && event.key === '/' && !state.isOpen)
-      ) {
-        event.preventDefault();
-
-        if (state.isOpen) {
-          state.isOpen = false;
-        } else if (!document.body.classList.contains('DocSearch--active')) {
-          open();
-        }
-      }
-
-      if (searchButtonRef && searchButtonRef.current === document.activeElement) {
-        if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
-          state.isOpen = true;
-          state.initialQuery = event.key;
-        }
-      }
-    });
-  });
-
   return (
-    <div class="docsearch">
+    <div
+      class="docsearch"
+      window:onKeyDown$={(event) => {
+        function open() {
+          // We check that no other DocSearch modal is showing before opening
+          // another one.
+          if (!document.body.classList.contains('DocSearch--active')) {
+            state.isOpen = true;
+          }
+        }
+        if (
+          (event.key === 'Escape' && state.isOpen) ||
+          // The `Cmd+K` shortcut both opens and closes the modal.
+          (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
+          // The `/` shortcut opens but doesn't close the modal because it's
+          // a character.
+          (!isEditingContent(event) && event.key === '/' && !state.isOpen)
+        ) {
+          // FIXME: not able to prevent
+          // event.preventDefault();
+
+          if (state.isOpen) {
+            state.isOpen = false;
+          } else if (!document.body.classList.contains('DocSearch--active')) {
+            open();
+          }
+        }
+
+        if (searchButtonRef && searchButtonRef.current === document.activeElement) {
+          if (/[a-zA-Z0-9]/.test(String.fromCharCode(event.keyCode))) {
+            state.isOpen = true;
+            state.initialQuery = event.key;
+          }
+        }
+      }}
+    >
       <DocSearchButton
         ref={searchButtonRef}
         onClick$={() => {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
The doc search component's {meta|ctrl}k keybinding was not working correctly. The default browser action was triggered along with the opening of `DocSearch` component.

# Use cases and why
To prevent the default browser behavior while opening `DocSearch` component.

<!-- Actual / expected behavior if it's a bug -->

- 1. Current behavior - the `DocSearch` component opening along with the default browser behavior. (for eg, focusing of address bar in chromium based browsers)
- 2. Expected behavior - prevent default browser behavior while opening `DocSearch` component.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
