### PR TITLE
feat: expose `QwikCityEnvData` type

### DIFF
--- a/packages/qwik-city/runtime/src/index.ts
+++ b/packages/qwik-city/runtime/src/index.ts
@@ -39,6 +39,7 @@ export type {
   RouteNavigate,
   DeferReturn,
   RequestEventBase,
+  QwikCityEnvData,
 } from './types';
 
 export { RouterOutlet, Content } from './router-outlet-component';


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Expose `QwikCityEnvData` type as public type

# Use cases and why

In my application, I want to use `useServerData('qwikcity')` but there is no exposed type for it. It would be nice if the type can be public to enhance DX. My workaround is using `console.log` to print out what is the result of `useServerData('qwikcity')` to be able to use things from it.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
