### PR TITLE
docs: update deprecated property

### DIFF
--- a/packages/docs/src/routes/tutorial/store/recursive/index.mdx
+++ b/packages/docs/src/routes/tutorial/store/recursive/index.mdx
@@ -13,7 +13,7 @@ To make the example work, you need to do one of two things:
 
 1. Wrap `{count:0}` in another [`useStore()`](/docs/components/state/index.mdx#usestore) call (which is a bit cumbersome)
 
-1. Allow `useStore` to recursively apply reactivity to all properties by passing the additional argument: `{recursive:true}`.
+1. Allow `useStore` to recursively apply reactivity to all properties by passing the additional argument: `{deep:true}`.
 
 > **Your task:** Update the sample with the [`useStore()`](/docs/components/state/index.mdx#usestore) function.
 


### PR DESCRIPTION
docs(packages/docs/src/routes/tutorial/store/recursive/index.mdx): update deprecated property

This commit addresses the following deprecation notice caused by following the tutorial: 
`(property) UseStoreOptions.recursive?: boolean` is `@deprecated` -- use `deep` instead

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This is a minor update to the Qwik tutorial replacing a deprecated options object property with its documented replacement property.

# Use cases and why

Tutorial documentation should whenever possible reflect the latest state of the framework, and shouldn't contain the use of deprecated symbols or features.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [N/A] Added new tests to cover the fix / functionality
