### PR TITLE
fix(ssr): match phrasing content validation to HTML spec

### DIFF
--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -99,6 +99,7 @@ const IS_PHASING = 1 << 5;
 const IS_ANCHOR = 1 << 6;
 const IS_BUTTON = 1 << 7;
 const IS_TABLE = 1 << 8;
+const IS_PHRASING_CONTAINER = 1 << 9;
 
 const createDocument = () => {
   const doc = { nodeType: 9 };
@@ -568,7 +569,7 @@ const renderNode = (
 
     // Reset HOST flags
     if (qDev) {
-      if (flags & IS_PHASING) {
+      if (flags & IS_PHASING && !(flags & IS_PHRASING_CONTAINER)) {
         if (!phasingContent[tagName]) {
           throw createJSXError(
             `<${tagName}> can not be rendered because one of its ancestor is a <p> or a <pre>.\n
@@ -610,6 +611,10 @@ This goes against the HTML spec: https://html.spec.whatwg.org/multipage/dom.html
         } else {
           flags |= IS_ANCHOR;
         }
+      }
+      if (tagName === 'svg' || tagName === 'math') {
+        // These types of elements are considered phrasing content, but contain children that aren't phrasing content.
+        flags |= IS_PHRASING_CONTAINER;
       }
       if (flags & IS_HEAD) {
         if (!headContent[tagName]) {
@@ -1000,8 +1005,10 @@ const headContent: Record<string, true | undefined> = {
 const phasingContent: Record<string, true | undefined> = {
   a: true,
   abbr: true,
+  area: true,
   audio: true,
   b: true,
+  bdi: true,
   bdo: true,
   br: true,
   button: true,
@@ -1011,6 +1018,7 @@ const phasingContent: Record<string, true | undefined> = {
   command: true,
   data: true,
   datalist: true,
+  del: true,
   dfn: true,
   em: true,
   embed: true,
@@ -1018,11 +1026,16 @@ const phasingContent: Record<string, true | undefined> = {
   iframe: true,
   img: true,
   input: true,
+  ins: true,
+  itemprop: true,
   kbd: true,
   keygen: true,
   label: true,
+  link: true,
+  map: true,
   mark: true,
   math: true,
+  meta: true,
   meter: true,
   noscript: true,
   object: true,
@@ -1035,12 +1048,14 @@ const phasingContent: Record<string, true | undefined> = {
   samp: true,
   script: true,
   select: true,
+  slot: true,
   small: true,
   span: true,
   strong: true,
   sub: true,
   sup: true,
   svg: true,
+  template: true,
   textarea: true,
   time: true,
   u: true,

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -323,6 +323,103 @@ renderSSRSuite('single simple children', async () => {
   );
 });
 
+renderSSRSuite('valid phrasing content', async () => {
+  await testSSR(
+    <body>
+      <p>
+        <del>Del</del>
+      </p>
+    </body>,
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body><p><del>Del</del></p></body>'
+  );
+  await testSSR(
+    <body>
+      <p>
+        <link rel="example" />
+      </p>
+    </body>,
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body><p><link rel="example"/></p></body>'
+  );
+  await testSSR(
+    <body>
+      <p>
+        <map name="my-map">
+          <area shape="poly" coords="0,0,10,10,10,0" href="/example" alt="Example" />
+        </map>
+        <img useMap="#my-map" src="/example.png" alt="Example" />
+      </p>
+    </body>,
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+      <body>
+        <p>
+          <map name="my-map">
+            <area shape="poly" coords="0,0,10,10,10,0" href="/example" alt="Example">
+          </map>
+          <img usemap="#my-map" src="/example.png" alt="Example">
+        </p>
+        </body>
+      </html>`
+  );
+  await testSSR(
+    <body>
+      <p>
+        <svg
+          viewBox="0 0 10 10"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+        >
+          <path d="M 0 0 L 10 10"></path>
+          <circle cx="5" cy="5" rx="5" ry="5"></circle>
+        </svg>
+      </p>
+    </body>,
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+      <body>
+        <p>
+          <svg 
+            viewBox="0 0 10 10" 
+            xmlns="http://www.w3.org/2000/svg" 
+            xmlns:xlink="http://www.w3.org/1999/xlink" 
+          >
+            <path d="M 0 0 L 10 10"></path>
+            <circle cx="5" cy="5" rx="5" ry="5"></circle>
+          </svg>
+        </p>
+      </body>
+    </html>`
+  );
+  await testSSR(
+    <body>
+      <p>
+        <math>
+          <semantics>
+            <mrow>
+              <mi>2</mi>
+              <mo>+</mo>
+              <mi>2</mi>
+            </mrow>
+          </semantics>
+        </math>
+      </p>
+    </body>,
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+      <body>
+        <p>
+          <math>
+            <semantics>
+              <mrow>
+                <mi>2</mi>
+                <mo>+</mo>
+                <mi>2</mi>
+              </mrow>
+            </semantics>
+          </math>
+        </p>
+      </body>
+    </html>`
+  );
+});
+
 renderSSRSuite('events', async () => {
   await testSSR(
     <body onClick$={() => console.warn('hol')}>hola</body>,


### PR DESCRIPTION
fixes #3257
fixes #2431

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

There is some phrasing content that we still throw validation errors on, for example `<del>` elements.

In terms of provenance, I generated this list by going to https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2 and running this command:

```
JSON.stringify([...document.getElementById('phrasing-content').nextElementSibling.nextElementSibling.querySelectorAll('code')].map(e => e.textContent).reduce((acc, el) => {
  acc[el] = true
  return acc
}, {keygen: true, command: true} /* These were already present but not in this list */), null, 2)
```

# Use cases and why

People want to be able to use HTML elements that are valid to use according to the spec

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
