### PR TITLE
docs(guides/qwik-nutshell/index.mdx): fix typo on variable name

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
@@ -345,7 +345,7 @@ export const Counter = component$(() => {
 import { component$, useSignal, useTask$ } from '@builder.io/qwik';
 
 export const Counter = component$(() => {
-  const currentPage = useSignal(0);
+  const page = useSignal(0);
   const listOfUsers = useSignal([]);
 
   // The `useTask$` hook is used to create a task.
@@ -356,7 +356,7 @@ export const Counter = component$(() => {
 
   // You can create multiple tasks, and they can be async.
   useTask$(async (taskContext) => {
-    // Since we want to re-run the task whenever the `page` changes, 
+    // Since we want to re-run the task whenever the `page` changes,
     // we need to track it.
     taskContext.track(() => page.value);
     console.log('Task executed before the first render AND when page changes');


### PR DESCRIPTION
# Overview

In the useTask$ example, a signal is created with the name currentPage. Later on the same example it's referred as "page" only.

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

In the useTask$ example on the `guides/qwik-nutshell`, a signal is created with the name currentPage. Later on the same example it's referred as "page" only.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [] Added new tests to cover the fix / functionality
