### PR TITLE
docs: adjust eslint rules mobile view

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/advanced/eslint/styles.css
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/eslint/styles.css
@@ -15,17 +15,27 @@
 
 .docs .ruleset-legend {
   @apply grid;
-  @apply grid-cols-4;
+  @apply grid-cols-1;
   @apply text-sm;
 }
 .docs .ruleset-legend > div {
   @apply list-none;
-  @apply my-6;
+  @apply my-3;
   @apply px-6;
 }
-.docs .ruleset-legend > div.panel-border {
-  @apply border-r;
-  @apply border-slate-200;
+@media screen and (min-width: 768px) {
+  .docs .ruleset-legend {
+    @apply grid-cols-4;
+  }
+  .docs .ruleset-legend > div {
+    @apply list-none;
+    @apply my-6;
+    @apply px-6;
+  }
+  .docs .ruleset-legend > div.panel-border {
+    @apply border-r;
+    @apply border-slate-200;
+  }
 }
 
 .icon {


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

the ruleset overview on mobile was odd formatted. this PR adjusts that issue for viewports < 768px.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
