### PR TITLE
chore: commented pr template intro

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 # Overview
+
 <!--
 The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 # Overview
-
+<!--
 The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:
 
 a) Fixes to the core, and
@@ -11,6 +11,8 @@ If your functionality can be delivered as a 3rd-Party Community Add-On, we encou
 If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.
 
 _— Build primitives is our mantra_
+
+-->
 
 # What is it?
 


### PR DESCRIPTION

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

The instructions text in the PR template should be wrapped in a comment as it is addressing the PR creator and not the PR readers

