### PR TITLE
docs: refine listener code problem explanation for clarity

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/advanced/qwikloader/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/qwikloader/index.mdx
@@ -64,4 +64,4 @@ Qwik serializes the event listeners into the DOM in the form of [QRLs](../qrl/in
 </div>
 ```
 
-The critical thing to notice is that Qwik generated an `on:click` attribute, containing the value `./chunk-a.js#Counter_button_onClick[0]`. In the above example the `on:click` attribute solves the listener location problem, and the attribute value solves the listener code location problem. By serializing the listeners into the HTML Qwik applications do not need to perform hydration on startup.
+The critical thing to notice is that Qwik generated an `on:click` attribute, containing the value `./chunk-a.js#Counter_button_onClick[0]`. In the above example the `on:click` attribute solves the listener location problem, and the attribute value solves the listener code problem. By serializing the listeners into the HTML Qwik applications do not need to perform hydration on startup.


### PR DESCRIPTION
# Overview

The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Two problems `listener location` and `listener code` are listed in [this documentation](https://qwik.builder.io/docs/advanced/qwikloader/#events-and-qwikloader):

<img width="1305" alt="截圖 2023-04-23 下午9 59 25" src="https://user-images.githubusercontent.com/16910748/233844105-c8d70108-b2dc-4a14-9ae3-23a92665ecfd.png">

So I think the additional "location" is a typo.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
