### PR TITLE
fix(qwik): support https & override origin for dev server

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -38,7 +38,10 @@ export async function configureDevServer(
   // qwik middleware injected BEFORE vite internal middlewares
   server.middlewares.use(async (req, res, next) => {
     try {
-      const domain = 'http://' + (req.headers.host ?? 'localhost');
+      const domain =
+        ((req.socket as any).encrypted || (req.connection as any).encrypted ? 'https' : 'http') +
+        '://' +
+        (req.headers[':authority'] ?? req.headers['host'] ?? 'localhost');
       const url = new URL(req.originalUrl!, domain);
 
       if (shouldSsrRender(req, url)) {

--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -9,6 +9,18 @@ import { NormalizedQwikPluginOptions, parseId } from './plugin';
 import type { QwikViteDevResponse } from './vite';
 import { formatError } from './vite-utils';
 
+const { ORIGIN, PROTOCOL_HEADER, HOST_HEADER } = process.env;
+
+function getOrigin(req: IncomingMessage) {
+  const headers = req.headers;
+  const protocol =
+    (PROTOCOL_HEADER && headers[PROTOCOL_HEADER]) ||
+    ((req.socket as any).encrypted || (req.connection as any).encrypted ? 'https' : 'http');
+  const host = (HOST_HEADER && headers[HOST_HEADER]) || headers[':authority'] || headers['host'];
+
+  return `${protocol}://${host}`;
+}
+
 export async function configureDevServer(
   server: ViteDevServer,
   opts: NormalizedQwikPluginOptions,
@@ -38,10 +50,7 @@ export async function configureDevServer(
   // qwik middleware injected BEFORE vite internal middlewares
   server.middlewares.use(async (req, res, next) => {
     try {
-      const domain =
-        ((req.socket as any).encrypted || (req.connection as any).encrypted ? 'https' : 'http') +
-        '://' +
-        (req.headers[':authority'] ?? req.headers['host'] ?? 'localhost');
+      const domain = ORIGIN ?? getOrigin(req);
       const url = new URL(req.originalUrl!, domain);
 
       if (shouldSsrRender(req, url)) {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

First of all, `<Link />` component will do nothing if the origin generated on server is different to our actual visiting origin.

We found that if you [enabled HTTPS](https://vitejs.dev/config/server-options.html#server-https) in `vite.config.ts`, the origin generated on server will be constantly `http://localhost`.

The problem code goes here:

https://github.com/BuilderIO/qwik/blob/c09b09cb3cd2b4043060f8d17ffeeca2bd3a80f4/packages/qwik/src/optimizer/src/plugins/vite-server.ts#L41

The code above lacks some checks for HTTPS server.

Furthermore, if we have nginx proxy to your dev server, generating the proper origin will be a little bit hard. We can use `proxy_set_header Host $host;` in nginx to make vite get the correct host, but we have no idea on identifying whether the proxy connection is HTTP or HTTPS.

I looked somewhere and found some interesting code here:

https://github.com/BuilderIO/qwik/blob/c09b09cb3cd2b4043060f8d17ffeeca2bd3a80f4/packages/qwik-city/middleware/node/http.ts#L8-L24

The code provided a way to override the origin manually in order to make sure we can have correct origin under all cases. I copied those logic to `vite-server.ts`, so we can have dev server to behavior the same as it.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. I want to enable HTTPS in vite for my dev.
  > We can have it work properly now.
- 2. I have nginx proxy for my dev server, and my real origin is little bit hard for vite to know.
  > We can use `env ORIGIN=https://xxxx pnpm run dev` to override server origin now.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
