### PR TITLE
Improve type for `userEvent` of `createDOM`

### DIFF
--- a/packages/qwik/src/testing/api.md
+++ b/packages/qwik/src/testing/api.md
@@ -11,7 +11,7 @@ import { RenderResult } from '@builder.io/qwik';
 export const createDOM: () => Promise<{
     render: (jsxElement: JSXNode) => Promise<RenderResult>;
     screen: HTMLElement;
-    userEvent: (queryOrElement: string | Element | null, eventNameCamel: string, eventPayload?: any) => Promise<void>;
+    userEvent: (queryOrElement: string | Element | keyof HTMLElementTagNameMap | null, eventNameCamel: string | keyof WindowEventMap, eventPayload?: any) => Promise<void>;
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/qwik/src/testing/library.ts
+++ b/packages/qwik/src/testing/library.ts
@@ -38,8 +38,8 @@ export const createDOM = async function () {
     },
     screen: host,
     userEvent: async function (
-      queryOrElement: string | Element | null,
-      eventNameCamel: string,
+      queryOrElement: string | Element | keyof HTMLElementTagNameMap | null,
+      eventNameCamel: string | keyof WindowEventMap,
       eventPayload: any = {}
     ) {
       if (typeof queryOrElement === 'string') {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Currently, when using `userEvent`, it's not so convenient that devs don't know which native HTML element tags are available as well as available DOM events.

This PR will provide better typing that:
- `queryOrElement` can give suggestion about all available HTML tags
- `eventNameCamel` can give suggestion about all existing DOM events

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
