### PR TITLE
draft: improve server$() cancellation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "concurrently \"npm:build.watch\" \"npm:test.watch\" \"npm:tsc.watch\" -n build,test,tsc -c green,magenta,cyan",
     "release.prepare": "pnpm lint && pnpm test.unit && tsm scripts/index.ts --tsc --build --api --eslint --platform-binding --wasm --prepare-release",
     "test": "pnpm build.full && pnpm test.unit && pnpm test.e2e",
-    "test.unit": "tsm node_modules/uvu/bin.js packages unit.ts --tsmconfig tsm.cjs",
+    "test.unit": "pnpm build && tsm node_modules/uvu/bin.js packages unit.ts --tsmconfig tsm.cjs",
     "test.unit.debug": "tsm --inspect-brk node_modules/uvu/bin.js packages unit.ts --tsmconfig tsm.cjs",
     "test.watch": "watchlist packages unit.ts -- pnpm test.unit",
     "test.rust": "make test",

--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -86,16 +86,13 @@ export async function fromNodeHttp(
         start(controller) {
           res.on('close', () => controller.error());
         },
-        write(chunk) {
-          return new Promise((resolve, reject) =>
-            res.write(chunk, (cb) => {
-              if (cb) {
-                reject(cb);
-              } else {
-                resolve();
-              }
-            })
-          );
+        write(chunk, controller) {
+          res.write(chunk, (error) => {
+            // FIXME: Ideally, we should forward the error instead of dropping it.
+            //        As it stands, however, we're not properly handling the rejection downstream,
+            //        leading to occasional ERR_UNHANDLED_REJECTION.
+            // controller.error(error);
+          });
         },
         close() {
           res.end();

--- a/packages/qwik-city/runtime/src/server-functions.unit.ts
+++ b/packages/qwik-city/runtime/src/server-functions.unit.ts
@@ -1,0 +1,57 @@
+import { test } from 'uvu';
+import { equal } from 'uvu/assert';
+import { exportedForTesting } from './server-functions';
+const { streamEvents } = exportedForTesting;
+import { ReadableStream } from 'node:stream/web';
+
+type SSE = ReturnType<typeof streamEvents> extends AsyncGenerator<infer X> ? X : never;
+
+const _ = async (s: string) => {
+  const bytes = new TextEncoder().encode(s);
+  const stream = new ReadableStream({
+    pull: (controller) => {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+
+  const result: SSE[] = [];
+  for await (const event of await streamEvents(stream)) {
+    result.push(event);
+  }
+  return result;
+};
+
+test('parse a single field, return one object', async () => {
+  equal(await _('data'), [{ data: '' }]);
+});
+
+test('parse two fields, return one object', async () => {
+  equal(await _('data\nevent'), [{ data: '', event: '' }]);
+});
+
+test('if only a comment, return an empty object', async () => {
+  equal(await _(':\n\n'), [{}]);
+});
+
+test('if only newlines, return nothing', async () => {
+  equal(await _('\n\n\n\n'), []);
+});
+
+test('if data provided several times, join with newline', async () => {
+  equal(await _('data\ndata'), [{ data: '\n' }]);
+});
+
+test('if data provided several times, return two objects', async () => {
+  equal(await _('data\n\ndata'), [{ data: '' }, { data: '' }]);
+});
+
+test('parse field value', async () => {
+  equal(await _('data:value'), [{ data: 'value' }]);
+});
+
+test('parse field value, skip optional space', async () => {
+  equal(await _('data: value'), [{ data: 'value' }]);
+});
+
+test.run();

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -157,6 +157,12 @@ export const _getContextElement: () => unknown;
 // @internal (undocumented)
 export const _getContextEvent: () => unknown;
 
+// Warning: (ae-forgotten-export) The symbol "InvokeContext" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-missing-underscore) The name "getInvokeContext" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export const getInvokeContext: () => InvokeContext;
+
 // Warning: (ae-internal-missing-underscore) The name "getLocale" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
@@ -447,8 +453,8 @@ export type PublicProps<PROPS extends {}> = TransformProps<PROPS> & ComponentBas
 export interface QRL<TYPE = any> {
     // (undocumented)
     __brand__QRL__: TYPE;
-    (signal: AbortSignal, ...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never>;
-    (...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never>;
+    // Warning: (ae-forgotten-export) The symbol "AbortablePromise" needs to be exported by the entry point index.d.ts
+    (...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): AbortablePromise<TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never>;
     // (undocumented)
     dev: QRLDev | null;
     // (undocumented)

--- a/packages/qwik/src/core/internal.ts
+++ b/packages/qwik/src/core/internal.ts
@@ -13,6 +13,7 @@ export {
   _getContextEvent,
   _jsxBranch,
   _waitUntilRendered,
+  getInvokeContext,
 } from './use/use-core';
 export { _jsxQ, _jsxC, _jsxS } from './render/jsx/jsx-runtime';
 export { _fnSignal } from './qrl/inlined-fn';

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -1,5 +1,6 @@
 import { implicit$FirstArg } from '../util/implicit_dollar';
 import { qDev, qRuntimeQrl } from '../util/qdev';
+import { AbortablePromise } from '../util/async';
 import type { QRLDev } from './qrl';
 import { createQRL } from './qrl-class';
 
@@ -133,20 +134,10 @@ export interface QRL<TYPE = any> {
 
   /**
    * Resolve the QRL of closure and invoke it.
-   * @param signal - An AbortSignal object.
    * @param args - Closure arguments.
    * @returns A promise of the return value of the closure.
    */
-  (signal: AbortSignal, ...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<
-    TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never
-  >;
-
-  /**
-   * Resolve the QRL of closure and invoke it.
-   * @param args - Closure arguments.
-   * @returns A promise of the return value of the closure.
-   */
-  (...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<
+  (...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): AbortablePromise<
     TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never
   >;
 

--- a/packages/qwik/src/core/use/use-core.ts
+++ b/packages/qwik/src/core/use/use-core.ts
@@ -48,6 +48,7 @@ export interface InvokeContext {
   $subscriber$: Subscriber | null | undefined;
   $renderCtx$: RenderContext | undefined;
   $locale$: string | undefined;
+  $signal$: AbortSignal | undefined;
 }
 
 let _context: InvokeContext | undefined;
@@ -69,6 +70,9 @@ export const tryGetInvokeContext = (): InvokeContext | undefined => {
   return _context;
 };
 
+/**
+ * @internal
+ */
 export const getInvokeContext = (): InvokeContext => {
   const ctx = tryGetInvokeContext();
   if (!ctx) {
@@ -156,6 +160,7 @@ export const newInvokeContext = (
     $renderCtx$: undefined,
     $subscriber$: undefined,
     $waitOn$: undefined,
+    $signal$: undefined,
   };
   seal(ctx);
   return ctx;

--- a/packages/qwik/src/core/util/async.ts
+++ b/packages/qwik/src/core/util/async.ts
@@ -1,0 +1,20 @@
+export class AbortablePromise<T> extends Promise<T> {
+  private readonly controller: AbortController;
+  public constructor(
+    executor: (
+      resolve: (value: T | PromiseLike<T>) => void,
+      reject: (reason?: any) => void,
+      signal: AbortSignal
+    ) => void
+  ) {
+    const controller = new AbortController();
+    super((resolve, reject) => {
+      executor(resolve, reject, controller.signal);
+    });
+    this.controller = controller;
+  }
+
+  public abort(reason?: any): void {
+    this.controller.abort(reason);
+  }
+}


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description
fixes: https://github.com/BuilderIO/qwik/issues/4268

#4214 introduced a way to cancel long running server functions, by allowing the user to provide an optional AbortSignal object as the first argument.

The problem I wanted to solve was to be able to cancel a long running async generator.

This new PR makes the following changes:
- Reverts the previous PR and removes the AbortSignal signature.
- Overrides `return()` of the AsyncGenerator, so that the underlying stream will be ended as a part of the cleanup. This allows the user to `break` from an async for-loop and have the connection terminated.
- Rework and simplify event streaming code in serverQrl, and ensure that no floating promises hang around. Got rid of the Transformer to make it easier to follow and to get rid of issues where we'd have to pass errors from one stream to the next.
- `server$()` now returns an AbortablePromise, allowing the user to terminate the connection. Added `$signal$` to the InvocationContext.
- Added a unit test for `streamEvents`

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
