### PR TITLE
fix(docs): enable tsconfig for docs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,7 +85,7 @@
   },
   "include": [
     "packages/create-qwik",
-    // "packages/docs",
+    "packages/docs",
     "packages/qwik/src",
     "packages/qwik-city",
     "packages/qwik-auth",


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

I dont know the reason why you disabled tsconfig for packages/docs at 2022.12.17.  @manucorporat 
but something not right when tsconfig is disabled.

for example:
![Xnip2023-03-15_23-09-04](https://user-images.githubusercontent.com/20167257/225354672-271af7e1-f069-4d02-8619-3f08ab798d43.jpg)



# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
