### PR TITLE
fix home dir creation when running pnpm create qwik@latest

### DIFF
--- a/packages/create-qwik/create-app.ts
+++ b/packages/create-qwik/create-app.ts
@@ -11,8 +11,7 @@ import {
 import { loadIntegrations } from '../qwik/src/cli/utils/integrations';
 import { logSuccessFooter } from '../qwik/src/cli/utils/log';
 import { updateApp } from '../qwik/src/cli/add/update-app';
-
-const os = require('node:os');
+import os from 'node:os';
 
 export async function runCreateCli(starterId: string, outDir: string) {
   if (writeToCwd()) {

--- a/packages/create-qwik/create-app.ts
+++ b/packages/create-qwik/create-app.ts
@@ -12,6 +12,8 @@ import { loadIntegrations } from '../qwik/src/cli/utils/integrations';
 import { logSuccessFooter } from '../qwik/src/cli/utils/log';
 import { updateApp } from '../qwik/src/cli/add/update-app';
 
+const os = require('node:os');
+
 export async function runCreateCli(starterId: string, outDir: string) {
   if (writeToCwd()) {
     // write to the current working directory

--- a/packages/create-qwik/create-app.ts
+++ b/packages/create-qwik/create-app.ts
@@ -176,7 +176,12 @@ function isValidOption(value: any) {
 }
 
 export function getOutDir(outDir: string) {
-  return resolve(process.cwd(), outDir);
+  // check if the outDir start with home ~
+  if (outDir.startsWith('~/')) {
+    return resolve(os.homedir(), outDir);
+  } else {
+    return resolve(process.cwd(), outDir);
+  }
 }
 
 export function writeToCwd() {


### PR DESCRIPTION
# What is it?
this is the same as #3744 for some reason i had the [@pull](https://github.com/apps/pull) bot enabled and it reset my branch to origin and the pr didn't end up getting merged into main with new changes.

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

When creating a new qwik project and it prompts for a project name/path it suggests to use `./project_name` but if you use `~/Projects/qwik` it will make a `~` folder in the current dir. 


# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
