### PR TITLE
docs: prNumber's type should be string

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
@@ -282,7 +282,7 @@ Use `useResource$()` to create a computed value that is derived asynchronously o
 import { component$, Resource, useResource$, useSignal } from '@builder.io/qwik';
 
 export default component$(() => {
-  const prNumber = useSignal(3576);
+  const prNumber = useSignal("3576");
 
   const prTitle = useResource$(async ({ track }) => {
     track(prNumber); // Requires explicit tracking of inputs


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The state `prNumber` will be changed by the `input`. So it should be string type to fix the error:

`Type 'Signal<number>' is not assignable to type 'Signal<string | undefined>'.`

![截圖 2023-04-02 下午10 24 42](https://user-images.githubusercontent.com/16910748/229358963-341e3d9f-5a1d-45c9-b3a3-a58de7364ae1.png)


# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
