### PR TITLE
docs: typo fix (Manaul -> Manual)

### DIFF
--- a/packages/docs/src/routes/docs/integrations/authjs/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/authjs/index.mdx
@@ -25,7 +25,7 @@ This command will add new packages:
 
 and create a new file named `plugin@auth.ts` with an example configuration.
 
-### Manaul Action Required
+### Manual Action Required
 
 After installing the auth package using `npm run qwik add auth` the `@auth/core` package will need to be added to the dependency optimzation settings of the `vite.config.js` file:
 


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

This is a small typo fix in a header of the [documentation](https://qwik.builder.io/docs/integrations/authjs/).

# Use cases and why

Not necessary.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] **(not necessary)** Added new tests to cover the fix / functionality
