### PR TITLE
fix(dev mode esm error): fixes error that require() cannot be used when in dev mode

### DIFF
--- a/packages/qwik/src/core/platform/platform.ts
+++ b/packages/qwik/src/core/platform/platform.ts
@@ -1,10 +1,12 @@
-import { isServer } from '@builder.io/qwik/build';
 import { qError, QError_qrlMissingChunk, QError_qrlMissingContainer } from '../error/error';
 import { getSymbolHash } from '../qrl/qrl-class';
 import type { QwikElement } from '../render/dom/virtual-element';
 import { qDynamicPlatform } from '../util/qdev';
 import { isObject } from '../util/types';
 import type { CorePlatform } from './types';
+
+const isServer: boolean = /*#__PURE__*/ (() =>
+  typeof process !== 'undefined' && !!process.versions && !!process.versions.node)();
 
 export const createPlatform = (): CorePlatform => {
   return {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Fixes the error that is detailed in #3321. This is a bandaid fix as I need to update to avoid the security issues. I am not sure of the underlying issue, however this uses the code that is in that file and seems to work just fine for now. Happy to work to solve the actual issue, but I think this is worth fixing in the mean time.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Detailed in #3321

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
