### PR TITLE
docs: Adds PostCSS to the integration menu

### DIFF
--- a/packages/docs/src/routes/integrations/menu.md
+++ b/packages/docs/src/routes/integrations/menu.md
@@ -6,6 +6,7 @@
 - [React](integration/react/index.mdx)
 - [Partytown](integration/partytown/index.mdx)
 - [Playwright](integration/playwright/index.mdx)
+- [PostCSS](integration/postcss/index.mdx)
 - [Styled-Vanilla-Extract](integration/styled-vanilla-extract/index.mdx)
 - [Tailwind CSS](integration/tailwind/index.mdx)
 - [Vitest](integration/vitest/index.mdx)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

The PR #3207 has added PostCSS integration. This modification allows to see the associated doc in the integration menu

# Use cases and why

Nope

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
