### PR TITLE
style(next-steps.tsx): correct grammar in copy text

### DIFF
--- a/starters/apps/basic/src/components/starter/next-steps/next-steps.tsx
+++ b/starters/apps/basic/src/components/starter/next-steps/next-steps.tsx
@@ -3,7 +3,7 @@ import styles from './next-steps.module.css';
 
 export const GETTING_STARTED_STEPS = [
   {
-    message: "Press and hold the <b>ALT</b> key to active 'Click-to-Source' mode",
+    message: "Press and hold the <b>ALT</b> key to activate 'Click-to-Source' mode",
   },
   {
     message: 'Select the title of this page while keeping the <b>ALT</b> key pressed',


### PR DESCRIPTION
Use the infinitive 'to activate' form of the verb.

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Copy text change to correct the grammar in a starter project.  I noticed this typo when checking out Qwik for the first time and felt that I could help others avoid that 'huh' moment and move right on to using Qwik.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Clearly communicate the intent of the message

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
