### PR TITLE
fix(docs): replace deprecated type RouteParams to PathParams

### DIFF
--- a/packages/docs/src/routes/examples/[...id]/index!.tsx
+++ b/packages/docs/src/routes/examples/[...id]/index!.tsx
@@ -1,5 +1,5 @@
 import { component$, useStyles$, useTask$, useStore } from '@builder.io/qwik';
-import type { RequestHandler, RouteParams, StaticGenerateHandler } from '@builder.io/qwik-city';
+import type { RequestHandler, PathParams, StaticGenerateHandler } from '@builder.io/qwik-city';
 import { Repl } from '../../../repl/repl';
 import styles from './examples.css?inline';
 import { Header } from '../../../components/header/header';
@@ -154,6 +154,6 @@ export const onStaticGenerate: StaticGenerateHandler = () => {
         });
       });
       return params;
-    }, [] as RouteParams[]),
+    }, [] as PathParams[]),
   };
 };

--- a/packages/docs/src/routes/qwikcity/api/index.mdx
+++ b/packages/docs/src/routes/qwikcity/api/index.mdx
@@ -74,7 +74,7 @@ Use the [`useLocation()`](/qwikcity/api/index.mdx#uselocation) function to retri
 
 ```tsx
 export interface RouteLocation {
-  readonly params: RouteParams; // Readonly<Record<string, string>>
+  readonly params: PathParams; // Readonly<Record<string, string>>
   readonly url: URL;
   readonly isNavigating: boolean;
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

fix(docs): replace deprecated type RouteParams to PathParams

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
