### PR TITLE
docs: update tutorial after useStore is deep recursive by default

### DIFF
--- a/packages/docs/src/routes/tutorial/store/recursive/index.mdx
+++ b/packages/docs/src/routes/tutorial/store/recursive/index.mdx
@@ -5,18 +5,15 @@ contributors:
   - manucorporat
   - mhevery
   - corscheid
+  - fkruczek
 ---
 
-This example features a store that contains other objects rather than just primitives. The `store.counter` property is an object literal.
+This example features a store that contains other objects rather than just primitives.
 
-The example doesn't work as is, because by default the `useStore` function only watches top-level properties.
+Because `useStore()` tracks deep reactivity by default, Arrays and Objects inside the store will also be reactive. 
 
-To make the example work, you need to do one of two things:
+For [`useStore()`](/docs/(qwik)/components/state/index.mdx#usestore) to track all nested properties, it needs to allocate a lot of [Proxy](docs/(qwik)/concepts/reactivity/index.mdx#proxy) objects. This can be a performance issue if you have a lot of nested properties. 
 
-1. Wrap `{count:0}` in another [`useStore()`](/docs/(qwik)/components/state/index.mdx#usestore) call (which is a bit cumbersome)
+In that case, you can pass the additional argument: `{deep: false}` to `useStore` to only track the top-level properties.
 
-1. Allow `useStore` to recursively apply reactivity to all properties by passing the additional argument: `{deep:true}`.
-
-> **Your task:** Update the sample with the [`useStore()`](/docs/(qwik)/components/state/index.mdx#usestore) function.
-
-Note that stores are not tied to any single component. In fact, you can pass stores from one component to another.
+> **Your task:** Add `{deep: false}` as a second argument to the [`useStore()`](/docs/(qwik)/components/state/index.mdx#usestore) function and modify event handlers to assign new values to the top-level properties of the store.

--- a/packages/docs/src/routes/tutorial/store/recursive/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/store/recursive/problem/app.tsx
@@ -17,5 +17,9 @@ interface DisplayProps {
   list: number[];
 }
 export const Display = component$((props: DisplayProps) => {
-  return <p>Count: {props.counter.count}, List length: {props.list.length}</p>
+  return (
+    <p>
+      Count: {props.counter.count}, List length: {props.list.length}
+    </p>
+  );
 });

--- a/packages/docs/src/routes/tutorial/store/recursive/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/store/recursive/problem/app.tsx
@@ -1,19 +1,21 @@
 import { component$, useStore } from '@builder.io/qwik';
 
 export default component$(() => {
-  const store = useStore({ counter: { count: 0 } });
+  const store = useStore({ counter: { count: 0 }, list: [0] });
 
   return (
     <>
-      <Display counter={store.counter} />
-      <button onClick$={() => store.counter.count++}>+1</button>
+      <Display counter={store.counter} list={store.list} />
+      <button onClick$={() => store.counter.count++}>+1 Count</button>
+      <button onClick$={() => store.list.push(0)}>+1 List element</button>
     </>
   );
 });
 
 interface DisplayProps {
   counter: { count: number };
+  list: number[];
 }
 export const Display = component$((props: DisplayProps) => {
-  return <p>Count: {props.counter.count}</p>;
+  return <p>Count: {props.counter.count}, List length: {props.list.length}</p>
 });

--- a/packages/docs/src/routes/tutorial/store/recursive/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/store/recursive/solution/app.tsx
@@ -6,8 +6,8 @@ export default component$(() => {
   return (
     <>
       <Display counter={store.counter} list={store.list} />
-      <button onClick$={() => store.counter = { count: ++store.counter.count }}>+1 Count</button>
-      <button onClick$={() => store.list = [...store.list, 0]}>+1 List element</button>
+      <button onClick$={() => (store.counter = { count: ++store.counter.count })}>+1 Count</button>
+      <button onClick$={() => (store.list = [...store.list, 0])}>+1 List element</button>
     </>
   );
 });
@@ -17,5 +17,9 @@ interface DisplayProps {
   list: number[];
 }
 export const Display = component$((props: DisplayProps) => {
-  return <p>Count: {props.counter.count}, List length: {props.list.length}</p>
+  return (
+    <p>
+      Count: {props.counter.count}, List length: {props.list.length}
+    </p>
+  );
 });

--- a/packages/docs/src/routes/tutorial/store/recursive/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/store/recursive/solution/app.tsx
@@ -1,19 +1,21 @@
 import { component$, useStore } from '@builder.io/qwik';
 
 export default component$(() => {
-  const store = useStore({ counter: { count: 0 } }, { deep: true });
+  const store = useStore({ counter: { count: 0 }, list: [0] }, { deep: false });
 
   return (
     <>
-      <Display counter={store.counter} />
-      <button onClick$={() => store.counter.count++}>+1</button>
+      <Display counter={store.counter} list={store.list} />
+      <button onClick$={() => store.counter = { count: ++store.counter.count }}>+1 Count</button>
+      <button onClick$={() => store.list = [...store.list, 0]}>+1 List element</button>
     </>
   );
 });
 
 interface DisplayProps {
   counter: { count: number };
+  list: number[];
 }
 export const Display = component$((props: DisplayProps) => {
-  return <p>Count: {props.counter.count}</p>;
+  return <p>Count: {props.counter.count}, List length: {props.list.length}</p>
 });


### PR DESCRIPTION
# Overview

Update the `Recursive Store` tutorial after setting useStore are deep recursive by default.

I think it's worth considering removing `{ deep: true }` in the rest of the tutorials and documentation, as it might be misleading.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Updated tutorial:
- present that useStore tracks deep reactivity by default
- teaches about {deep: false} argument to useStore

I've also removed this paragraph:
`Note that stores are not tied to any single component. In fact, you can pass stores from one component to another`. 
It is not related to this tutorial, and neither was it before.

# Use cases and why

The current tutorial considers that the useStore function only watches top-level properties by default. That is not true.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
