### PR TITLE
refactor: stop using deprecated RouteLocation APIs

### DIFF
--- a/packages/docs/src/components/builder-content/index.tsx
+++ b/packages/docs/src/components/builder-content/index.tsx
@@ -9,7 +9,7 @@ export default component$<{
 }>((props) => {
   const location = useLocation();
   const builderContentRsrc = useResource$<any>(({ cache }) => {
-    const query = location.query;
+    const query = location.url.searchParams;
     const render =
       typeof query.get === 'function' ? query.get('render') : (query as { render?: string }).render;
     const isSDK = render === 'sdk';
@@ -19,9 +19,9 @@ export default component$<{
         {
           model: props.model!,
           apiKey: props.apiKey!,
-          options: getBuilderSearchParams(location.query),
+          options: getBuilderSearchParams(query),
           userAttributes: {
-            urlPath: location.pathname,
+            urlPath: location.url.pathname,
           },
         },
         getContent
@@ -31,7 +31,7 @@ export default component$<{
         {
           apiKey: props.apiKey,
           model: props.model,
-          urlPath: location.pathname,
+          urlPath: location.url.pathname,
         },
         getBuilderContent
       );

--- a/packages/docs/src/components/content-nav/content-nav.tsx
+++ b/packages/docs/src/components/content-nav/content-nav.tsx
@@ -6,7 +6,7 @@ export const ContentNav = component$(() => {
   useStyles$(styles);
 
   const { menu } = useContent();
-  const { pathname } = useLocation();
+  const { url } = useLocation();
 
   if (!menu) {
     return null;
@@ -14,8 +14,8 @@ export const ContentNav = component$(() => {
 
   const items = flattenMenu(menu);
 
-  const prev = getNav(items, pathname, -1);
-  const next = getNav(items, pathname, 1);
+  const prev = getNav(items, url.pathname, -1);
+  const next = getNav(items, url.pathname, 1);
 
   return (
     <nav class="content-nav border-t border-slate-300 flex flex-wrap py-4">

--- a/packages/docs/src/components/header/header.tsx
+++ b/packages/docs/src/components/header/header.tsx
@@ -21,7 +21,7 @@ import { BUILDER_MODEL, BUILDER_PUBLIC_API_KEY } from '../../constants';
 export const Header = component$(() => {
   useStyles$(styles);
   const globalStore = useContext(GlobalStore);
-  const pathname = new URL(useLocation().url).pathname;
+  const pathname = useLocation().url.pathname;
 
   useBrowserVisibleTask$(() => {
     globalStore.theme = getColorPreference();

--- a/packages/docs/src/components/on-this-page/on-this-page.tsx
+++ b/packages/docs/src/components/on-this-page/on-this-page.tsx
@@ -12,8 +12,8 @@ export const OnThisPage = component$(() => {
   const { headings } = useContent();
   const contentHeadings = headings?.filter((h) => h.level <= 3) || [];
 
-  const { pathname } = useLocation();
-  const editUrl = `https://github.com/BuilderIO/qwik/edit/main/packages/docs/src/routes${pathname}index.mdx`;
+  const { url } = useLocation();
+  const editUrl = `https://github.com/BuilderIO/qwik/edit/main/packages/docs/src/routes${url.pathname}index.mdx`;
 
   return (
     <aside class="on-this-page fixed text-sm z-20 bottom-0 right-[max(0px,calc(50%-42rem))] overflow-y-auto hidden xl:block xl:w-[16rem] xl:top-[9rem]">

--- a/packages/docs/src/components/router-head/router-head.tsx
+++ b/packages/docs/src/components/router-head/router-head.tsx
@@ -5,7 +5,7 @@ import { Vendor } from './vendor';
 import { ThemeScript } from './theme-script';
 
 export const RouterHead = component$(() => {
-  const { href } = useLocation();
+  const { url } = useLocation();
   const head = useDocumentHead();
   const title = head.title ? `${head.title} - Qwik` : `Qwik - Framework reimagined for the edge`;
   const description =
@@ -16,7 +16,7 @@ export const RouterHead = component$(() => {
     <>
       <title>{title}</title>
       <meta name="description" content={description} />
-      <link rel="canonical" href={href} />
+      <link rel="canonical" href={url.href} />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta name="apple-mobile-web-app-title" content="Qwik" />
       <meta name="application-name" content="Qwik" />
@@ -29,7 +29,7 @@ export const RouterHead = component$(() => {
 
       {import.meta.env.PROD && (
         <>
-          <Social title={title} description={description} href={href} />
+          <Social title={title} description={description} href={url.href} />
           <Vendor />
         </>
       )}

--- a/packages/docs/src/components/sidebar/sidebar.tsx
+++ b/packages/docs/src/components/sidebar/sidebar.tsx
@@ -9,9 +9,9 @@ export const SideBar = component$(() => {
 
   const globalStore = useContext(GlobalStore);
   const { menu } = useContent();
-  const { pathname } = useLocation();
-  const breadcrumbs = createBreadcrumbs(menu, pathname);
-  const isQwikCity = pathname.startsWith('/qwikcity/');
+  const { url } = useLocation();
+  const breadcrumbs = createBreadcrumbs(menu, url.pathname);
+  const isQwikCity = url.pathname.startsWith('/qwikcity/');
   return (
     <aside class="sidebar">
       <nav class="breadcrumbs">
@@ -48,7 +48,7 @@ export const SideBar = component$(() => {
         >
           <CloseIcon width={24} height={24} />
         </button>
-        <Items items={menu?.items} pathname={pathname} allOpen={isQwikCity} />
+        <Items items={menu?.items} pathname={url.pathname} allOpen={isQwikCity} />
       </nav>
     </aside>
   );

--- a/packages/docs/src/routes/docs/cheat/best-practices/index.mdx
+++ b/packages/docs/src/routes/docs/cheat/best-practices/index.mdx
@@ -97,11 +97,11 @@ When using the `if typeof window !== "undefined"` pattern you'll soon find it wi
 ```ts
 const location = useLocation();
 
-if (location.href.includes('foo')) {
+if (location.url.href.includes('foo')) {
   // Do the thing
 }
 //OR
-doTheThing(location.query);
+doTheThing(location.url.searchParams);
 ```
 
 ## EXCEPTION

--- a/packages/docs/src/routes/docs/layout!.tsx
+++ b/packages/docs/src/routes/docs/layout!.tsx
@@ -9,7 +9,7 @@ import styles from '../docs.css?inline';
 
 export default component$(() => {
   const loc = useLocation();
-  const noRightMenu = ['/docs/overview/'].includes(loc.pathname);
+  const noRightMenu = ['/docs/overview/'].includes(loc.url.pathname);
   useStyles$(styles);
 
   return (

--- a/packages/docs/src/routes/qwikcity/advanced/menu/index.mdx
+++ b/packages/docs/src/routes/qwikcity/advanced/menu/index.mdx
@@ -98,7 +98,7 @@ import { component$ } from '@builder.io/qwik';
 import { useLocation, useContent } from '@builder.io/qwik-city';
 export default component$(() => {
   const { menu } = useContent();
-  const { pathname } = useLocation();
+  const { url } = useLocation();
 
   return (
     <div class="menu">
@@ -112,7 +112,7 @@ export default component$(() => {
                     <a
                       href={item.href}
                       class={{
-                        'is-active': pathname === item.href,
+                        'is-active': url.pathname === item.href,
                       }}
                     >
                       {item.text}

--- a/packages/docs/src/routes/qwikcity/api/index.mdx
+++ b/packages/docs/src/routes/qwikcity/api/index.mdx
@@ -105,7 +105,7 @@ export default component$(() => {
   return (
     <>
       <h1>SKU</h1>
-      <p>pathname: {loc.pathname}</p>
+      <p>pathname: {loc.url.pathname}</p>
       <p>skuId: {loc.params.skuId}</p>
     </>
   );

--- a/packages/docs/src/routes/tutorial/layout!.tsx
+++ b/packages/docs/src/routes/tutorial/layout!.tsx
@@ -15,13 +15,13 @@ export default component$(() => {
   useStyles$(styles);
   useStyles$(`html,body { margin: 0; height: 100%; overflow: hidden; }`);
 
-  const { pathname } = useLocation();
+  const { url } = useLocation();
   const panelStore = useStore(() => ({
     active: 'Tutorial',
     list: PANELS,
   }));
   const store = useStore<TutorialStore>(() => {
-    const p = pathname.split('/');
+    const p = url.pathname.split('/');
     const appId = `${p[2]}/${p[3]}`;
     const t = getTutorial(appId)!;
 

--- a/starters/apps/basic/src/routes/flower/index.tsx
+++ b/starters/apps/basic/src/routes/flower/index.tsx
@@ -35,7 +35,7 @@ export default component$(() => {
         }}
         class={{
           host: true,
-          pride: loc.query.get('pride') === 'true',
+          pride: loc.url.searchParams.get('pride') === 'true',
         }}
       >
         {Array.from({ length: state.number }, (_, i) => (

--- a/starters/apps/documentation-site/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/starters/apps/documentation-site/src/components/breadcrumbs/breadcrumbs.tsx
@@ -8,7 +8,7 @@ export const Breadcrumbs = component$(() => {
   const { menu } = useContent();
   const loc = useLocation();
 
-  const breadcrumbs = createBreadcrumbs(menu, loc.pathname);
+  const breadcrumbs = createBreadcrumbs(menu, loc.url.pathname);
   if (breadcrumbs.length === 0) {
     return null;
   }

--- a/starters/apps/documentation-site/src/components/header/header.tsx
+++ b/starters/apps/documentation-site/src/components/header/header.tsx
@@ -6,7 +6,7 @@ import styles from './header.css?inline';
 export default component$(() => {
   useStyles$(styles);
 
-  const { pathname } = useLocation();
+  const { url } = useLocation();
 
   return (
     <header>
@@ -14,10 +14,10 @@ export default component$(() => {
         <QwikLogo />
       </a>
       <nav>
-        <a href="/docs" class={{ active: pathname.startsWith('/docs') }}>
+        <a href="/docs" class={{ active: url.pathname.startsWith('/docs') }}>
           Docs
         </a>
-        <a href="/about-us" class={{ active: pathname.startsWith('/about-us') }}>
+        <a href="/about-us" class={{ active: url.pathname.startsWith('/about-us') }}>
           About Us
         </a>
       </nav>

--- a/starters/apps/documentation-site/src/components/menu/menu.tsx
+++ b/starters/apps/documentation-site/src/components/menu/menu.tsx
@@ -20,7 +20,7 @@ export default component$(() => {
                     <Link
                       href={item.href}
                       class={{
-                        'is-active': loc.pathname === item.href,
+                        'is-active': loc.url.pathname === item.href,
                       }}
                     >
                       {item.text}

--- a/starters/apps/documentation-site/src/components/on-this-page/on-this-page.tsx
+++ b/starters/apps/documentation-site/src/components/on-this-page/on-this-page.tsx
@@ -8,8 +8,8 @@ export default component$(() => {
   const { headings } = useContent();
   const contentHeadings = headings?.filter((h) => h.level === 2 || h.level === 3) || [];
 
-  const { pathname } = useLocation();
-  const editUrl = `#update-your-edit-url-for-${pathname}`;
+  const { url } = useLocation();
+  const editUrl = `#update-your-edit-url-for-${url.pathname}`;
 
   return (
     <aside class="on-this-page">

--- a/starters/apps/qwikcity-test/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/starters/apps/qwikcity-test/src/components/breadcrumbs/breadcrumbs.tsx
@@ -6,9 +6,9 @@ export const Breadcrumbs = component$(() => {
   useStyles$(styles);
 
   const { menu } = useContent();
-  const { pathname } = useLocation();
+  const { url } = useLocation();
 
-  const breadcrumbs = createBreadcrumbs(menu, pathname);
+  const breadcrumbs = createBreadcrumbs(menu, url.pathname);
   if (breadcrumbs.length === 0) {
     return null;
   }

--- a/starters/apps/qwikcity-test/src/components/content-nav/content-nav.tsx
+++ b/starters/apps/qwikcity-test/src/components/content-nav/content-nav.tsx
@@ -5,13 +5,13 @@ import styles from './content-nav.css?inline';
 export const ContentNav = component$(() => {
   useStyles$(styles);
 
-  const { pathname } = useLocation();
+  const { url } = useLocation();
 
   const { menu } = useContent();
   const items = flattenMenu(menu);
 
-  const prev = getNav(items, pathname, -1);
-  const next = getNav(items, pathname, 1);
+  const prev = getNav(items, url.pathname, -1);
+  const next = getNav(items, url.pathname, 1);
 
   return (
     <nav class="content-nav">

--- a/starters/apps/qwikcity-test/src/components/header/header.tsx
+++ b/starters/apps/qwikcity-test/src/components/header/header.tsx
@@ -20,42 +20,42 @@ export default component$(() => {
         <nav data-test-header-links>
           <Link
             href="/qwikcity-test/blog/"
-            class={{ active: loc.pathname.startsWith('/qwikcity-test/blog/') }}
+            class={{ active: loc.url.pathname.startsWith('/qwikcity-test/blog/') }}
             data-test-link="blog-home"
           >
             Blog
           </Link>
           <Link
             href="/qwikcity-test/docs/"
-            class={{ active: loc.pathname.startsWith('/qwikcity-test/docs/') }}
+            class={{ active: loc.url.pathname.startsWith('/qwikcity-test/docs/') }}
             data-test-link="docs-home"
           >
             Docs
           </Link>
           <Link
             href="/qwikcity-test/actions/"
-            class={{ active: loc.pathname.startsWith('/qwikcity-test/actions/') }}
+            class={{ active: loc.url.pathname.startsWith('/qwikcity-test/actions/') }}
             data-test-link="docs-actions"
           >
             Actions
           </Link>
           <Link
             href="/qwikcity-test/api/"
-            class={{ active: loc.pathname.startsWith('/qwikcity-test/api/') }}
+            class={{ active: loc.url.pathname.startsWith('/qwikcity-test/api/') }}
             data-test-link="api-home"
           >
             API
           </Link>
           <Link
             href="/qwikcity-test/products/hat/"
-            class={{ active: loc.pathname.startsWith('/qwikcity-test/products/') }}
+            class={{ active: loc.url.pathname.startsWith('/qwikcity-test/products/') }}
             data-test-link="products-hat"
           >
             Products
           </Link>
           <Link
             href="/qwikcity-test/about-us/"
-            class={{ active: loc.pathname.startsWith('/qwikcity-test/about-us/') }}
+            class={{ active: loc.url.pathname.startsWith('/qwikcity-test/about-us/') }}
             data-test-link="about-us"
           >
             About Us
@@ -68,7 +68,7 @@ export default component$(() => {
           ) : (
             <Link
               href="/qwikcity-test/sign-in/"
-              class={{ active: loc.pathname.startsWith('/qwikcity-test/sign-in/') }}
+              class={{ active: loc.url.pathname.startsWith('/qwikcity-test/sign-in/') }}
               data-test-link="sign-out"
             >
               Sign In

--- a/starters/apps/qwikcity-test/src/components/menu/menu.tsx
+++ b/starters/apps/qwikcity-test/src/components/menu/menu.tsx
@@ -6,7 +6,7 @@ export const Menu = component$(() => {
   useStyles$(styles);
 
   const { menu } = useContent();
-  const { pathname } = useLocation();
+  const { url } = useLocation();
 
   return (
     <aside class="menu">
@@ -21,7 +21,7 @@ export const Menu = component$(() => {
                       data-test-menu-link={item.href}
                       href={item.href}
                       class={{
-                        'is-active': pathname === item.href,
+                        'is-active': url.pathname === item.href,
                       }}
                     >
                       {item.text}

--- a/starters/apps/qwikcity-test/src/components/router-head/vendor.tsx
+++ b/starters/apps/qwikcity-test/src/components/router-head/vendor.tsx
@@ -3,7 +3,7 @@ import type { RouteLocation } from '@builder.io/qwik-city';
 export const Vendor = ({ loc }: VendorProps) => {
   return (
     <>
-      <script dangerouslySetInnerHTML={`console.log("🧨 Analytics! ${loc.pathname}");`} />
+      <script dangerouslySetInnerHTML={`console.log("🧨 Analytics! ${loc.url.pathname}");`} />
     </>
   );
 };

--- a/starters/apps/qwikcity-test/src/routes/(common)/[country]/[city]/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/[country]/[city]/index.tsx
@@ -33,7 +33,7 @@ export default component$(() => {
       </p>
       <p>
         <span>loc.query.get('unit'): </span>
-        <code data-test-params="unit">{loc.query.get('unit') || 'C'}</code>
+        <code data-test-params="unit">{loc.url.searchParams.get('unit') || 'C'}</code>
       </p>
       <p>
         <span>resource weather.forecast: </span>
@@ -53,9 +53,9 @@ export default component$(() => {
   );
 });
 
-export const head: DocumentHead = ({ resolveValue, params, query }) => {
+export const head: DocumentHead = ({ resolveValue, params, url }) => {
   const weather = resolveValue(useWeatherLoader);
-  const forecast = query.get('forecast') || '10day';
+  const forecast = url.searchParams.get('forecast') || '10day';
 
   return {
     title: `Weather: ${weather.country} ${params.city}, ${weather.temperature}${weather.unit}, ${forecast}`,

--- a/starters/apps/qwikcity-test/src/routes/(common)/api/layout-api.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/api/layout-api.tsx
@@ -29,8 +29,8 @@ export default component$(() => {
   );
 });
 
-export const head: DocumentHead = ({ pathname }) => {
+export const head: DocumentHead = ({ url }) => {
   return {
-    title: `API: ${pathname}`,
+    title: `API: ${url.pathname}`,
   };
 };

--- a/starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, DocumentHead, loader$ } from '@builder.io/qwik-city'
 import os from 'node:os';
 
 export default component$(() => {
-  const { params, pathname } = useLocation();
+  const { params, url } = useLocation();
   const store = useStore({ productFetchData: '' });
 
   const product = useProductLoader();
@@ -25,7 +25,7 @@ export default component$(() => {
       <p>
         <button
           onClick$={async () => {
-            const rsp = await fetch(pathname, {
+            const rsp = await fetch(url.pathname, {
               headers: {
                 accept: 'application/json',
               },
@@ -33,7 +33,7 @@ export default component$(() => {
             store.productFetchData = JSON.stringify(await rsp.json(), null, 2);
           }}
         >
-          fetch("{pathname}") data
+          fetch("{url.pathname}") data
         </button>
       </p>
 

--- a/starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx
@@ -2,14 +2,14 @@ import { component$ } from '@builder.io/qwik';
 import { useLocation, type DocumentHead } from '@builder.io/qwik-city';
 
 export default component$(() => {
-  const { pathname, params } = useLocation();
+  const { url, params } = useLocation();
 
   return (
     <div>
       <h1>
         Docs: {params.category} {params.id}
       </h1>
-      <p>pathname: {pathname}</p>
+      <p>pathname: {url.pathname}</p>
       <p>category: {params.category}</p>
       <p>id: {params.id}</p>
     </div>

--- a/starters/features/styled-vanilla-extract/src/routes/styled-flower/index.tsx
+++ b/starters/features/styled-vanilla-extract/src/routes/styled-flower/index.tsx
@@ -51,7 +51,7 @@ export default component$(() => {
         style={{
           '--state': `${state.count * 0.1}`,
         }}
-        class={loc.query['pride'] && pride}
+        class={loc.url.searchParams.get('pride') && pride}
       >
         {Array.from({ length: state.number }, (_, i) => (
           <Square key={i} class={{ [odd]: i % 2 === 0 }} style={{ '--index': `${i + 1}` }} />


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Since some `RouteLocation` APIs are now deprecated, I updated docs and starters so they don't use deprecated APIs anymore. I think that I have updated everything except some [utils.ts](https://github.com/BuilderIO/qwik/blob/2a15662cb176a4ee8e9733e122c619c4b76c3ee6/packages/qwik-city/runtime/src/utils.ts) APIs like [`getClientNavPath`](https://github.com/BuilderIO/qwik/blob/2a15662cb176a4ee8e9733e122c619c4b76c3ee6/packages/qwik-city/runtime/src/utils.ts#L49) or [`getPrefetchDataset`](https://github.com/BuilderIO/qwik/blob/2a15662cb176a4ee8e9733e122c619c4b76c3ee6/packages/qwik-city/runtime/src/utils.ts#L70) that may have still be using these deprecated APIs.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
