### PR TITLE
docs(useLocation): extend docs with deeply nested child routes

### DIFF
--- a/packages/docs/src/routes/qwikcity/api/index.mdx
+++ b/packages/docs/src/routes/qwikcity/api/index.mdx
@@ -75,9 +75,9 @@ Use the [`useLocation()`](/qwikcity/api/index.mdx#uselocation) function to retri
 ```tsx
 export interface RouteLocation {
   readonly params: RouteParams; // Record<string,string>
-  readonly href: string;
-  readonly pathname: string;
-  readonly query: Record<string, string>;
+  readonly href: string; // @deprecated Use `url` instead
+  readonly pathname: string; // @deprecated Use `url` instead
+  readonly query: Record<string, string>; // @deprecated Use `url` instead
   readonly isNavigating: boolean;
   readonly url: URL;
 }
@@ -91,11 +91,12 @@ The return value of [`useLocation()`](/qwikcity/api/index.mdx#uselocation) is si
 
 Assume you have:
 
-- Route: `https://example.com/sku/[skuId]`
+- File: `src/routes/sku/[skuId]/index.tsx`
 - User navigates to: `https://example.com/sku/1234`
-- Then the `skuId` can be retrieved through `useLocation().params.skuId`.
+- Then the `skuId` can be retrieved through `useLocation().params.skuId`
 
 ```tsx
+// src/routes/sku/[skuId]/index.tsx
 import { component$ } from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
 
@@ -116,8 +117,40 @@ The above code would generate:
 
 ```html
 <h1>SKU</h1>
-<p>pathname: /sku/1234</p>
+<p>pathname: /sku/1234/</p>
 <p>skuId: 1234</p>
+```
+
+You can also use `...` syntax to indicate deeply nested child routes. For example:
+
+- File: `src/routes/post/[...all]/index.tsx`
+- User navigates to: `https://example.com/post/2023/id/title`
+- Then the `all` can be retrieved through `useLocation().params.all`
+
+```tsx
+// src/routes/post/[...all]/index.tsx
+import { component$ } from '@builder.io/qwik';
+import { useLocation } from '@builder.io/qwik-city';
+
+export default component$(() => {
+  const loc = useLocation();
+
+  return (
+    <>
+      <h1>POST</h1>
+      <p>pathname: {loc.url.pathname}</p>
+      <p>all: {loc.params.all}</p>
+    </>
+  );
+});
+```
+
+The above code would generate:
+
+```html
+<h1>POST</h1>
+<p>pathname: /post/2023/id/title/</p>
+<p>all: 2023/id/title</p>
 ```
 
 > Notice that `useLocation` is a read-only API, you should never attempt to mutate the values of the `loc` object returned. Instead look into the `useNavigate()` API.

--- a/packages/docs/src/routes/qwikcity/api/index.mdx
+++ b/packages/docs/src/routes/qwikcity/api/index.mdx
@@ -74,12 +74,9 @@ Use the [`useLocation()`](/qwikcity/api/index.mdx#uselocation) function to retri
 
 ```tsx
 export interface RouteLocation {
-  readonly params: RouteParams; // Record<string,string>
-  readonly href: string; // @deprecated Use `url` instead
-  readonly pathname: string; // @deprecated Use `url` instead
-  readonly query: Record<string, string>; // @deprecated Use `url` instead
-  readonly isNavigating: boolean;
+  readonly params: RouteParams; // Readonly<Record<string, string>>
   readonly url: URL;
+  readonly isNavigating: boolean;
 }
 ```
 
@@ -119,38 +116,6 @@ The above code would generate:
 <h1>SKU</h1>
 <p>pathname: /sku/1234/</p>
 <p>skuId: 1234</p>
-```
-
-You can also use `...` syntax to indicate deeply nested child routes. For example:
-
-- File: `src/routes/post/[...all]/index.tsx`
-- User navigates to: `https://example.com/post/2023/id/title`
-- Then the `all` can be retrieved through `useLocation().params.all`
-
-```tsx
-// src/routes/post/[...all]/index.tsx
-import { component$ } from '@builder.io/qwik';
-import { useLocation } from '@builder.io/qwik-city';
-
-export default component$(() => {
-  const loc = useLocation();
-
-  return (
-    <>
-      <h1>POST</h1>
-      <p>pathname: {loc.url.pathname}</p>
-      <p>all: {loc.params.all}</p>
-    </>
-  );
-});
-```
-
-The above code would generate:
-
-```html
-<h1>POST</h1>
-<p>pathname: /post/2023/id/title/</p>
-<p>all: 2023/id/title</p>
 ```
 
 > Notice that `useLocation` is a read-only API, you should never attempt to mutate the values of the `loc` object returned. Instead look into the `useNavigate()` API.

--- a/packages/docs/src/routes/qwikcity/routing/index.mdx
+++ b/packages/docs/src/routes/qwikcity/routing/index.mdx
@@ -40,8 +40,8 @@ src/
     └── layout.tsx            # This layout is used for all pages
 ```
 
-- **`[id]`** is a directory that represents a dynamic route segment, in this example `id` is the param.
-- **`[...catchall]`** is a directory that represents a dynamic catch-all route, in this example `catchall` is the param.
+- **`[id]`** is a directory that represents a dynamic route segment, in this example `id` is the string parameter accessible by `getLocation().params.id`.
+- **`[...catchall]`** is a directory that represents a dynamic catch-all route, in this example `catchall` is the string parameter accessible by `getLocation().params.catchall`.
 - **`index.ext` files** are the pages/endpoints.
 - **`layout.ext` files** are the layouts.
 
@@ -50,8 +50,8 @@ src/
 Special named directories with square brackets, such as `[paramName]` and `[...catchAll]` can be used to match route segments which are dynamic:
 
 ```
-src/routes/blog/index.tsx → /blog/:slug (/blog/hello-world)
-src/routes/user/[username]/index.tsx → /user/:username/settings (/user/foo/)
+src/routes/blog/index.tsx → /blog
+src/routes/user/[username]/index.tsx → /user/:username (/user/foo)
 src/routes/post/[...all]/index.tsx → /post/* (/post/2020/id/title)
 ```
 
@@ -62,7 +62,7 @@ src/
     │   └── index.tsx         # https://example.com/blog
     ├── post/
     │   └── [...all]/
-    │       └── index.tsx     # https://example.com/post/2020/id/title/2020/12/03
+    │       └── index.tsx     # https://example.com/post/2020/id/title
     └── user/
         └── [username]/
             └── index.tsx     # https://example.com/user/foo


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Extend docs by explaining `...` routes syntax with an example.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
