### PR TITLE
docs(tutorial/events/synchronous): fix 404 on link to useVisibleTask$

### DIFF
--- a/packages/docs/src/routes/tutorial/events/synchronous/index.mdx
+++ b/packages/docs/src/routes/tutorial/events/synchronous/index.mdx
@@ -10,4 +10,4 @@ While not a common use case, you may occasionally need to process events synchro
 
 Since Qwik processes asynchronously by default, your code must be explicitly configured for synchronous calls. This example shows how to eagerly load an event handler that processes a synchronous event.
 
-> **Your task:** Convert the `onClick$` from asynchronous event to synchronous event by using [`useVisibleTask$`](https://qwik.builder.io/docs/(qwik)/components/tasks/#usevisibletask) lifecycle and [normal event registration](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).
+> **Your task:** Convert the `onClick$` from asynchronous event to synchronous event by using [`useVisibleTask$`](/docs/(qwik)/components/tasks/index.mdx#usevisibletask) lifecycle and [normal event registration](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This fixes the rendered href for the link, which contained a literal "(docs)" instead of being
parsed to the appropriate link.

# Use cases and why

The actual behavior is that clicking on the link for `useVisibleTask$` would direct to https://qwik.builder.io/docs/(qwik)/components/tasks/#usevisibletask.

The expected behavior is that it should link to direct to https://qwik.builder.io/docs/components/tasks/#usevisibletask.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
