### PR TITLE
fix: allow `false` type in BaseClassList

### DIFF
--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -169,6 +169,7 @@ export type BaseClassList =
   | string
   | undefined
   | null
+  | false
   | Record<string, boolean | string | number | null | undefined>
   | BaseClassList[];
 export type ClassList = BaseClassList | BaseClassList[];


### PR DESCRIPTION
# Overview

this allows for doing things like this

```tsx
<div
  class={[
    !show.value && 'hidden',
    'text-white ...'
  ]}>
```

  I quite like this format compared to objects, and right now I instead have to do this due to `false` not being allowed

```tsx
<div 
  class={[
    !show.value ? 'hidden' : null,
    'text-white ...'
  ]}>
```

From what I can tell `serializeClass` already supports this, we just need the typings to reflect that

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
