### PR TITLE
fix(docs/code-sandbox): only scroll the pre to prevent title scroll

### DIFF
--- a/packages/docs/src/components/code-sandbox/index.tsx
+++ b/packages/docs/src/components/code-sandbox/index.tsx
@@ -32,7 +32,7 @@ export default component$<{
       <div
         class="overflow-auto slot-container mb-4"
         style={{
-          maxHeight: maxHeight ? maxHeight + 'px' : 'none',
+          '--pretty-code-fragment-max-height': maxHeight ? maxHeight + 'px' : 'none',
         }}
       >
         <Slot name={tabs ? String(activeTab.value) : ''} />

--- a/packages/docs/src/routes/docs/docs.css
+++ b/packages/docs/src/routes/docs/docs.css
@@ -188,6 +188,12 @@ h6 a:hover .icon {
   margin: 20px 0;
 }
 
+[data-rehype-pretty-code-fragment] pre {
+  overflow: auto;
+  border-radius: 8px;
+  max-height: var(--pretty-code-fragment-max-height);
+}
+
 [data-rehype-pretty-code-title] {
   padding: 5px 15px;
   background: #4199d3;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

When horizontally scrolling a code box in an mdx file the title bar doesn't stay in position.  As it bonus it also improves scrolling ui for code boxes with tabs.

Before - With Tabs

https://user-images.githubusercontent.com/5641964/234129904-d15d9de4-4877-4b8b-9bd5-01f90f976760.mov

After - With Tabs

https://user-images.githubusercontent.com/5641964/234129900-dd1fbb7f-67ee-426a-bfac-f074f9dce757.mov

Before - With Title

https://user-images.githubusercontent.com/5641964/234129908-52c27379-5927-4d46-86ad-67ca4fdabc3f.mov

After - With Title

https://user-images.githubusercontent.com/5641964/234129910-aa084784-9a3c-43db-adb0-0b8154426b58.mov

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
