### PR TITLE
refactor: use `Readonly` utility type for `ReadonlySignal` type

### DIFF
--- a/packages/qwik/src/core/state/signal.ts
+++ b/packages/qwik/src/core/state/signal.ts
@@ -25,9 +25,7 @@ export interface Signal<T = any> {
 /**
  * @public
  */
-export interface ReadonlySignal<T = any> {
-  readonly value: T;
-}
+export type ReadonlySignal<T = any> = Readonly<Signal<T>>;
 
 /**
  * @public


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Use ts `Readonly` utility type for `ReadonlySignal` instead of manually declaring the interface with `readonly` keyword for property.

# Use cases and why

This will make the type definition simpler

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
