### PR TITLE
Add Error Serializers for custom and nested errors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,17 @@
+# Introduction
+
+The Qwik Team and Qwik Community are grateful for all the PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:
+
+a) Fixes to the core, and
+
+b) Framework functionality that can only be achieved by the core.
+
+If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.
+
+If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.
+
+*— Build primitives are our mantra*
+
 # What is it?
 
 - [ ] Feature / enhancement

--- a/packages/qwik/src/core/container/serializers.ts
+++ b/packages/qwik/src/core/container/serializers.ts
@@ -25,6 +25,7 @@ import { getOrCreateProxy } from '../state/store';
 import { QObjectManagerSymbol } from '../state/constants';
 import { parseDerivedSignal, serializeDerivedSignal } from '../qrl/inlined-fn';
 import type { QwikElement } from '../render/dom/virtual-element';
+import { deserializeError, serializeError } from '../error/error_serializer';
 
 /**
  * 0, 8, 9, A, B, C, D
@@ -181,14 +182,8 @@ const RegexSerializer: Serializer<RegExp> = {
 const ErrorSerializer: Serializer<Error> = {
   prefix: '\u000E',
   test: (v) => v instanceof Error,
-  serialize: (obj) => {
-    return obj.message;
-  },
-  prepare: (text) => {
-    const err = new Error(text);
-    err.stack = undefined;
-    return err;
-  },
+  serialize: (obj) => serializeError(obj),
+  prepare: (text) => deserializeError(text),
   fill: undefined,
 };
 

--- a/packages/qwik/src/core/error/error_serializer.ts
+++ b/packages/qwik/src/core/error/error_serializer.ts
@@ -1,0 +1,161 @@
+/**
+ * This file enables the serialization and deserialization 
+ * of Error objects and custom error objects. It supports
+ * nested errors for systems that require this, such as GraphQL
+ * libraries. Stack traces and circular referenes are omitted.
+ */
+
+/**
+ * Serialize an error object into a string, removing
+ * stack traces and circular references.
+ * 
+ * @param error 
+ * @returns serialized error as a string
+ */
+export const serializeError = (error: any) => {
+    const errPrims = cloneErrorPrimitives(error);
+    return JSON.stringify(errPrims);
+}
+
+/**
+ * Deserialize an error object from a string,
+ * removes unnecessary fields and rebuilds
+ * nested error objects, before returning a
+ * new Error object.
+ * 
+ * @param serializedError 
+ * @returns 
+ */
+export const deserializeError = (serializedError: string) => {
+    const errPrims = JSON.parse(serializedError);
+
+    if (typeof errPrims === 'object' && errPrims !== null) {
+        // Get what we need and jettison the rest
+        const { __errMessage, __deepErrors, stack, ...rest }: any = errPrims;
+        const error = new Error(__errMessage);
+        Object.assign(error, rest);
+        delete error.stack;
+
+        if (__deepErrors) {
+            // Rebuild the deep errors
+            deserializeDeepErrors(error, errPrims.__deepErrors);
+        }
+
+        return error;
+    }
+
+    throw new Error(`Unable to deserialize error: ${serializedError}`);
+}
+
+/**
+ * Recursively extract primitive values from an object or array,
+ * including handling of circular references and pruning the
+ * stack trace from Error objects, and returns a new object with
+ * only primitive values.
+ */
+const cloneErrorPrimitives = (obj: any): any => {
+    const __deepErrors = Array<string>();
+
+    const clone = (obj: any, path: string | undefined = undefined, cache: Set<any> = new Set()): any => {
+        if (obj === null || typeof obj !== 'object' || typeof obj === 'function') {
+            // If the object is a primitive type or null or function, return it
+            return obj;
+        }
+
+        // If the object has already been processed, return it
+        if (cache.has(obj)) return;
+
+        // Add the object to the cache
+        cache.add(obj);
+
+        const clonedObj: any = Array.isArray(obj) ? [] : {};
+
+        const isError = obj instanceof Error;
+        for (const key in obj) {
+            if (isError && key == 'stack') continue;  // Not needed, just to be safe
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                // Recursively clone each property of the object
+                clonedObj[key] = clone(obj[key], path ? `${path}.${key}` : key, cache);
+            }
+        }
+
+        // If the object is an Error, add a special property to the clone
+        // and add the path to the __deepErrors array
+        if (isError) {
+            path && __deepErrors.push(path);
+            clonedObj.__errMessage = obj.message;
+        }
+
+        return clonedObj;
+    };
+
+    const clonedErr = clone(obj);
+    clonedErr.__deepErrors = __deepErrors;
+    return clonedErr;
+};
+
+/**
+ * Rebuild any nested Error objects that were serialized
+ * and inserts them back into the appropriate locations
+ * within the parent Error object. Stack trace and circular
+ * refereces are omitted.
+ * 
+ * @param obj 
+ * @param deepErrorPaths 
+ */
+const deserializeDeepErrors = (obj: any, deepErrorPaths: string[] | undefined) => {
+    deepErrorPaths?.forEach(path => {
+        const pathKeys = path.split('.');
+
+        // Traverse the object to the deep error
+        let parentObj: any;
+        let objKey: string | undefined;
+        let deepErrObj = obj;
+        pathKeys.forEach((key, i) => {
+            objKey = key;
+            parentObj = deepErrObj;
+            deepErrObj = deepErrObj[pathKeys[i]];
+        });
+
+        // Rebuild the object with an Error instance
+        if (objKey) {
+            const { __errMessage, stack, ...rest }: any = deepErrObj;
+            const deepError = new Error(__errMessage);
+            delete deepError.stack;
+            Object.assign(deepError, rest);
+            parentObj[objKey] = deepError;
+        }
+    });
+}
+
+/**
+ * THIS IS A VALIDATION OBJECT FOR TESTING
+ *
+    const validate = {
+      e1: new Error("Standard Error"),
+      c: {},
+      o: {
+        e2: new CustomError("Custom Error", {
+          e3: new Error("Super Deep Standard Error"),
+        }),
+        c: {},
+        stack: "keep me",
+        n: null,
+        b: true,
+        v: 123,
+        s: "abc",
+        u: undefined,
+        f: () => "function!",
+      },
+      stack: "keep me",
+      n: null,
+      b: true,
+      v: 123,
+      s: "abc",
+      u: undefined,
+      f: () => "function!"
+    };
+    validate.c = validate;
+    validate.o.c = validate;
+
+ */

