### PR TITLE
docs: fix edit this page

### DIFF
--- a/packages/docs/src/components/on-this-page/on-this-page.tsx
+++ b/packages/docs/src/components/on-this-page/on-this-page.tsx
@@ -24,7 +24,10 @@ const makeEditPageUrl = (url: string): string => {
     'routing',
     'speculative-module-fetching',
     'static-assets',
+    'sitemaps',
   ];
+
+  const nonGroupedDirectories = ['integrations', 'deployments'];
 
   const urlPathnames = url.split('/').filter((pathname) => pathname !== '');
 
@@ -34,6 +37,10 @@ const makeEditPageUrl = (url: string): string => {
   }
 
   const qwikDocsPathname = urlPathnames.at(1) as string;
+
+  if (nonGroupedDirectories.includes(qwikDocsPathname)) {
+    return urlPathnames.join('/');
+  }
 
   if (qwikDocsPathname.includes('advanced')) {
     // since we advanced named folder in (qwik) and (qwikcity) this will ensure both are not conflicting.

--- a/packages/docs/src/components/on-this-page/on-this-page.tsx
+++ b/packages/docs/src/components/on-this-page/on-this-page.tsx
@@ -27,7 +27,7 @@ const makeEditPageUrl = (url: string): string => {
     'sitemaps',
   ];
 
-  const nonGroupedDirectories = ['integrations', 'deployments'];
+  const whitelistedDirectories = ['integrations', 'deployments', 'community'];
 
   const urlPathnames = url.split('/').filter((pathname) => pathname !== '');
 
@@ -38,7 +38,10 @@ const makeEditPageUrl = (url: string): string => {
 
   const qwikDocsPathname = urlPathnames.at(1) as string;
 
-  if (nonGroupedDirectories.includes(qwikDocsPathname)) {
+  if (
+    whitelistedDirectories.includes(urlPathnames.at(0) as string) ||
+    whitelistedDirectories.includes(qwikDocsPathname)
+  ) {
     return urlPathnames.join('/');
   }
 


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

fixes #3939 
the `edit this page` was invalid for all pages under `integrations`, `deployments`, `community` and under `advanced` the `sitemap` link

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
