### PR TITLE
refactor(starters/apps/empty/src/global.css): remove redundant comment

### DIFF
--- a/starters/apps/empty/src/global.css
+++ b/starters/apps/empty/src/global.css
@@ -1,7 +1,0 @@
-/**
- * WHAT IS THIS FILE?
- *
- * Globally applied styles. No matter which components are in the page or matching route,
- * the styles in here will be applied to the Document, without any sort of CSS scoping.
- *
- */


### PR DESCRIPTION
closes #4287

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description
There is a comment in the [starters/apps/empty/src/global.css](https://github.com/BuilderIO/qwik/blob/main/starters/apps/empty/src/global.css) file, when creating the qwik-app with the help of this command `npm create qwik@latest`, the content of the [Base global.css](https://github.com/BuilderIO/qwik/blob/main/starters/apps/base/src/global.css) is being added to the empty app's global css file resulting in duplicate comment. 

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
