### PR TITLE
Feature: Added Utils API (Framework Agnostic) - Stringify functions and logic to be inserted in header <script />

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -9,6 +9,7 @@
     "Almeida",
     "amet",
     "antipattern",
+    "apos",
     "Arcrole",
     "asynchronicity",
     "basepath",
@@ -287,5 +288,7 @@
     "wmode",
     "xlink"
   ],
-  "enableFiletypes": ["mdx"]
+  "enableFiletypes": [
+    "mdx"
+  ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -288,7 +288,5 @@
     "wmode",
     "xlink"
   ],
-  "enableFiletypes": [
-    "mdx"
-  ]
+  "enableFiletypes": ["mdx"]
 }

--- a/packages/docs/src/components/router-head/theme-script.tsx
+++ b/packages/docs/src/components/router-head/theme-script.tsx
@@ -9,3 +9,31 @@ export const ThemeScript = () => {
             )`;
   return <script dangerouslySetInnerHTML={themeScript} />;
 };
+
+// we want to keep logic as much as possible in typescript
+// the following reduces the maintenance cost of keeping logic as string
+// and also allows us to use typescript to ensure the logic is correct
+// at a later date, when the new combineInlines is available, we can use it here
+// as follows:
+// **************************************************************
+// import { combineInlines } from '@builder.io/qwik';
+
+// export const themeStorageKey = 'theme-preference';
+
+// function setTheme() {
+//   const colorTheme = localStorage.getItem(themeStorageKey);
+//   if (colorTheme === 'dark') {
+//     document.documentElement.classList.add('dark');
+//   } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+//     localStorage.setItem(themeStorageKey, colorTheme || 'dark');
+//     document.documentElement.classList.add('dark');
+//     document.documentElement.classList.remove('light');
+//   } else {
+//     document.documentElement.classList.add('light');
+//     document.documentElement.classList.remove('dark');
+//   }
+// }
+
+// export const ThemeScript = () => {
+//   return <script dangerouslySetInnerHTML={combineInlines([setTheme])} />;
+// };

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -66,6 +66,9 @@ export interface AriaAttributes {
 export type AriaRole = 'alert' | 'alertdialog' | 'application' | 'article' | 'banner' | 'button' | 'cell' | 'checkbox' | 'columnheader' | 'combobox' | 'complementary' | 'contentinfo' | 'definition' | 'dialog' | 'directory' | 'document' | 'feed' | 'figure' | 'form' | 'grid' | 'gridcell' | 'group' | 'heading' | 'img' | 'link' | 'list' | 'listbox' | 'listitem' | 'log' | 'main' | 'marquee' | 'math' | 'menu' | 'menubar' | 'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'navigation' | 'none' | 'note' | 'option' | 'presentation' | 'progressbar' | 'radio' | 'radiogroup' | 'region' | 'row' | 'rowgroup' | 'rowheader' | 'scrollbar' | 'search' | 'searchbox' | 'separator' | 'slider' | 'spinbutton' | 'status' | 'switch' | 'tab' | 'table' | 'tablist' | 'tabpanel' | 'term' | 'textbox' | 'timer' | 'toolbar' | 'tooltip' | 'tree' | 'treegrid' | 'treeitem' | (string & {});
 
 // @public
+export const combineInlines: (fns: (string | Function)[], execute?: boolean) => string;
+
+// @public
 export const component$: <PROPS extends {}>(onMount: OnRenderFn<PROPS>) => Component<PROPS>;
 
 // @public
@@ -146,6 +149,9 @@ export interface FunctionComponent<P = Record<string, any>> {
     // (undocumented)
     (props: P, key: string | null, flags: number): JSXNode | null;
 }
+
+// @public
+export const functionToString: (fn: Function, execute?: boolean) => string;
 
 // @internal (undocumented)
 export const _getContextElement: () => unknown;

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -116,6 +116,7 @@ export type { ErrorBoundaryStore } from './render/error-handling';
 export type { ValueOrPromise } from './util/types';
 export type { Signal } from './state/signal';
 export type { NoSerialize } from './state/common';
+export { functionToString, combineInlines } from './util/transform';
 export { noSerialize, mutable } from './state/common';
 export { _fnSignal } from './qrl/inlined-fn';
 export { version } from './version';

--- a/packages/qwik/src/core/util/transform.ts
+++ b/packages/qwik/src/core/util/transform.ts
@@ -1,0 +1,44 @@
+/**
+ * Convert a function to a string, optionally executing it.
+ * @param fn - Function to convert
+ * @param execute - Whether to execute the function
+ * @returns String
+ * @public
+ * @remarks arrow functions are not supported
+ */
+export const functionToString = (fn: Function, execute = true): string => {
+  let toStr = fn.toString();
+
+  // No support for arrow functions as they don't have a name.
+  if (!toStr.startsWith('function')) {
+    throw new Error('Arrow functions are not supported');
+  }
+
+  if (execute) {
+    const functionName = fn.name;
+    toStr = `${toStr}\n${functionName ? functionName + '();' : ''}`;
+  }
+  return toStr.replace(/\s+/g, ' ').trim() + '\n';
+};
+
+/**
+ * Combine a list of functions or strings into a single string, optionally
+ * executing them in the order they are passed in.
+ *
+ * @param fns - List of functions or strings
+ * @param execute - Whether to execute the functions
+ * @returns String
+ * @public
+ */
+export const combineInlines = (fns: (string | Function)[], execute = true): string => {
+  const toStr = fns.reduce((acc: string, fn: string | Function) => {
+    if (typeof fn === 'function') {
+      return `${acc}${functionToString(fn, execute)}`;
+    } else if (typeof fn === 'string') {
+      return `${acc} ${fn}`;
+    }
+    throw new Error('Invalid argument type for combineInlines');
+  }, '');
+
+  return toStr.replace(/\s+/g, ' ').trim() + '\n';
+};

--- a/packages/qwik/src/core/util/transform.unit.ts
+++ b/packages/qwik/src/core/util/transform.unit.ts
@@ -1,0 +1,76 @@
+import { suite } from 'uvu';
+import { equal, throws } from 'uvu/assert';
+import { combineInlines, functionToString } from './transform';
+
+const functionToStringSuite = suite('functionToString');
+functionToStringSuite('convert a function to a string, with auto execution on', () => {
+  function addFunc() {
+    const a = 2;
+    const b = 1;
+    return a + b;
+  }
+  const actual = functionToString(addFunc);
+  const expected =
+    `function addFunc(){const a=2;const b=1;return a+b} addFunc();`.replace(/\s+/g, ' ').trim() +
+    '\n';
+  equal(actual, expected);
+});
+
+functionToStringSuite('convert a function to a string, without executing', () => {
+  function addFunc() {
+    const a = 2;
+    const b = 1;
+    return a + b;
+  }
+  const actual = functionToString(addFunc, false);
+  const expected =
+    `function addFunc(){const a=2;const b=1;return a+b}`.replace(/\s+/g, ' ').trim() + '\n';
+  equal(actual, expected);
+});
+
+functionToStringSuite('throw error for arrow function to string', () => {
+  const addFunc = () => {
+    const a = 2;
+    const b = 1;
+    return a + b;
+  };
+  throws(() => functionToString(addFunc));
+});
+
+const combineInlinesSuite = suite('combineInlines');
+combineInlinesSuite('combine two functions, to be executed in order', () => {
+  function addFunc(): number {
+    return 1 + 2;
+  }
+  function subFunc(): number {
+    return 1 - 2;
+  }
+  const actual = combineInlines([addFunc, subFunc]);
+  const expected = `function addFunc(){return 1+2} addFunc(); function subFunc(){return 1-2} subFunc(); \n`;
+  equal(actual.replace(/\s+/g, ' '), expected.replace(/\s+/g, ' '));
+});
+
+combineInlinesSuite('combine two functions without execution option', () => {
+  function addFunc(): number {
+    return 1 + 2;
+  }
+  function subFunc(): number {
+    return 1 - 2;
+  }
+  const actual = combineInlines([addFunc, subFunc], false);
+  const expected = `function addFunc(){return 1+2} function subFunc(){return 1-2}\n`;
+  equal(actual.replace(/\s+/g, ' '), expected.replace(/\s+/g, ' '));
+});
+
+combineInlinesSuite('combine one functions and a some string', () => {
+  function addFunc(): number {
+    return 1 + 2;
+  }
+  const runThis = 'document.documentElement.classList.add("dark");';
+  const actual = combineInlines([addFunc, runThis]);
+  const expected = `function addFunc(){return 1+2} addFunc(); document.documentElement.classList.add("dark");\n`;
+  equal(actual.replace(/\s+/g, ' '), expected.replace(/\s+/g, ' '));
+});
+
+combineInlinesSuite.run();
+functionToStringSuite.run();


### PR DESCRIPTION
# What is it?

- [ x ] Feature/enhancement

# Description

Having the capability to execute custom logic before the first document is rendered would be highly beneficial. Unfortunately, with Qwik, all elements are serialized in advance, making it impossible for any code to run beforehand. This can result in theme flickers as shown in the example below.

To run custom JavaScript logic or functions prior to the initial document render, it is necessary to convert the logic or function into a string and add it to a <script /> tag within the <head/> section.

This pull request introduces simple functions that enable any custom logic or function to be serialized and even automatically invoked if desired.

# Use cases and why

For instance, when choosing a theme mode, selecting 'dark' before rendering 'light' is crucial. Otherwise, it may result in an undesirable flicker from 'light' to 'dark'.

Similarly, setting the 'lang' attribute on the `<HTML />` tag can be done instead of hardcoding it on the `<BODY />` tag. 

This pull request aims to resolve problems such as the flicker that is mentioned in [this](https://github.com/BuilderIO/qwik/issues/3391) issue. Prior to this feature, we were required to maintain logic in string format, which made it challenging to maintain, and caused us to lose the benefits of elslint, typescript, and IDE error checking.

```typescript
// theme-script.tsx
export const themeStorageKey = 'theme-preference';

