### PR TITLE
fix(website): adjust header color on light theme

### DIFF
--- a/packages/docs/src/components/header/header.css
+++ b/packages/docs/src/components/header/header.css
@@ -11,6 +11,25 @@
     background: var(--bg-header-color);
     backdrop-filter: blur(23px) saturate(4.5);
   }
+
+  /* TODO: remove this when styles are adjusted for sub sections */
+  .main .header-container {
+    background: #101010;
+    color: #e3e2e9;
+  }
+
+  .main .DocSearch.DocSearch-Button {
+    background: #101010;
+  }
+
+  .main .sun-and-moon:not(:hover) > :is(.moon, .sun, .sun-beams) {
+    fill: #e3e2e9 !important;
+    stroke: #e3e2e9 !important;
+  }
+  .main .sun-and-moon:is(:hover) > :is(.moon, .sun, .sun-beams) {
+    fill: #b9b8be !important;
+    stroke: #b9b8be !important;
+  }
 }
 
 .fixed-header .header-container {

--- a/packages/docs/src/routes/index.tsx
+++ b/packages/docs/src/routes/index.tsx
@@ -8,8 +8,9 @@ import { QWIK_MODEL, QWIK_PUBLIC_API_KEY } from '../constants';
 
 export default component$(() => {
   const showNewDesign = useLocation().url.searchParams.get('render') === 'v2';
+  const isHomePage = useLocation().url.pathname === '/';
   return (
-    <>
+    <div class={{ main: isHomePage }}>
       <Header />
       <main>
         {showNewDesign ? (
@@ -21,7 +22,7 @@ export default component$(() => {
       <div class="px-4">
         <Footer />
       </div>
-    </>
+    </div>
   );
 });
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Quick adjustment of header colors when light mode is active.

## Current
![Bildschirmfoto 2023-05-01 um 22 04 32](https://user-images.githubusercontent.com/3241476/235521962-53cd56ba-187b-4d62-8284-08ffd5675c7e.png)

## Adjusted
![Bildschirmfoto 2023-05-01 um 22 04 51](https://user-images.githubusercontent.com/3241476/235521933-109d250b-04aa-40cd-9fed-79f90c90791a.png)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
