### PR TITLE
docs: Add Modular Forms to community projects on docs

### DIFF
--- a/packages/docs/src/routes/community/projects/index.mdx
+++ b/packages/docs/src/routes/community/projects/index.mdx
@@ -15,6 +15,12 @@ contributors:
 - <a href="https://papanasi.js.org/" target="_blank">
     Papanasi - a universal UI library based on Mitosis
   </a>
+  
+#### Form libraries
+
+- <a href="https://github.com/fabian-hiller/modular-forms" target="_blank">
+    Modular Forms - The modular and type-safe form library for Qwik
+  </a>
 
 #### Integrations
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

I have added [Modular Forms](https://modularforms.dev/) to the community projects on the docs website. Would a link on the [ecosystem page](https://qwik.builder.io/ecosystem/) be interesting as well? If so, I'll add that.
