### PR TITLE
fix(qwik): update object based vite config properly

### DIFF
--- a/packages/qwik/src/cli/code-mod/code-mod.ts
+++ b/packages/qwik/src/cli/code-mod/code-mod.ts
@@ -386,7 +386,14 @@ function updatePluginsArray(
   if (updates.vitePlugins) {
     for (const vitePlugin of updates.vitePlugins) {
       const pluginExp = createPluginCall(ts, vitePlugin);
-      if (pluginExp) {
+      const pluginName = (pluginExp?.expression as Identifier | null)?.escapedText;
+      const alreadyDefined = elms.some(
+        (el) =>
+          ts.isCallExpression(el) &&
+          ts.isIdentifier(el.expression) &&
+          el.expression.escapedText === pluginName
+      );
+      if (pluginExp && !alreadyDefined) {
         elms.push(pluginExp);
       }
     }
@@ -406,7 +413,7 @@ function updatePluginsArray(
   return ts.factory.updateArrayLiteralExpression(arr, elms);
 }
 
-function createPluginCall(ts: TypeScript, vitePlugin: string) {
+function createPluginCall(ts: TypeScript, vitePlugin: string): CallExpression | null {
   if (typeof vitePlugin === 'string') {
     const tmp = ts.createSourceFile(
       'tmp.ts',
@@ -415,7 +422,7 @@ function createPluginCall(ts: TypeScript, vitePlugin: string) {
     );
     for (const s of tmp.statements) {
       if (ts.isExportAssignment(s)) {
-        return s.expression;
+        return s.expression as CallExpression;
       }
     }
   }

--- a/packages/qwik/src/cli/code-mod/code-mod.ts
+++ b/packages/qwik/src/cli/code-mod/code-mod.ts
@@ -311,6 +311,11 @@ function updateDefineConfig(ts: TypeScript, callExp: CallExpression, updates: Vi
         );
         continue;
       }
+
+      if (ts.isObjectLiteralExpression(exp)) {
+        args.push(updateVitConfigObj(ts, exp, updates));
+        continue;
+      }
     }
 
     args.push(exp);

--- a/packages/qwik/src/cli/code-mod/code-mod.unit.ts
+++ b/packages/qwik/src/cli/code-mod/code-mod.unit.ts
@@ -54,6 +54,20 @@ test('add qwik vite plugin config', () => {
   match(outputText, 'qwikVite({ ssr: { outDir: "netlify/edge-functions/entry.netlify" } })');
 });
 
+test('add qwik vite plugin config for object based vite config', () => {
+  const sourceText = `
+    export default defineConfig({
+      plugins: [
+        qwikVite(),
+      ],
+    });
+  `;
+  const outputText = updateViteConfig(ts, sourceText, {
+    qwikViteConfig: { ssr: `{ outDir: 'netlify/edge-functions/entry.netlify' }` },
+  })!;
+  match(outputText, 'qwikVite({ ssr: { outDir: "netlify/edge-functions/entry.netlify" } })');
+});
+
 test('add vite plugin', () => {
   const sourceText = `
     export default defineConfig(() => {
@@ -62,6 +76,20 @@ test('add vite plugin', () => {
           qwikVite(),
         ],
       };
+    });
+  `;
+  const outputText = updateViteConfig(ts, sourceText, {
+    vitePlugins: [`netlifyEdge({ functionName: 'entry.netlify' })`],
+  })!;
+  match(outputText, 'netlifyEdge({ functionName: "entry.netlify" })');
+});
+
+test('add vite plugin to object based config', () => {
+  const sourceText = `
+    export default defineConfig({
+      plugins: [
+        qwikVite(),
+      ],
     });
   `;
   const outputText = updateViteConfig(ts, sourceText, {
@@ -79,6 +107,21 @@ test('update vite config', () => {
           qwikVite(),
         ],
       };
+    });
+  `;
+  const outputText = updateViteConfig(ts, sourceText, {
+    viteConfig: { ssr: `{ target: 'webworker', noExternal: true }` },
+  })!;
+  match(outputText, 'ssr: { target: "webworker", noExternal: true');
+});
+
+test('update object based vite config', () => {
+  const sourceText = `
+    export default defineConfig({
+      ssr: {},
+      plugins: [
+        qwikVite(),
+      ],
     });
   `;
   const outputText = updateViteConfig(ts, sourceText, {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
1. Vite's `defineConfig` supports both function and object as a config, right now only functions are supported.
This means that configs defined like this will not be updated
```ts
export default defineConfig({
    plugins: [
      qwikVite(),
    ]
});
```

2. If plugin already exists with "plugins" array, it should not duplicate it
# Use cases and why
1. Users can update configs to the object-based one and qwik should still be able to update it.
2. Should not add duplicated values for the plugins

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
