### PR TITLE
core: remove currentTarget from BaseSyntheticEvent

### DIFF
--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -3,7 +3,6 @@ export interface SyntheticEvent<T = Element, E = Event>
 
 interface BaseSyntheticEvent<E = object, C = any, T = any> {
   nativeEvent: E;
-  currentTarget: C;
   target: T;
   bubbles: boolean;
   cancelable: boolean;


### PR DESCRIPTION
as it is not supported (it will always be null)

altenratively we could type it as `null` and add a jsdoc comment (or @deprecated flag) explaining that you won't find it here

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Use cases and why

preventDefault is not supported, so don't include it in types

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
