### PR TITLE
Change lite components to inlined jsx functions

### DIFF
--- a/packages/docs/src/routes/docs/components/lite-components/index.mdx
+++ b/packages/docs/src/routes/docs/components/lite-components/index.mdx
@@ -1,18 +1,19 @@
 ---
-title: Lite components
+title: Inlined JSX Functions
 contributors:
   - voluntadpear
   - RATIU5
   - ykou
   - adamdbradley
+  - nnelgxorz
 ---
 
-# Lite Components
+# Inlined JSX Functions
 
-In addition to standard Qwik components that have all of its lazy-loaded properties, Qwik also supports lightweight (lite) components that act more like traditional frameworks.
+In addition to standard Qwik components that have all of its lazy-loaded properties, Qwik also supports inlined jsx functions that act more like components in traditional frameworks.
 
 ```tsx
-// Lite component: declared using a standard function.
+// Inlined JSX Function: declared using a standard function.
 export const MyButton = (props: { text: string }) => {
   return <button>{props.text}</button>;
 };
@@ -28,13 +29,13 @@ export const MyApp = component$(() => {
 });
 ```
 
-In the above example, the `MyButton` is a lite component. Lite components' lazy loading is merged with the regular component they are part of. In this case:
+In the above example, the `MyButton` is a Inlined JSX Function. Inlined JSX Functions' are merged with the regular component they are part of. In this case:
 
 - `MyButton` will get bundled with the `MyApp` render function.
 - Whenever the render function of `MyApp` executes, it will also force the execution of `MyButton`.
 - `MyButton` does not have a host element.
 
-You can think of lightweight components as being inlined into the component, where they are instantiated.
+Inlined JSX functions are inlined into the component where they are instantiated.
 
 > **Limitations**
-> Unlike regular Qwik components, lite components can not use `use` methods, such as `useSignal` or `useStore`. As it name implies, lite components are better used sparsely for lightweight pieces of markup since they offer the convenience of being bundled with the parent component.
+> Unlike regular Qwik components, Inlined JSX Functions can not use `use` methods, such as `useSignal` or `useStore`. As it name implies, Inlined JSX Functions are better used sparsely for lightweight pieces of markup since they offer the convenience of being bundled with the parent component.

--- a/packages/docs/src/routes/docs/components/overview/index.mdx
+++ b/packages/docs/src/routes/docs/components/overview/index.mdx
@@ -243,4 +243,4 @@ The Optimizer splits Qwik components into the host element and the behavior of t
 
 ## See Also
 
-- [Lite components](../lite-components/index.mdx)
+- [Inlined JSX Functions](../lite-components/index.mdx)

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -19,7 +19,7 @@
 - [Slots](components/projection/index.mdx)
 - [Rendering](components/rendering/index.mdx)
 - [Styling](components/styles/index.mdx)
-- [Lite components](components/lite-components/index.mdx)
+- [Inlined JSX Functions](components/lite-components/index.mdx)
 
 ## Cheat Sheet
 

--- a/packages/docs/src/routes/tutorial/component/lite/index.mdx
+++ b/packages/docs/src/routes/tutorial/component/lite/index.mdx
@@ -1,15 +1,16 @@
 ---
-title: Lite Component
+title: Inlined JSX Function
 contributors:
   - adamdbradley
   - the-r3aper7
   - manucorporat
+  - nnelgxorz
 ---
 
 One of Qwik's super powers lies in its lazy-loading features. Each component will generate a separate Symbol which is downloaded on demand. This allows you to build a large application with many components and only download the components that are needed for the current view.
 
-But for some cases you may want to load a component together with the parent component. For example, if you have a `<Greeter>` component that is always used with the `<App>` component, you may want to load the `<Greeter>` component with the `<App>` component. This is called a [lite or lightweight component](/docs/components/lite-components).
+But for some cases you may want to load a component together with the parent component. For example, if you have a `<Greeter>` component that is always used with the `<App>` component, you may want to load the `<Greeter>` component with the `<App>` component. This is called an [inline jsx function](/docs/components/lite-components).
 
-In this example, the `<App>` and a `<Greeter>` components are prepared for you. The `<Greeter />` component is declared using the [`component$()`](/docs/components/overview/index.mdx#component) method and is a Qwik component. Remove the [`component$()`](/docs/components/overview/index.mdx#component) to convert `<Greeter>` to a [lite component](/docs/components/lite-components).
+In this example, the `<App>` and a `<Greeter>` components are prepared for you. The `<Greeter />` component is declared using the [`component$()`](/docs/components/overview/index.mdx#component) method and is a Qwik component. Remove the [`component$()`](/docs/components/overview/index.mdx#component) to convert `<Greeter>` to a [inlined jsx function](/docs/components/lite-components).
 
 Open the `Symbols` tab and notice that the `<Greeter />` component is no longer an independent export, but instead is bundled as part of the `<App>` component.

--- a/packages/docs/src/routes/tutorial/tutorial-menu.json
+++ b/packages/docs/src/routes/tutorial/tutorial-menu.json
@@ -73,7 +73,7 @@
       },
       {
         "id": "lite",
-        "title": "Lite Components",
+        "title": "Inlined JSX Function",
         "enableHtmlOutput": true,
         "enableClientOutput": true,
         "enableSsrOutput": true


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Rename lite components to inlined jsx functions. Lite components implies to people that they have benefits over component$, which they do not.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
