### PR TITLE
fix(jsx types): make `QwikIntrinsicElements` extend `IntrinsicElements`, not `IntrinsicHtmlElements`

### DIFF
--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -516,15 +516,17 @@ export interface QwikFocusEvent<T = Element> extends SyntheticEvent<T, NativeFoc
     target: EventTarget & T;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IntrinsicHTMLElements" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "IntrinsicElements" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export interface QwikIntrinsicElements extends IntrinsicHTMLElements {
+export interface QwikIntrinsicElements extends IntrinsicElements {
     // Warning: (ae-forgotten-export) The symbol "QwikCustomHTMLAttributes" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "QwikCustomHTMLElement" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "QwikCustomSVGAttributes" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "QwikCustomSVGElement" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    [key: string]: QwikCustomHTMLAttributes<QwikCustomHTMLElement>;
+    [key: string]: QwikCustomHTMLAttributes<QwikCustomHTMLElement> | QwikCustomSVGAttributes<QwikCustomSVGElement>;
     // Warning: (ae-forgotten-export) The symbol "QwikScriptHTMLAttributes" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-elements.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-elements.ts
@@ -1,4 +1,9 @@
-import type { HTMLAttributes, IntrinsicHTMLElements, ScriptHTMLAttributes } from './jsx-generated';
+import type {
+  HTMLAttributes,
+  IntrinsicElements,
+  SVGAttributes,
+  ScriptHTMLAttributes,
+} from './jsx-generated';
 
 interface QwikScriptHTMLAttributes<T> extends ScriptHTMLAttributes<T> {
   events?: string[];
@@ -8,7 +13,12 @@ interface QwikCustomHTMLAttributes<T> extends HTMLAttributes<T> {
   [key: string]: any;
 }
 
+interface QwikCustomSVGAttributes<T> extends SVGAttributes<T> {
+  [key: string]: any;
+}
+
 interface QwikCustomHTMLElement extends HTMLElement {}
+interface QwikCustomSVGElement extends SVGElement {}
 
 /**
  * @public
@@ -20,7 +30,9 @@ export interface QwikIntrinsicAttributes {
 /**
  * @public
  */
-export interface QwikIntrinsicElements extends IntrinsicHTMLElements {
+export interface QwikIntrinsicElements extends IntrinsicElements {
   script: QwikScriptHTMLAttributes<HTMLScriptElement>;
-  [key: string]: QwikCustomHTMLAttributes<QwikCustomHTMLElement>;
+  [key: string]:
+    | QwikCustomHTMLAttributes<QwikCustomHTMLElement>
+    | QwikCustomSVGAttributes<QwikCustomSVGElement>;
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Previously, it was impossible to access JSX types for SVG elements because `QwikIntrinsicElements` extended `IntrinsicHTMLElements`, rather than `IntrinsicElements` (which itself extends both `IntrinsicHTMLElements` and `IntrinsicSVGElements`.

fix #3934

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Previously:

```tsx
// has type `QwikCustomHTMLAttributes<QwikCustomHTMLElement>`
type WeaklyTyped = QwikJSX.IntrinsicElements["svg"];
```

Now:
```tsx
// has type `SVGProps<SVGSVGElement>`
type StronglyTyped = QwikJSX.IntrinsicElements["svg"];
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
    -  There were a couple test failures after implementing this, since now all of a sudden props for SVG were being typechecked where they weren't before (they were falling through to `QwikCustomHTMLAttributes`) -- if you want me to add more tests, let me know :)