### PR TITLE
feat(qwik-auth): support credentials provider using useAuthSignin action

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -69,22 +69,46 @@ export const getCurrentPageForAction = (req: RequestEventCommon) => req.url.href
 
 export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikAuthConfig>) {
   const useAuthSignin = globalAction$(
-    async ({ providerId, callbackUrl, ...rest }, req) => {
-      callbackUrl ??= getCurrentPageForAction(req);
+    async ({ providerId, callbackUrl: deprecated, options, authorizationParams }, req) => {
+      if (deprecated) {
+        console.warn(
+          '\x1b[33mWARNING: callbackUrl is deprecated - use options.callbackUrl instead\x1b[0m'
+        );
+      }
+      const { callbackUrl = deprecated ?? getCurrentPageForAction(req), ...rest } = options ?? {};
+
+      const isCredentials = providerId === 'credentials';
+
       const auth = await authOptions(req);
-      const body = new URLSearchParams({ callbackUrl });
+      const body = new URLSearchParams({ callbackUrl: callbackUrl as string });
       Object.entries(rest).forEach(([key, value]) => {
         body.set(key, String(value));
       });
-      const pathname = '/api/auth/signin' + (providerId ? `/${providerId}` : '');
-      const data = await authAction(body, req, pathname, auth);
+
+      const baseSignInUrl = `/api/auth/${isCredentials ? 'callback' : 'signin'}${
+        providerId ? `/${providerId}` : ''
+      }`;
+      const signInUrl = `${baseSignInUrl}?${new URLSearchParams(authorizationParams)}`;
+
+      const data = await authAction(body, req, signInUrl, auth);
+
       if (data.url) {
         throw req.redirect(301, data.url);
       }
     },
     zod$({
-      providerId: z.string().optional(),
+      providerId: z.string(),
       callbackUrl: z.string().optional(),
+      options: z
+        .object({
+          callbackUrl: z.string(),
+        })
+        .passthrough()
+        .partial()
+        .optional(),
+      authorizationParams: z
+        .union([z.string(), z.custom<URLSearchParams>(), z.record(z.string())])
+        .optional(),
     })
   );
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Adds support for using the credentials provider with the useAuthSign action.  It also brings the parameters into alignment with other @authjs/core libraries (sveltekit and solid-start)

Suggestions as to how to handle the deprecation of the callbackUrl parameter location are welcomed.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
