### PR TITLE
fix(mdx): add wrapping div to tables 

### DIFF
--- a/packages/docs/src/routes/api/api.css
+++ b/packages/docs/src/routes/api/api.css
@@ -70,6 +70,7 @@
   margin: 10px auto;
   padding: 80px 30px 0;
   max-width: 1060px;
+  overflow: hidden;
 }
 
 .docs.api .section-title {
@@ -216,4 +217,7 @@
 .docs.api [data-kind-label="N"]:before {
     content: 'N';
     background: #5cb85c;
+}
+.docs.api .table-wrapper {
+  overflow-x: auto;
 }

--- a/packages/docs/src/routes/docs/docs.css
+++ b/packages/docs/src/routes/docs/docs.css
@@ -203,6 +203,7 @@ h6 a:hover .icon {
 
 .docs article pre {
   padding: 18px 15px;
+  overflow: auto;
 }
 
 :root {

--- a/packages/qwik-city/buildtime/markdown/mdx.ts
+++ b/packages/qwik-city/buildtime/markdown/mdx.ts
@@ -1,6 +1,6 @@
 import type { CompileOptions } from '@mdx-js/mdx/lib/compile';
 import { SourceMapGenerator } from 'source-map';
-import { rehypePage, rehypeSlug, renameClassname } from './rehype';
+import { rehypePage, rehypeSlug, renameClassname, wrapTableWithDiv } from './rehype';
 import { rehypeSyntaxHighlight } from './syntax-highlight';
 import type { BuildContext } from '../types';
 import { parseFrontmatter } from './frontmatter';
@@ -63,6 +63,7 @@ export async function createMdxTransformer(ctx: BuildContext): Promise<MdxTransf
       ...coreRehypePlugins,
       [rehypePage, ctx],
       renameClassname,
+      wrapTableWithDiv,
     ],
   };
 

--- a/packages/qwik-city/buildtime/markdown/rehype.ts
+++ b/packages/qwik-city/buildtime/markdown/rehype.ts
@@ -58,6 +58,22 @@ export function renameClassname(): Transformer {
   };
 }
 
+export function wrapTableWithDiv(): Transformer {
+  return (ast) => {
+    const mdast = ast as Root;
+
+    visit(mdast, 'element', (node: any) => {
+      if (node.tagName === 'table' && !node.done) {
+        const table = { ...node };
+        table.done = true;
+        node.tagName = 'div';
+        node.properties = { className: 'table-wrapper' };
+        node.children = [table];
+      }
+    });
+  };
+}
+
 function updateContentLinks(mdast: Root, opts: NormalizedPluginOptions, sourcePath: string) {
   visit(mdast, 'element', (node: any) => {
     const tagName = node && node.type === 'element' && node.tagName.toLowerCase();

--- a/starters/apps/qwikcity-test/src/routes/mdx/index.mdx
+++ b/starters/apps/qwikcity-test/src/routes/mdx/index.mdx
@@ -1,0 +1,4 @@
+| Name   | Type   | Description          |
+| ------ | ------ | -------------------- |
+| `name` | string | Name of the resource |
+| `path` | string | Path to the resource |

--- a/starters/e2e/qwikcity/mdx.spec.ts
+++ b/starters/e2e/qwikcity/mdx.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('mdx tables ', () => {
+  const wrapperClassName = '.table-wrapper';
+  test(`should be wrapped with a div that has the class name ${wrapperClassName}`, async ({
+    page,
+  }) => {
+    await page.goto('/qwikcity-test/mdx/');
+    const tableWrapperElm = page.locator(wrapperClassName);
+    await expect(tableWrapperElm).toBeVisible();
+
+    const tableElm = page.locator('.table-wrapper > table');
+    await expect(tableElm).toBeVisible();
+  });
+});


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

Fix API docs overflow issue on mobile
- wrap all mdx tables with a div with class `.table-wrapper`
- fix overflow styles.
- add e2e test


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
