### PR TITLE
docs: Use correct variable name in onScroll function

### DIFF
--- a/packages/docs/src/routes/docs/advanced/dollar/index.mdx
+++ b/packages/docs/src/routes/docs/advanced/dollar/index.mdx
@@ -238,7 +238,7 @@ This works but is a lot of work. The developer is responsible for putting the co
 ```tsx
 function onScroll(fnQrl: QRL<() => void>) {
   document.addEventListener('scroll', async () => {
-    const fn = await qImport.resolve();
+    const fn = await fnQrl.resolve();
     fn();
   });
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

The variable that was used in the `onScroll` function example didn't exist. I replaced it with the right one.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality
