### PR TITLE
`useStore(...)` proxy now handles `delete proxy[k]`

### DIFF
--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -97,8 +97,8 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
 
   // no need to handle `immutable` and `recursive` for now
   deleteProperty(target: TargetType, prop: string | symbol): boolean {
-    if(!delete target[prop])return false;
-    if(typeof prop=="string")this.$manager$.$notifySubs$(isArray(target)?undefined:prop);
+    if (!delete target[prop]) return false;
+    if (typeof prop == 'string') this.$manager$.$notifySubs$(isArray(target) ? undefined : prop);
     return true;
   }
 

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -98,7 +98,7 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
   // no need to handle `immutable` and `recursive` for now
   deleteProperty(target: TargetType, prop: string | symbol): boolean{
     // intentionally prevents deletion of symbols(like `QOjectTargetSymbol`)
-    if (typeof property == "string" && Object.prototype.hasOwnProperty.call(target, property)) {
+    if (typeof prop == "string" && Object.prototype.hasOwnProperty.call(target, prop)) {
       delete target[prop]; this.$manager$.$notifySubs$(prop); return true;
     }; return false;
   }

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -96,11 +96,14 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
   ) {}
 
   // no need to handle `immutable` and `recursive` for now
-  deleteProperty(target: TargetType, prop: string | symbol): boolean{
+  deleteProperty(target: TargetType, prop: string | symbol): boolean {
     // intentionally prevents deletion of symbols(like `QOjectTargetSymbol`)
-    if (typeof prop == "string" && Object.prototype.hasOwnProperty.call(target, prop)) {
-      delete target[prop]; this.$manager$.$notifySubs$(prop); return true
-    } return false;
+    if (typeof prop == 'string' && Object.prototype.hasOwnProperty.call(target, prop)) {
+      delete target[prop];
+      this.$manager$.$notifySubs$(prop);
+      return true;
+    }
+    return false;
   }
 
   get(target: TargetType, prop: string | symbol): any {

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -95,7 +95,13 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
     private $manager$: LocalSubscriptionManager
   ) {}
 
-  
+  // no need to handle `immutable` and `recursive` for now
+  deleteProperty(target: TargetType, prop: string | symbol): boolean{
+    // intentionally prevents deletion of symbols(like `QOjectTargetSymbol`)
+    if (typeof property == "string" && Object.prototype.hasOwnProperty.call(target, property)) {
+      delete target[prop]; this.$manager$.$notifySubs$(prop); return true;
+    }; return false;
+  }
 
   get(target: TargetType, prop: string | symbol): any {
     if (typeof prop === 'symbol') {

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -96,10 +96,10 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
   ) {}
 
   deleteProperty(target: TargetType, prop: string | symbol): boolean {
-    const flags = target[QObjectFlagsSymbol] ?? 0
+    const flags = target[QObjectFlagsSymbol] ?? 0;
     if (flags & QObjectImmutable) throw qError(QError_immutableProps);
-    if (!delete target[prop]) return false
-    this.$manager$.$notifySubs$(typeof prop != 'string'||isArray(target) ? undefined : prop);
+    if (!delete target[prop]) return false;
+    this.$manager$.$notifySubs$(typeof prop != 'string' || isArray(target) ? undefined : prop);
     return true;
   }
 

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -96,10 +96,11 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
   ) {}
 
   deleteProperty(target: TargetType, prop: string | symbol): boolean {
+    if(typeof prop != 'string')return false;
     const flags = target[QObjectFlagsSymbol] ?? 0;
     if (flags & QObjectImmutable) throw qError(QError_immutableProps);
     if (!delete target[prop]) return false;
-    this.$manager$.$notifySubs$(typeof prop != 'string' || isArray(target) ? undefined : prop);
+    this.$manager$.$notifySubs$(isArray(target) ? undefined : prop);
     return true;
   }
 

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -99,8 +99,8 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
   deleteProperty(target: TargetType, prop: string | symbol): boolean{
     // intentionally prevents deletion of symbols(like `QOjectTargetSymbol`)
     if (typeof prop == "string" && Object.prototype.hasOwnProperty.call(target, prop)) {
-      delete target[prop]; this.$manager$.$notifySubs$(prop); return true;
-    }; return false;
+      delete target[prop]; this.$manager$.$notifySubs$(prop); return true
+    } return false;
   }
 
   get(target: TargetType, prop: string | symbol): any {

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -97,13 +97,9 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
 
   // no need to handle `immutable` and `recursive` for now
   deleteProperty(target: TargetType, prop: string | symbol): boolean {
-    // intentionally prevents deletion of symbols(like `QOjectTargetSymbol`)
-    if (typeof prop == 'string' && Object.prototype.hasOwnProperty.call(target, prop)) {
-      delete target[prop];
-      this.$manager$.$notifySubs$(prop);
-      return true;
-    }
-    return false;
+    if(!delete target[prop])return false;
+    if(typeof prop=="string")this.$manager$.$notifySubs$(isArray(target)?undefined:prop);
+    return true;
   }
 
   get(target: TargetType, prop: string | symbol): any {

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -96,10 +96,8 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
   ) {}
 
   deleteProperty(target: TargetType, prop: string | symbol): boolean {
-    if (typeof prop != 'string') return false;
-    const flags = target[QObjectFlagsSymbol] ?? 0;
-    if (flags & QObjectImmutable) throw qError(QError_immutableProps);
-    if (!delete target[prop]) return false;
+    if (target[QObjectFlagsSymbol] & QObjectImmutable) throw qError(QError_immutableProps);
+    if (typeof prop != 'string' || !delete target[prop]) return false;
     this.$manager$.$notifySubs$(isArray(target) ? undefined : prop);
     return true;
   }

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -96,7 +96,7 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
   ) {}
 
   deleteProperty(target: TargetType, prop: string | symbol): boolean {
-    if(typeof prop != 'string')return false;
+    if (typeof prop != 'string') return false;
     const flags = target[QObjectFlagsSymbol] ?? 0;
     if (flags & QObjectImmutable) throw qError(QError_immutableProps);
     if (!delete target[prop]) return false;

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -95,10 +95,11 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
     private $manager$: LocalSubscriptionManager
   ) {}
 
-  // no need to handle `immutable` and `recursive` for now
   deleteProperty(target: TargetType, prop: string | symbol): boolean {
-    if (!delete target[prop]) return false;
-    if (typeof prop == 'string') this.$manager$.$notifySubs$(isArray(target) ? undefined : prop);
+    const flags = target[QObjectFlagsSymbol] ?? 0
+    if (flags & QObjectImmutable) throw qError(QError_immutableProps);
+    if (!delete target[prop]) return false
+    this.$manager$.$notifySubs$(typeof prop != 'string'||isArray(target) ? undefined : prop);
     return true;
   }
 

--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -95,6 +95,8 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
     private $manager$: LocalSubscriptionManager
   ) {}
 
+  
+
   get(target: TargetType, prop: string | symbol): any {
     if (typeof prop === 'symbol') {
       if (prop === QOjectTargetSymbol) return target;

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -473,10 +473,10 @@ export const Issue3398 = component$(() => {
   );
 });
 
-export const Pr3475 = component$(() => {
-  const store = useStore<{key?:string}>({key:"data"})
-  return <button
-        id="pr-3475-button"
-        onClick$={() => delete store.key}
-      >{store.key}</button>
-});
+export const Pr3475 = component$(() =>
+  ((store) => (
+    <button id="pr-3475-button" onClick$={() => delete store.key}>
+      {store.key}
+    </button>
+  ))(useStore<{ key?: string }>({ key: 'data' }))
+);

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -74,7 +74,7 @@ export const RenderChildren = component$(() => {
       <Issue3398 />
       <Issue3479 />
       <Issue3481 />
-      
+
       <Pr3475 />
     </>
   );

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -6,8 +6,6 @@ import {
   useStore,
   useStylesScoped$,
   useTask$,
-  useBrowserVisibleTask$,
-  useVisibleTask$,
 } from '@builder.io/qwik';
 import { delay } from '../streaming/demo';
 

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -6,6 +6,8 @@ import {
   useStore,
   useStylesScoped$,
   useTask$,
+  useBrowserVisibleTask$,
+  useVisibleTask$,
 } from '@builder.io/qwik';
 import { delay } from '../streaming/demo';
 
@@ -60,6 +62,7 @@ export const Render = component$(() => {
       <Issue2414 />
       <Issue3178 />
       <Issue3398 />
+      <Pr3475 />
     </>
   );
 });
@@ -468,4 +471,12 @@ export const Issue3398 = component$(() => {
       <Title tag={tag.value}></Title>
     </div>
   );
+});
+
+export const Pr3475 = component$(() => {
+  const store = useStore<{key?:string}>({key:"data"})
+  return <button
+        id="pr-3475-button"
+        onClick$={() => delete store.key}
+      >{store.key}</button>
 });

--- a/starters/e2e/e2e.render.spec.ts
+++ b/starters/e2e/e2e.render.spec.ts
@@ -307,8 +307,8 @@ test.describe('render', () => {
 
   test('pr3475', async ({ page }) => {
     const ref = page.locator('#pr-3475-button');
-    await expect(page.locator('h1#issue-3398-tag')).toHaveText('data');
+    await expect(ref).toHaveText('data');
     await ref.click();
-    await expect(page.locator('h1#issue-3398-tag')).not.toHaveText('data');
+    await expect(ref).not.toHaveText('data');
   });
 });

--- a/starters/e2e/e2e.render.spec.ts
+++ b/starters/e2e/e2e.render.spec.ts
@@ -256,4 +256,11 @@ test.describe('render', () => {
     await expect(page.locator('h1#issue-3398-tag')).toHaveText('Hello h1');
     await expect(page.locator('h1#issue-3398-tag')).not.hasAttribute('children');
   });
+
+  test("pr3475",async({page})=>{
+    const ref = page.locator('#pr-3475-button');
+    await expect(page.locator('h1#issue-3398-tag')).toHaveText('data');
+    await ref.click();
+    await expect(page.locator('h1#issue-3398-tag')).not.toHaveText("data");
+  })
 });

--- a/starters/e2e/e2e.render.spec.ts
+++ b/starters/e2e/e2e.render.spec.ts
@@ -257,10 +257,10 @@ test.describe('render', () => {
     await expect(page.locator('h1#issue-3398-tag')).not.hasAttribute('children');
   });
 
-  test("pr3475",async({page})=>{
+  test('pr3475', async ({ page }) => {
     const ref = page.locator('#pr-3475-button');
     await expect(page.locator('h1#issue-3398-tag')).toHaveText('data');
     await ref.click();
-    await expect(page.locator('h1#issue-3398-tag')).not.toHaveText("data");
-  })
+    await expect(page.locator('h1#issue-3398-tag')).not.toHaveText('data');
+  });
 });


### PR DESCRIPTION
# What is it?

- [X] Bug

# Description

previously proxy objects don't implement `deleteProperty` handler, thus:
1. the implicit default implementation allows deletion of any key, including symbolic ones, which could be problematic
2. deleting a key won't trigger subscribers' update callback, which could be considered a BUG

# Use cases and why

```javascript
const store=useStore({key:1})
componentCall(store) // internally uses `store.key`
delete store.key // this is valid javascript and store usage, but it won't trigger reactivity inside `componentCall`
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