export const ThemeScript = () => {
  const themeScript = `
        document.firstElementChild
            .setAttribute('data-theme',
                localStorage.getItem('${themeStorageKey}') ??
                (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
            )`;
  return <script dangerouslySetInnerHTML={themeScript} />;
};
```
And call it like:

```typescript
//  router-head.tsx like:
export const RouterHead = component$(() => {
      // .... 
     return (
      <>
      <ThemeScript />
       // ... 
      </>
     )
});

```

With the new functionality, we would have:
``` typescript
// theme-script.tsx
import { combineInlines } from '@builder.io/qwik';

export const themeStorageKey = 'theme-preference';

// leave the executable logic in typescript
function setTheme() {
  const colorTheme = localStorage.getItem(themeStorageKey);
  if (colorTheme === 'dark') {
    document.documentElement.classList.add('dark');
  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
    localStorage.setItem(themeStorageKey, colorTheme || 'dark');
    document.documentElement.classList.add('dark');
    document.documentElement.classList.remove('light');
  } else {
    document.documentElement.classList.add('light');
    document.documentElement.classList.remove('dark');
  }
}

export const ThemeScript = () => {
  return <script dangerouslySetInnerHTML={combineInlines([setTheme])} />;
};

// multiple scripts/logic: const inline = combineInlines([setTheme, setLang, `console.log('init done');`]);

```
And call it before:

```typescript
//  router-head.tsx like:
export const RouterHead = component$(() => {
      // .... 
     return (
      <>
      <ThemeScript />
       // ... 
      </>
     )
});

````

# Checklist:

- [ x ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ x ] I have performed a self-review of my own code
- [ x ] Added new tests to cover the fix/functionality

# Notes
- This feature was tested on the `docs` within `qwik` application and a standalone external project.
- Docs will be updated post-merged and enabled internally within the Qwik repo. (ex: `docs` theme change)