### PR TITLE
fix: display performance loss message after dev server is ready

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import type { Render, RenderToStreamOptions } from '@builder.io/qwik/server';
-import { bgMagenta, magenta } from 'kleur/colors';
+import { magenta } from 'kleur/colors';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 import type { Connect, ViteDevServer } from 'vite';
@@ -202,8 +202,10 @@ export async function configureDevServer(
     return next(err);
   });
 
-  console.log(`\n❗️ ${bgMagenta('Expect significant performance loss in development.')}\n`);
-  console.log(`\n❗️ ${magenta("Disabling the browser's cache results in waterfall requests.")}'`);
+  setTimeout(() => {
+    console.log(`\n  ❗️ ${magenta('Expect significant performance loss in development.')}`);
+    console.log(`  ❗️ ${magenta("Disabling the browser's cache results in waterfall requests.")}`);
+  }, 1000);
 }
 
 export async function configurePreviewServer(


### PR DESCRIPTION
# Overview

This PR closes #3903.

# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

The message about performance loss in development should appear after the dev server is ready. I previously had a PR merged which displayed such message, but it was pushed above and, therefore, not easily seen.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality
