### PR TITLE
docs: Update ssg preview instructions

### DIFF
--- a/packages/docs/src/routes/qwikcity/guides/static-site-generation/index.mdx
+++ b/packages/docs/src/routes/qwikcity/guides/static-site-generation/index.mdx
@@ -41,13 +41,13 @@ Running the above command will make the following changes to your project:
 - A `build.server` script will be automatically added to your `package.json` file.
 - A `adapters/static/vite.config.ts` file will be created.
 
-In node you can run the generation after building using:
+Your build files will be generated into the `dist` folder.
+
+You can build and preview your static site using:
 
 ```shell
-node server/entry.ssr.js
+npm run preview
 ```
-
-Your build files will be generated into the `dist` folder.
 
 ### SSG Config
 

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -128,6 +128,11 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
               res.setHeader(key, value);
             });
 
+            const cookieHeaders = requestEv.cookie.headers();
+            if (cookieHeaders.length > 0) {
+              res.setHeader('Set-Cookie', cookieHeaders);
+            }
+
             (res as QwikViteDevResponse)._qwikEnvData = {
               ...(res as QwikViteDevResponse)._qwikEnvData,
               ...serverData,

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -128,11 +128,6 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
               res.setHeader(key, value);
             });
 
-            const cookieHeaders = requestEv.cookie.headers();
-            if (cookieHeaders.length > 0) {
-              res.setHeader('Set-Cookie', cookieHeaders);
-            }
-
             (res as QwikViteDevResponse)._qwikEnvData = {
               ...(res as QwikViteDevResponse)._qwikEnvData,
               ...serverData,


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Current SSG guide recommends running node to preview your site, which may have been correct at one point.

However, we have a full Vite integration now and `npm run preview` is the best option now.

Closes: #3250

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
