### PR TITLE
fix(create-interactive.ts): make script remove only contents of targe…

### DIFF
--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import fs from 'node:fs';
-import path, { join, relative } from 'node:path';
+import { join, relative } from 'node:path';
 import {
   text,
   select,
@@ -75,7 +75,7 @@ export async function runCreateInteractiveCli() {
         .readdir(outDir)
         .then((filePaths) =>
           filePaths.forEach((pathToFile) =>
-            fs.promises.rm(path.join(outDir, pathToFile), { recursive: true })
+            fs.promises.rm(join(outDir, pathToFile), { recursive: true })
           )
         );
     }

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import fs from 'node:fs';
-import { join, relative } from 'node:path';
+import path, { join, relative } from 'node:path';
 import {
   text,
   select,
@@ -61,7 +61,7 @@ export async function runCreateInteractiveCli() {
       )}" already exists and is not empty. What would you like to do?`,
       options: [
         { value: 'exit', label: 'Do not overwrite this directory and exit' },
-        { value: 'replace', label: 'Overwrite and replace this directory' },
+        { value: 'replace', label: 'Remove contents of this directory' },
       ],
     });
 
@@ -71,7 +71,13 @@ export async function runCreateInteractiveCli() {
     }
 
     if (existingOutDirAnswer === 'replace') {
-      removeExistingOutDirPromise = fs.promises.rm(outDir, { recursive: true });
+      fs.promises
+        .readdir(outDir)
+        .then((filePaths) =>
+          filePaths.forEach((pathToFile) =>
+            fs.promises.rm(path.join(outDir, pathToFile), { recursive: true })
+          )
+        );
     }
   }
 

--- a/packages/create-qwik/create-interactive.ts
+++ b/packages/create-qwik/create-interactive.ts
@@ -51,7 +51,7 @@ export async function runCreateInteractiveCli() {
 
   log.info(`Creating new project in ${bgBlue(' ' + outDir + ' ')} ... 🐇`);
 
-  let removeExistingOutDirPromise: Promise<void> | null = null;
+  let removeExistingOutDirPromise: Promise<void | void[]> | null = null;
 
   if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
     const existingOutDirAnswer = await select({
@@ -71,11 +71,13 @@ export async function runCreateInteractiveCli() {
     }
 
     if (existingOutDirAnswer === 'replace') {
-      fs.promises
+      removeExistingOutDirPromise = fs.promises
         .readdir(outDir)
         .then((filePaths) =>
-          filePaths.forEach((pathToFile) =>
-            fs.promises.rm(join(outDir, pathToFile), { recursive: true })
+          Promise.all(
+            filePaths.map((pathToFile) =>
+              fs.promises.rm(join(outDir, pathToFile), { recursive: true })
+            )
           )
         );
     }


### PR DESCRIPTION
…t folder

Instead of removing entire target folder, which can be locked by editor, only remove contents of this folder

#4199

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Makes installation script remove contents of target folder instead of deleting folder itself to prevent error when it is locked by editor.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. When running installation script from inside open editor

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
