### PR TITLE
fix: 🐛 Update starters vite-tsconfig-paths dependency to latest

### DIFF
--- a/packages/create-qwik/package.json
+++ b/packages/create-qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-qwik",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "description": "Interactive CLI for create Qwik projects and adding features.",
   "bin": "./create-qwik.cjs",
   "main": "./index.cjs",

--- a/starters/apps/base/package.json
+++ b/starters/apps/base/package.json
@@ -28,7 +28,7 @@
     "prettier": "latest",
     "typescript": "latest",
     "vite": "latest",
-    "vite-tsconfig-paths": "3.5.0"
+    "vite-tsconfig-paths": "4.2.0"
   },
   "engines": {
     "node": ">=16.8.0 <18.0.0 || >=18.11"


### PR DESCRIPTION
Update starters vite-tsconfig-paths dependency to latest to fix dependency issues when installing dependencies in starters

BREAKING CHANGE: 🧨 Unable to install Qwik starter dependencies

✅ Closes: #3792

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Bump vite-tsconfig-paths dependency to latest.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Unable to install dependencies when creating new Qwik apps. After updating vite-tsconfig-paths dependency all dependencies can be installed. App runs locally and works as expected.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
