### PR TITLE
fix: fix issue where RequestEvent.platform is overwritten in dev-server

### DIFF
--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -178,9 +178,7 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
 
         if (requestHandlers.length > 0) {
           const serverRequestEv = await fromNodeHttp(url, req, res, 'dev');
-          if (ctx.opts.platform) {
-            serverRequestEv.platform = ctx.opts.platform;
-          }
+          Object.assign(serverRequestEv.platform, ctx.opts.platform);
 
           const manifest: QwikManifest = {
             symbols: {},


### PR DESCRIPTION
# Overview

In developer mode, RequestEvent.platform is always overwritten. `incomingMessage` is always undefined because `normalizeOptions` ensures that `opts.platform` is always set. 

As I don't know the purpose of being able to override the platform object using userOpts, I decided to go for `Object.assign` for this. Allowing us to override what we want, and leave the rest (that came from `fromNodeHttp`). I removed the surrounding `if`, as normalizeOptions already guarantees that it's true-ish.

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
