### PR TITLE
docs: add `edit` button to example browser

### DIFF
--- a/packages/docs/src/components/code-example/index.css
+++ b/packages/docs/src/components/code-example/index.css
@@ -23,12 +23,27 @@
   margin: 0;
   padding: 0;
   list-style: none;
+  align-items: center;
   gap: 8px;
 }
 
 .browser .bar > ul > li {
   margin: 0;
   padding: 0;
+}
+
+.browser .bar > ul > li.edit {
+  position: relative;
+  top: -2px;
+}
+.browser .bar > ul > li.edit > a {
+  color: #666;
+}
+.browser .bar > ul > li.edit > a:hover {
+  color: #222;
+}
+:global(:root[data-theme='dark']) .browser .bar > ul > li.edit > a:hover {
+  color: #aaa;
 }
 
 .browser .url .url-link {

--- a/packages/docs/src/components/code-example/index.tsx
+++ b/packages/docs/src/components/code-example/index.tsx
@@ -1,6 +1,7 @@
 import { component$, useContext, useStylesScoped$ } from '@builder.io/qwik';
 import { CodeBlock } from '../code-block/code-block';
 import { useLocation } from '@builder.io/qwik-city';
+import { EditIcon } from '../svgs/edit-icon';
 import { GlobalStore } from '../../context';
 import CSS from './index.css?inline';
 
@@ -13,12 +14,13 @@ export default component$<{
   const location = useLocation();
   const state = useContext(GlobalStore);
   const browserURL = new URL(examplePath({ path: src.path }), location.url).toString();
+  const editUrl = `https://github.com/BuilderIO/qwik/edit/main/packages/docs${src.path}`;
   return (
     <div>
       <CodeBlock code={src.code} path={src.path} language="tsx" />
       {sandbox !== false && (
         <div class="browser shadow-xl">
-          <div class="bar bg-slate-200 rounded-tl-md rounded-tr-md flex flex-row justify-left px-5 py-2 gap-6">
+          <div class="bar bg-slate-200 rounded-tl-md rounded-tr-md flex flex-row justify-left px-5 py-2 gap-5">
             <ul>
               <li>
                 <span class="bg-red-600 rounded-full w-3 h-3 inline-block"></span>
@@ -35,6 +37,13 @@ export default component$<{
                 {browserURL}
               </a>
             </div>
+            <ul>
+              <li class="edit">
+                <a href={editUrl} rel="noopener" target="_blank" title="edit this snippet">
+                  <EditIcon width={20} height={20} />
+                </a>
+              </li>
+            </ul>
           </div>
           <div>
             <iframe


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
Snippet browser now offers an edit button to edit the snippet.

## Screens
![Bildschirm­foto 2023-03-31 um 23 54 21](https://user-images.githubusercontent.com/3241476/229239994-0b2eb696-d2d3-423a-a719-c3384aac30d4.png)
![Bildschirm­foto 2023-03-31 um 23 54 54](https://user-images.githubusercontent.com/3241476/229239998-4abf5821-96d6-4f28-9406-c7234d121be0.png)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
