### PR TITLE
Support users passing an excluded path for the generated manifest

### DIFF
--- a/packages/qwik-city/adapters/netlify-edge/api.md
+++ b/packages/qwik-city/adapters/netlify-edge/api.md
@@ -12,6 +12,7 @@ export function netlifyEdgeAdapter(opts?: NetlifyEdgeAdapterOptions): any;
 
 // @public (undocumented)
 export interface NetlifyEdgeAdapterOptions extends ServerAdapterOptions {
+    excludedPath?: string[];
     functionRoutes?: boolean;
     staticPaths?: string[];
 }

--- a/packages/qwik-city/adapters/netlify-edge/api.md
+++ b/packages/qwik-city/adapters/netlify-edge/api.md
@@ -12,7 +12,7 @@ export function netlifyEdgeAdapter(opts?: NetlifyEdgeAdapterOptions): any;
 
 // @public (undocumented)
 export interface NetlifyEdgeAdapterOptions extends ServerAdapterOptions {
-    excludedPath?: string[];
+    excludedPath?: string;
     functionRoutes?: boolean;
     staticPaths?: string[];
 }

--- a/packages/qwik-city/adapters/netlify-edge/vite/index.ts
+++ b/packages/qwik-city/adapters/netlify-edge/vite/index.ts
@@ -49,7 +49,7 @@ export function netlifyEdgeAdapter(opts: NetlifyEdgeAdapterOptions = {}): any {
               path: basePathname + '*',
               function: 'entry.netlify-edge',
               cache: 'manual',
-              excludedPath: Array.isArray(opts.excludedPath) ? opts.excludedPath : []
+              excludedPath: Array.isArray(opts.excludedPath) ? opts.excludedPath : [],
             },
           ],
           version: 1,

--- a/packages/qwik-city/adapters/netlify-edge/vite/index.ts
+++ b/packages/qwik-city/adapters/netlify-edge/vite/index.ts
@@ -49,7 +49,7 @@ export function netlifyEdgeAdapter(opts: NetlifyEdgeAdapterOptions = {}): any {
               path: basePathname + '*',
               function: 'entry.netlify-edge',
               cache: 'manual',
-              excludedPath: Array.isArray(opts.excludedPath) ? opts.excludedPath : [],
+              excludedPath: opts.excludedPath || '',
             },
           ],
           version: 1,
@@ -97,10 +97,10 @@ export interface NetlifyEdgeAdapterOptions extends ServerAdapterOptions {
    */
   staticPaths?: string[];
   /**
-   * Manually add pathnames that should be excluded from the edge function routes
+   * Manually add path pattern that should be excluded from the edge function routes
    * that are created by the 'manifest.json' file.
    */
-  excludedPath?: string[];
+  excludedPath?: string;
 }
 
 /**

--- a/packages/qwik-city/adapters/netlify-edge/vite/index.ts
+++ b/packages/qwik-city/adapters/netlify-edge/vite/index.ts
@@ -49,6 +49,7 @@ export function netlifyEdgeAdapter(opts: NetlifyEdgeAdapterOptions = {}): any {
               path: basePathname + '*',
               function: 'entry.netlify-edge',
               cache: 'manual',
+              excludedPath: Array.isArray(opts.excludedPath) ? opts.excludedPath : []
             },
           ],
           version: 1,
@@ -95,6 +96,11 @@ export interface NetlifyEdgeAdapterOptions extends ServerAdapterOptions {
    * come from a static file, rather than a server-side rendered response.
    */
   staticPaths?: string[];
+  /**
+   * Manually add pathnames that should be excluded from the edge function routes
+   * that are created by the 'manifest.json' file.
+   */
+  excludedPath?: string[];
 }
 
 /**

--- a/starters/adapters/netlify-edge/README.md
+++ b/starters/adapters/netlify-edge/README.md
@@ -35,7 +35,7 @@ To override the generated manifest, you can [add a declaration](https://docs.net
 
 Netlify-specific option fields that can be passed to the adapter options:
 
-- `excludedPath` this option accepts a `string` array and represents which glob patterns should not go through the generated Edge Functions.
+- `excludedPath` this option accepts a `string` array of glob patterns and represents which paths should not go through the generated Edge Functions.
 
 
 ### Deployments

--- a/starters/adapters/netlify-edge/README.md
+++ b/starters/adapters/netlify-edge/README.md
@@ -31,6 +31,13 @@ To override the generated manifest, you can [add a declaration](https://docs.net
   function = "auth"
 ```
 
+### Addition Adapter Options
+
+Netlify-specific option fields that can be passed to the adapter options:
+
+- `excludedPath` this option accepts a `string` array and represents which glob patterns should not go through the generated Edge Functions.
+
+
 ### Deployments
 
 You can [deploy your site to Netlify](https://docs.netlify.com/site-deploys/create-deploys/) either via a Git provider integration or through the Netlify CLI. This starter site includes a `netlify.toml` file to configure your build for deployment.

--- a/starters/adapters/netlify-edge/README.md
+++ b/starters/adapters/netlify-edge/README.md
@@ -37,7 +37,6 @@ Netlify-specific option fields that can be passed to the adapter options:
 
 - `excludedPath` this option accepts a `string` array of glob patterns and represents which paths should not go through the generated Edge Functions.
 
-
 ### Deployments
 
 You can [deploy your site to Netlify](https://docs.netlify.com/site-deploys/create-deploys/) either via a Git provider integration or through the Netlify CLI. This starter site includes a `netlify.toml` file to configure your build for deployment.

--- a/starters/adapters/netlify-edge/README.md
+++ b/starters/adapters/netlify-edge/README.md
@@ -35,7 +35,7 @@ To override the generated manifest, you can [add a declaration](https://docs.net
 
 Netlify-specific option fields that can be passed to the adapter options:
 
-- `excludedPath` this option accepts a `string` array of glob patterns and represents which paths should not go through the generated Edge Functions.
+- `excludedPath` this option accepts a `string` glob pattern that represents which path pattern should not go through the generated Edge Functions.
 
 ### Deployments
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
A user reported a challenge where they were unable to use the qwik adapter and Netlify Forms. The issue was essentially that they need to have a route that the generated Edge Function does not process so that it goes through Netlify as expected.

# Use cases and why

For certain tools, there might be a special path that the edge functions should ignore to allow other CDN capabilities to work. When that need arises, this should allow developers to exclude a path that's needed for non-qwik site purposes. 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
