### PR TITLE
docs: fix useStylesScoped$

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/styles/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/styles/index.mdx
@@ -141,13 +141,13 @@ export const Cmp = component$(() => {
 
 ## Scoped CSS
 
-To use scoped CSS, you can use the `useStyleScoped$()` hook exported from `@builder.io/qwik`.
+To use scoped CSS, you can use the `useStylesScoped$()` hook exported from `@builder.io/qwik`.
 
 ```tsx {4-8} title="src/components/MyComponent/MyComponent.tsx"
-import { component$, useStyleScoped$ } from '@builder.io/qwik';
+import { component$, useStylesScoped$ } from '@builder.io/qwik';
 
 export default component$(() => {
-  useStyleScoped$(`
+  useStylesScoped$(`
     .container {
       background-color: red;
     }
@@ -165,12 +165,12 @@ You can also import an external CSS file. For that you need to add the `?inline`
 ```
 
 ```tsx {3,6} title="src/components/MyComponent/MyComponent.tsx"
-import { component$, useStyleScoped$ } from '@builder.io/qwik';
+import { component$, useStylesScoped$ } from '@builder.io/qwik';
 
 import styles from './MyComponent.css?inline';
 
 export default component$(() => {
-  useStyleScoped$(styles);
+  useStylesScoped$(styles);
   return <div class="container">Hello world</div>;
 });
 ```


### PR DESCRIPTION
Fix wrong hook name, `useStyleScoped$` should be change to `useStylesScoped$`

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Fix wrong hook name, `useStyleScoped$` should be change to `useStylesScoped$`

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
