### PR TITLE
feat: allow platform mocking for local development

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/advanced/vite/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/vite/index.mdx
@@ -4,6 +4,7 @@ contributors:
   - zanettin
   - manucorporat
   - cunzaizhuyi
+  - cayter
 ---
 
 # Vite
@@ -232,6 +233,15 @@ mdxPlugins?: MdxPlugins;
 * MDX Options https://mdxjs.com/
 */
 mdx?: any;
+```
+
+#### `platform`
+
+```js
+/**
+* The platform object which can be used to mock the Cloudflare bindings.
+*/
+platform?: Record<string, unknown>;
 ```
 
 ## Troubleshooting

--- a/packages/qwik-city/buildtime/context.ts
+++ b/packages/qwik-city/buildtime/context.ts
@@ -85,6 +85,7 @@ function normalizeOptions(
   }
 
   opts.mdx = opts.mdx || {};
+  opts.platform = opts.platform || {};
 
   return opts;
 }

--- a/packages/qwik-city/buildtime/markdown/markdown-url.unit.ts
+++ b/packages/qwik-city/buildtime/markdown/markdown-url.unit.ts
@@ -79,6 +79,7 @@ const menuFilePath = join(routesDir, 'docs', 'menu.md');
         rehypeAutolinkHeadings: true,
       },
       mdx: {},
+      platform: {},
     };
     equal(getMarkdownRelativeUrl(opts, menuFilePath, t.href), t.expect);
   });

--- a/packages/qwik-city/buildtime/routing/resolve-source-file.unit.ts
+++ b/packages/qwik-city/buildtime/routing/resolve-source-file.unit.ts
@@ -48,6 +48,7 @@ test('resolveLayout', () => {
         rehypeAutolinkHeadings: true,
       },
       mdx: {},
+      platform: {},
     };
     const sourceFile: RouteSourceFile = {
       ...getSourceFile(c.fileName)!,

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -147,6 +147,10 @@ export interface PluginOptions {
    * MDX Options https://mdxjs.com/
    */
   mdx?: any;
+  /**
+   * The platform object which can be used to mock the Cloudflare bindings.
+   */
+  platform?: Record<string, unknown>;
 }
 
 export interface MdxPlugins {

--- a/packages/qwik-city/buildtime/vite/api.md
+++ b/packages/qwik-city/buildtime/vite/api.md
@@ -37,6 +37,8 @@ export interface QwikCityVitePluginOptions extends Omit<PluginOptions, 'basePath
     //
     // (undocumented)
     mdxPlugins?: MdxPlugins;
+    // (undocumented)
+    platform?: Record<string, unknown>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -169,6 +169,9 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
 
         if (requestHandlers.length > 0) {
           const serverRequestEv = await fromNodeHttp(url, req, res, 'dev');
+          if (ctx.opts.platform) {
+            serverRequestEv.platform = ctx.opts.platform;
+          }
 
           const { completion, requestEv } = runQwikCity(
             serverRequestEv,

--- a/packages/qwik-city/buildtime/vite/types.ts
+++ b/packages/qwik-city/buildtime/vite/types.ts
@@ -7,6 +7,7 @@ import type { BuildContext, BuildEntry, BuildRoute, PluginOptions, MdxPlugins } 
 export interface QwikCityVitePluginOptions extends Omit<PluginOptions, 'basePathname'> {
   mdxPlugins?: MdxPlugins;
   mdx?: MdxOptions;
+  platform?: Record<string, unknown>;
 }
 
 /**

--- a/packages/qwik-city/utils/fs.unit.ts
+++ b/packages/qwik-city/utils/fs.unit.ts
@@ -258,6 +258,7 @@ test('createFileId, Layout', () => {
         rehypeAutolinkHeadings: true,
       },
       mdx: {},
+      platform: {},
     };
     const pathname = getPathnameFromDirPath(opts, t.dirPath);
     equal(pathname, t.expect, t.dirPath);
@@ -357,6 +358,7 @@ test('parseRouteIndexName', () => {
         rehypeAutolinkHeadings: true,
       },
       mdx: {},
+      platform: {},
     };
     const pathname = getMenuPathname(opts, t.filePath);
     equal(pathname, t.expect);


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

This PR is to allow platform mocking for local development, i.e. closes #2280. When working with Cloudflare Pages, we'd need to access D1/KV/Durable Objects/etc. As Qwik City is currently using vite dev server which it doesn't know what wrangler/miniflare bindings are available, we'd need to initialise the Cloudflare Pages platform object and pass it to `qwikCity()` so that we can access it in the `routeLoader$()`.

#### How To Configure Cloudflare Pages Bindings
`vite.config.ts`
```ts
...
import { Miniflare, Log, LogLevel } from 'miniflare';

async function getMiniflareBindings() {
  const mf = new Miniflare({
    log: new Log(LogLevel.INFO),
    ...
    script: `
      addEventListener("fetch", (event) => {
        event.waitUntil(Promise.resolve(event.request.url));
        event.respondWith(new Response(event.request.headers.get("X-Message")));
      });
      
      addEventListener("scheduled", (event) => {
        event.waitUntil(Promise.resolve(event.scheduledTime));
      });`
  });

  return mf.getBindings();
}

export default defineConfig(() => ({
  plugins: [
    qwikCity({
      platform: await getMiniflareBindings(),
    }),
    qwikVite(),
    ...
  ]
}); 
```

#### How To Access Cloudflare Pages Bindings
`src/routes/index.tsx`
```tsx
export const useLoaderData = routeLoader$(
  async (ev: RequestEventLoader<PlatformCloudflarePages>) => {
    console.log(ev.platform);

    return {};
  },
);

export default component$(() => {
  const signal = useLoaderData();

  return <></>;
});
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
