### PR TITLE
docs: fix documentation about array push example

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
@@ -25,6 +25,7 @@ contributors:
   - wtlin1228
   - AnthonyPAlicea
   - sreeisalso
+  - mori5321
 ---
 
 import CodeSandbox from '../../../../../components/code-sandbox/index.tsx';
@@ -114,8 +115,7 @@ export default component$(() => {
       </button>
       <br />
       <button onClick$={() => {
-        // Because store is deep watched, this will trigger a re-render
-        store.list.push(`Item ${store.list.length}`);
+        store.list = [...store.list, `Item ${store.list.length}`]
       }}>
         Add to list
       </button>


### PR DESCRIPTION
# Overview
fix documentation about an example about Array.push reactivity.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

According to this document and my experiments, Qwik at this time does not provide reactivity for Array.push. Despite the fact, the document recommend to use Array.push for store. 

# Use cases and why

n/a

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
