### PR TITLE
fix(starter-basic): Replace Deprecated loc.href With loc.url.href

### DIFF
--- a/starters/apps/basic/src/components/router-head/router-head.tsx
+++ b/starters/apps/basic/src/components/router-head/router-head.tsx
@@ -12,7 +12,7 @@ export const RouterHead = component$(() => {
     <>
       <title>{head.title}</title>
 
-      <link rel="canonical" href={loc.href} />
+      <link rel="canonical" href={loc.url.href} />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug Fix
- [ ] Docs / tests

# Description

A recent commmit replaced the `loc.url.href` property in the basic starter's `router-head` component with the deprecated `loc.href`. This commit reverts that change to prevent the deprecation warning on new projects.

# Actual / expected behavior

<!-- Actual / expected behavior if it's a bug -->

 ### Actual 
Deprecation warning on `loc.href`

### Expected
No deprecation warning

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
