### PR TITLE
Fix handling of request body in Azure Functions

### DIFF
--- a/packages/qwik-city/middleware/azure-swa/index.ts
+++ b/packages/qwik-city/middleware/azure-swa/index.ts
@@ -36,11 +36,10 @@ export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
   async function onAzureSwaRequest(context: Context, req: HttpRequest): Promise<AzureResponse> {
     try {
       const url = new URL(req.headers['x-ms-original-url']!);
-      const options = {
-        method: req.method,
+      const options: RequestInit = {
+        method: req.method || 'GET',
         headers: req.headers,
-        body: req.body,
-        duplex: 'half' as any,
+        body: req.bufferBody || req.rawBody || req.body,
       };
 
       const serverRequestEv: ServerRequestEvent<AzureResponse> = {
@@ -53,7 +52,7 @@ export function createQwikCity(opts: QwikCityAzureOptions): AzureFunction {
             return process.env[key];
           },
         },
-        request: new Request(url, options as any),
+        request: new Request(url, options),
         getWritableStream: (status, headers, cookies, resolve) => {
           const response: AzureResponse = {
             status,


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

The `body` in the Azure Function request is a parsed version of the original request body. For JSON requests the body is already parsed as an object. This results in duplicate parsing (in Azure and then in the Qwik handler). This fix uses the newly availble bufferBody and rawBody if available.

Fixes #3367

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
