### PR TITLE
docs: add site reference with leaflet maps and consume osm data

### DIFF
--- a/packages/docs/scripts/pages.json
+++ b/packages/docs/scripts/pages.json
@@ -139,5 +139,9 @@
   {
     "href": "https://pay4me.app",
     "tags": "sass"
+  },
+  {
+    "href": "https://qwik-osm-poc.netlify.app/",
+    "tags": "site"
   }
 ]


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

I add the reference of a personal project with Qwik 1.0.0 in which I work with Leaflet Maps in the framework together with interesting functionalities like `useComputed$` and loading information from a NestJS API that consumes data from POIs from OpenStreetMap

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
