### PR TITLE
Tutorial wording fix

### DIFF
--- a/packages/docs/src/routes/tutorial/composing/dollar/index.mdx
+++ b/packages/docs/src/routes/tutorial/composing/dollar/index.mdx
@@ -5,7 +5,7 @@ contributors:
   - adamdbradley
 ---
 
-The powerful, part of Optimizer is that you can create your own APIs with `$` suffix.
+A powerful feature of the Optimizer is that you can create your own APIs with a `$` suffix.
 
 Imagine that we would like to have a delay method that lazy loads its callback. Normally we would have to write something like this:
 
@@ -54,10 +54,8 @@ export const delay$ = implicit$FirstArg(delayQrl);
 Here are the types to make it clearer as to what is going on.
 
 ```tsx
-declare;
-delayQrl: (fn: QRL<() => T>, delayInMs: number) => Promise<T>;
-declare;
-delay$: (fn: () => T, delayInMs: number) => Promise<T>;
+declare function delayQrl<T>(fn: QRL<() => T>, delayInMs: number): Promise<T>;
+declare function delay$<T>(fn: () => T, delayInMs: number): Promise<T>;
 ```
 
 The above allows us to use `delay$` in an inlined fashion, but the Optimizer converts the `delay$` to `delayQrl` form.

--- a/packages/docs/src/routes/tutorial/context/basic/index.mdx
+++ b/packages/docs/src/routes/tutorial/context/basic/index.mdx
@@ -7,12 +7,12 @@ contributors:
   - shairez
 ---
 
-Use context to pass data to child components without explicitly passing it through components (known as prop drilling). Context is useful to share data that is needed throughout the application components. For example styling information, application state, or currently logged-in user.
+Use context to pass data to child components without explicitly passing it through components (known as prop drilling). Context is useful to share data that is needed in components throughout the application, such as styling information, application state, or the currently logged-in user.
 
-To use context you need three parts:
+The code to use a context is divided into three parts:
 
