### PR TITLE
fix(azure-swa): SSR build should target Node.js environment

### DIFF
--- a/starters/adapters/azure-swa/adapters/azure-swa/vite.config.ts
+++ b/starters/adapters/azure-swa/adapters/azure-swa/vite.config.ts
@@ -16,8 +16,7 @@ export default extendConfig(baseConfig, () => {
       },
     },
     ssr: {
-      target: 'webworker',
-      noExternal: true,
+      noExternal: /.*/,
     },
     plugins: [azureSwaAdapter()],
   };


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Azure Static Web Apps support a full Node.js environment. The Vite config for the starter should target Node as default.

All external modules are packed inside the bundle so that they do not have to be declared in the package.json.

# Use cases and why

See https://github.com/BuilderIO/qwik-city-e2e/pull/6

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
