### PR TITLE
docs(qwik): fix Typo from on:lick to on:click

### DIFF
--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -103,7 +103,7 @@ import { createQRL } from './qrl-class';
  *
  * ```
  * <div q:base="/build/">
- *   <button on:lick="./chunk-abc.js#onClick">...</button>
+ *   <button on:click="./chunk-abc.js#onClick">...</button>
  * </div>
  * ```
  *

--- a/packages/qwik/src/core/readme.md
+++ b/packages/qwik/src/core/readme.md
@@ -322,7 +322,7 @@ The above code needs to be serialized into DOM such as:
 
 ```
 <div q:base="/build/">
-  <button on:lick="./chunk-abc.js#onClick">...</button>
+  <button on:click="./chunk-abc.js#onClick">...</button>
 </div>
 ```
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Just found this typo while going through the qwik code. 

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
