### PR TITLE
Docs | onInput$ successfully updating signal value in code example

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/rendering/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/rendering/index.mdx
@@ -177,11 +177,11 @@ export default component$(() => {
     <form>
       <input type="text"
         value={firstName.value}
-        onInput$={(_, el) => firstName.value = firstName.value }
+        onInput$={(_, el) => firstName.value = el.value }
       />
       <input type="checkbox"
         checked={acceptConditions.value}
-        onChange$={(_, el) => acceptConditions.value = firstName.checked }
+        onChange$={(_, el) => acceptConditions.value = el.checked }
       />
       <div>First name: {firstName.value}</div>
     </form>


### PR DESCRIPTION
Helped someone out in the discord and noticed the example here wasn't updating the signal value. Instead of using our el argument the signal was equal to itself.

Here's a stackblitz example to show updating an example signal value using el instead. https://stackblitz.com/edit/qwik-starter-kyypes?file=src/routes/index.tsx

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
