### PR TITLE
fix: tfoot inside table

### DIFF
--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -623,7 +623,7 @@ This goes against the HTML spec: https://html.spec.whatwg.org/multipage/dom.html
       } else {
         if (flags & IS_TABLE && !tableContent[tagName]) {
           throw createJSXError(
-            `The <table> element requires that its direct children to be '<tbody>' or '<thead>', instead, '<${tagName}>' was rendered.`,
+            `The <table> element requires that its direct children to be '<tbody>', '<thead>' or '<tfoot>', instead, '<${tagName}>' was rendered.`,
             node
           );
         }
@@ -1051,6 +1051,7 @@ const htmlContent: Record<string, true | undefined> = {
 const tableContent: Record<string, true | undefined> = {
   tbody: true,
   thead: true,
+  tfoot: true,
 };
 
 const headContent: Record<string, true | undefined> = {

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -417,6 +417,11 @@ const Issue2414 = component$(() => {
         ) : (
           <></>
         )}
+        <tfoot>
+          <tr>
+            <td colSpan={3}>{table.value === undefined ? '' : table.value.length}</td>
+          </tr>
+        </tfoot>
       </table>
     </>
   );


### PR DESCRIPTION
`<tfoot>` is also a permitted direct child of `<table>`.

Sources:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table#try_it:~:text=Flow%20content-,Permitted%20content,-In%20this%20order
- https://html.spec.whatwg.org/multipage/tables.html#the-table-element

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

I was surprised to see the following error when writing the following HTML in my component:

```html
<table>
  <thead>…</thead>
  <tbody>…</tbody>
  <tfoot>…</tfoot>
</table>
```

```
The <table> element requires that its direct children to be '<tbody>' or '<thead>', instead, '<tfoot>' was rendered.
```

The HTML spec and MDN describe what are permitted direct children of `<table>`, they include the `<thead>` and `<tbody>` for sure but also `<tfoot>` and some other tags I never heard of.

As a workaround in my project I tried placing `<tfoot>` inside `<tbody>` but I then for the following error: `Uncaught (in promise) Error: close not found` which was caused by the browser reordering misplaced tags and the `<!--/qv-->` node being moved outside the `<tbody>`.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
