### PR TITLE
Update qwik-nutshell/index.mdx

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
@@ -299,7 +299,7 @@ In practice, `useSignal` and `useStore` are very similar -- `useSignal(0) === us
 - When you want a reactive object that you can easily add properties to.
 
 ```tsx
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useStore } from '@builder.io/qwik';
 
 export const Counter = component$(() => {
   // The `useStore` hook is used to create a reactive store.


### PR DESCRIPTION
# Overview
Fix typo in a nutshell section

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types/ typos

# Description

The `useStore(initialValue?)` section's code sample imports `useSignal` instead. This PR simply corrects the typo :)

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
