### PR TITLE
starter(cli): re-add additional notes after integration install

### DIFF
--- a/packages/qwik/src/cli/add/run-add-interactive.ts
+++ b/packages/qwik/src/cli/add/run-add-interactive.ts
@@ -2,11 +2,11 @@
 import type { AppCommand } from '../utils/app-command';
 import { loadIntegrations, sortIntegrationsAndReturnAsClackOptions } from '../utils/integrations';
 import { bgBlue, bold, magenta, cyan, bgMagenta } from 'kleur/colors';
-import { bye, getPackageManager, panic, printHeader } from '../utils/utils';
+import { bye, getPackageManager, panic, printHeader, note } from '../utils/utils';
 import { updateApp } from './update-app';
 import type { IntegrationData, UpdateAppResult } from '../types';
 import { relative } from 'node:path';
-// import { logSuccessFooter, logNextStep } from '../utils/log';
+import { logNextStep } from '../utils/log';
 import { runInPkg } from '../utils/install-deps';
 import { intro, isCancel, select, log, spinner, outro } from '@clack/prompts';
 
@@ -153,11 +153,13 @@ async function logUpdateAppResult(pkgManager: string, result: UpdateAppResult) {
 }
 
 function logUpdateAppCommitResult(result: UpdateAppResult) {
+  const nextSteps = result.integration.pkgJson.__qwik__?.nextSteps;
+  if (nextSteps) {
+    note(logNextStep(nextSteps), 'Note');
+  }
+
   outro(`🦄 ${bgMagenta(` Success! `)} Added ${bold(cyan(result.integration.id))} to your app`);
 
   // TODO: `logSuccessFooter` returns a string, but we don't use it!
   // logSuccessFooter(result.integration.docs);
-  // const nextSteps = result.integration.pkgJson.__qwik__?.nextSteps;
-  // TODO: `logNextStep` returns a string, but we don't use it!
-  // logNextStep(nextSteps);
 }

--- a/packages/qwik/src/cli/add/update-app.ts
+++ b/packages/qwik/src/cli/add/update-app.ts
@@ -71,7 +71,7 @@ export async function updateApp(pkgManager: string, opts: UpdateAppOptions) {
       if (!passed) {
         const errorMessage = `${bgRed(
           ` ${pkgManager} install failed `
-        )}\n   You might need to run "${cyan(
+        )}\n You might need to run "${cyan(
           `${pkgManager} install`
         )}" manually inside the root of the project.`;
 

--- a/packages/qwik/src/cli/code-mod/code-mod.ts
+++ b/packages/qwik/src/cli/code-mod/code-mod.ts
@@ -42,7 +42,6 @@ export function updateViteConfig(ts: TypeScript, sourceText: string, updates?: V
           statements.push(
             ts.factory.updateExportAssignment(
               s,
-              s.decorators,
               s.modifiers,
               updateDefineConfig(ts, s.expression, updates)
             )
@@ -252,7 +251,6 @@ function appendImports(
     }
 
     const newNamedImport = ts.factory.createImportDeclaration(
-      undefined,
       undefined,
       ts.factory.createImportClause(false, defaultIdentifier, namedBindings),
       ts.factory.createStringLiteral(importPath)

--- a/packages/qwik/src/cli/utils/log.ts
+++ b/packages/qwik/src/cli/utils/log.ts
@@ -26,8 +26,8 @@ export function logNextStep(nextSteps: NextSteps | undefined) {
   const outString = [];
   if (nextSteps) {
     outString.push(`🟣 ${bgMagenta(` ${nextSteps.title ?? 'Action Required!'} `)}`);
-    nextSteps.lines.forEach((step) => outString.push(`   ${step}`));
     outString.push(``);
+    nextSteps.lines.forEach((step) => outString.push(`   ${step}`));
   }
   return outString.join('\n');
 }

--- a/starters/adapters/static/package.json
+++ b/starters/adapters/static/package.json
@@ -10,13 +10,9 @@
       "https://qwik.builder.io/qwikcity/static-site-generation/overview/"
     ],
     "nextSteps": {
-      "title": "New scripts were added!",
       "lines": [
-        "-----------------------------------------------------",
-        " ATTENTION:",
         " You must change the 'origin' url under staticAdapter",
-        " inside 'vite.config.ts'",
-        "------------------------------------------------------"
+        " inside 'vite.config.ts'"
       ]
     }
   }

--- a/starters/features/partytown/package.json
+++ b/starters/features/partytown/package.json
@@ -31,12 +31,10 @@
     ],
     "nextSteps": {
       "lines": [
-        "------------------------------------------------",
-        "You must add the next component <QwikPartytown/>;",
-        "If you check more arguments ",
-        "https://partytown.builder.io/configuration",
-        "root.tsx -------------------------------------",
-        ""
+        " Please add the <QwikPartytown/> component",
+        " to your root.tsx file.",
+        " Have a look at the docs for more info: ",
+        " https://partytown.builder.io/configuration"
       ]
     }
   }

--- a/starters/features/react/package.json
+++ b/starters/features/react/package.json
@@ -20,10 +20,8 @@
     "nextSteps": {
       "title": "New folders created!",
       "lines": [
-        "",
         " - /src/routes/react: New public route showcasing react integration",
-        " - /src/integrations/react: Here's where react component live",
-        ""
+        " - /src/integrations/react: Here's where the react component lives"
       ]
     },
     "viteConfig": {

--- a/starters/features/tailwind/package.json
+++ b/starters/features/tailwind/package.json
@@ -15,13 +15,11 @@
     ],
     "nextSteps": {
       "lines": [
-        "------------------------------------------------",
-        "You must add the next lines into global.css file",
-        "global.css -------------------------------------",
+        " Please add the following lines to your global.css file:",
         "",
-        "@tailwind base;",
-        "@tailwind components;",
-        "@tailwind utilities;"
+        " @tailwind base;",
+        " @tailwind components;",
+        " @tailwind utilities;"
       ]
     }
   }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Since `v0.19.0` the CLI did no longer printed out info about actions which are required by the developer after a successful install. This PR brings this info back in the new CLI style. Affected adapters and integrations are:
- `static`
- `react`
- `tailwind`
- `partytown`

In addition two deprecation warnings caused by ts upgrade to version > `4.8.0` were fixed.

# Testing instructions
- clone the repo
- switch to correct branch
- run `rm -rf qwik-app`
- run `pnpm cli` (keep defaults)
- run `cd qwik-app`
- run `pnpm qwik add` and select & test the adapters and integrations 🎉 

# Screens
![Bildschirmfoto 2023-03-15 um 23 33 37](https://user-images.githubusercontent.com/3241476/225460592-84158447-a4dd-4481-9b3b-efcfc80bcbb7.png)
![Bildschirmfoto 2023-03-15 um 23 33 55](https://user-images.githubusercontent.com/3241476/225460598-16607f83-be63-4b11-ad8f-713305bafe31.png)
![Bildschirmfoto 2023-03-15 um 23 40 32](https://user-images.githubusercontent.com/3241476/225460601-1f2f5c09-c600-4c75-ab18-4a361e5e5a4a.png)
![Bildschirmfoto 2023-03-15 um 23 40 52](https://user-images.githubusercontent.com/3241476/225460604-49796647-bd07-42f2-99fa-849b861b5b91.png)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
