### PR TITLE
Docs: The onSubmitCompleted$ handler

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
@@ -131,48 +131,42 @@ Here's an example of the `onSubmitCompleted$` handler used to edit an item in a 
 ```tsx title="src/components/EditForm.tsx"
 import { component$, type Signal, useSignal } from '@builder.io/qwik';
 import { Form } from '@builder.io/qwik-city';
-import styles from './editform.module.css';
-import { Check, X } from 'example-icons';
-import type { listItem } from '../../routes/index';
-import { useEditFromListAction } from '../../routes/index';
+import { type ListItem, useEditFromListAction } from '../../routes/index';
 
 export interface EditFormProps {
   item: listItem;
   editingIdSignal: Signal<string>;
 }
 
-export const EditForm = component$(
+const EditForm = component$(
   ({ item, editingIdSignal }: EditFormProps) => {
     const editAction = useEditFromListAction();
 
     return (
-      <div class={styles.wrapper}>
+      <div>
         <Form
           action={editAction}
-          class={styles.form}
           onSubmitCompleted$={() => {
             editingIdSignal.value = '';
           }}
           spaReset
         >
           <input
-            ref={inputRef}
-            class={styles.edit}
             type="text"
             value={item.text}
             name="text"
             id={`edit-${item.id}`}
           />
-          {/* Include the hidden input field for the "id" attribute */}
+          {/* Sends item.id with form data on submission. */}
           <input type="hidden" name="id" value={item.id} />
-          <button class={styles.done} type="submit">
-            <Check />
+          <button type="submit">
+            Submit
           </button>
         </Form>
 
-        <div class={styles.remove}>
+        <div>
           <button onClick$={() => (editingIdSignal.value = '')}>
-            <X />
+            Cancel
           </button>
         </div>
       </div>

--- a/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
@@ -122,6 +122,69 @@ export default component$(() => {
 
 In the example above, the `addUser` action is triggered when the user clicks the button. The `action.submit()` method returns a `Promise` that resolves when the action is done.
 
+## Actions with Event Handlers
+
+We can use the `onSubmitCompleted$` event handler after an action is executed successfully and returns some data. It is particularly useful when you need to perform additional tasks, such as resetting UI elements or updating the application state, once an action has been completed successfully.
+
+Here's an example of the `onSubmitCompleted$` handler used to edit an item in a EditForm component of a todo app.
+
+```tsx title="src/components/EditForm.tsx"
+import { component$, type Signal, useSignal } from '@builder.io/qwik';
+import { Form } from '@builder.io/qwik-city';
+import styles from './editform.module.css';
+import { Check, X } from 'example-icons';
+import type { listItem } from '../../routes/index';
+import { useEditFromListAction } from '../../routes/index';
+
+export interface EditFormProps {
+  item: listItem;
+  editingIdSignal: Signal<string>;
+}
+
+export const EditForm = component$(
+  ({ item, editingIdSignal }: EditFormProps) => {
+    const editAction = useEditFromListAction();
+
+    return (
+      <div class={styles.wrapper}>
+        <Form
+          action={editAction}
+          class={styles.form}
+          onSubmitCompleted$={() => {
+            editingIdSignal.value = '';
+          }}
+          spaReset
+        >
+          <input
+            ref={inputRef}
+            class={styles.edit}
+            type="text"
+            value={item.text}
+            name="text"
+            id={`edit-${item.id}`}
+          />
+          {/* Include the hidden input field for the "id" attribute */}
+          <input type="hidden" name="id" value={item.id} />
+          <button class={styles.done} type="submit">
+            <Check />
+          </button>
+        </Form>
+
+        <div class={styles.remove}>
+          <button onClick$={() => (editingIdSignal.value = '')}>
+            <X />
+          </button>
+        </div>
+      </div>
+    );
+  }
+);
+
+export default EditForm;
+```
+
+In this example, `onSubmitCompleted$` is used to reset the editingIdSignal value to an empty string once the form submission is completed successfully. This allows the application to update its state and return to the default view.
+
 ## Validation and type safety
 
 Qwik comes with built-in support for [Zod](https://zod.dev/), a TypeScript-first schema validation that can be used directly with actions, using the `zod$()` function.


### PR DESCRIPTION
Tried my best to add a section about the onSubmitCompleted$ event handler in the docs.

Can someone explain to me the need for 

{15-18} /firstName/#a /lastName/#b /email/#c

At the top of the code examples? I left it out since I didn't quite understand what it meant. 

I hope my documentation changes can help! A friend in the discord came across this event handler in the type definitions and it was the perfect solution to my EditForm component in my todo app. Here's the live version to see how it works

https://qwik-todo-app.netlify.app/

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
