### PR TITLE
fix: keep multiple form properties

### DIFF
--- a/packages/qwik-city/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/middleware/request-handler/request-event.ts
@@ -315,7 +315,7 @@ const formToObj = (formData: FormData): Record<string, any> => {
           current[k] = value;
         }
       } else {
-        current = current[k] = {};
+        current = current[k] = { ...current[k] };
       }
     }
   });

--- a/starters/apps/qwikcity-test/src/routes/(common)/actions/issue3497/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/actions/issue3497/index.tsx
@@ -1,0 +1,31 @@
+import { component$ } from '@builder.io/qwik';
+import { Form, globalAction$ } from '@builder.io/qwik-city';
+
+export const useDotNotationAction = globalAction$(async (payload) => {
+  return {
+    success: true,
+    payload,
+  };
+});
+
+export default component$(() => {
+  const dotNotation = useDotNotationAction();
+
+  return (
+    <>
+      <h1>Dot Notation Form Inputs</h1>
+      <Form action={dotNotation} id="dot-notation-form">
+        <input type="hidden" name="credentials.username" value="user" />
+        <input type="hidden" name="credentials.password" value="pass" />
+        <input type="hidden" name="array[]" value="1" />
+        <input type="hidden" name="array[]" value="2" />
+        <button id="issue3497-button" disabled={dotNotation.isRunning}>
+          Dot Notation
+        </button>
+      </Form>
+      {dotNotation.value?.success && (
+        <div id="issue3497-success">{JSON.stringify(dotNotation.value.payload)}</div>
+      )}
+    </>
+  );
+});

--- a/starters/e2e/qwikcity/actions.spec.ts
+++ b/starters/e2e/qwikcity/actions.spec.ts
@@ -128,5 +128,19 @@ test.describe('actions', () => {
         await expect(page.locator('#issue2644-list > li')).toHaveText(['AAA', 'BBB']);
       });
     });
+
+    test.describe('issue3497', () => {
+      test('should parse formdata', async ({ page }) => {
+        await page.goto('/qwikcity-test/actions/issue3497/');
+        const success = page.locator('#issue3497-success');
+
+        await expect(success).toBeHidden();
+        await page.locator('#issue3497-button').click();
+        await expect(success).toHaveText(
+          '{"credentials":{"username":"user","password":"pass"},"array":["1","2"]}'
+        );
+        await expect(true).toBeTruthy();
+      });
+    });
   }
 });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently when parsing form data it appears that each nested property overwrites the last.

Given example:
```html
<Form action={test}>
  <input type="hidden" name="options.username" value="user" />
  <input type="hidden" name="options.password" value="pass" />
  <input type="hidden" name="multi[]" value="1" />
  <input type="hidden" name="multi[]" value="2" />
  <button>Test</button>
</Form>
```

I would expect the formdata returned to be:
```js
{
  "options": {
    "username": "user",
    "password": "pass"
  },
  "multi": [
    "1",
    "2"
  ]
}
```

Instead it's currently returning:
```js
{
  "options": {
    "password": "pass"
  },
  "multi": [
    "1",
    "2"
  ]
}
```

Closes #3497
It may also impact #3183

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
