### PR TITLE
fix: correctly pass `locale` from QwikCity to Qwik

### DIFF
--- a/packages/qwik-city/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/middleware/request-handler/request-event.ts
@@ -161,7 +161,7 @@ export function createRequestEvent(
     },
 
     locale: (_locale?: string) => {
-      if (typeof locale === 'string') {
+      if (typeof _locale === 'string') {
         locale = _locale;
       }
       return locale || '';

--- a/starters/apps/qwikcity-test/src/routes/locale/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/locale/index.tsx
@@ -1,0 +1,14 @@
+import { component$, getLocale } from '@builder.io/qwik';
+import type { RequestHandler } from '@builder.io/qwik-city';
+
+export const onRequest: RequestHandler = ({ locale }) => {
+  locale('test-locale');
+};
+
+export default component$(() => {
+  return (
+    <div>
+      Current locale: <span class="locale">{getLocale()}</span>
+    </div>
+  );
+});

--- a/starters/e2e/qwikcity/locale.spec.ts
+++ b/starters/e2e/qwikcity/locale.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Qwik City locale API', () => {
+  test('pass locale to Qwik', async ({ page }) => {
+    await page.goto('/qwikcity-test/locale');
+    const locale = page.locator('.locale');
+    const qContainer = page.locator('[q\\:container]');
+    await expect(locale).toHaveText('test-locale');
+    await expect(qContainer).toHaveAttribute('q:locale', 'test-locale');
+  });
+});


### PR DESCRIPTION
fix #3228

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
