### PR TITLE
fix(doc-search): unable to prevent default  - revert

### DIFF
--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -1,5 +1,5 @@
 import type { SearchClient } from 'algoliasearch/lite';
-import { component$, useStore, useStyles$, useRef } from '@builder.io/qwik';
+import { component$, useStore, useStyles$, useSignal } from '@builder.io/qwik';
 import type { DocSearchHit, InternalDocSearchHit, StoredDocSearchHit } from './types';
 import { ButtonTranslations, DocSearchButton } from './doc-search-button';
 import { DocSearchModal, ModalTranslations } from './doc-search-modal';
@@ -64,7 +64,7 @@ export const DocSearch = component$((props: DocSearchProps) => {
     snippetLength: 10,
   });
 
-  const searchButtonRef = useRef();
+  const searchButtonRef = useSignal();
 
   return (
     <div

--- a/packages/docs/src/components/docsearch/doc-search.tsx
+++ b/packages/docs/src/components/docsearch/doc-search.tsx
@@ -1,5 +1,5 @@
 import type { SearchClient } from 'algoliasearch/lite';
-import { component$, useStore, useStyles$, useSignal } from '@builder.io/qwik';
+import { component$, useStore, useStyles$, useRef } from '@builder.io/qwik';
 import type { DocSearchHit, InternalDocSearchHit, StoredDocSearchHit } from './types';
 import { ButtonTranslations, DocSearchButton } from './doc-search-button';
 import { DocSearchModal, ModalTranslations } from './doc-search-modal';
@@ -64,12 +64,11 @@ export const DocSearch = component$((props: DocSearchProps) => {
     snippetLength: 10,
   });
 
-  const searchButtonRef = useSignal();
+  const searchButtonRef = useRef();
 
   return (
     <div
       class="docsearch"
-      preventdefault:keyDown={!state.isOpen}
       window:onKeyDown$={(event) => {
         function open() {
           // We check that no other DocSearch modal is showing before opening
@@ -86,6 +85,9 @@ export const DocSearch = component$((props: DocSearchProps) => {
           // a character.
           (!isEditingContent(event) && event.key === '/' && !state.isOpen)
         ) {
+          // FIXME: not able to prevent
+          // event.preventDefault();
+
           if (state.isOpen) {
             state.isOpen = false;
           } else if (!document.body.classList.contains('DocSearch--active')) {


### PR DESCRIPTION
Reverts BuilderIO/qwik#3211

revert because all key downs are now prevented when the search modal is closed, such es search, copy, etc