### PR TITLE
Fix link to zod validation docs

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -187,7 +187,7 @@ Code explanation:
 
 Things to note:
 
-- For validation, see [zod validation](/docs/action/#zod-validation).
+- For validation, see [zod validation](/docs/action/#validation-and-type-safety).
 - The `routeAction$` works even if JavaScript is disabled.
 - If JavaScript is enabled, the `Form` component will prevent the browser from posting the form and instead post the data using JavaScript and emulate the browser's native form behavior without a full refresh.
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

This PR fixes the link to the zod validation docs in the getting started page.



# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

