### PR TITLE
fix: pass --mode argument to child build commands

### DIFF
--- a/packages/qwik/src/cli/build/run-build-command.ts
+++ b/packages/qwik/src/cli/build/run-build-command.ts
@@ -31,6 +31,7 @@ export async function runBuildCommand(app: AppCommand) {
   const runSsgScript = getScript('ssg');
   const buildTypes = getScript('build.types');
   const lint = getScript('lint');
+  const mode = app.getArg('mode');
 
   const scripts = [
     buildTypes,
@@ -84,7 +85,8 @@ export async function runBuildCommand(app: AppCommand) {
   }
 
   if (buildClientScript) {
-    await execaCommand(buildClientScript, {
+    const script = attachArg(buildClientScript, 'mode', mode);
+    await execaCommand(script, {
       stdio: 'inherit',
       cwd: app.rootDir,
     }).catch(() => {
@@ -98,7 +100,8 @@ export async function runBuildCommand(app: AppCommand) {
   const step2: Promise<Step>[] = [];
 
   if (buildLibScript) {
-    const libBuild = execaCommand(buildLibScript, {
+    const script = attachArg(buildLibScript, 'mode', mode);
+    const libBuild = execaCommand(script, {
       cwd: app.rootDir,
       env: {
         FORCE_COLOR: 'true',
@@ -122,7 +125,8 @@ export async function runBuildCommand(app: AppCommand) {
   }
 
   if (buildPreviewScript) {
-    const previewBuild = execaCommand(buildPreviewScript, {
+    const script = attachArg(buildPreviewScript, 'mode', mode);
+    const previewBuild = execaCommand(script, {
       cwd: app.rootDir,
       env: {
         FORCE_COLOR: 'true',
@@ -146,7 +150,8 @@ export async function runBuildCommand(app: AppCommand) {
   }
 
   if (buildServerScript) {
-    const serverBuild = execaCommand(buildServerScript, {
+    const script = attachArg(buildServerScript, 'mode', mode);
+    const serverBuild = execaCommand(script, {
       cwd: app.rootDir,
       env: {
         FORCE_COLOR: 'true',
@@ -260,5 +265,12 @@ export async function runBuildCommand(app: AppCommand) {
   }
 
   console.log(``);
+}
+
+function attachArg(command: string, key: string, value?: string): string {
+  if (value !== undefined) {
+    return `${command} --${key} ${value}`;
+  }
+  return command
 }
 

--- a/packages/qwik/src/cli/utils/app-command.ts
+++ b/packages/qwik/src/cli/utils/app-command.ts
@@ -49,4 +49,18 @@ export class AppCommand {
     }
     return this._rootPkgJson!;
   }
+
+  getArg(name: string): string | undefined {
+    const key = `--${name}`;
+    const matcher = new RegExp(`^${key}($|=)`);
+    const index = this.args.findIndex((arg) => matcher.test(arg));
+    if (index === -1) {
+      return;
+    }
+
+    if (this.args[index].includes('=')) {
+      return this.args[index].split('=')[1];
+    }
+    return this.args[index + 1];
+  }
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

fixes https://github.com/BuilderIO/qwik/issues/3840

Currently its not possible to switch .env files based on custom vite `--mode`. This PR passes the mode argument from `qwik build` to `qwik build.client`, `qwik build.server`, `qwik build.preview`

# Use cases and why

Cant currently create and specify custom .env files such as `.env.staging`

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