-- `createContextId()`: this creates a serializable ID for the context. Make sure that this id is unique within your application.
-- `useContextProvider()`: At a parent component call this method to publish the context value. All children (and grandchildren) that are descendants of this component will be able to retrieve the context.
+- `createContextId()`: this creates a serializable ID for the context. Make sure that this ID is unique within your application.
+- `useContextProvider()`: In a parent component, call this method to publish the context value. All children (and grandchildren) that are descendants of this component will be able to retrieve the context.
 - [`useContext()`](/docs/(qwik)/components/context/index.mdx#usecontext) to retrieve the context and use it in any component.
 
 In this example, we would like to pass the `TodosStore` to the `<Items>` component. Update the code to use [`useContext()`](/docs/(qwik)/components/context/index.mdx#usecontext) to retrieve the value.

--- a/packages/docs/src/routes/tutorial/context/basic/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/context/basic/problem/app.tsx
@@ -3,10 +3,10 @@ import { component$, createContextId, useContextProvider, useStore } from '@buil
 interface TodosStore {
   items: string[];
 }
-export const TodosContext = createContextId<TodosStore>('Todos');
+export const todosContext = createContextId<TodosStore>('Todos');
 export default component$(() => {
   useContextProvider(
-    TodosContext,
+    todosContext,
     useStore<TodosStore>({
       items: ['Learn Qwik', 'Build Qwik app', 'Profit'],
     })

--- a/packages/docs/src/routes/tutorial/context/basic/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/context/basic/solution/app.tsx
@@ -9,10 +9,10 @@ import {
 interface TodosStore {
   items: string[];
 }
-export const TodosContext = createContextId<TodosStore>('Todos');
+export const todosContext = createContextId<TodosStore>('Todos');
 export default component$(() => {
   useContextProvider(
-    TodosContext,
+    todosContext,
     useStore<TodosStore>({
       items: ['Learn Qwik', 'Build Qwik app', 'Profit'],
     })
@@ -22,7 +22,7 @@ export default component$(() => {
 });
 
 export const Items = component$(() => {
-  const todos = useContext(TodosContext);
+  const todos = useContext(todosContext);
   return (
     <ul>
       {todos.items.map((item) => (

--- a/packages/docs/src/routes/tutorial/events/preventdefault/index.mdx
+++ b/packages/docs/src/routes/tutorial/events/preventdefault/index.mdx
@@ -7,7 +7,7 @@ contributors:
 
 For some events browsers have default behavior. For example, when you click a link, the browser will usually navigate to the link's `href`. There are times when we would like to prevent that. For this reason `Event` API contains `preventDefault()` method.
 
-Browser events are synchronous, but because Qwik is fine-grained loadable Qwik execution model is asynchronous. This means that at the time when the event is triggered, the event handler is not yet loaded. By the time the event is loaded the event has already been processed by the browser and calling `preventDefault()` will have no effect.
+Browser events are synchronous, but because Qwik is fine-grained the loadable Qwik execution model is asynchronous. This means that at the time the event is triggered, the event handler is not yet loaded. By the time the event is loaded the event has already been processed by the browser and calling `preventDefault()` will have no effect.
 
 To solve this Qwik provides a declarative API to automatically call `preventDefault()` when the event is triggered. This is achieved by adding `preventdefault:<event-name>` attribute to the element. This allows the Qwikloader to synchronously call `preventDefault()` when the event is triggered.
 

--- a/packages/docs/src/routes/tutorial/hooks/use-on/index.mdx
+++ b/packages/docs/src/routes/tutorial/hooks/use-on/index.mdx
@@ -5,7 +5,7 @@ contributors:
   - adamdbradley
 ---
 
-Use `useOn()` / `useOnDocument()` / `useOnWindow()` to programmatically set up listeners for on host elements. This is useful when you are creating custom APIs and don't have access to place these events in the JSX or if the events are not known ahead of time, such as if they are created based on component props.
+Use `useOn()` / `useOnDocument()` / `useOnWindow()` to programmatically set up listeners on host elements. This is useful when you are creating custom APIs and don't have access to place these events in the JSX or if the events are not known ahead of time, such as if they are created based on component props.
 
 ### Example
 

--- a/packages/docs/src/routes/tutorial/introduction/resource/index.mdx
+++ b/packages/docs/src/routes/tutorial/introduction/resource/index.mdx
@@ -41,7 +41,7 @@ Use [`useResource$()`](/docs/(qwik)/components/state/index.mdx) to set up how th
   });
 ```
 
-The [`useResource$()`](/docs/(qwik)/components/state/index.mdx) function returns a `ResourceReturn` object, which is a Promise-like object that can be serialized by Qwik. The [`useResource$()`](/docs/(qwik)/components/state/index.mdx) function allows you to `track` store properties so that the [`useResource$()`](/docs/(qwik)/components/state/index.mdx) function can be reactive on store changes. The `cleanup` function allows you to register a code that needs to be run to release resources from the previous run. Finally, the [`useResource$()`](/docs/(qwik)/components/state/index.mdx) function returns a promise that will resolve to the value.
+The [`useResource$()`](/docs/(qwik)/components/state/index.mdx) function returns a `ResourceReturn` object, which is a Promise-like object that can be serialized by Qwik. The [`useResource$()`](/docs/(qwik)/components/state/index.mdx) function allows you to `track` store properties so that the [`useResource$()`](/docs/(qwik)/components/state/index.mdx) function can be reactive on store changes. The `cleanup` function allows you to register code that needs to be run to release resources from the previous run. Finally, the [`useResource$()`](/docs/(qwik)/components/state/index.mdx) function returns a promise that will resolve to the value.
 
 ## Rendering data
 

--- a/packages/docs/src/routes/tutorial/props/closures/index.mdx
+++ b/packages/docs/src/routes/tutorial/props/closures/index.mdx
@@ -16,12 +16,12 @@ Props must be serializable so that Qwik can resume and render each component ind
 
 Functions passing across serializable boundaries must be done through QRLs. QRLs are serialized forms of a function. (See [QRL](/docs/(qwik)/advanced/qrl/index.mdx) in the advanced section.)
 
-Qwik has convenience APIs that end in `$` these are equivalent to calling `$()` directly. These two lines are equivalent:
+Qwik has convenience APIs that end in `$` - these are equivalent to calling `$()` directly. These two lines are equivalent:
 
 - inline: `useTask$(() => {...}/>`
 - explicit: `const callbackQrl = $(() => {...}); useTaskQrl(callbackQrl)`
 
-Most of the time we use the first form as it allows us to inline our callbacks directly into the API. But at times it is necessary to use the second form so that we can separate where the function is declared and where it is used.
+Most of the time we use the first form as it allows us to inline our callbacks directly into the API. But at times it is necessary to use the second form so that we can separate where the function is declared from where it is used.
 
 ## Declaring callback props
 

--- a/packages/docs/src/routes/tutorial/props/store/index.mdx
+++ b/packages/docs/src/routes/tutorial/props/store/index.mdx
@@ -13,9 +13,7 @@ A better approach is to only re-render `<Display>` component by passing in the `
 
 > **Your task**: Change the code to pass in `store` rather than `store.count`.
 
-Two benefits emerge by making the above change:
-
-- The `<App>` component doesn't need to be downloaded or re-rendered.
+By making the above change, the `<App>` component doesn't need to be downloaded or re-rendered.
 
 ## Best Practice
 

--- a/packages/docs/src/routes/tutorial/reactivity/explicit/index.mdx
+++ b/packages/docs/src/routes/tutorial/reactivity/explicit/index.mdx
@@ -11,7 +11,7 @@ In addition to implicit reactivity created by the templates, Qwik supports expli
 
 In this example clicking on `+1` updates `count` immediately. What we would like is to update the `delay count` after a 2-second delay. If `count` is updated before the 2 seconds are up then the timer is restarted.
 
-Notice that [`useTask$()`](/docs/(qwik)/components/tasks/index.mdx#usetask) callback receives `track` function. Use the `track` function to tell Qwik which properties should trigger this watch. The `track` function creates subscriptions in store. On each invocation of [`useTask$()`](/docs/(qwik)/components/tasks/index.mdx#usetask) the subscriptions are cleared, so it is important to always set up a new set of subscriptions. This is useful if the set of subscriptions changes during the function lifetime.
+Notice that the [`useTask$()`](/docs/(qwik)/components/tasks/index.mdx#usetask) callback receives a `track` function. Use the `track` function to tell Qwik which properties should trigger the task's watcher. The `track` function creates subscriptions in the store. On each invocation of [`useTask$()`](/docs/(qwik)/components/tasks/index.mdx#usetask) the subscriptions are cleared, so it is important to always set up a new set of subscriptions. This is useful if the set of subscriptions changes during the function's lifetime.
 
 The [`useTask$()`](/docs/(qwik)/components/tasks/index.mdx#usetask) callback function can return a cleanup function. The clean-up function is invoked on the next [`useTask$()`](/docs/(qwik)/components/tasks/index.mdx#usetask) callback execution or when the component is removed. In our case, the cleanup function is used for returning code which clears the `setTimeout`.
 

--- a/packages/docs/src/routes/tutorial/style/styles/index.mdx
+++ b/packages/docs/src/routes/tutorial/style/styles/index.mdx
@@ -31,9 +31,9 @@ The problem with this approach is that we will load styles twice.
 What is needed is to load the styles independently from the component. This is what [`useStyles$()`](/docs/(qwik)/components/styles/index.mdx#usestyles) is for. There are two scenarios:
 
 1. The component is rendered on the server and the styles are inserted into `<head>` as part of the SSR.
-   - Adding a new instance of a component to the application does not require that we load the styles as they are already included as part of SSR.
+   > Adding a new instance of a component to the application does not require that we load the styles as they are already included as part of SSR.
 2. The component is rendered on the client for the first time. In that case, the new component does not have styles in the `<head>` as the component was not part of SSR.
-   - Adding a new component that was not part of SSR requires that styles are loaded and inserted into `<head>`.
+   > Adding a new component that was not part of SSR requires that styles are loaded and inserted into `<head>`.
 
 ### Example
 

--- a/packages/docs/src/routes/tutorial/understanding/capturing/index.mdx
+++ b/packages/docs/src/routes/tutorial/understanding/capturing/index.mdx
@@ -5,7 +5,7 @@ contributors:
   - manucorporat
 ---
 
-In this example, we will explore how Qwik serializes the component state. A naive approach would be for Qwik to simply save all of the state associated with the `useStore()`. Qwik is more intelligent about the approach and tries to tree shake the stores that are not needed by the client.
+In this example, we will explore how Qwik serializes component state. A naive approach would be for Qwik to simply save all of the state associated with the `useStore()`. Qwik is more intelligent about the approach and tries to tree shake the stores that are not needed by the client.
 
 The example consists of:
 

--- a/packages/docs/src/routes/tutorial/understanding/capturing/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/understanding/capturing/problem/app.tsx
@@ -9,7 +9,7 @@ export default component$(() => {
   const store = useStore<AppStore>(
     {
       counter: { count: 1 },
-      largeData: { data: 'PRETEND THIS IS LARGE DATASET' },
+      largeData: { data: 'PRETEND THIS IS A LARGE DATASET' },
     },
     { deep: true }
   );

--- a/packages/docs/src/routes/tutorial/understanding/capturing/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/understanding/capturing/solution/app.tsx
@@ -9,7 +9,7 @@ export default component$(() => {
   const store = useStore<AppStore>(
     {
       counter: { count: 1 },
-      largeData: { data: 'PRETEND THIS IS LARGE DATASET' },
+      largeData: { data: 'PRETEND THIS IS A LARGE DATASET' },
     },
     { deep: true }
   );

--- a/packages/docs/src/routes/tutorial/understanding/treeshaking/index.mdx
+++ b/packages/docs/src/routes/tutorial/understanding/treeshaking/index.mdx
@@ -5,11 +5,11 @@ contributors:
   - adamdbradley
 ---
 
-A key concept of Qwik is that Qwik only loads code for components in the client that need to be re-rendered. If a component is static (does not need to be re-rendered), Qwik will not load the component. This is a form of dynamic tree-shaking. Here word dynamic is used to differentiate it from the classical static tree-shaking.
+A key concept of Qwik is that Qwik only loads code for components in the client that need to be re-rendered. If a component is static (does not need to be re-rendered), Qwik will not load the component. This is a form of dynamic tree-shaking. Here the word dynamic is used to differentiate it from the classical static tree-shaking.
 
 ## Static vs. Dynamic Tree-shaking
 
-Static tree-shaking is how the bundler removes unreachable code. In the case of an application, all components are reachable. This is because the component is reachable on the initial render in SSR. Otherwise, the component would not be visible to the client. So static tree-shaker can't remove any components from our initial application render tree.
+Static tree-shaking is how the bundler removes unreachable code. In the case of an application, all components are reachable. This is because the component is reachable on the initial render in SSR. Otherwise, the component would not be visible to the client. So a static tree-shaker can't remove any components from our initial application render tree.
 
 Dynamic tree-shaking refers to the fact that after the initial render, the component is no longer reachable from operations the user can perform. The component is only reachable under initial SSR rendering but not from subsequent user interactions. This is why we use the term dynamic tree-shaking to differentiate it from the static tree-shaking that bundler will do.
 
@@ -17,13 +17,13 @@ Static tree-shaking has the disadvantage that it does not take the runtime conte
 
 ### Example
 
-Interact with the example by clicking on the `+1` button. Few things to notice:
+Interact with the example by clicking on the `+1` button. A few things to notice:
 
-- Server must execute all components. So from the server point of view, all of the components are needed.
+- The server must execute all components. So from the server point of view, all of the components are needed.
 - On the client hitting `+1` does not require loading the `<App>` because it does not need to re-render. Therefore `<App>` is never loaded on the client.
 
 Now edit `Child` and delete the binding to `{props.store.count}`. Notice that now the child is no longer rendered on the client, and its associated render code is never loaded.
 
-Qwik determines which components are need-based in the runtime context of the application. Databinding determines whether the component is considered static or dynamic and, therefore, whether the component will be tree-shaken.
+Qwik determines which components are needed based on the runtime context of the application. Databinding determines whether the component is considered static or dynamic and, therefore, whether the component will be tree-shaken.
 
-In practice, many components are static in the application, and they never need to be loaded into the client.
+In practice, many components are static in the application, and they never need to be loaded from the client.

--- a/packages/docs/src/routes/tutorial/understanding/treeshaking/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/understanding/treeshaking/problem/app.tsx
@@ -34,10 +34,10 @@ export const Child = component$((props: { store: CountStore }) => {
 });
 
 export const GrandChild = component$((props: { store: CountStore }) => {
-  console.log('Render: <GroundChild/>');
+  console.log('Render: <GrandChild/>');
   return (
     <>
-      <code>&lt;GrandChild&lt;</code>
+      <code>&lt;GrandChild&gt;</code>
       This component is also dynamic because it is bound to <code>props.store.count</code>
       {props.store.count}
     </>


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ X] Docs / tests / types / typos

# Description

Fixes to the **tutorial** of:
- English grammar and wording
- Code examples.

## Fixes to English Wording
The fixes to the English are minor -- mainly the insertion of articles ('a', 'the') into the wording.  They improve the legibility and credibility of the tutorial for native English speakers.

## Fixes to Code Examples
The fixes to code examples are:
- fixes to constant name casing
- correct use of TypeScript
- English grammar in strings.

# Use cases and why
The fixes are to the documentation and code examples only.

# Checklist:

- [X ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X ] I have performed a self-review of my own code
- [ X] I have made corresponding changes to the documentation
- [ N] Added new tests to cover the fix / functionality

(No tests are required as the only changes are to documentation.)
