### PR TITLE
docs: fix typo in Form actions page

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
@@ -27,7 +27,7 @@ export const useChangePassword = routeAction$((data) => {
 - `globalAction$()` however, can be declared anywhere in the `src` folder. Since `globalAction$()` are globally available, they are recommended when the action needs to be shared across multiple routes, or when the action doesn't need to access any user data. For example, a `useLogin` action that logs in a user.  Think about it like a "public" action.
 
 ```tsx
-export const useChangePassword = globalAction$((data) => {
+export const useLogin = globalAction$((data) => {
   // ...
 });
 ```


### PR DESCRIPTION
Corrected variable name by renaming  *useChangePassword* to *useLogin* in globalAction$'s example

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Fix the typo issue in globalAction$'s example in the Form actions page

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
