### PR TITLE
docs: Rename "Lite Component" to "Inline Component"

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/inline-components/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/inline-components/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lite components
+title: Inline components
 contributors:
   - voluntadpear
   - RATIU5
@@ -11,17 +11,17 @@ contributors:
   - the-r3aper7
 ---
 
-# Lite Components
+# Inline Components
 
 In addition to the standard `component$()` with all of it's lazy-loaded
-properties, Qwik also supports lightweight (lite) components that act more
-like traditional frameworks. Lite components may also be called inline
+properties, Qwik also supports lightweight (inline) components that act more
+like traditional frameworks. Inline components may also be called inline
 components.
 
 ```tsx
 import { component$ } from '@builder.io/qwik';
 
-// Lite component: declared using a standard function.
+// Inline component: declared using a standard function.
 export const MyButton = (props: { text: string }) => {
   return <button>{props.text}</button>;
 };
@@ -37,8 +37,8 @@ export const MyApp = component$(() => {
 });
 ```
 
-In the above example, `MyButton` is a lite component.
-Unlike the standard `component$()`, lite components cannot be individually
+In the above example, `MyButton` is a inline component.
+Unlike the standard `component$()`, inline components cannot be individually
 lazy-loaded; instead they are bundled with their parent component. In this case:
 
 - `MyButton` will get bundled with the `MyApp` component.
@@ -49,10 +49,10 @@ rendered.
 You can think of lightweight components as being inlined into the component where they are instantiated.
 
 ## Limitations
-Lite components come with some limitations that the standard `component$()`
-does not have. Lite components:
+Inline components come with some limitations that the standard `component$()`
+does not have. Inline components:
 - Cannot use `use` methods such as `useSignal` or `useStore`.
 
-As the name implies, lite components are best used sparingly for
+As the name implies, inline components are best used sparingly for
 lightweight pieces of markup since they offer the convenience of being
 bundled with the parent component.

--- a/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
@@ -179,4 +179,4 @@ As you can see in the above example, the `<!--qv-->` acts as a marker where the 
 
 ## See Also
 
-- [Lite components](../lite-components/index.mdx)
+- [Inline components](../inline-components/index.mdx)

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -18,7 +18,7 @@
 - [Slots](</docs/(qwik)/components/projection/index.mdx>)
 - [Rendering](</docs/(qwik)/components/rendering/index.mdx>)
 - [Styling](</docs/(qwik)/components/styles/index.mdx>)
-- [Lite components](</docs/(qwik)/components/lite-components/index.mdx>)
+- [Inline components](</docs/(qwik)/components/inline-components/index.mdx>)
 
 ## Routing (Qwik City)
 

--- a/packages/docs/src/routes/tutorial/component/lite/index.mdx
+++ b/packages/docs/src/routes/tutorial/component/lite/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lite Component
+title: Inline Component
 contributors:
   - adamdbradley
   - the-r3aper7
@@ -8,8 +8,8 @@ contributors:
 
 One of Qwik's super powers lies in its lazy-loading features. Each component will generate a separate Symbol which is downloaded on demand. This allows you to build a large application with many components and only download the components that are needed for the current view.
 
-But for some cases you may want to load a component together with the parent component. For example, if you have a `<Greeter>` component that is always used with the `<App>` component, you may want to load the `<Greeter>` component with the `<App>` component. This is called a [lite or lightweight component](/docs/(qwik)/components/lite-components).
+But for some cases you may want to load a component together with the parent component. For example, if you have a `<Greeter>` component that is always used with the `<App>` component, you may want to load the `<Greeter>` component with the `<App>` component. This is called an [inline component](/docs/(qwik)/components/inline-components).
 
-In this example, the `<App>` and a `<Greeter>` components are prepared for you. The `<Greeter />` component is declared using the [`component$()`](/docs/(qwik)/components/overview/index.mdx#component) method and is a Qwik component. Remove the [`component$()`](/docs/(qwik)/components/overview/index.mdx#component) to convert `<Greeter>` to a [lite component](/docs/(qwik)/components/lite-components).
+In this example, the `<App>` and a `<Greeter>` components are prepared for you. The `<Greeter />` component is declared using the [`component$()`](/docs/(qwik)/components/overview/index.mdx#component) method and is a Qwik component. Remove the [`component$()`](/docs/(qwik)/components/overview/index.mdx#component) to convert `<Greeter>` to a [inline component](/docs/(qwik)/components/inline-components).
 
 Open the `Symbols` tab and notice that the `<Greeter />` component is no longer an independent export, but instead is bundled as part of the `<App>` component.

--- a/packages/docs/src/routes/tutorial/tutorial-menu.json
+++ b/packages/docs/src/routes/tutorial/tutorial-menu.json
@@ -73,7 +73,7 @@
       },
       {
         "id": "lite",
-        "title": "Lite Components",
+        "title": "Inline Components",
         "enableHtmlOutput": true,
         "enableClientOutput": true,
         "enableSsrOutput": true


### PR DESCRIPTION
the feedbaack is that "lite" sounds like they are "lighter/faster" and implies the standard components are "heavy" / "slow" vs this is just a function that provides inline JSX