### PR TITLE
docs: move qwik city into the qwik city section

### DIFF
--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -4,8 +4,6 @@
 
 - [Overview](</docs/(qwik)/index.mdx>)
 - [Getting Started](</docs/(qwik)/getting-started/index.mdx>)
-- [Qwik City](</docs/(qwikcity)/qwikcity/index.mdx>)
-- [Project structure](</docs/(qwikcity)/project-structure/index.mdx>)
 - [FAQ](</docs/(qwik)/faq/index.mdx>)
 
 ## Component
@@ -23,6 +21,8 @@
 
 ## Routing
 
+- [Qwik City](</docs/(qwikcity)/qwikcity/index.mdx>)
+- [Project structure](</docs/(qwikcity)/project-structure/index.mdx>)
 - [Routing](</docs/(qwikcity)/routing/index.mdx>)
 - [Route Loaders](</docs/(qwikcity)/route-loader/index.mdx>)
 - [Form actions](</docs/(qwikcity)/action/index.mdx>)


### PR DESCRIPTION
right now it's intermixed with the introduction which I always found confusion

this colocates all qwik city stuff together and makes a better get started flow imo - where you start with overview, then get started, then FAQs, then components (which is more standard among other frameworks)