### PR TITLE
feat: add message about performance loss in development

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import type { Render, RenderToStreamOptions } from '@builder.io/qwik/server';
+import { bgMagenta, magenta } from 'kleur/colors';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 import type { Connect, ViteDevServer } from 'vite';
@@ -200,6 +201,9 @@ export async function configureDevServer(
     }
     return next(err);
   });
+
+  console.log(`\n❗️ ${bgMagenta('Expect significant performance loss in development.')}\n`);
+  console.log(`\n❗️ ${magenta("Disabling the browser's cache results in waterfall requests.")}'`);
 }
 
 export async function configurePreviewServer(


### PR DESCRIPTION
# Overview

The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

This PR closes #3301. A developer new to Qwik may not realize that a development build paired with a browser whose cache is disabled is expected to have significant performance loss.

# Use cases and why

- 1. Run `npm run dev`
- 2. See a warning about the performance loss in development.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality
