### PR TITLE
docs(component): use setInterval for updating clock in useVisibleTask$()

### DIFF
--- a/packages/docs/src/routes/tutorial/hooks/use-visible-task/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-visible-task/solution/app.tsx
@@ -15,11 +15,9 @@ export const Clock = component$(() => {
     second: 0,
   });
 
-  useVisibleTask$(({ track }) => {
-    track(store);
-    updateClock(store);
-    const tmrId = setTimeout(() => updateClock(store), 1000);
-    return () => clearTimeout(tmrId);
+  useVisibleTask$(() => {
+    const intervalId = setInterval(() => updateClock(store), 1000);
+    return () => clearTimeout(intervalId);
   });
 
   return (


### PR DESCRIPTION
This PR updates the useVisibleTask$() hook to use `setInterval` instead of `setTimeout` for updating the clock every second, as requested in the problem description:

<img width="549" alt="qwik-tuto" src="https://user-images.githubusercontent.com/48165230/223873279-dc15a77c-db54-4324-b7d6-8ddb2816e878.png">

The cleanup function is also updated accordingly.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
