### PR TITLE
docs: add `bunx create-qwik` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ As users interact with the site, only the necessary parts of the site load on-de
 npm create qwik@latest
 # or
 pnpm create qwik@latest
-# or
 yarn create qwik@latest
+bunx create-qwik@latest
 ```
 
 - Understand the difference between [resumable and replayable](https://qwik.builder.io/docs/concepts/resumable/) applications.

--- a/packages/docs/src/routes/docs/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/getting-started/index.mdx
@@ -32,6 +32,7 @@ Choose the package manager you prefer and run one of the following command:
 npm create qwik@latest
 pnpm create qwik@latest
 yarn create qwik
+bunx create-qwik
 ```
 
 The CLI will guide you through an interactive menu to set the project-name, select one of the starters and asks if you want to install the dependencies.

--- a/packages/docs/src/routes/qwikcity/project-structure/index.mdx
+++ b/packages/docs/src/routes/qwikcity/project-structure/index.mdx
@@ -12,9 +12,11 @@ To follow along with this guide, run the Qwik CLI in your command line:
 
 ```shell
 npm create qwik@latest
+# or
+pnpm create qwik@latest
+yarn create qwik
+bunx create-qwik
 ```
-
-> Notice that you can also use the package manager of your choice, `yarn create qwik@latest` or `pnpm create qwik@latest`.
 
 When prompted, choose a name for your project and Basic as your starter.
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

I've tried `bunx create-qwik` and `bun start`, it works!
so, we should add `bunx create-qwik` command into docs.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
