### PR TITLE
fix: add 'aspect-ratio' to qwik-dom CSS props

### DIFF
--- a/packages/qwik-dom/lib/cssparser.js
+++ b/packages/qwik-dom/lib/cssparser.js
@@ -3676,6 +3676,7 @@ nth
 
     appearance:
       'icon | window | desktop | workspace | document | tooltip | dialog | button | push-button | hyperlink | radio | radio-button | checkbox | menu-item | tab | menu | menubar | pull-down-menu | pop-up-menu | list-menu | radio-group | checkbox-group | outline-tree | range | field | combo-box | signature | password | normal | none | inherit',
+    'aspect-ratio': 1,
     azimuth: function (expression) {
       var simple = '<angle> | leftwards | rightwards | inherit',
         direction =


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
This adds one missing CSS prop to qwik-dom, however really it needs all the props from #3135 to be added. I thought I'd just do this one to see if it's ok, rather than doing the full work of adding all the rest before checking.

# Use cases and why

https://stackblitz.com/edit/qwik-starter-4n8fmu?file=package.json,repro.test.tsx

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
