### PR TITLE
Improve use 'use-not-root' behavious in es-lint plugin

### DIFF
--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -57,22 +57,6 @@ export const useSession5 = () => useContext().value + 10;
 
       `
 export const useSession1 = () => {
-  myExpression() ?? useContext();
-}
-
-export const useSession2 = () => {
-  return myExpression() ?? useContext();
-}
-
-export const useSession3 = () => myExpression() ?? useContext();
-
-export const useSession4 = () => myExpression() ?? useContext().value 
-
-export const useSession5 = () => myExpression() ?? useContext().value + 10;
-`,
-
-      `
-export const useSession1 = () => {
   useContext()?.value;
 }
 

--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -24,7 +24,7 @@ const testConfig = {
 };
 
 const ruleTester = new RuleTester(testConfig as any);
-test('no-use-after-await', () => {
+test('use-method-usage', () => {
   ruleTester.run('my-rule', rules['use-method-usage'] as any, {
     valid: [
       `
@@ -54,6 +54,40 @@ export const useSession4 = () => useContext().value;
 export const useSession5 = () => useContext().value + 10;
 
 `,
+
+      `
+export const useSession1 = () => {
+  myExpression() ?? useContext();
+}
+
+export const useSession2 = () => {
+  return myExpression() ?? useContext();
+}
+
+export const useSession3 = () => myExpression() ?? useContext();
+
+export const useSession4 = () => myExpression() ?? useContext().value 
+
+export const useSession5 = () => myExpression() ?? useContext().value + 10;
+`,
+
+      `
+export const useSession1 = () => {
+  useContext()?.value;
+}
+
+export const useSession2 = () => {
+  return useContext()?.value;
+}
+
+export const useSession3 = () => useContext()?.value;
+
+export const useSession4 = () => useContext()?.value;
+
+export const useSession5 = () => useContext()?.value; + 10;
+
+`,
+
       `
       export const HelloWorld = component$(async () => {
           useMethod();
@@ -108,6 +142,39 @@ export const useSession5 = () => useContext().value + 10;
             });
           });`,
         errors: [{ messageId: 'use-after-await' }],
+      },
+
+      {
+        code: `export function noUseSession() {
+          useContext();
+        }`,
+        errors: [{ messageId: 'use-wrong-function' }],
+      },
+      {
+        code: `export const noUseSession = () => {
+          useContext();
+        }`,
+        errors: [{ messageId: 'use-wrong-function' }],
+      },
+      {
+        code: `export const noUseSession = () => {
+         return useContext();
+        }`,
+        errors: [{ messageId: 'use-wrong-function' }],
+      },
+      {
+        code: `export const noUseSession = () => useContext();`,
+        errors: [{ messageId: 'use-wrong-function' }],
+      },
+      {
+        code: `export const noUseSession = () => useContext().value;`,
+        errors: [{ messageId: 'use-wrong-function' }],
+      },
+      {
+        code: `export const noUseSession = () => {
+         return useContext();
+        }`,
+        errors: [{ messageId: 'use-wrong-function' }],
       },
     ],
   });

--- a/packages/eslint-plugin-qwik/src/useMethodUsage.ts
+++ b/packages/eslint-plugin-qwik/src/useMethodUsage.ts
@@ -58,7 +58,6 @@ export const useMethodUsage: Rule.RuleModule = {
             case 'UnaryExpression':
             case 'ReturnStatement':
             case 'BlockStatement':
-            case 'LogicalExpression':
             case 'ChainExpression':
               break;
             case 'ArrowFunctionExpression':

--- a/packages/eslint-plugin-qwik/src/useMethodUsage.ts
+++ b/packages/eslint-plugin-qwik/src/useMethodUsage.ts
@@ -58,6 +58,8 @@ export const useMethodUsage: Rule.RuleModule = {
             case 'UnaryExpression':
             case 'ReturnStatement':
             case 'BlockStatement':
+            case 'LogicalExpression':
+            case 'ChainExpression':
               break;
             case 'ArrowFunctionExpression':
             case 'FunctionExpression':


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

I expanded the `eslint-plugin-qwik` to support the following cases:

```ts

export const useMyCustom = () => {
  return myExpression() ??  useContext();
}

export const useSession3 = () => useContext()?.value;

```




# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
