### PR TITLE
docs: fix overflowing content on home page

### DIFF
--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -175,6 +175,7 @@ html {
     Segoe UI Symbol, 'Noto Color Emoji';
   background-color: var(--bg-color);
   color: var(--text-color);
+  overflow: auto;
 }
 
 a,


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

fix the overflowing content issue:

BEFORE:

https://user-images.githubusercontent.com/6682981/235467724-e4e04a60-4d77-4a69-9f5d-396438e408c0.mov

AFTER:

https://user-images.githubusercontent.com/6682981/235467815-20039ac4-c2f5-4f02-ac86-ba28e959ec44.mov

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
