### PR TITLE
Fix: Click-To-Source HTML

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -497,7 +497,7 @@ const DEV_QWIK_INSPECTOR = (opts: NormalizedQwikPluginOptions['devTools'], srcDi
 </script>
 <div id="qwik-inspector-info-popup" aria-hidden="true">Click-to-Source: ${hotKeys.join(
     ' + '
-  )}</p></div>
+  )}</div>
 `;
 };
 

--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -495,9 +495,7 @@ const DEV_QWIK_INSPECTOR = (opts: NormalizedQwikPluginOptions['devTools'], srcDi
 
 })();
 </script>
-<div id="qwik-inspector-info-popup" aria-hidden="true">Click-to-Source: ${hotKeys.join(
-    ' + '
-  )}</div>
+<div id="qwik-inspector-info-popup" aria-hidden="true">Click-to-Source: ${hotKeys.join(' + ')}</div>
 `;
 };
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Was trying to inspect & prettify the HTML output of Qwik but prettier refused to because of this invalid closing `p` tag without a matching open tag.