### PR TITLE
docs(tutorial): replace deprecated function in Qwik context tutorial editor

### DIFF
--- a/packages/docs/src/routes/tutorial/context/basic/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/context/basic/problem/app.tsx
@@ -1,9 +1,9 @@
-import { component$, createContext, useContextProvider, useStore } from '@builder.io/qwik';
+import { component$, createContextId, useContextProvider, useStore } from '@builder.io/qwik';
 
 interface TodosStore {
   items: string[];
 }
-export const TodosContext = createContext<TodosStore>('Todos');
+export const TodosContext = createContextId<TodosStore>('Todos');
 export default component$(() => {
   useContextProvider(
     TodosContext,

--- a/packages/docs/src/routes/tutorial/context/basic/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/context/basic/solution/app.tsx
@@ -1,6 +1,6 @@
 import {
   component$,
-  createContext,
+  createContextId,
   useContextProvider,
   useContext,
   useStore,
@@ -9,7 +9,7 @@ import {
 interface TodosStore {
   items: string[];
 }
-export const TodosContext = createContext<TodosStore>('Todos');
+export const TodosContext = createContextId<TodosStore>('Todos');
 export default component$(() => {
   useContextProvider(
     TodosContext,


### PR DESCRIPTION
This commit addresses the following deprecation notice present in the tutorial editor: 
'createContext' is deprecated. 
`@deprecated` — Please use `createContextId` instead.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This is a minor update to the Qwik tutorial replacing a deprecated function with its documented replacement property.

# Use cases and why

Tutorial documentation should whenever possible reflect the latest state of the framework, and shouldn't contain the use of deprecated symbols or features.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
