### PR TITLE
fix: export ClassList for easier typing of components with a `class` prop

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -79,6 +79,20 @@
       "mdFile": "qwik.resourcectx.cache.md"
     },
     {
+      "name": "ClassList",
+      "id": "classlist",
+      "hierarchy": [
+        {
+          "name": "ClassList",
+          "id": "classlist"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type ClassList = BaseClassList | BaseClassList[];\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts",
+      "mdFile": "qwik.classlist.md"
+    },
+    {
       "name": "cleanup",
       "id": "renderresult-cleanup",
       "hierarchy": [

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -173,6 +173,14 @@ cache(policyOrMilliseconds: number | 'immutable'): void;
 
 void
 
+## ClassList
+
+```typescript
+export type ClassList = BaseClassList | BaseClassList[];
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
+
 ## cleanup
 
 ```typescript

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -65,6 +65,11 @@ export interface AriaAttributes {
 // @public (undocumented)
 export type AriaRole = 'alert' | 'alertdialog' | 'application' | 'article' | 'banner' | 'button' | 'cell' | 'checkbox' | 'columnheader' | 'combobox' | 'complementary' | 'contentinfo' | 'definition' | 'dialog' | 'directory' | 'document' | 'feed' | 'figure' | 'form' | 'grid' | 'gridcell' | 'group' | 'heading' | 'img' | 'link' | 'list' | 'listbox' | 'listitem' | 'log' | 'main' | 'marquee' | 'math' | 'menu' | 'menubar' | 'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'navigation' | 'none' | 'note' | 'option' | 'presentation' | 'progressbar' | 'radio' | 'radiogroup' | 'region' | 'row' | 'rowgroup' | 'rowheader' | 'scrollbar' | 'search' | 'searchbox' | 'separator' | 'slider' | 'spinbutton' | 'status' | 'switch' | 'tab' | 'table' | 'tablist' | 'tabpanel' | 'term' | 'textbox' | 'timer' | 'toolbar' | 'tooltip' | 'tree' | 'treegrid' | 'treeitem' | (string & {});
 
+// Warning: (ae-forgotten-export) The symbol "BaseClassList" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type ClassList = BaseClassList | BaseClassList[];
+
 // @public
 export const component$: <PROPS = unknown, ARG extends {} = PROPS extends {} ? PropFunctionProps<PROPS> : {}>(onMount: OnRenderFn<ARG>) => Component<PROPS extends {} ? PROPS : ARG>;
 

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -59,6 +59,7 @@ export type {
   JSXTagName,
   JSXChildren,
   ComponentBaseProps,
+  ClassList,
 } from './render/jsx/types/jsx-qwik-attributes';
 export type { FunctionComponent, JSXNode } from './render/jsx/types/jsx-node';
 export type { QwikDOMAttributes, QwikJSX } from './render/jsx/types/jsx-qwik';

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -171,7 +171,7 @@ export type BaseClassList =
   | null
   | Record<string, boolean | string | number | null | undefined>
   | BaseClassList[];
-  
+
 /**
  * @public
  */

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -171,6 +171,10 @@ export type BaseClassList =
   | null
   | Record<string, boolean | string | number | null | undefined>
   | BaseClassList[];
+  
+/**
+ * @public
+ */
 export type ClassList = BaseClassList | BaseClassList[];
 
 export interface QwikProps<T> extends PreventDefault<T> {


### PR DESCRIPTION
a common pattern in React is to take className as a prop, like

```tsx
function MyComponent(props: { className?: string }) {
  return <div className={`${props.className || ''} my-class`}>...</div>
}

<MyComponent className="some-class" />
```

But Qwik supports a more elegant API for classes, but it is a bit awkward to work with the types for as the actual type is not exported.

So today I do this:

```tsx
import type  { HTMLAttributes } from '@builder.io/qwik'

function MyComponent(props: { class?: HTMLAttributes<HTMLElement>["class"] }) {
  return <div class={[props.class, 'my-class']}>...</div>
}
```

but it would be much nicer to just do

```tsx
import type  { ClassList } from '@builder.io/qwik'

function MyComponent(props: { class?: ClassList }) {
  return <div class={[props.class, 'my-class']}>...</div>
}
```

This PR exports ClassList so we can do this

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
