### PR TITLE
fix(qwik-auth): replace accidently removed optional chain on providerId

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -97,7 +97,7 @@ export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikA
       }
     },
     zod$({
-      providerId: z.string(),
+      providerId: z.string().optional(),
       callbackUrl: z.string().optional(),
       options: z
         .object({


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

This was erroneously removed in a previous PR

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
