### PR TITLE
Fix Playground: `<html>` duplicate

### DIFF
--- a/packages/docs/src/routes/playground/app/root.tsx
+++ b/packages/docs/src/routes/playground/app/root.tsx
@@ -2,13 +2,13 @@ import App from './app';
 
 export const Root = () => {
   return (
-    <html>
+    <>
       <head>
         <title>Hello Qwik</title>
       </head>
       <body>
         <App />
       </body>
-    </html>
+    </>
   );
 };


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Fixes this playground error: 
<img width="962" alt="CleanShot 2023-03-20 at 12 59 04@2x" src="https://user-images.githubusercontent.com/1393142/226398090-ecb1c078-6424-4e90-a23c-0af144a2cf88.png">
