### PR TITLE
fix: service-worker.js should work with basePathname

### DIFF
--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -252,11 +252,13 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions): any {
           // ssr build
           const manifest = qwikPlugin!.api.getManifest();
           const clientOutDir = qwikPlugin!.api.getClientOutDir();
-
+          
           if (manifest && clientOutDir) {
+            const clientOutBaseDir = join(clientOutDir, api.getBasePathname().replace(/^\/|\/$/, ''));
+
             for (const swEntry of ctx.serviceWorkers) {
               try {
-                const swClientDistPath = join(clientOutDir, swEntry.chunkFileName);
+                const swClientDistPath = join(clientOutBaseDir, swEntry.chunkFileName);
                 const swCode = await fs.promises.readFile(swClientDistPath, 'utf-8');
                 try {
                   const swCodeUpdate = prependManifestToServiceWorker(ctx, manifest, swCode);


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

See this bug: https://github.com/BuilderIO/qwik/issues/4043

This PR fixes `service-worker.js` generation with non-root `basePathname` by adding the `basePathname` in the path when looking for the `service-worker.js` to `prependManifestToServiceWorker`.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

The expected behavior is the `service-worker.js` should intercept and cache the Qwik files properly.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
