### PR TITLE
docs: Added a short readme for the Azure SWA adapter.

### DIFF
--- a/starters/adapters/azure-swa/README.md
+++ b/starters/adapters/azure-swa/README.md
@@ -1,0 +1,12 @@
+## Create your Static Web App on Azure
+
+1. Follow [this](https://learn.microsoft.com/en-us/azure/static-web-apps/overview) guide to create a Static Web App. This guide will also detail how to generate a github action or Azure Pipeline (see "Quickstarts" section)
+
+2. If you're using github actions, make sure to add skip_api_build with true value.
+``` yml
+  app_location: "/"
+  api_location: "azure-functions"
+  output_location: "dist"
+  skip_api_build: true  # <--- add this line
+  ###### End of Repository/Build Configurations ######
+```

--- a/starters/adapters/azure-swa/README.md
+++ b/starters/adapters/azure-swa/README.md
@@ -3,10 +3,11 @@
 1. Follow [this](https://learn.microsoft.com/en-us/azure/static-web-apps/overview) guide to create a Static Web App. This guide will also detail how to generate a github action or Azure Pipeline (see "Quickstarts" section)
 
 2. If you're using github actions, make sure to add skip_api_build with true value.
-``` yml
-  app_location: "/"
-  api_location: "azure-functions"
-  output_location: "dist"
-  skip_api_build: true  # <--- add this line
-  ###### End of Repository/Build Configurations ######
+
+```yml
+app_location: '/'
+api_location: 'azure-functions'
+output_location: 'dist'
+skip_api_build: true # <--- add this line
+###### End of Repository/Build Configurations ######
 ```


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The github action that gets automatically generated by Azure Static Web Apps website/vscode extension doesn't work by default. We need to set the "skip_api_build" to true for it to succeed. I've added this information in a short readme file.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
