### PR TITLE
fix(security): Remove PureFunctionSerializer

### DIFF
--- a/packages/qwik/src/core/container/serializers.ts
+++ b/packages/qwik/src/core/container/serializers.ts
@@ -226,20 +226,6 @@ const ComponentSerializer: Serializer<Component<any>> = {
   },
 };
 
-const PureFunctionSerializer: Serializer<Function> = {
-  prefix: '\u0011',
-  test: (obj) => typeof obj === 'function' && obj.__qwik_serializable__ !== undefined,
-  serialize: (obj) => {
-    return obj.toString();
-  },
-  prepare: (data) => {
-    const fn = new Function('return ' + data)();
-    fn.__qwik_serializable__ = true;
-    return fn;
-  },
-  fill: undefined,
-};
-
 const SignalSerializer: Serializer<SignalImpl<any>> = {
   prefix: '\u0012',
   test: (v) => v instanceof SignalImpl,
@@ -335,21 +321,20 @@ const FormDataSerializer: Serializer<FormData> = {
 };
 
 const serializers: Serializer<any>[] = [
-  QRLSerializer,
-  SignalSerializer,
-  SignalWrapperSerializer,
-  WatchSerializer,
-  ResourceSerializer,
-  URLSerializer,
-  DateSerializer,
-  RegexSerializer,
-  ErrorSerializer,
-  DocumentSerializer,
-  ComponentSerializer,
-  PureFunctionSerializer,
-  NoFiniteNumberSerializer,
-  URLSearchParamsSerializer,
-  FormDataSerializer,
+  QRLSerializer, ////////////// \u0002
+  SignalSerializer, /////////// \u0012
+  SignalWrapperSerializer, //// \u0013
+  WatchSerializer, //////////// \u0003
+  ResourceSerializer, ///////// \u0004
+  URLSerializer, ////////////// \u0005
+  DateSerializer, ///////////// \u0006
+  RegexSerializer, //////////// \u0007
+  ErrorSerializer, //////////// \u000E
+  DocumentSerializer, ///////// \u000F
+  ComponentSerializer, //////// \u0010
+  NoFiniteNumberSerializer, /// \u0014
+  URLSearchParamsSerializer, // \u0015
+  FormDataSerializer, ///////// \u0016
 ];
 
 const collectorSerializers = /*#__PURE__*/ serializers.filter((a) => a.collect);


### PR DESCRIPTION
Remove PureFunctionSerializer which is a source of security issue as it would allow a client to inject code into server.

https://huntr.dev/bounties/63f1ff91-48f3-4886-a179-103f1ddd8ff8/

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
