### PR TITLE
docs: add padding around homepage footer

### DIFF
--- a/packages/docs/src/routes/layout.tsx
+++ b/packages/docs/src/routes/layout.tsx
@@ -10,7 +10,9 @@ export default component$(() => {
       <main>
         <Slot />
       </main>
-      <Footer />
+      <div class="px-4">
+        <Footer />
+      </div>
     </>
   );
 });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Add padding around the footer on the homepage, so it doesn't directly collide with the edges of the viewport. Other pages add this padding in the layout itself, so just the homepage (from what I've found so far) needed it to be added 

# Use cases and why

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
