### PR TITLE
docs: make errors in the repl red so they are noticeable

### DIFF
--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -144,7 +144,7 @@ pre[class*='language-'] {
   --repl-diagnostics-hover-border-color: rgba(255, 0, 144, 0.46);
   --repl-diagnostics-active-border-color: rgb(255, 0, 144);
   --repl-commands-color: var(--qwik-light-blue);
-  --repl-tab-bg-color: var(--qwik-dark-blue);
+  --repl-tab-bg-color: var(--bg-color);
   --repl-border-color: rgba(255, 255, 255, 0.2);
 
   --tutorial-nav-button-text-color: #ffffff;

--- a/packages/docs/src/repl/repl-output-panel.tsx
+++ b/packages/docs/src/repl/repl-output-panel.tsx
@@ -61,7 +61,7 @@ export const ReplOutputPanel = ({ input, store }: ReplOutputPanelProps) => {
 
         <ReplTabButton
           text={`Diagnostics${diagnosticsLen > 0 ? ` (${diagnosticsLen})` : ``}`}
-          cssClass={{ 'repl-tab-diagnostics': true }}
+          cssClass={{ 'repl-tab-diagnostics': true, 'has-errors': diagnosticsLen > 0 }}
           isActive={store.selectedOutputPanel === 'diagnostics'}
           onClick$={async () => {
             store.selectedOutputPanel = 'diagnostics';

--- a/packages/docs/src/repl/repl.css
+++ b/packages/docs/src/repl/repl.css
@@ -104,6 +104,10 @@
   border-top-color: var(--repl-diagnostics-active-border-color);
 }
 
+.repl-tab-diagnostics.has-errors {
+  color: red;
+}
+
 .repl-tab-diagnostics:not(.active-tab):hover {
   border-top-color: var(--repl-diagnostics-hover-border-color);
 }


### PR DESCRIPTION
currenly it is not clear when your code is erroring. You see no logs and the only indication is a tiny "1" in the far right of the screen

This will leave the user thinking the repl is broken, as it does not say "there was an error" in the preview

This makes the diagnostics tab turn red to make it more clear there is an error under there that you should look at

<img width="1243" alt="Screenshot 2023-03-29 at 12 36 22 PM" src="https://user-images.githubusercontent.com/844291/228648785-c7d5cd7c-5bdd-4306-8a87-4d4c4c95cea8.png">


