### PR TITLE
fix(cookie.ts): fix cookies with equal signs

### DIFF
--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -57,11 +57,10 @@ const parseCookieString = (cookieString: string | undefined | null) => {
   if (typeof cookieString === 'string' && cookieString !== '') {
     const cookieSegments = cookieString.split(';');
     for (const cookieSegment of cookieSegments) {
-      const cookieSplit = cookieSegment.split('=');
-      if (cookieSplit.length > 1) {
-        cookie[decodeURIComponent(cookieSplit[0].trim())] = decodeURIComponent(
-          cookieSplit[1].trim()
-        );
+      const separatorIndex = cookieSegment.indexOf('=');
+      if (separatorIndex !== -1) {
+        cookie[decodeURIComponent(cookieSegment.slice(0, separatorIndex).trim())] =
+          decodeURIComponent(cookieSegment.slice(separatorIndex + 1).trim());
       }
     }
   }

--- a/packages/qwik-city/middleware/request-handler/cookie.unit.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.unit.ts
@@ -12,7 +12,7 @@ export interface TestData {
 
 test('parses cookie', () => {
   const cookieValues = {
-    a: 'hello',
+    a: 'hello=world',
     b: '25',
     c: '{"hello": "world"}',
   };
@@ -29,7 +29,7 @@ test('parses cookie', () => {
     equal(cookie.get(key)?.value, value);
   });
   equal(Object.keys(cookie.getAll()).length, 3);
-  equal(cookie.getAll().a.value, 'hello');
+  equal(cookie.getAll().a.value, 'hello=world');
   equal(cookie.getAll().b.number(), 25);
   equal(cookie.getAll().c.json(), { hello: 'world' });
 });


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Cookies with equal signs are be parsed incorrectly. Everything after and including the equal sign is dropped because of how `String.prototype.split` works. I have changed the parser to use `String.prototype.indexOf` and `String.prototype.slice` instead.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Base64 encoding often include equal signs for padding.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
