### PR TITLE
docs: fix nx docs capitalization

### DIFF
--- a/packages/docs/src/routes/community/projects/index.mdx
+++ b/packages/docs/src/routes/community/projects/index.mdx
@@ -41,7 +41,7 @@ contributors:
 <div class="card-grid">
   <a class="card card-center" href="https://github.com/qwikifiers/qwik-nx">
     <p class="icon" align="center"><img src="https://raw.githubusercontent.com/qwikifiers/qwik-nx/main/assets/qwik-nx.png" width="256px"/></p>
-    <h3>Qwik NX - A plugin for nx (the monorepo management tool)</h3>
+    <h3>Qwik Nx - A plugin for nx (the monorepo management tool)</h3>
   </a>
   <a class="card card-center" href="https://github.com/wmertens/styled-vanilla-extract">
     <p class="icon">⚡️+💅</p>

--- a/packages/docs/src/routes/docs/integrations/nx/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/nx/index.mdx
@@ -1,13 +1,13 @@
 ---
-title: Qwik and NX
+title: Qwik and Nx
 keywords: 'monorepo, nx, enterprise'
 contributors:
   - shairez
 ---
 
-# NX and enterprise scale monorepos
+# Nx and enterprise scale monorepos
 
-[NX](https://nx.dev/) is a robust and extensible development platform designed to simplify the management 
+[Nx](https://nx.dev/) is a robust and extensible development platform designed to simplify the management 
 of large-scale monorepos containing multiple applications and libraries by offering powerful tools for code generation, 
 build orchestration, dependency management, and code sharing.
 
@@ -16,7 +16,7 @@ Qwik integrates with nx beautifully by using the [qwik-nx](https://github.com/qw
 
 ## Main features
 
-* Generate a new NX workspace using a "Qwik" preset
+* Generate a new Nx workspace using a "Qwik" preset
 * Generate Qwik applications and libraries.
 * Generate Qwik components and routes.
 * Generate Storybook, React Qwikify, Cloudflare configuration and much more

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -40,7 +40,7 @@
 - [Icons](integrations/icons/index.mdx)
 - [Internationalization](integrations/i18n/index.mdx)
 - [Modular Forms](integrations/modular-forms/index.mdx)
-- [NX Monorepos](integrations/nx/index.mdx)
+- [Nx Monorepos](integrations/nx/index.mdx)
 - [Partytown](integrations/partytown/index.mdx)
 - [Playwright](integrations/playwright/index.mdx)
 - [PostCSS](integrations/postcss/index.mdx)


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

The `Nx` in [Qwik and Nx](https://qwik.builder.io/docs/integrations/nx/) is incorrectly capitalized.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Proper capitalization is uppercase `N` followed by lowercase `x`

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
