### PR TITLE
starter: CLI allow current directory as app target

### DIFF
--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -12,7 +12,7 @@ import {
   isCancel,
   log,
 } from '@clack/prompts';
-import { bgBlue, red } from 'kleur/colors';
+import { bgBlue, red, white } from 'kleur/colors';
 import type { CreateAppOptions } from '../qwik/src/cli/types';
 import { backgroundInstallDeps } from '../qwik/src/cli/utils/install-deps';
 import { createApp, getOutDir, logCreateAppResult } from './create-app';
@@ -20,7 +20,7 @@ import { getPackageManager, note, runCommand, wait } from '../qwik/src/cli/utils
 import { loadIntegrations } from '../qwik/src/cli/utils/integrations';
 
 export async function runCreateInteractiveCli() {
-  intro(`Let's create a ${bgBlue(' Qwik App ')} ✨ (v${(globalThis as any).QWIK_VERSION})`);
+  intro(`Let's create a ${bgBlue(white(' Qwik App '))} ✨ (v${(globalThis as any).QWIK_VERSION})`);
 
   await wait(500);
 
@@ -29,12 +29,8 @@ export async function runCreateInteractiveCli() {
     (await text({
       message: 'Where would you like to create your new project?',
       placeholder: defaultProjectName,
-      validate(value) {
-        if (value.trim() === '.' || value.trim() === './') {
-          return "Please don't use '.' or './' and let qwik create the directory for you.";
-        }
-      },
-    })) || defaultProjectName;
+      initialValue: defaultProjectName,
+    })) || '';
 
   if (isCancel(projectNameAnswer)) {
     cancel('Operation cancelled.');
@@ -52,14 +48,16 @@ export async function runCreateInteractiveCli() {
 
   const outDir: string = getOutDir(projectNameAnswer.trim());
 
+  log.info(`Creating new project in ${bgBlue(white(' ' + outDir + ' '))} 🐇`);
+
   let removeExistingOutDirPromise: Promise<void> | null = null;
 
-  if (fs.existsSync(outDir)) {
+  if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
     const existingOutDirAnswer = await select({
       message: `Directory "./${relative(
         process.cwd(),
         outDir
-      )}" already exists. What would you like to do?`,
+      )}" already exists and is not empty. What would you like to do?`,
       options: [
         { value: 'exit', label: 'Do not overwrite this directory and exit' },
         { value: 'replace', label: 'Overwrite and replace this directory' },

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -12,7 +12,7 @@ import {
   isCancel,
   log,
 } from '@clack/prompts';
-import { bgBlue, red, white } from 'kleur/colors';
+import { bgBlue, red } from 'kleur/colors';
 import type { CreateAppOptions } from '../qwik/src/cli/types';
 import { backgroundInstallDeps } from '../qwik/src/cli/utils/install-deps';
 import { createApp, getOutDir, logCreateAppResult } from './create-app';
@@ -20,7 +20,7 @@ import { getPackageManager, note, runCommand, wait } from '../qwik/src/cli/utils
 import { loadIntegrations } from '../qwik/src/cli/utils/integrations';
 
 export async function runCreateInteractiveCli() {
-  intro(`Let's create a ${bgBlue(white(' Qwik App '))} ✨ (v${(globalThis as any).QWIK_VERSION})`);
+  intro(`Let's create a ${bgBlue(' Qwik App ')} ✨ (v${(globalThis as any).QWIK_VERSION})`);
 
   await wait(500);
 
@@ -48,7 +48,7 @@ export async function runCreateInteractiveCli() {
 
   const outDir: string = getOutDir(projectNameAnswer.trim());
 
-  log.info(`Creating new project in ${bgBlue(white(' ' + outDir + ' '))} 🐇`);
+  log.info(`Creating new project in ${bgBlue(' ' + outDir + ' ')} 🐇`);
 
   let removeExistingOutDirPromise: Promise<void> | null = null;
 

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -48,7 +48,7 @@ export async function runCreateInteractiveCli() {
 
   const outDir: string = getOutDir(projectNameAnswer.trim());
 
-  log.info(`Creating new project in ${bgBlue(' ' + outDir + ' ')} 🐇`);
+  log.info(`Creating new project in ${bgBlue(' ' + outDir + ' ')} ... 🐇`);
 
   let removeExistingOutDirPromise: Promise<void> | null = null;
 


### PR DESCRIPTION
# Overview

# What is it?
- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

fixes #3901 
allow user to install qwik into the current directory.

## Install into not empty directory
![Bildschirmfoto_2023-04-24_um_22_27_42](https://user-images.githubusercontent.com/3241476/234109939-5b9bb2b7-3c4f-4406-9f43-d49e4b2fe1b6.png)
(missing space on `qwik app`s blue background is already fixed)

## Install into empty directory
![Bildschirmfoto_2023-04-24_um_22_28_17](https://user-images.githubusercontent.com/3241476/234109953-ae1ad536-ad92-47ff-bea6-c4ab8aaef247.png)

# Testing  Instructions
- run `pnpm cli`
- quit it right away (we just need the file statics in place)
- create a new directory
- cd into it
- run ` node ../packages/create-qwik/dist/create-qwik.cjs`
- add nothing, `.` or `./` when asked for the  app directory
- check the new output line where the app will be installed
- install and check the output
- redo all of them but also add at least one file into the new created directory to check the handling there

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
