### PR TITLE
fix: correct a type error occurring when the `requestEvent.fail()` is returned in the `actionQrl` or `loaderQrl`

### DIFF
--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -408,7 +408,7 @@ export interface ActionConstructor {
       options: ActionOptions
     ) => ValueOrPromise<O>,
     options?: ActionOptions
-  ): Action<StrictUnion<O>>;
+  ): Action<StrictUnion<O> extends { failed?: true } ? StrictUnion<O> : O>;
 
   // Without validation
   <O extends Record<string, any> | void | null, REST extends DataValidator[]>(
@@ -452,7 +452,7 @@ export interface ActionConstructorQRL {
       (form: JSONObject, event: RequestEventAction, options: ActionOptions) => ValueOrPromise<O>
     >,
     options?: ActionOptions
-  ): Action<StrictUnion<O>>;
+  ): Action<StrictUnion<O> extends { failed?: true } ? StrictUnion<O> : O>;
 
   // Without validation
   <O extends Record<string, any> | void | null, REST extends DataValidator[]>(
@@ -476,7 +476,7 @@ export interface LoaderConstructor {
   <O>(
     loaderFn: (event: RequestEventLoader) => ValueOrPromise<O>,
     options?: LoaderOptions
-  ): Loader<StrictUnion<O>>;
+  ): Loader<StrictUnion<O> extends { failed?: true } ? StrictUnion<O> : O>;
 
   // With validation
   <O extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
@@ -493,7 +493,7 @@ export interface LoaderConstructorQRL {
   <O>(
     loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<O>>,
     options?: LoaderOptions
-  ): Loader<StrictUnion<O>>;
+  ): Loader<StrictUnion<O> extends { failed?: true } ? StrictUnion<O> : O>;
 
   // With validation
   <O extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -321,9 +321,13 @@ type StrictUnionHelper<T, TAll> = T extends any
 
 type StrictUnion<T> = Prettify<StrictUnionHelper<T, T>>;
 
-type Prettify<T> = {} & {
-  [K in keyof T]?: T[K];
-};
+type Prettify<T> = T extends { failed: true }
+  ? {} & {
+      [K in keyof T]?: T[K];
+    }
+  : {} & {
+      [K in keyof T]: T[K];
+    };
 
 /**
  * @public
@@ -401,6 +405,22 @@ export interface ActionConstructor {
   >;
 
   // Without validation
+  <O extends Function>(
+    actionQrl: (
+      form: JSONObject,
+      event: RequestEventAction,
+      options: ActionOptions
+    ) => ValueOrPromise<O>,
+    options?: ActionOptions
+  ): Action<
+    O extends () => Promise<infer R>
+      ? StrictUnion<R>
+      : O extends () => infer S
+      ? StrictUnion<S>
+      : never
+  >;
+
+  // Without validation
   <O>(
     actionQrl: (
       form: JSONObject,
@@ -408,7 +428,7 @@ export interface ActionConstructor {
       options: ActionOptions
     ) => ValueOrPromise<O>,
     options?: ActionOptions
-  ): Action<StrictUnion<O> extends { failed?: true } ? StrictUnion<O> : O>;
+  ): Action<StrictUnion<O>>;
 
   // Without validation
   <O extends Record<string, any> | void | null, REST extends DataValidator[]>(
@@ -447,12 +467,26 @@ export interface ActionConstructorQRL {
   >;
 
   // Without validation
+  <O extends Function>(
+    actionQrl: QRL<
+      (form: JSONObject, event: RequestEventAction, options: ActionOptions) => ValueOrPromise<O>
+    >,
+    options?: ActionOptions
+  ): Action<
+    O extends () => Promise<infer R>
+      ? StrictUnion<R>
+      : O extends () => infer S
+      ? StrictUnion<S>
+      : never
+  >;
+
+  // Without validation
   <O>(
     actionQrl: QRL<
       (form: JSONObject, event: RequestEventAction, options: ActionOptions) => ValueOrPromise<O>
     >,
     options?: ActionOptions
-  ): Action<StrictUnion<O> extends { failed?: true } ? StrictUnion<O> : O>;
+  ): Action<StrictUnion<O>>;
 
   // Without validation
   <O extends Record<string, any> | void | null, REST extends DataValidator[]>(
@@ -473,10 +507,21 @@ export interface LoaderOptions {
  */
 export interface LoaderConstructor {
   // Without validation
-  <O>(
+  <O extends Function>(
     loaderFn: (event: RequestEventLoader) => ValueOrPromise<O>,
     options?: LoaderOptions
-  ): Loader<StrictUnion<O> extends { failed?: true } ? StrictUnion<O> : O>;
+  ): Loader<
+    O extends () => Promise<infer R>
+      ? StrictUnion<R>
+      : O extends () => infer S
+      ? StrictUnion<S>
+      : never
+  >;
+
+  // Without validation
+  <O>(loaderFn: (event: RequestEventLoader) => ValueOrPromise<O>, options?: LoaderOptions): Loader<
+    StrictUnion<O>
+  >;
 
   // With validation
   <O extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
@@ -490,10 +535,22 @@ export interface LoaderConstructor {
  */
 export interface LoaderConstructorQRL {
   // Without validation
+  <O extends Function>(
+    loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<O>>,
+    options?: LoaderOptions
+  ): Loader<
+    O extends () => Promise<infer R>
+      ? StrictUnion<R>
+      : O extends () => infer S
+      ? StrictUnion<S>
+      : never
+  >;
+
+  // Without validation
   <O>(
     loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<O>>,
     options?: LoaderOptions
-  ): Loader<StrictUnion<O> extends { failed?: true } ? StrictUnion<O> : O>;
+  ): Loader<StrictUnion<O>>;
 
   // With validation
   <O extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -408,7 +408,7 @@ export interface ActionConstructor {
       options: ActionOptions
     ) => ValueOrPromise<O>,
     options?: ActionOptions
-  ): Action<O>;
+  ): Action<StrictUnion<O>>;
 
   // Without validation
   <O extends Record<string, any> | void | null, REST extends DataValidator[]>(
@@ -452,7 +452,7 @@ export interface ActionConstructorQRL {
       (form: JSONObject, event: RequestEventAction, options: ActionOptions) => ValueOrPromise<O>
     >,
     options?: ActionOptions
-  ): Action<O>;
+  ): Action<StrictUnion<O>>;
 
   // Without validation
   <O extends Record<string, any> | void | null, REST extends DataValidator[]>(
@@ -476,7 +476,7 @@ export interface LoaderConstructor {
   <O>(
     loaderFn: (event: RequestEventLoader) => ValueOrPromise<O>,
     options?: LoaderOptions
-  ): Loader<O>;
+  ): Loader<StrictUnion<O>>;
 
   // With validation
   <O extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
@@ -493,7 +493,7 @@ export interface LoaderConstructorQRL {
   <O>(
     loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<O>>,
     options?: LoaderOptions
-  ): Loader<O>;
+  ): Loader<StrictUnion<O>>;
 
   // With validation
   <O extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

`routeAction$`, `globalAction$` and `routeLoader$` have incorrect type when the `requestEvent.fail(...)` is returned in the `actionQrl` or `loaderQrl`. 

ex:

```ts
export const useRouteActionWithFail = routeAction$((data, requestEvent) => {
  if (Math.random() > 1) {
    return requestEvent.fail(500, {
      sad: 'sad',
      errorMessage: 'why',
    });
  } 

  return {
    happy: 'happy',
    day: 'day',
  };
});
```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

## Actual

![截圖 2023-04-30 上午3 29 09](https://user-images.githubusercontent.com/16910748/235320885-24901cc1-80d2-4d06-ab42-8e11f12f7871.png)


## Expected behavior

The type errors should not appear.

To facilitate the reproduction of this bug, here is my testing code.

```tsx
export const useRouteAction = routeAction$((data, requestEvent) => {
  return {
    happy: 'happy',
    day: 'day',
  };
});

export const useRouteActionWithFail = routeAction$((data, requestEvent) => {
  if (Math.random() > 1) {
    return requestEvent.fail(500, {
      sad: 'sad',
      errorMessage: 'why',
    });
  }

  return {
    happy: 'happy',
    day: 'day',
  };
});

export const useRouteActionWithFailWithValidation = routeAction$((data, requestEvent) => {
  if (Math.random() > 1) {
    return requestEvent.fail(500, {
      sad: 'sad',
      errorMessage: 'why',
    });
  }

  return {
    happy: 'happy',
    day: 'day',
  };
}, zod$({}));

export const useRouteLoader = routeLoader$((requestEvent) => {
  return {
    happy: 'happy',
    day: 'day',
  };
});

export const useRouteLoaderWithFail = routeLoader$((requestEvent) => {
  if (Math.random() > 1) {
    return requestEvent.fail(500, {
      sad: 'sad',
      errorMessage: 'why',
    });
  }

  return {
    happy: 'happy',
    day: 'day',
  };
});

export const useRouteLoaderWithFailWithValidation = routeLoader$((requestEvent) => {
  if (Math.random() > 1) {
    return requestEvent.fail(500, {
      sad: 'sad',
      errorMessage: 'why',
    });
  }

  return {
    happy: 'happy',
    day: 'day',
  };
}, zod$({}));

export default component$(() => {
  const routeAction = useRouteAction();
  routeAction.value?.happy;
  routeAction.value?.day;

  const routeActionWithFail = useRouteActionWithFail();
  routeActionWithFail.value?.happy; // ❌ Property 'happy' does not exist on type 'FailReturn<...>'
  routeActionWithFail.value?.day; // ❌ Property 'day' does not exist on type 'FailReturn<...>'
  routeActionWithFail.value?.sad; // ❌ Property 'sad' does not exist on type 'FailReturn<...>'
  routeActionWithFail.value?.errorMessage; // ❌ Property 'errorMessage' does not exist on type 

  const routeActionWithFailWithValidation = useRouteActionWithFailWithValidation();
  routeActionWithFailWithValidation.value?.happy; 
  routeActionWithFailWithValidation.value?.day;
  routeActionWithFailWithValidation.value?.sad;
  routeActionWithFailWithValidation.value?.errorMessage;'FailReturn<...>'

  const routeLoader = useRouteLoader();
  routeLoader.value.happy;
  routeLoader.value.day;

  const routeLoaderWithFail = useRouteLoaderWithFail();
  routeLoaderWithFail.value.happy; // ❌ Property 'happy' does not exist on type 'FailReturn<...>'
  routeLoaderWithFail.value.day; // ❌ Property 'day' does not exist on type 'FailReturn<...>'
  routeLoaderWithFail.value.sad; // ❌ Property 'sad' does not exist on type 'FailReturn<...>'
  routeLoaderWithFail.value.errorMessage;  // ❌ Property 'errorMessage' does not exist on type 'FailReturn<...>'

  const routeLoaderWithFailValidation = useRouteLoaderWithFailWithValidation();
  routeLoaderWithFailValidation.value.happy;
  routeLoaderWithFailValidation.value.day;
  routeLoaderWithFailValidation.value.sad;
  routeLoaderWithFailValidation.value.errorMessage;

  return <></>;
});

```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
