### PR TITLE
docs: fix links to Vercel docs

### DIFF
--- a/packages/docs/src/routes/deployments/vercel-edge/index.mdx
+++ b/packages/docs/src/routes/deployments/vercel-edge/index.mdx
@@ -9,7 +9,7 @@ contributors:
 
 # Vercel Edge Adaptor
 
-Qwik City Vercel Edge adaptor allows you to connect Qwik City to [Vercel Edge Functions](https://vercel.com/docs/(qwik)/concepts/functions/edge-functions).
+Qwik City Vercel Edge adaptor allows you to connect Qwik City to [Vercel Edge Functions](https://vercel.com/docs/concepts/functions/edge-functions).
 
 ## Installation
 
@@ -51,13 +51,13 @@ To deploy the application for development:
 npm run deploy
 ```
 
-Notice that you might need a [Vercel account](https://vercel.com/docs/(qwik)/concepts/get-started) in order to complete this step!
+Notice that you might need a [Vercel account](https://vercel.com/docs/concepts/get-started) in order to complete this step!
 
 ## Production deploy
 
 After installing the integration using `npm run qwik add vercel-edge`, the project is ready to be deployed to Vercel. However, you will need to create a git repository and push the code to it.
 
-Please refer to the Vercel docs for more information on how to deploy your site: [Vercel docs](https://vercel.com/docs/(qwik)/concepts/deployments/overview)
+Please refer to the Vercel docs for more information on how to deploy your site: [Vercel docs](https://vercel.com/docs/concepts/deployments/overview)
 
 ## Advanced
 
@@ -78,7 +78,7 @@ The compiled middleware will be built in the `.vercel/output` directory.
 
 ### Vercel Edge Functions
 
-[Vercel Edge Functions](https://vercel.com/docs/(qwik)/concepts/functions/edge-functions) are deployed globally by default on Vercel's Edge Network and enable you to move server-side logic to the Edge, close to your visitor's origin.
+[Vercel Edge Functions](https://vercel.com/docs/concepts/functions/edge-functions) are deployed globally by default on Vercel's Edge Network and enable you to move server-side logic to the Edge, close to your visitor's origin.
 
 Edge Functions use the Vercel Edge Runtime, which is built on the same high-performance V8 JavaScript and WebAssembly engine that is used by the Chrome browser. By taking advantage of this small runtime, Edge Functions can have faster cold boots and higher scalability than Serverless Functions.
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

fix links to Vercel docs

# Use cases and why

Nope

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
