### PR TITLE
fix: Allow TSAsExpression for useFunctions

### DIFF
--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -104,6 +104,11 @@ export const HelloWorld = component$(async () => {
             return <div></div>
           });
         });`,
+      `export const HelloWorld = component$(async () => {
+          const test = useFunction() as string;
+        
+          });
+          `,
     ],
     invalid: [
       {

--- a/packages/eslint-plugin-qwik/src/useMethodUsage.ts
+++ b/packages/eslint-plugin-qwik/src/useMethodUsage.ts
@@ -63,6 +63,7 @@ export const useMethodUsage: Rule.RuleModule = {
             case 'Property':
             case 'ObjectExpression':
             case 'CallExpression':
+            case 'TSAsExpression':
               break;
             case 'ArrowFunctionExpression':
             case 'FunctionExpression':


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

The lint plugin does not accept `TSAsExpression` as a parent of useFunctions

```
`export const HelloWorld = component$(async () => {
          const test = useFunction() as string;
  });
```

*NOTE*

There seems to be a typing issues, not 100% sure what do to with this ...

```
Type '"TSAsExpression"' is not comparable to type '"ArrayExpression" | "ArrayPattern" | "ArrowFunctionExpression" | "AssignmentExpression" | "AssignmentPattern" | "AwaitExpression" | "BinaryExpression" | "BlockStatement" | ... 62 more ... | "YieldExpression"'
```

<img width="1024" alt="image" src="https://github.com/BuilderIO/qwik/assets/19932895/eb6da794-2dc6-448b-8b97-86192bc7f39a">



# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
