### PR TITLE
docs: enable JSX output for inlined examples

### DIFF
--- a/packages/docs/src/components/code-example/index.tsx
+++ b/packages/docs/src/components/code-example/index.tsx
@@ -2,9 +2,9 @@ import { component$, useStylesScoped$ } from '@builder.io/qwik';
 import { CodeBlock } from '../code-block/code-block';
 import { useLocation } from '@builder.io/qwik-city';
 import CSS from './index.css?inline';
-// import loadLanguages from 'prismjs/components/';
+import loadLanguages from 'prismjs/components/';
 
-// loadLanguages(['markup', 'css', 'javascript', 'json', 'jsx', 'tsx']);
+loadLanguages(['markup', 'css', 'javascript', 'json', 'jsx', 'tsx']);
 
 export default component$<{
   src: { code: string; path: string };


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
