### PR TITLE
fix: update cloudflare starter to use latest Wrangler

### DIFF
--- a/starters/adapters/cloudflare-pages/package.json
+++ b/starters/adapters/cloudflare-pages/package.json
@@ -6,7 +6,7 @@
     "serve": "wrangler pages dev ./dist"
   },
   "devDependencies": {
-    "wrangler": "^2.20.0"
+    "wrangler": "^3.0.0"
   },
   "__qwik__": {
     "priority": 40,


### PR DESCRIPTION
Wrangler 3.0.0 has now been released, so we should encourage new Qwik + Cloudflare projects to use it.