### PR TITLE
fix(supabase-auth-helpers-qwik): use `requestEvent.request.headers` in `getRequestHeader()`

### DIFF
--- a/packages/supabase-auth-helpers-qwik/src/utils/createSupabaseClient.ts
+++ b/packages/supabase-auth-helpers-qwik/src/utils/createSupabaseClient.ts
@@ -140,7 +140,7 @@ export function createServerClient<
     supabaseUrl,
     supabaseKey,
     getRequestHeader: (key) => {
-      return requestEv.headers.get(key) ?? undefined;
+      return requestEv.request.headers.get(key) ?? undefined;
     },
     getCookie: (name) => {
       return requestEv.cookie.get(name)?.value;


### PR DESCRIPTION
# Overview
Previously used `requestEvent.headers` are actually response headers.
We should use `requestEvent.request.headers` instead.
<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Use cases and why

This fixes also this error when using `supabase.auth.getUser()`:
```
Error: The "host" request header is not available
    at isSecureEnvironment (D:\src\qwik-app\node_modules\@supabase\auth-helpers-shared\dist\index.js:216:11)
    at Object.removeItem (D:\src\qwik-app\node_modules\@supabase\auth-helpers-shared\dist\index.js:394:31)
    at D:\src\qwik-app\node_modules\@supabase\gotrue-js\dist\main\lib\helpers.js:145:19
    at Generator.next (<anonymous>)
    at D:\src\qwik-app\node_modules\@supabase\gotrue-js\dist\main\lib\helpers.js:31:71
    at new Promise (<anonymous>)
    at __awaiter (D:\src\qwik-app\node_modules\@supabase\gotrue-js\dist\main\lib\helpers.js:27:12)
    at removeItemAsync (D:\src\qwik-app\node_modules\@supabase\gotrue-js\dist\main\lib\helpers.js:144:43)
    at SupabaseAuthClient.<anonymous> (D:\src\qwik-app\node_modules\@supabase\gotrue-js\dist\main\GoTrueClient.js:1105:53)
    at Generator.next (<anonymous>)
```

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
