### PR TITLE
Add live cookie value support to fix stale values

### DIFF
--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -67,7 +67,6 @@ const parseCookieString = (cookieString: string | undefined | null) => {
   return cookie;
 };
 
-const DELETED_COOKIE = '_qDeleted';
 const REQ_COOKIE = Symbol('request-cookies');
 const RES_COOKIE = Symbol('response-cookies');
 const LIVE_COOKIE = Symbol('live-cookies');
@@ -75,7 +74,7 @@ const LIVE_COOKIE = Symbol('live-cookies');
 export class Cookie implements CookieInterface {
   private [REQ_COOKIE]: Record<string, string>;
   private [RES_COOKIE]: Record<string, string> = {};
-  private [LIVE_COOKIE]: Record<string, string> = {};
+  private [LIVE_COOKIE]: Record<string, string | null> = {};
 
   constructor(cookieString?: string | undefined | null) {
     this[REQ_COOKIE] = parseCookieString(cookieString);
@@ -84,7 +83,7 @@ export class Cookie implements CookieInterface {
 
   get(cookieName: string, live: boolean = true) {
     const value = this[live ? LIVE_COOKIE : REQ_COOKIE][cookieName];
-    if (!value || (live && value === DELETED_COOKIE)) {
+    if (!value) {
       return null;
     }
     return {
@@ -126,7 +125,7 @@ export class Cookie implements CookieInterface {
 
   delete(name: string, options?: Pick<CookieOptions, 'path' | 'domain'>) {
     this.set(name, 'deleted', { ...options, maxAge: 0 });
-    this[LIVE_COOKIE][name] = DELETED_COOKIE;
+    this[LIVE_COOKIE][name] = null;
   }
 
   headers() {

--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -79,7 +79,7 @@ export class Cookie implements CookieInterface {
 
   constructor(cookieString?: string | undefined | null) {
     this[REQ_COOKIE] = parseCookieString(cookieString);
-    this[REQ_COOKIE] = { ...this[REQ_COOKIE] };
+    this[LIVE_COOKIE] = { ...this[REQ_COOKIE] };
   }
 
   get(cookieName: string, live: boolean = true) {

--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -67,20 +67,24 @@ const parseCookieString = (cookieString: string | undefined | null) => {
   return cookie;
 };
 
+const DELETED_COOKIE = '_qDeleted';
 const REQ_COOKIE = Symbol('request-cookies');
 const RES_COOKIE = Symbol('response-cookies');
+const LIVE_COOKIE = Symbol('live-cookies');
 
 export class Cookie implements CookieInterface {
   private [REQ_COOKIE]: Record<string, string>;
   private [RES_COOKIE]: Record<string, string> = {};
+  private [LIVE_COOKIE]: Record<string, string> = {};
 
   constructor(cookieString?: string | undefined | null) {
     this[REQ_COOKIE] = parseCookieString(cookieString);
+    this[REQ_COOKIE] = { ...this[REQ_COOKIE] };
   }
 
-  get(cookieName: string) {
-    const value = this[REQ_COOKIE][cookieName];
-    if (!value) {
+  get(cookieName: string, live: boolean = true) {
+    const value = this[live ? LIVE_COOKIE : REQ_COOKIE][cookieName];
+    if (!value || (live && value === DELETED_COOKIE)) {
       return null;
     }
     return {
@@ -94,15 +98,15 @@ export class Cookie implements CookieInterface {
     };
   }
 
-  getAll() {
-    return Object.keys(this[REQ_COOKIE]).reduce((cookies, cookieName) => {
+  getAll(live: boolean = true) {
+    return Object.keys(this[live ? LIVE_COOKIE : REQ_COOKIE]).reduce((cookies, cookieName) => {
       cookies[cookieName] = this.get(cookieName)!;
       return cookies;
     }, {} as Record<string, CookieValue>);
   }
 
-  has(cookieName: string) {
-    return !!this[REQ_COOKIE][cookieName];
+  has(cookieName: string, live: boolean = true) {
+    return !!this[live ? LIVE_COOKIE : REQ_COOKIE][cookieName];
   }
 
   set(
@@ -110,6 +114,9 @@ export class Cookie implements CookieInterface {
     cookieValue: string | number | Record<string, any>,
     options: CookieOptions = {}
   ) {
+    this[LIVE_COOKIE][cookieName] =
+      typeof cookieValue === 'string' ? cookieValue : JSON.stringify(cookieValue);
+
     const resolvedValue =
       typeof cookieValue === 'string'
         ? cookieValue
@@ -119,6 +126,7 @@ export class Cookie implements CookieInterface {
 
   delete(name: string, options?: Pick<CookieOptions, 'path' | 'domain'>) {
     this.set(name, 'deleted', { ...options, maxAge: 0 });
+    this[LIVE_COOKIE][name] = DELETED_COOKIE;
   }
 
   headers() {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

Fix for Issue #3625

Cookie values become stale on the sever-side once they are `set` and there is no way to read the current value. The bug occurs because values are only saved in `RES_COOKIE` and all methods of reading come from the old `REQ_COOKIE`.

With this PR, cookies return the current `live` value sever-side so all code requesting the value from `get`, `has`, and `getAll` received the current live values.

To preserve access to the original cookie values at request time, an optional `live` flag was added that defaults to live, but if turned off, the original (stale) values can be accessed.

# Use cases and why

Stale cooke data tastes bad and breaks things. Requiring the developer to figure out this problem, and then write hacked workarounds is immense painful and ultimately break.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
