### PR TITLE
docs: Make the tutorial buttons more prominent

### DIFF
--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -95,9 +95,9 @@ pre[class*='language-'] {
   --repl-log-text: #0e201a;
   --repl-border-color: #e3e3e3;
 
-  --tutorial-nav-button-bg-color: var(--bg-color);
-  --tutorial-nav-button-hover-bg-color: var(--qwik-blue);
-  --tutorial-nav-button-text-color: var(--qwik-dark-blue);
+  --tutorial-nav-button-bg-color: var(--qwik-dark-blue);
+  --tutorial-nav-button-hover-bg-color: var(--bg-color);
+  --tutorial-nav-button-text-color: #ffffff;
 
   --examples-header-text-color: #494949;
   --examples-active-bg-color: #e2ebff;
@@ -134,9 +134,6 @@ pre[class*='language-'] {
   --code-border-color: #525252;
   --blockquote-bg-color: #353639;
 
-  --tutorial-nav-button-bg-color: var(--qwik-dark-blue);
-  --tutorial-nav-button-hover-bg-color: var(--bg-color);
-
   --repl-tab-button-hover-bg-color: #ffffff25;
   --repl-tab-button-input-hover-border-color: #c3c1de75;
   --repl-tab-button-input-active-border-color: #d8c2fa;
@@ -146,8 +143,6 @@ pre[class*='language-'] {
   --repl-commands-color: var(--qwik-light-blue);
   --repl-tab-bg-color: var(--bg-color);
   --repl-border-color: rgba(255, 255, 255, 0.2);
-
-  --tutorial-nav-button-text-color: #ffffff;
 
   --examples-header-text-color: var(--text-color);
   --examples-active-bg-color: #1d1d1d;


### PR DESCRIPTION
I had no idea there was a "show me" button.

They are nice and prominent in dark mode, but blend in in light mode, so lets use the more bold styling for light mode too

<img width="1483" alt="Screenshot 2023-03-29 at 5 39 29 PM" src="https://user-images.githubusercontent.com/844291/228698669-61abd743-31f4-4821-8395-e05c852056de.png">

<img width="1483" alt="Screenshot 2023-03-29 at 5 39 31 PM" src="https://user-images.githubusercontent.com/844291/228698664-e742f47a-cb2d-42ca-841f-8ba147fd0b7b.png">
