### PR TITLE
fix: partytown scripts not included in build

### DIFF
--- a/starters/features/partytown/package.json
+++ b/starters/features/partytown/package.json
@@ -9,21 +9,15 @@
     "viteConfig": {
       "imports": [
         {
-          "namedImports": [
-            "partytownVite"
-          ],
+          "namedImports": ["partytownVite"],
           "importPath": "@builder.io/partytown/utils"
         },
         {
-          "namedImports": [
-            "join"
-          ],
+          "namedImports": ["join"],
           "importPath": "path"
         }
       ],
-      "vitePlugins": [
-        "partytownVite({dest: join(__dirname, 'public', '~partytown')})"
-      ]
+      "vitePlugins": ["partytownVite({dest: join(__dirname, 'dist', '~partytown')})"]
     },
     "docs": [
       "https://partytown.builder.io/",

--- a/starters/features/partytown/package.json
+++ b/starters/features/partytown/package.json
@@ -9,15 +9,21 @@
     "viteConfig": {
       "imports": [
         {
-          "namedImports": ["partytownVite"],
+          "namedImports": [
+            "partytownVite"
+          ],
           "importPath": "@builder.io/partytown/utils"
         },
         {
-          "namedImports": ["join"],
+          "namedImports": [
+            "join"
+          ],
           "importPath": "path"
         }
       ],
-      "vitePlugins": ["partytownVite({dest: join(__dirname, 'dist', '~partytown')})"]
+      "vitePlugins": [
+        "partytownVite({dest: join(__dirname, 'dist', '~partytown')})"
+      ]
     },
     "docs": [
       "https://partytown.builder.io/",


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

The Qwik Partytown integration runs after Qwik City, copying files into the public folder *after* the build.

This PR changes the output directory to dist, so Partytown files are always included.

Closes: #3191 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
