### PR TITLE
fix: fix bug where qrl.apply is not awaited in dev

### DIFF
--- a/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
@@ -293,7 +293,7 @@ async function pureServerFunction(ev: RequestEvent) {
         let result: unknown;
         try {
           if (isDev) {
-            result = measure(ev, `server_${qrl.getSymbol()}`, () => qrl.apply(ev, args));
+            result = await measure(ev, `server_${qrl.getSymbol()}`, () => qrl.apply(ev, args));
           } else {
             result = await qrl.apply(ev, args);
           }


### PR DESCRIPTION
This PR fixes a bug that was introduced by an earlier commit, where `measure()` is not properly awaited in development mode. The bug prevents async remote functions from being resolved and serialized back to the client.
