### PR TITLE
docs(packages/docs/src/routes/docs/(qwik)/components/resource/index.m…

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/resource/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/resource/index.mdx
@@ -20,7 +20,7 @@ contributors:
 
 This hook allows you to generate computed values asynchronously, typically used for fetching external data (resources.) The hook is called when the component is mounted (and when the tracked values change.) The `useResource$` hook is meant to be used with the `<Resource />`. The `<Resource />` component is a convenient way to render the resource state, such as loaded, resolved, or rejected.
 
-The important thing to understand about `useResource$` is that it executes on the initial component render (just like `useTask$`.) Often time it is desirable to start fetching the data on the server as part of SSR before the component is rendered. Fetching data as part of SSR is a more common and preferred way of loading data and is done through [`routeLoader$`](docs/route-loader/) API instead. `useResource$` is a more low-level API that is useful when you want to fetch data on the client.
+The important thing to understand about `useResource$` is that it executes on the initial component render (just like `useTask$`.) Often time it is desirable to start fetching the data on the server as part of SSR before the component is rendered. Fetching data as part of SSR is a more common and preferred way of loading data and is done through [`routeLoader$`](docs/(qwikcity)/route-loader/index.mdx) API instead. `useResource$` is a more low-level API that is useful when you want to fetch data on the client.
 
 > Just like all the `use-` hooks, it must be called within the context of [`component$()`](/docs/(qwik)/components/overview/index.mdx#component), and all the [hook rules apply](/docs/(qwik)/components/lifecycle/index.mdx#use-method-rules).
 > 
@@ -28,7 +28,7 @@ The important thing to understand about `useResource$` is that it executes on th
 > - `useResource$` allows you to return a "value".
 > - `useResource$` does not block rendering while the resource is being resolved.
 >
-> See [`routeLoader$`](docs/route-loader/) for fetching data as part of SSR.
+> See [`routeLoader$`](docs/(qwikcity)/route-loader/index.mdx) for fetching data as part of SSR.
 
 ## Example
 


### PR DESCRIPTION
…dx): fixes links to routeLoader

Fixes links to correct location of routeLoader$ documentation.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
