### PR TITLE
fix(cloudflare-pages adapter): fix wrong request type and move waitUntil to ctx object

### DIFF
--- a/packages/qwik-city/middleware/cloudflare-pages/api.md
+++ b/packages/qwik-city/middleware/cloudflare-pages/api.md
@@ -7,7 +7,7 @@
 import type { ServerRenderOptions } from '@builder.io/qwik-city/middleware/request-handler';
 
 // @public (undocumented)
-export function createQwikCity(opts: QwikCityCloudflarePagesOptions): (ctx: EventPluginContext) => Promise<Response>;
+export function createQwikCity(opts: QwikCityCloudflarePagesOptions): (eventPluginContext: EventPluginContext) => Promise<Response>;
 
 // @public (undocumented)
 export interface EventPluginContext {
@@ -24,11 +24,13 @@ export interface EventPluginContext {
 // @public (undocumented)
 export interface PlatformCloudflarePages {
     // (undocumented)
+    ctx: {
+        waitUntil: EventPluginContext['waitUntil'];
+    };
+    // (undocumented)
     env: EventPluginContext['env'];
     // (undocumented)
-    request: EventPluginContext['env'];
-    // (undocumented)
-    waitUntil: EventPluginContext['waitUntil'];
+    request: EventPluginContext['request'];
 }
 
 // @public (undocumented)

--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -26,9 +26,9 @@ export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
   if (opts.manifest) {
     setServerPlatform(opts.manifest);
   }
-  async function onCloudflarePagesRequest(ctx: EventPluginContext) {
+  async function onCloudflarePagesRequest(eventPluginContext: EventPluginContext) {
     try {
-      const { request, env, waitUntil, next } = ctx;
+      const { request, env, waitUntil, next } = eventPluginContext;
       const url = new URL(request.url);
 
       if (isStaticPath(request.method, url)) {
@@ -70,7 +70,12 @@ export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
           resolve(response);
           return writable;
         },
-        platform: ctx,
+        platform: {
+          request,
+          env,
+          ctx: { waitUntil },
+          next,
+        },
       };
 
       // send request to qwik city request handler
@@ -131,8 +136,10 @@ export interface EventPluginContext {
  * @public
  */
 export interface PlatformCloudflarePages {
-  request: EventPluginContext['env'];
-  waitUntil: EventPluginContext['waitUntil'];
+  request: EventPluginContext['request'];
+  ctx: {
+    waitUntil: EventPluginContext['waitUntil'];
+  };
   env: EventPluginContext['env'];
 }
 


### PR DESCRIPTION
fix the wrong type assigned to the request field of PlatformCloudflarePages

also move waitUntil into a ctx object, this follows more closely the proper Cloudflare apis and will make it easier to move to the preferred pages advanced mode later

# Overview

The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
