### PR TITLE
Add support for server$ cancelation using AbortSignal

### DIFF
--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -87,13 +87,15 @@ export async function fromNodeHttp(
           res.on('close', () => controller.error());
         },
         write(chunk) {
-          return new Promise((resolve, reject) => res.write(chunk, cb => {
-            if (cb) {
-              reject(cb);
-            } else {
-              resolve();
-            }
-          }))
+          return new Promise((resolve, reject) =>
+            res.write(chunk, (cb) => {
+              if (cb) {
+                reject(cb);
+              } else {
+                resolve();
+              }
+            })
+          );
         },
         close() {
           res.end();

--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -82,15 +82,23 @@ export async function fromNodeHttp(
       if (cookieHeaders.length > 0) {
         res.setHeader('Set-Cookie', cookieHeaders);
       }
-      const stream = new WritableStream<Uint8Array>({
+      return new WritableStream<Uint8Array>({
+        start(controller) {
+          res.on('close', () => controller.error());
+        },
         write(chunk) {
-          res.write(chunk);
+          return new Promise((resolve, reject) => res.write(chunk, cb => {
+            if (cb) {
+              reject(cb);
+            } else {
+              resolve();
+            }
+          }))
         },
         close() {
           res.end();
         },
       });
-      return stream;
     },
     platform: {
       ssr: true,

--- a/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
@@ -317,7 +317,7 @@ async function pureServerFunction(ev: RequestEvent) {
             }
             ev.headers.set('Content-Type', 'application/qwik-json');
             const message = await qwikSerializer._serializeData(item, true);
-            stream.write(encoder.encode(`event: qwik\ndata: ${message}\n\n`));
+            await stream.write(encoder.encode(`event: qwik\ndata: ${message}\n\n`));
           }
           stream.close();
         } else {

--- a/packages/qwik-city/runtime/src/server-functions.ts
+++ b/packages/qwik-city/runtime/src/server-functions.ts
@@ -281,7 +281,7 @@ export const zod$: ZodConstructor = /*#__PURE__*/ implicit$FirstArg(zodQrl) as a
 /**
  * @public
  */
-export const serverQrl: ServerConstructorQRL = (qrl: QRL<(...arss: any[]) => any>) => {
+export const serverQrl: ServerConstructorQRL = (qrl: QRL<(...args: any[]) => any>) => {
   if (isServer) {
     const captured = qrl.getCaptured();
     if (captured && captured.length > 0 && !_getContextElement()) {
@@ -291,6 +291,7 @@ export const serverQrl: ServerConstructorQRL = (qrl: QRL<(...arss: any[]) => any
 
   function stuff() {
     return $(async function (this: any, ...args: any[]) {
+      const signal = args.length > 0 && args[0] instanceof AbortSignal ? (args.shift() as AbortSignal) : undefined;
       if (isServer) {
         const requestEvent = useQwikCityEnv()?.ev ?? this ?? _getContextEvent();
         return qrl.apply(requestEvent, args);
@@ -315,13 +316,14 @@ export const serverQrl: ServerConstructorQRL = (qrl: QRL<(...arss: any[]) => any
             'Content-Type': 'application/qwik-json',
             'X-QRL': hash,
           },
+          signal,
           body,
         });
 
         const contentType = res.headers.get('Content-Type');
         if (res.ok && contentType === 'text/event-stream') {
           const { writable, readable } = getSSETransformer();
-          res.body?.pipeTo(writable);
+          res.body?.pipeTo(writable, { signal });
           return streamAsyncIterator(readable, ctxElm ?? document.documentElement);
         } else if (contentType === 'application/qwik-json') {
           const str = await res.text();

--- a/packages/qwik-city/runtime/src/server-functions.ts
+++ b/packages/qwik-city/runtime/src/server-functions.ts
@@ -291,7 +291,10 @@ export const serverQrl: ServerConstructorQRL = (qrl: QRL<(...args: any[]) => any
 
   function stuff() {
     return $(async function (this: any, ...args: any[]) {
-      const signal = args.length > 0 && args[0] instanceof AbortSignal ? (args.shift() as AbortSignal) : undefined;
+      const signal =
+        args.length > 0 && args[0] instanceof AbortSignal
+          ? (args.shift() as AbortSignal)
+          : undefined;
       if (isServer) {
         const requestEvent = useQwikCityEnv()?.ev ?? this ?? _getContextEvent();
         return qrl.apply(requestEvent, args);

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -447,6 +447,7 @@ export type PublicProps<PROPS extends {}> = TransformProps<PROPS> & ComponentBas
 export interface QRL<TYPE = any> {
     // (undocumented)
     __brand__QRL__: TYPE;
+    (signal: AbortSignal, ...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never>;
     (...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never>;
     // (undocumented)
     dev: QRLDev | null;

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -133,6 +133,16 @@ export interface QRL<TYPE = any> {
 
   /**
    * Resolve the QRL of closure and invoke it.
+   * @param signal - An AbortSignal object.
+   * @param args - Closure arguments.
+   * @returns A promise of the return value of the closure.
+   */
+  (signal: AbortSignal, ...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<
+    TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never
+  >;
+
+  /**
+   * Resolve the QRL of closure and invoke it.
    * @param args - Closure arguments.
    * @returns A promise of the return value of the closure.
    */


### PR DESCRIPTION
# Overview

When using `yield` in a server function, it makes no sense that it will continue even after the client connection has ended. In addition, I found that I needed to be able to cancel long running server functions from the client-side somehow. 
This PR adds support for passing an AbortSignal object when calling the server function.

This is not a complete PR yet, I merely want to check the temperature and see if this is an acceptable addition to the framework. The code works now, but only tested with the dev server.

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

This PR introduces a couple of changes:
1. It adds a second signature to the QRL interface; to allow passing an AbortSignal object as a first argument to the server function.
2. Amends `serverQrl` to allow passing an AbortSignal - in which case it will be handed over to `fetch`. In essence, this just terminates the connection to the server.
4. Fixes the node middleware to ensure the writable stream is closed when the connection is closed.

# Use cases and why

I wanted to stream OpenAI generated text to the client by yielding new tokens. But quickly noticed that the server function would continue yielding tokens- even after leaving the page. This could be solved with a dedicated route, but I think being able to cancel long running server functions is not an outlandish idea.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
