### PR TITLE
fix(cli): app name is a placeholder again

### DIFF
--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -28,7 +28,7 @@ export async function runCreateInteractiveCli() {
   const projectNameAnswer =
     (await text({
       message: `Where would you like to create your new project? ${gray(
-        `(Use '.' or './' for current directory.)`
+        `(Use '.' or './' for current directory)`
       )}`,
       placeholder: defaultProjectName,
     })) || defaultProjectName;

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -12,7 +12,7 @@ import {
   isCancel,
   log,
 } from '@clack/prompts';
-import { bgBlue, red } from 'kleur/colors';
+import { bgBlue, red, gray } from 'kleur/colors';
 import type { CreateAppOptions } from '../qwik/src/cli/types';
 import { backgroundInstallDeps } from '../qwik/src/cli/utils/install-deps';
 import { createApp, getOutDir, logCreateAppResult } from './create-app';
@@ -27,10 +27,11 @@ export async function runCreateInteractiveCli() {
   const defaultProjectName = './qwik-app';
   const projectNameAnswer =
     (await text({
-      message: 'Where would you like to create your new project?',
+      message: `Where would you like to create your new project? ${gray(
+        `Use '.' or './' for current directory.)`
+      )}`,
       placeholder: defaultProjectName,
-      initialValue: defaultProjectName,
-    })) || '';
+    })) || defaultProjectName;
 
   if (isCancel(projectNameAnswer)) {
     cancel('Operation cancelled.');

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -28,7 +28,7 @@ export async function runCreateInteractiveCli() {
   const projectNameAnswer =
     (await text({
       message: `Where would you like to create your new project? ${gray(
-        `Use '.' or './' for current directory.)`
+        `(Use '.' or './' for current directory.)`
       )}`,
       placeholder: defaultProjectName,
     })) || defaultProjectName;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

fixes #4026

To cover all requirements, we've switched back to a placeholder value and added  a new hint how to install into the current directory.
![Bildschirmfoto_2023-05-03_um_07_13_41](https://user-images.githubusercontent.com/3241476/235836999-31b4df57-ef61-4faf-bf18-abd5235fe281.png)

# Testing  Instructions

- run `pnpm cli`
- quit it right away (we just need the file statics in place)
- create a new directory
- cd into it
- run ` node ../packages/create-qwik/dist/create-qwik.cjs`
- add `.` or `./` when asked for the  app directory
- check the new output line where the app will be installed
- install and check the output
- redo all of them but also add at least one file into the new created directory to check the handling there

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
