### PR TITLE
docs: fix Qwik SDK missing site information for targeting

### DIFF
--- a/packages/docs/src/components/builder-content/index.tsx
+++ b/packages/docs/src/components/builder-content/index.tsx
@@ -28,6 +28,7 @@ export default component$<{
           options: getBuilderSearchParams(query),
           userAttributes: {
             urlPath: location.url.pathname,
+            site: 'qwik.builder.io',
           },
         },
         getContent


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

-----
<a href="https://stackblitz.com/~/github.com/builderio/qwik/tree/mhevery%2Fpatch-36479"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/builderio/qwik/tree/mhevery%2Fpatch-36479)._