--- a/packages/qwik/src/core/error/error_serializer.ts
+++ b/packages/qwik/src/core/error/error_serializer.ts
@@ -33,7 +33,7 @@ export const deserializeError = (serializedError: string) => {
     // Get what we need and jettison the rest
     const { __errMessage, __constructorName, __deepErrors, stack, ...rest }: any = errPrims;
     stack;
-    const ErrorClass = dynamicErrorClass(__constructorName);
+    const ErrorClass = getErrorClass(__constructorName);
     const error = new ErrorClass(__errMessage);
     Object.assign(error, rest);
     delete error.stack;
@@ -128,7 +128,7 @@ const deserializeDeepErrors = (obj: any, deepErrorPaths: string[] | undefined) =
     if (objKey) {
       const { __errMessage, __constructorName, stack, ...rest }: any = deepErrObj;
       stack;
-      const ErrorClass = dynamicErrorClass(__constructorName);
+      const ErrorClass = getErrorClass(__constructorName);
       const error = new ErrorClass(__errMessage);
       delete error.stack;
       Object.assign(error, rest);
@@ -137,7 +137,11 @@ const deserializeDeepErrors = (obj: any, deepErrorPaths: string[] | undefined) =
   });
 };
 
-function dynamicErrorClass(constructorName: string): any {
+function getErrorClass(constructorName: string): any {
+  // If the constructor name is "Error", return the build-in Error class
+  if (constructorName === 'Error') return Error;
+
+  // Create a dynamic class that extends Error
   const DynamicErrorClass = class extends Error {
     constructor(...args: any[]) {
       super(...args);
@@ -150,33 +154,32 @@ function dynamicErrorClass(constructorName: string): any {
 }
 
 /**
-   * THIS IS A VALIDATION OBJECT FOR TESTING
-   *
-      const validate = {
-        e1: new Error("Standard Error"),
+ * THIS IS A VALIDATION OBJECT FOR TESTING
+ *
+    const validate = {
+    e1: new Error("Standard Error"),
+    c: {},
+    o: {
+        e2: new CustomError("Custom Error", {
+        e3: new Error("Super Deep Standard Error"),
+        }),
         c: {},
-        o: {
-          e2: new CustomError("Custom Error", {
-            e3: new Error("Super Deep Standard Error"),
-          }),
-          c: {},
-          stack: "keep me",
-          n: null,
-          b: true,
-          v: 123,
-          s: "abc",
-          u: undefined,
-          f: () => "function!",
-        },
         stack: "keep me",
         n: null,
         b: true,
         v: 123,
         s: "abc",
         u: undefined,
-        f: () => "function!"
-      };
-      validate.c = validate;
-      validate.o.c = validate;
-  
-   */
+        f: () => "function!",
+    },
+    stack: "keep me",
+    n: null,
+    b: true,
+    v: 123,
+    s: "abc",
+    u: undefined,
+    f: () => "function!"
+    };
+    validate.c = validate;
+    validate.o.c = validate;
+*/

--- a/packages/qwik/src/core/error/error_serializer.ts
+++ b/packages/qwik/src/core/error/error_serializer.ts
@@ -8,7 +8,7 @@ export const serializeError = (error: any) => {
   if (Object.keys(error).length === 0) return `{"__qName": "Error","message":"${error.message}"}`; // Keep it screamin' fast! (IN) <--- This is the most common case
 
   // Serialize Custom Error / Object with errors
-  return JSON.stringify(cloneErrorPrimitives(error));
+  return JSON.stringify(cloneError(error));
 };
 
 export const deserializeError = (serializedError: string) => {
@@ -31,7 +31,7 @@ export const deserializeError = (serializedError: string) => {
   throw new Error(`Unable to deserialize error: ${serializedError}`); // Whoops!
 };
 
-const cloneErrorPrimitives = (obj: any): any => {
+const cloneError = (obj: any): any => {
   const __qDeep: string[] = [];
 
   function clone(obj: any, path: string | undefined = undefined, cache: Set<any> = new Set()) {
@@ -41,7 +41,7 @@ const cloneErrorPrimitives = (obj: any): any => {
     if (cache.has(obj)) return;
     cache.add(obj);
 
-    // Clone the object, "stack" is automatically removed (somehow magically)
+    // Clone the object, "stack" is automagically removed
     const clonedObj: any = Array.isArray(obj) ? [] : {};
     for (const key in obj) {
       if (Object.prototype.hasOwnProperty.call(obj, key)) {

--- a/packages/qwik/src/core/error/error_serializer.ts
+++ b/packages/qwik/src/core/error/error_serializer.ts
@@ -1,5 +1,5 @@
 /**
- * This file enables the serialization and deserialization 
+ * This file enables the serialization and deserialization
  * of Error objects and custom error objects. It supports
  * nested errors for systems that require this, such as GraphQL
  * libraries. Stack traces and circular referenes are omitted.
@@ -8,44 +8,44 @@
 /**
  * Serialize an error object into a string, removing
  * stack traces and circular references.
- * 
- * @param error 
+ *
+ * @param error
  * @returns serialized error as a string
  */
 export const serializeError = (error: any) => {
-    const errPrims = cloneErrorPrimitives(error);
-    return JSON.stringify(errPrims);
-}
+  const errPrims = cloneErrorPrimitives(error);
+  return JSON.stringify(errPrims);
+};
 
 /**
  * Deserialize an error object from a string,
  * removes unnecessary fields and rebuilds
  * nested error objects, before returning a
  * new Error object.
- * 
- * @param serializedError 
- * @returns 
+ *
+ * @param serializedError
+ * @returns
  */
 export const deserializeError = (serializedError: string) => {
-    const errPrims = JSON.parse(serializedError);
+  const errPrims = JSON.parse(serializedError);
 
-    if (typeof errPrims === 'object' && errPrims !== null) {
-        // Get what we need and jettison the rest
-        const { __errMessage, __deepErrors, stack, ...rest }: any = errPrims;
-        const error = new Error(__errMessage);
-        Object.assign(error, rest);
-        delete error.stack;
+  if (typeof errPrims === 'object' && errPrims !== null) {
+    // Get what we need and jettison the rest
+    const { __errMessage, __deepErrors, stack, ...rest }: any = errPrims;
+    const error = new Error(__errMessage);
+    Object.assign(error, rest);
+    delete error.stack;
 
-        if (__deepErrors) {
-            // Rebuild the deep errors
-            deserializeDeepErrors(error, errPrims.__deepErrors);
-        }
-
-        return error;
+    if (__deepErrors) {
+      // Rebuild the deep errors
+      deserializeDeepErrors(error, errPrims.__deepErrors);
     }
 
-    throw new Error(`Unable to deserialize error: ${serializedError}`);
-}
+    return error;
+  }
+
+  throw new Error(`Unable to deserialize error: ${serializedError}`);
+};
 
 /**
  * Recursively extract primitive values from an object or array,
@@ -54,44 +54,48 @@ export const deserializeError = (serializedError: string) => {
  * only primitive values.
  */
 const cloneErrorPrimitives = (obj: any): any => {
-    const __deepErrors = Array<string>();
+  const __deepErrors = Array<string>();
 
-    const clone = (obj: any, path: string | undefined = undefined, cache: Set<any> = new Set()): any => {
-        if (obj === null || typeof obj !== 'object' || typeof obj === 'function') {
-            // If the object is a primitive type or null or function, return it
-            return obj;
-        }
+  const clone = (
+    obj: any,
+    path: string | undefined = undefined,
+    cache: Set<any> = new Set()
+  ): any => {
+    if (obj === null || typeof obj !== 'object' || typeof obj === 'function') {
+      // If the object is a primitive type or null or function, return it
+      return obj;
+    }
 
-        // If the object has already been processed, return it
-        if (cache.has(obj)) return;
+    // If the object has already been processed, return it
+    if (cache.has(obj)) return;
 
-        // Add the object to the cache
-        cache.add(obj);
+    // Add the object to the cache
+    cache.add(obj);
 
-        const clonedObj: any = Array.isArray(obj) ? [] : {};
+    const clonedObj: any = Array.isArray(obj) ? [] : {};
 
-        const isError = obj instanceof Error;
-        for (const key in obj) {
-            if (isError && key == 'stack') continue;  // Not needed, just to be safe
-            if (Object.prototype.hasOwnProperty.call(obj, key)) {
-                // Recursively clone each property of the object
-                clonedObj[key] = clone(obj[key], path ? `${path}.${key}` : key, cache);
-            }
-        }
+    const isError = obj instanceof Error;
+    for (const key in obj) {
+      if (isError && key == 'stack') continue; // Not needed, just to be safe
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        // Recursively clone each property of the object
+        clonedObj[key] = clone(obj[key], path ? `${path}.${key}` : key, cache);
+      }
+    }
 
-        // If the object is an Error, add a special property to the clone
-        // and add the path to the __deepErrors array
-        if (isError) {
-            path && __deepErrors.push(path);
-            clonedObj.__errMessage = obj.message;
-        }
+    // If the object is an Error, add a special property to the clone
+    // and add the path to the __deepErrors array
+    if (isError) {
+      path && __deepErrors.push(path);
+      clonedObj.__errMessage = obj.message;
+    }
 
-        return clonedObj;
-    };
+    return clonedObj;
+  };
 
-    const clonedErr = clone(obj);
-    clonedErr.__deepErrors = __deepErrors;
-    return clonedErr;
+  const clonedErr = clone(obj);
+  clonedErr.__deepErrors = __deepErrors;
+  return clonedErr;
 };
 
 /**
@@ -99,63 +103,63 @@ const cloneErrorPrimitives = (obj: any): any => {
  * and inserts them back into the appropriate locations
  * within the parent Error object. Stack trace and circular
  * refereces are omitted.
- * 
- * @param obj 
- * @param deepErrorPaths 
+ *
+ * @param obj
+ * @param deepErrorPaths
  */
 const deserializeDeepErrors = (obj: any, deepErrorPaths: string[] | undefined) => {
-    deepErrorPaths?.forEach(path => {
-        const pathKeys = path.split('.');
+  deepErrorPaths?.forEach((path) => {
+    const pathKeys = path.split('.');
 
-        // Traverse the object to the deep error
-        let parentObj: any;
-        let objKey: string | undefined;
-        let deepErrObj = obj;
-        pathKeys.forEach((key, i) => {
-            objKey = key;
-            parentObj = deepErrObj;
-            deepErrObj = deepErrObj[pathKeys[i]];
-        });
-
-        // Rebuild the object with an Error instance
-        if (objKey) {
-            const { __errMessage, stack, ...rest }: any = deepErrObj;
-            const deepError = new Error(__errMessage);
-            delete deepError.stack;
-            Object.assign(deepError, rest);
-            parentObj[objKey] = deepError;
-        }
+    // Traverse the object to the deep error
+    let parentObj: any;
+    let objKey: string | undefined;
+    let deepErrObj = obj;
+    pathKeys.forEach((key, i) => {
+      objKey = key;
+      parentObj = deepErrObj;
+      deepErrObj = deepErrObj[pathKeys[i]];
     });
-}
+
+    // Rebuild the object with an Error instance
+    if (objKey) {
+      const { __errMessage, stack, ...rest }: any = deepErrObj;
+      const deepError = new Error(__errMessage);
+      delete deepError.stack;
+      Object.assign(deepError, rest);
+      parentObj[objKey] = deepError;
+    }
+  });
+};
 
 /**
- * THIS IS A VALIDATION OBJECT FOR TESTING
- *
-    const validate = {
-      e1: new Error("Standard Error"),
+* THIS IS A VALIDATION OBJECT FOR TESTING
+*
+  const validate = {
+    e1: new Error("Standard Error"),
+    c: {},
+    o: {
+      e2: new CustomError("Custom Error", {
+        e3: new Error("Super Deep Standard Error"),
+      }),
       c: {},
-      o: {
-        e2: new CustomError("Custom Error", {
-          e3: new Error("Super Deep Standard Error"),
-        }),
-        c: {},
-        stack: "keep me",
-        n: null,
-        b: true,
-        v: 123,
-        s: "abc",
-        u: undefined,
-        f: () => "function!",
-      },
       stack: "keep me",
       n: null,
       b: true,
       v: 123,
       s: "abc",
       u: undefined,
-      f: () => "function!"
-    };
-    validate.c = validate;
-    validate.o.c = validate;
-
- */
+      f: () => "function!",
+    },
+    stack: "keep me",
+    n: null,
+    b: true,
+    v: 123,
+    s: "abc",
+    u: undefined,
+    f: () => "function!"
+  };
+  validate.c = validate;
+  validate.o.c = validate;
+ 
+*/

--- a/packages/qwik/src/core/error/error_serializer.ts
+++ b/packages/qwik/src/core/error/error_serializer.ts
@@ -106,20 +106,20 @@ export const makeClassInstance = (className: string, errorMessage?: string) => {
   let instance: any;
   if (errorMessage) {
     // Create a dynamic error
-    class DynamicError extends Error {
+    class DeserializedError extends Error {
       constructor(message: string) {
         super(message);
         this.name = className;
         delete this.stack;
       }
     }
-    instance = new DynamicError(errorMessage);
+    instance = new DeserializedError(errorMessage);
   } else {
     // Create a dynamic class
-    class DynamicClass {
+    class DeserializedClass {
       constructor() {}
     }
-    instance = new DynamicClass();
+    instance = new DeserializedClass();
   }
 
   Object.defineProperty(instance, 'name', { value: className });


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

<h1>This PR enables the serialization and deserialization of Error and Custom Error objects.
It serializes and deserializes primitive values and rebuilds nested Error objects in a targeted fashion.</h1>

The `serializeError` function takes an Error or Custom Error object as input and clones its primitive values using the `cloneErrorPrimitives` function before returning the resulting object in a JSON string format.

The `deserializeError` function takes a serialized Error object string as input and converts it back into an Error or Custom Error object with only the necessary primitive values. It accomplishes this by parsing the input string into an object, extracting the needed values and creating a new Error object with those values. If the input string contains nested Error objects, it will rebuild them by calling the `deserializeDeepErrors` function.

The `cloneErrorPrimitives` function recursively extracts all primitive values from an object or array, including handling of circular references, pruning the stack trace from Error objects, and returning a new object with only primitive values. This function is called by `serializeError` to extract the necessary values from the Error object.

Finally, the `deserializeDeepErrors` function rebuilds any nested Error objects that were serialized. It takes the rebuilt Error objects and inserts them back into the appropriate locations within the parent Error object.

# Use cases and why

<h2>As-is implemented, a simple string is *NOT* enough.</h2>

1. Complete Error and Custom errors are necessary when working with many backend systems.
2. Some backend systems such as GraphQL servers even return nested errors arrays which would be lost with the existing serializer, reducing the top level error to a string that is recreated on deserialization.
3. Other systems use fields like `code` and `status` which are not supported.
4. Other workarounds like simply using `JSON.stringify()` and `JSON.parse()` on an error or custom error objects is not natively simple due to issues like: **a)** circular references, and **b)** needing to reconstitute the nested errors on deserialization.  

<strong>Related Conversation in Discord:</strong> [HERE](https://discord.com/channels/842438759945601056/1085107180384030750)

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [1/2 ] Added new tests to cover the fix / functionality

Validation object provided for custom error testing.
