### PR TITLE
server$ fixes, and improvements

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/server$/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/server$/index.mdx
@@ -13,6 +13,12 @@ contributors:
 
 `server$` is a form of RPC (Remote Procedure Call) mechanism between the client and server, just like a traditional HTTP endpoint but strongly typed thanks to Typescript, and easier to maintain.
 
+Your new function will have the following signature:
+`([AbortSignal, ] ...): Promise<T>`
+
+`AbortSignal` is optional, and allows you to cancel a long running request by terminating the connection.
+Please note that depending on your server runtime, the function on the server may or may not terminate immediately as it depends on how client disconnections are handled by said runtime.
+
 ```tsx
 import { component$, useSignal } from '@builder.io/qwik';
 import { server$ } from '@builder.io/qwik-city';
@@ -77,6 +83,9 @@ const addUser = server$(async function(id: number, fullName: string, address: Ad
 ## Streaming responses
 
 `server$` can return a stream of data by using an async generator. This is useful for streaming data from the server to the client.
+
+Terminating the generator on the client side (e.g. by calling `return()` on the generator, or by breaking out from your async for-loop) will terminate the connection. As with `AbortSignal` -
+how the generator will terminate on the server side depends on the server runtime and how client disconnects are handled.
 
 ```tsx
 import { component$, useSignal } from '@builder.io/qwik';

--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -86,16 +86,14 @@ export async function fromNodeHttp(
         start(controller) {
           res.on('close', () => controller.error());
         },
-        write(chunk) {
-          return new Promise((resolve, reject) =>
-            res.write(chunk, (cb) => {
-              if (cb) {
-                reject(cb);
-              } else {
-                resolve();
-              }
-            })
-          );
+        write(chunk, controller) {
+          res.write(chunk, (error) => {
+            if (error) {
+              // FIXME: Ideally, we would like to inform the writer that this was an error.
+              //        Not all writers seem to handle rejections, though.
+              // controller.error(error);
+            }
+          });
         },
         close() {
           res.end();

--- a/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
@@ -309,15 +309,14 @@ async function pureServerFunction(ev: RequestEvent) {
           return;
         }
         if (isAsyncIterator(result)) {
-          ev.headers.set('Content-Type', 'text/event-stream');
+          ev.headers.set('Content-Type', 'text/qwik-json-stream');
           const stream = ev.getWritableStream().getWriter();
           for await (const item of result) {
             if (isDev) {
               verifySerializable(qwikSerializer, item, qrl);
             }
-            ev.headers.set('Content-Type', 'application/qwik-json');
             const message = await qwikSerializer._serializeData(item, true);
-            await stream.write(encoder.encode(`event: qwik\ndata: ${message}\n\n`));
+            await stream.write(encoder.encode(`${message}\n`));
           }
           stream.close();
         } else {

--- a/packages/qwik-city/runtime/src/server-functions.ts
+++ b/packages/qwik-city/runtime/src/server-functions.ts
@@ -311,23 +311,33 @@ export const serverQrl: ServerConstructorQRL = (qrl: QRL<(...args: any[]) => any
           return arg;
         });
         const hash = qrl.getHash();
-        const path = `?qfunc=${qrl.getHash()}`;
-        const body = await _serializeData([qrl, ...filtered], false);
-        const res = await fetch(path, {
+        const res = await fetch(`?qfunc=${hash}`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/qwik-json',
             'X-QRL': hash,
           },
           signal,
-          body,
+          body: await _serializeData([qrl, ...filtered], false),
         });
 
         const contentType = res.headers.get('Content-Type');
-        if (res.ok && contentType === 'text/event-stream') {
-          const { writable, readable } = getSSETransformer();
-          res.body?.pipeTo(writable, { signal });
-          return streamAsyncIterator(readable, ctxElm ?? document.documentElement);
+        if (res.ok && contentType === 'text/qwik-json-stream' && res.body) {
+          return (async function* () {
+            try {
+              for await (const result of deserializeStream(
+                res.body!,
+                ctxElm ?? document.documentElement,
+                signal
+              )) {
+                yield result;
+              }
+            } finally {
+              if (!signal?.aborted) {
+                await res.body!.cancel();
+              }
+            }
+          })();
         } else if (contentType === 'application/qwik-json') {
           const str = await res.text();
           const obj = await _deserializeData(str, ctxElm ?? document.documentElement);
@@ -382,73 +392,28 @@ const getValidators = (rest: (CommonLoaderActionOptions | DataValidator)[], qrl:
   };
 };
 
-const getSSETransformer = () => {
-  // Convert the stream into a stream of lines
-  let currentLine = '';
-  const encoder = new TextDecoder();
-  const transformer = new TransformStream<Uint8Array, SSEvent>({
-    transform(chunk, controller) {
-      const lines = encoder.decode(chunk).split('\n\n');
-      for (let i = 0; i < lines.length - 1; i++) {
-        const line = currentLine + lines[i];
-        if (line.length === 0) {
-          controller.terminate();
-          break;
-        } else {
-          controller.enqueue(parseEvent(line));
-          currentLine = '';
-        }
-      }
-      currentLine += lines[lines.length - 1];
-    },
-  });
-  return transformer;
-};
-
-interface SSEvent {
-  data: string;
-  [key: string]: string;
-}
-const parseEvent = (message: string): SSEvent => {
-  const lines = message.split('\n');
-  const event: SSEvent = {
-    data: '',
-  };
-  let data = '';
-  for (const line of lines) {
-    if (line.startsWith('data: ')) {
-      data += line.slice(6) + '\n';
-    } else {
-      const [key, value] = line.split(':');
-      if (typeof key === 'string' && typeof value === 'string') {
-        event[key] = value.trim();
-      }
-    }
-  }
-  event.data = data;
-  return event;
-};
-
-async function* streamAsyncIterator(
-  stream: ReadableStream<SSEvent>,
-  ctxElm: unknown
-): AsyncGenerator<unknown> {
-  // Get a lock on the stream
+const deserializeStream = async function* (
+  stream: ReadableStream<Uint8Array>,
+  ctxElm: unknown,
+  signal?: AbortSignal
+) {
   const reader = stream.getReader();
-
   try {
-    while (true) {
-      // Read from the stream
-      const { done, value } = await reader.read();
-      // Exit if we're done
-      if (done) {
-        return;
+    let buffer = '';
+    const decoder = new TextDecoder();
+    while (!signal?.aborted) {
+      const result = await reader.read();
+      if (result.done) {
+        break;
       }
-      // Else yield the chunk
-      const obj = await _deserializeData(value.data, ctxElm);
-      yield obj;
+      buffer += decoder.decode(result.value, { stream: true });
+      const lines = buffer.split(/\n/);
+      buffer = lines.pop()!;
+      for (const line of lines) {
+        yield await _deserializeData(line, ctxElm);
+      }
     }
   } finally {
     reader.releaseLock();
   }
-}
+};


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

This PR improves cancellation when using server$ async generator.

- Simplify the streaming code, and use a simple newline delimited result with `qwik-json-stream` content type.
- Fix a bug that could lead to ERR_STREAM_DESTROYED.
- Add proper async generator cleanup. Now, whenever the client breaks out from an async generator for-loop (or otherwise call `return()` on the generator), the connection will be closed.
- Updates server$ documentation (fixes #4268)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
