### PR TITLE
feat(qwik-city/404): add possible routes to dev server

### DIFF
--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -21,7 +21,6 @@ import {
 } from '../../middleware/request-handler/user-response';
 import { getQwikCityServerData } from '../../middleware/request-handler/response-page';
 import { updateBuildContext } from '../build';
-import { getErrorHtml } from '../../middleware/request-handler/error-handler';
 import { getExtension, normalizePath } from '../../utils/fs';
 import { getMenuLoader, getPathParams } from '../../runtime/src/routing';
 import { fromNodeHttp, getUrl } from '../../middleware/node/http';
@@ -249,7 +248,7 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
         //       there's two ways handling HMR for page endpoint with error
         // 1. Html response inject `import.meta.hot.accept('./pageEndpoint_FILE_URL', () => { location.reload })`
         // 2. watcher, diff previous & current file content, a bit expensive
-        const html = getErrorHtml(404, new Error('not found'));
+        const html = getUnmatchedRouteHtml(url, ctx);
         res.statusCode = 404;
         res.setHeader('Content-Type', 'text/html; charset=utf-8');
         res.end(html);
@@ -261,6 +260,37 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
       next(e);
     }
   };
+}
+
+export function getUnmatchedRouteHtml(url: URL, ctx: BuildContext): string {
+  const blue = '#006ce9';
+  return `
+  <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="Status" content="404">
+      <title>404 Not Found</title>
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+      <style>
+        body { color: ${blue}; background-color: #fafafa; padding: 30px; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Roboto, sans-serif; }
+        div, p { max-width: 70vw; margin: 60px auto 30px auto; background: white; border-radius: 4px; box-shadow: 0px 0px 50px -20px ${blue}; word-break: break-word; }
+        div { display: flex; flex-direction: column; }
+        strong { display: inline-block; padding: 15px; background: ${blue}; color: white; }
+        span { display: inline-block; padding: 15px; }
+        a { padding: 15px; }
+        a:hover { background-color: rgba(0, 108, 233, 0.125); }
+      </style>
+    </head>
+    <body>
+      <p><strong>404</strong> <span>${url.pathname} not found.</span></p>
+    
+      <div>
+        <strong>Available Routes</strong>
+        
+        ${ctx.routes.map((route) => `<a href="${route.pathname}">${route.pathname}</a>`).join('')}
+      </div>
+    </body>
+  </html>`;
 }
 
 /**


### PR DESCRIPTION
# Overview

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Currently, when reaching a 404 page in dev server,
you'll receive a generic error page without much detail.

This PR adds links to all available routes.

without overflow:
<img width="1634" alt="image" src="https://github.com/BuilderIO/qwik/assets/6171622/f5ff66c1-168d-4685-9d5b-6350b227e32e">

with overflow:
<img width="1623" alt="image" src="https://github.com/BuilderIO/qwik/assets/6171622/a55fc128-329c-47e2-a33a-2df275caa740">

closes #4085


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

# Things we want to do next:
- Add a search box (need to figure out how to achieve this?)
- Add component names for each link (probably root that hosts the page?) 
- Add dynamic path parameters value input for dynamic routes  