### PR TITLE
docs: Clean up Qwik City docs

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/project-structure/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/project-structure/index.mdx
@@ -6,27 +6,6 @@ contributors:
 
 # Project Structure
 
-## Create a new project
-
-To follow along with this guide, run the Qwik CLI in your command line:
-
-```shell
-npm create qwik@latest
-```
-
-> Notice that you can also use the package manager of your choice, `yarn create qwik@latest` or `pnpm create qwik@latest`.
-
-When prompted, choose a name for your project and Basic as your starter.
-
-> Note: the `start` script attempts to launch the site in system’s browser,
-> which in headless environments (e.g., within a container)
-> could cause the command to fail with an error.
-> Edit `package.json` to remove the `--open` flag.
-
-The command will ask you a few questions and create a new project for you.
-
-## Project structure
-
 A typical Qwik project looks like this:
 
 ```bash

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -19,7 +19,7 @@
 - [Styling](</docs/(qwik)/components/styles/index.mdx>)
 - [Lite components](</docs/(qwik)/components/lite-components/index.mdx>)
 
-## Routing
+## Routing (Qwik City)
 
 - [Qwik City](</docs/(qwikcity)/qwikcity/index.mdx>)
 - [Project structure](</docs/(qwikcity)/project-structure/index.mdx>)

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -4,6 +4,7 @@
 
 - [Overview](</docs/(qwik)/index.mdx>)
 - [Getting Started](</docs/(qwik)/getting-started/index.mdx>)
+- [Project structure](</docs/(qwikcity)/project-structure/index.mdx>)
 - [FAQ](</docs/(qwik)/faq/index.mdx>)
 
 ## Component
@@ -22,7 +23,6 @@
 ## Routing (Qwik City)
 
 - [Qwik City](</docs/(qwikcity)/qwikcity/index.mdx>)
-- [Project structure](</docs/(qwikcity)/project-structure/index.mdx>)
 - [Routing](</docs/(qwikcity)/routing/index.mdx>)
 - [Route Loaders](</docs/(qwikcity)/route-loader/index.mdx>)
 - [Form actions](</docs/(qwikcity)/action/index.mdx>)


### PR DESCRIPTION
Add Qwik City to the main nav (really feels like needs to be in there)

Also remove the repeated "getting started" section from "project structure" doc because we have a dedicated page for this, and moves it back to the introduction (right after the get started page)