### PR TITLE
docs: Fix broken links for "API" and "Qwik City & Routing" on "Welcome to Qwik" (Introduction) Page

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/index.mdx
@@ -30,7 +30,7 @@ Qwik is a new kind of web framework that can deliver instant loading web applica
     <p class="icon">🤔</p>
     <h3>Why Qwik?</h3>
   </a>
-  <a class="card card-center" href="/docs/(qwik)/components/overview/">
+  <a class="card card-center" href="/docs/components/overview/">
     <p class="icon">📚</p>
     <h3>API</h3>
   </a>
@@ -38,7 +38,7 @@ Qwik is a new kind of web framework that can deliver instant loading web applica
     <p class="icon">{getCommunity()}</p>
     <h3>Community</h3>
   </a>
-  <a class="card card-center" href="/qwikcity/overview/">
+  <a class="card card-center" href="/docs/qwikcity/">
     <p class="icon">🌃</p>
     <h3>Qwik City & Routing</h3>
   </a>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This PR fixes the two broken links on `Welcome to Qwik (Introduction)` page of the docs.

Currently, the `API` card redirects to a `404 not found` page.

![image](https://user-images.githubusercontent.com/38442554/228510587-c8a5e226-7888-4d08-8345-dd7d7fe7e82b.png)


The `Qwik City & Routing` card doesn't redirect to a `404 not found` page but the link is still broken and it just redirects back to `/docs/`.

The `API` card will now redirect to `/docs/components/overview/` and the `Qwik City & Routing` card will redirect to `/docs/qwikcity/`.

# Use cases and why

- broken links are not fun 
- helps the user explore the docs easier

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
