### PR TITLE
feat: added event payload to support userEvent change with custom payload

### DIFF
--- a/packages/qwik/src/testing/api.md
+++ b/packages/qwik/src/testing/api.md
@@ -11,7 +11,7 @@ import { RenderResult } from '@builder.io/qwik';
 export const createDOM: () => Promise<{
     render: (jsxElement: JSXNode) => Promise<RenderResult>;
     screen: HTMLElement;
-    userEvent: (queryOrElement: string | Element | null, eventNameCamel: string) => Promise<void>;
+    userEvent: (queryOrElement: string | Element | null, eventNameCamel: string, eventPayload?: any) => Promise<void>;
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/qwik/src/testing/library.ts
+++ b/packages/qwik/src/testing/library.ts
@@ -12,11 +12,12 @@ import type { JSXNode } from '@builder.io/qwik/jsx-runtime';
 async function triggerUserEvent(
   root: Element,
   selector: string,
-  eventNameCamel: string
+  eventNameCamel: string,
+  eventPayload: any = {}
 ): Promise<void> {
   for (const element of Array.from(root.querySelectorAll(selector))) {
     const kebabEventName = fromCamelToKebabCase(eventNameCamel);
-    const event = { type: kebabEventName };
+    const event = { type: kebabEventName, ...eventPayload };
     const attrName = 'on:' + kebabEventName;
     await dispatch(element, attrName, event);
   }
@@ -36,12 +37,16 @@ export const createDOM = async function () {
       return qwik.render(host, jsxElement);
     },
     screen: host,
-    userEvent: async function (queryOrElement: string | Element | null, eventNameCamel: string) {
+    userEvent: async function (
+      queryOrElement: string | Element | null,
+      eventNameCamel: string,
+      eventPayload: any = {}
+    ) {
       if (typeof queryOrElement === 'string') {
-        return triggerUserEvent(host, queryOrElement, eventNameCamel);
+        return triggerUserEvent(host, queryOrElement, eventNameCamel, eventPayload);
       }
       const kebabEventName = fromCamelToKebabCase(eventNameCamel);
-      const event = { type: kebabEventName };
+      const event = { type: kebabEventName, ...eventPayload };
       const attrName = 'on:' + kebabEventName;
       await dispatch(queryOrElement, attrName, event);
       await getTestPlatform().flush();


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
Updated the `userEvent` test util to include a custom payload.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Trigger a change event for an element with a target event `e.target.value`

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
