### PR TITLE
fix: add space after assert failure message

### DIFF
--- a/packages/qwik/src/core/error/assert.ts
+++ b/packages/qwik/src/core/error/assert.ts
@@ -3,7 +3,7 @@ import { isElement, isQwikElement } from '../util/element';
 import { logErrorAndStop } from '../util/log';
 import { qDev } from '../util/qdev';
 
-const ASSERT_DISCLAIMER = 'Internal assert, this is likely caused by a bug in Qwik';
+const ASSERT_DISCLAIMER = 'Internal assert, this is likely caused by a bug in Qwik: ';
 
 export function assertDefined<T>(
   value: T,


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

There was a bit of confusion [in discord](https://discord.com/channels/842438759945601056/1106586400435994694/1106586400435994694) because of the following message:

![image](https://github.com/BuilderIO/qwik/assets/22112134/47dcbda5-447c-49b7-9a4c-d8a6e5fc2e9c)

This string is always followed by a secondary error text so we can just add a bit of separation.


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
