### PR TITLE
fix(qwik-city): fix qinit event in RouterOutlet

### DIFF
--- a/packages/qwik-city/runtime/src/router-outlet-component.ts
+++ b/packages/qwik-city/runtime/src/router-outlet-component.ts
@@ -5,7 +5,7 @@ import {
   JSXNode,
   SkipRender,
   useContext,
-  useOnWindow,
+  useOnDocument,
   _IMMUTABLE,
   _jsxBranch,
 } from '@builder.io/qwik';
@@ -18,7 +18,7 @@ import { ContentInternalContext } from './contexts';
 export const RouterOutlet = component$(() => {
   _jsxBranch();
 
-  useOnWindow(
+  useOnDocument(
     'qinit',
     $(() => {
       const POPSTATE_FALLBACK_INITIALIZED = '_qCityPopstateFallback';


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

`qinit` event is dispatched into `document` instead of `window`, so the listener in `useOnWindow` is never triggered. This change fixes the issue by changing the hook to `useOnDocument`.

# Use cases and why

This would fix the missing registration of fallback listener

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
