### PR TITLE
Redirect docs fix - index.mdx

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/redirects/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/redirects/index.mdx
@@ -17,24 +17,24 @@ import type { RequestEvent } from '@builder.io/qwik-city';
 import { checkAuthorization } from '../auth'; // Your authorization code
 import type { DashboardData } from '../types'; // Your types
 
-export const onGet = async ({ cookie, redirect }: RequestEvent) => {
+export const onGet = async ({ cookie, response }: RequestEvent) => {
   const isAuthorized = checkAuthorization(cookie.get('cookie'));
 
   if (!isAuthorized) {
     // User is not authorized!
     // throw the redirect response to
     // relocate the user to the log-in page
-    throw redirect(302, '/login');
+    throw response.redirect('/login', 302);
   } else {
     // ...
   }
 };
 ```
 
-The `redirect()` function, which was destructured in the RequestHandler function arguments, takes a redirect status code and URL.
+The `redirect()` function, called on the response object which was destructured in the RequestHandler function arguments, takes a URL snf redirect status code.
 
 ```tsx
-throw redirect(302, '/login');
+throw redirect('/login', 302);
 ```
 
 [Common redirect status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages):

--- a/packages/docs/src/routes/docs/(qwikcity)/guides/redirects/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/redirects/index.mdx
@@ -31,7 +31,7 @@ export const onGet = async ({ cookie, response }: RequestEvent) => {
 };
 ```
 
-The `redirect()` function, called on the response object which was destructured in the RequestHandler function arguments, takes a URL snf redirect status code.
+The `redirect()` function, called on the response object which was destructured in the RequestHandler function arguments, takes a URL and a redirect status code.
 
 ```tsx
 throw redirect('/login', 302);


### PR DESCRIPTION

# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

`redirect()` is on the `response` object, not the `RequestEvent` directly.  Also, the type definition file says (in a comment) that the default status code is 307, but here it says it's 302. When I try a redirect, I only see 200 status codes in the network tab (both when I set it to 301 and when I don't pass in a code, expecting the default), but maybe I'm doing it wrong. 

Also, the params of `redirect()` are reversed. 

Also, it would be nice if there was a brief note about why we are supposed to `throw` the response.redirect() return value, since it's not an `Error` object. I've never seen that pattern.

my `onGet`:
```
export const onGet: RequestHandler<BlogData> = async ({ params, response }) => {
  const res = await fetch("http://localhost:3000/blogs/" + params.id);
  if (!res.ok) {
    throw response.redirect("/", 301);
  }
  const data = await res.json();
  return data;
};
```

# Use cases and why

I am just starting to learn Qwik and this was the first docs page I needed help from. 
This is my first PR to a open source project :)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
