### PR TITLE
docs: better font family for code block on windows

### DIFF
--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -32,7 +32,7 @@
 }
 
 .docs article pre code[data-language='tsx'] {
-  font-family: Menlo, Monaco, 'Courier New', monospace;
+  font-family: Menlo, Monaco, 'Lucida Console', Consolas, 'Courier New', monospace;
   font-weight: normal;
   font-size: 14px;
   font-feature-settings: 'liga' 0, 'calt' 0;

--- a/packages/docs/src/repl/repl.css
+++ b/packages/docs/src/repl/repl.css
@@ -129,7 +129,7 @@
 .repl-output-panel .repl-tab {
   background-color: var(--bg-color);
 
-  font-family: Menlo, Monaco, 'Courier New', monospace;
+  font-family: Menlo, Monaco, 'Lucida Console', Consolas, 'Courier New', monospace;
   font-weight: normal;
   font-size: 12px;
   font-feature-settings: 'liga' 0, 'calt' 0;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Font for code blocks on windows is not very visible.

Before:
![obraz](https://user-images.githubusercontent.com/78650133/229837805-bff1fd6d-0cf0-45f3-922d-969b14aa2b77.png)

After:
![obraz](https://user-images.githubusercontent.com/78650133/229837852-3522a931-5066-4a9d-8aea-4d4e194bbd43.png)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
