### PR TITLE
feat: Add MDX rehypeSyntaxHighlight plugin options

### DIFF
--- a/packages/qwik-city/buildtime/markdown/mdx.ts
+++ b/packages/qwik-city/buildtime/markdown/mdx.ts
@@ -34,9 +34,17 @@ export async function createMdxTransformer(ctx: BuildContext): Promise<MdxTransf
 
   if (
     typeof coreMdxPlugins?.rehypeSyntaxHighlight === 'undefined' ||
-    coreMdxPlugins.rehypeSyntaxHighlight
+    (typeof coreMdxPlugins?.rehypeSyntaxHighlight === 'boolean' &&
+      coreMdxPlugins.rehypeSyntaxHighlight)
   ) {
     coreRehypePlugins.push(rehypeSyntaxHighlight);
+  }
+
+  if (
+    typeof coreMdxPlugins?.rehypeSyntaxHighlight === 'object' &&
+    coreMdxPlugins.rehypeSyntaxHighlight.enabled !== false
+  ) {
+    coreRehypePlugins.push([rehypeSyntaxHighlight, coreMdxPlugins.rehypeSyntaxHighlight]);
   }
 
   if (

--- a/packages/qwik-city/buildtime/markdown/mdx.ts
+++ b/packages/qwik-city/buildtime/markdown/mdx.ts
@@ -26,8 +26,13 @@ export async function createMdxTransformer(ctx: BuildContext): Promise<MdxTransf
 
   const coreRemarkPlugins = [];
 
-  if (typeof coreMdxPlugins?.remarkGfm === 'undefined' || coreMdxPlugins.remarkGfm) {
+  if (
+    typeof coreMdxPlugins?.remarkGfm === 'undefined' ||
+    (typeof coreMdxPlugins?.remarkGfm === 'boolean' && coreMdxPlugins.remarkGfm)
+  ) {
     coreRemarkPlugins.push(remarkGfm);
+  } else if (typeof coreMdxPlugins?.remarkGfm === 'object') {
+    coreRemarkPlugins.push([remarkGfm, coreMdxPlugins.remarkGfm]);
   }
 
   const coreRehypePlugins = [];
@@ -38,20 +43,18 @@ export async function createMdxTransformer(ctx: BuildContext): Promise<MdxTransf
       coreMdxPlugins.rehypeSyntaxHighlight)
   ) {
     coreRehypePlugins.push(rehypeSyntaxHighlight);
-  }
-
-  if (
-    typeof coreMdxPlugins?.rehypeSyntaxHighlight === 'object' &&
-    coreMdxPlugins.rehypeSyntaxHighlight.enabled !== false
-  ) {
+  } else if (typeof coreMdxPlugins?.rehypeSyntaxHighlight === 'object') {
     coreRehypePlugins.push([rehypeSyntaxHighlight, coreMdxPlugins.rehypeSyntaxHighlight]);
   }
 
   if (
     typeof coreMdxPlugins?.rehypeAutolinkHeadings === 'undefined' ||
-    coreMdxPlugins.rehypeAutolinkHeadings
+    (typeof coreMdxPlugins?.rehypeAutolinkHeadings === 'boolean' &&
+      coreMdxPlugins.rehypeAutolinkHeadings)
   ) {
     coreRehypePlugins.push(rehypeAutolinkHeadings);
+  } else if (typeof coreMdxPlugins?.rehypeAutolinkHeadings === 'object') {
+    coreRehypePlugins.push([rehypeAutolinkHeadings, coreMdxPlugins.rehypeAutolinkHeadings]);
   }
 
   const mdxOpts: CompileOptions = {

--- a/packages/qwik-city/buildtime/markdown/syntax-highlight.ts
+++ b/packages/qwik-city/buildtime/markdown/syntax-highlight.ts
@@ -3,8 +3,13 @@ import { toString } from 'hast-util-to-string';
 import { visit } from 'unist-util-visit';
 import { refractor } from 'refractor';
 import tsxLang from 'refractor/lang/tsx.js';
+import type { RehypeSyntaxHighlightOptions } from '../types';
 
-export function rehypeSyntaxHighlight(): Transformer {
+export function rehypeSyntaxHighlight(opts?: RehypeSyntaxHighlightOptions): Transformer {
+  if (opts?.setup) {
+    opts.setup(refractor);
+  }
+
   refractor.register(tsxLang);
 
   return async (ast) => {

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -160,7 +160,6 @@ export interface PluginOptions {
 }
 
 export interface RehypeSyntaxHighlightOptions {
-  enabled?: boolean;
   setup?: (refractor: Refractor) => void;
 }
 

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -1,4 +1,6 @@
 import type { refractor } from 'refractor';
+import type { Options as RemarkGfmOptions } from 'remark-gfm';
+import type { Options as RehypeAutolinkHeadingsOptions } from 'rehype-autolink-headings';
 
 type Refractor = typeof refractor;
 
@@ -163,9 +165,9 @@ export interface RehypeSyntaxHighlightOptions {
 }
 
 export interface MdxPlugins {
-  remarkGfm?: boolean;
+  remarkGfm?: boolean | RemarkGfmOptions;
   rehypeSyntaxHighlight?: boolean | RehypeSyntaxHighlightOptions;
-  rehypeAutolinkHeadings?: boolean;
+  rehypeAutolinkHeadings?: boolean | RehypeAutolinkHeadingsOptions;
 }
 
 export interface NormalizedPluginOptions extends Required<PluginOptions> {}

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -1,3 +1,7 @@
+import type { refractor } from 'refractor';
+
+type Refractor = typeof refractor;
+
 export interface BuildContext {
   rootDir: string;
   opts: NormalizedPluginOptions;
@@ -153,10 +157,15 @@ export interface PluginOptions {
   platform?: Record<string, unknown>;
 }
 
+export interface RehypeSyntaxHighlightOptions {
+  enabled?: boolean;
+  setup?: (refractor: Refractor) => void;
+}
+
 export interface MdxPlugins {
-  remarkGfm: boolean;
-  rehypeSyntaxHighlight: boolean;
-  rehypeAutolinkHeadings: boolean;
+  remarkGfm?: boolean;
+  rehypeSyntaxHighlight?: boolean | RehypeSyntaxHighlightOptions;
+  rehypeAutolinkHeadings?: boolean;
 }
 
 export interface NormalizedPluginOptions extends Required<PluginOptions> {}

--- a/packages/qwik-city/buildtime/vite/api.md
+++ b/packages/qwik-city/buildtime/vite/api.md
@@ -6,6 +6,8 @@
 
 import { CompileOptions } from '@mdx-js/mdx/lib/compile';
 import { ConfigEnv } from 'vite';
+import type { Options } from 'remark-gfm';
+import type { Options as Options_2 } from 'rehype-autolink-headings';
 import type { refractor } from 'refractor';
 import { UserConfigExport } from 'vite';
 

--- a/packages/qwik-city/buildtime/vite/api.md
+++ b/packages/qwik-city/buildtime/vite/api.md
@@ -6,6 +6,7 @@
 
 import { CompileOptions } from '@mdx-js/mdx/lib/compile';
 import { ConfigEnv } from 'vite';
+import type { refractor } from 'refractor';
 import { UserConfigExport } from 'vite';
 
 // @public (undocumented)


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

fixes #3603

Add plugin options for all 3 core plugins.

# Use cases and why

```jsx
// vite.config.mts

import fsharp from "refractor/lang/fsharp";

export default defineConfig(() => {
  return {
    plugins: [
      qwikCity({
        mdxPlugins: {
          remarkGfm: {
            singleTilde: false,
          },
          rehypeSyntaxHighlight: {
            setup(refractor) {
              refractor.register(fsharp)
            }
          },
          rehypeAutolinkHeadings: false,
        }
      })
    ]
  }
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
