### PR TITLE
docs: fix reactivity counter example to `useStore` so that description matches code

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/concepts/reactivity/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/concepts/reactivity/index.mdx
@@ -48,7 +48,7 @@ Because of the above constraints, Qwik uses proxies to keep track of the reactiv
 ```tsx
 export const Counter = component$(() => {
   const store = useStore({ count: 0 });
- 
+
   return <button onClick$={() => store.count++}>{store.count}</button>;
 });
 ```

--- a/packages/docs/src/routes/docs/(qwik)/concepts/reactivity/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/concepts/reactivity/index.mdx
@@ -47,9 +47,9 @@ Because of the above constraints, Qwik uses proxies to keep track of the reactiv
 
 ```tsx
 export const Counter = component$(() => {
-  const count = useSignal(0);
-
-  return <button onClick$={() => count.value++}>{count.value}</button>;
+  const store = useStore({ count: 0 });
+ 
+  return <button onClick$={() => store.count++}>{store.count}</button>;
 });
 ```
 


### PR DESCRIPTION

# Overview
fixes #4235
<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
