### PR TITLE
feat: add staleIfError option for request.cacheControl, also adds docs on caching and caching to starters

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
@@ -16,8 +16,8 @@ For instance, we can add an `onGet` export to our root [layout](/docs/(qwikcity)
 import { component$, Slot } from "@builder.io/qwik";
 import type { RequestHandler } from "@builder.io/qwik-city";
 
-export const onGet: RequestHandler = async (request) => {
-  request.cacheControl({
+export const onGet: RequestHandler = async ({ cacheControl }) => {
+  cacheControl({
     // Always serve a cached response by default, up to a week stale
     staleWhileRevalidate: 60 * 60 * 24 * 7,
     // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
@@ -36,15 +36,15 @@ export default component$(() => {
 
 With the above setup we will not only have better performance (pages are always served instantly from cache), but can have significantly decreased hosting costs, as our server (or edge functions) only need to run max once every 5 seconds per page.
 
-## `request.cacheControl`
+## `cacheControl`
 
 Any method that takes a [request event](https://qwik.builder.io/docs/advanced/request-handling/#request-event) can call `request.cacheControl` to set the cache control headers for the response:
 
 ```tsx title="src/routes/layout.tsx"
 import type { RequestHandler } from "@builder.io/qwik-city";
 
-export const onGet: RequestHandler = async (request) => {
-  request.cacheControl({
+export const onGet: RequestHandler = async ({ cacheControl }) => {
+  cacheControl({
     public: true,
     maxAge: 5,
     sMaxAge: 10,
@@ -59,8 +59,8 @@ You can also override this as well. For instance, perhaps you have a defualt cac
 import type { RequestHandler } from "@builder.io/qwik-city";
 
 // Override caching for /dashboard pages to not cache as they are unique per visitor
-export const onGet: RequestHandler = async (request) => {
-  request.cacheControl({
+export const onGet: RequestHandler = async ({ cacheControl }) => {
+  cacheControl({
     public: false,
     maxAge: 0,
     sMaxAge: 0,
@@ -83,10 +83,10 @@ You can conditionally change cache behaviors with any logic you like:
 ```tsx title="src/routes/layout.tsx"
 import type { RequestHandler } from "@builder.io/qwik-city";
 
-export const onGet: RequestHandler = async (request) => {
+export const onGet: RequestHandler = async ({ cacheControl, url }) => {
   // Only our homepage is public and should be CDN cached. Other pages are unique per visitor
-  if (request.url.pathname === '/') {
-    request.cacheControl({
+  if (url.pathname === '/') {
+    cacheControl({
       public: true,
       maxAge: 5,
       staleWhileRevalidate: 60 * 60 * 24 * 365,

--- a/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
@@ -8,9 +8,11 @@ contributors:
 
 Caching responses is critical for keeping your site as fast as possible, both for [pages](/docs/(qwikcity)/pages/index.mdx) as well as [endpoints](/docs/(qwikcity)/endpoints/index.mdx).
 
-A good default is to use [stale-while-revalidate](https://web.dev/stale-while-revalidate/) caching for all responses. For instance, we can add an `onGet` export to our root [layout](/docs/(qwikcity)/layout/index.mdx) (`src/routes/layout.tsx`) like so:
+A good default is to use [stale-while-revalidate](https://web.dev/stale-while-revalidate/) caching for all responses. 
 
-```tsx
+For instance, we can add an `onGet` export to our root [layout](/docs/(qwikcity)/layout/index.mdx) (`src/routes/layout.tsx`) like so, to apply good caching defaults site-wide:
+
+```tsx title="src/routes/layout.tsx"
 import { component$, Slot } from "@builder.io/qwik";
 import type { RequestHandler } from "@builder.io/qwik-city";
 
@@ -38,7 +40,7 @@ With the above setup we will not only have better performance (pages are always 
 
 Any method that takes a [request event](https://qwik.builder.io/docs/advanced/request-handling/#request-event) can call `request.cacheControl` to set the cache control headers for the response:
 
-```tsx
+```tsx title="src/routes/layout.tsx"
 import type { RequestHandler } from "@builder.io/qwik-city";
 
 export const onGet: RequestHandler = async (request) => {
@@ -51,6 +53,23 @@ export const onGet: RequestHandler = async (request) => {
 };
 ```
 
+You can also override this as well. For instance, perhaps you have a defualt caching at the root, but want to disable caching for a specific page, you can override this with nested layouts
+
+```tsx title="src/routes/dashboard/layout.tsx"
+import type { RequestHandler } from "@builder.io/qwik-city";
+
+// Override caching for /dashboard pages to not cache as they are unique per visitor
+export const onGet: RequestHandler = async (request) => {
+  request.cacheControl({
+    public: false,
+    maxAge: 0,
+    sMaxAge: 0,
+    staleWhileRevalidate: 0,
+  });
+};
+
+```
+
 You can see the full [API reference](https://qwik.builder.io/api/qwik-city-middleware-request-handler/) of options you can pass to `request.cacheControl`.
 
 ## When not to cache
@@ -61,7 +80,7 @@ For high traffic pages that look the same to everyone, such as a homepage, cachi
 
 You can conditionally change cache behaviors with any logic you like:
 
-```tsx
+```tsx title="src/routes/layout.tsx"
 import type { RequestHandler } from "@builder.io/qwik-city";
 
 export const onGet: RequestHandler = async (request) => {

--- a/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
@@ -84,7 +84,7 @@ You can conditionally change cache behaviors with any logic you like:
 import type { RequestHandler } from "@builder.io/qwik-city";
 
 export const onGet: RequestHandler = async (request) => {
-  // Only our homepage is public and should be cached. Other pages are unique per visitor
+  // Only our homepage is public and should be CDN cached. Other pages are unique per visitor
   if (request.url.pathname === '/') {
     request.cacheControl({
       public: true,

--- a/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
@@ -34,7 +34,7 @@ export default component$(() => {
 
 With the above setup we will not only have better performance (pages are always served instantly from cache), but can have significantly decreased hosting costs, as our server (or edge functions) only need to run max once every 5 seconds per page.
 
-## `Request.cacheControl`
+## `request.cacheControl`
 
 Any method that takes a [request event](https://qwik.builder.io/docs/advanced/request-handling/#request-event) can call `request.cacheControl` to set the cache control headers for the response:
 
@@ -52,3 +52,26 @@ export const onGet: RequestHandler = async (request) => {
 ```
 
 You can see the full [API reference](https://qwik.builder.io/api/qwik-city-middleware-request-handler/) of options you can pass to `request.cacheControl`.
+
+## When not to cache
+
+Caching is a good default, but not right for every page all the time. If you have URLs on your site that will show different content to different people - such as pages only for logged in users, or pages that show different content based on the user's location, you should not cache those pages using cache-control headers in the response, and server side render the contents of those pages on a per-visitor basis.
+
+For high traffic pages that look the same to everyone, such as a homepage, caching is the best thing to do for performance and cost. But for pages only for loggeed in users, and as a result probably have some degree less traffic, disabling caching may be wise.
+
+You can conditionally change cache behaviors with any logic you like:
+
+```tsx
+import type { RequestHandler } from "@builder.io/qwik-city";
+
+export const onGet: RequestHandler = async (request) => {
+  // Only our homepage is public and should be cached. Other pages are unique per visitor
+  if (request.url.pathname === '/') {
+    request.cacheControl({
+      public: true,
+      maxAge: 5,
+      staleWhileRevalidate: 60 * 60 * 24 * 365,
+    });
+  }
+};
+```

--- a/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
@@ -1,0 +1,54 @@
+---
+title: Qwik City - Caching
+contributors:
+  - steve8708
+---
+
+# Caching Responses
+
+Caching responses is critical for keeping your site as fast as possible, both for [pages](/docs/(qwikcity)/pages/index.mdx) as well as [endpoints](/docs/(qwikcity)/endpoints/index.mdx).
+
+A good default is to use [stale-while-revalidate](https://web.dev/stale-while-revalidate/) caching for all responses. For instance, we can add an `onGet` export to our root [layout](/docs/(qwikcity)/layout/index.mdx) (`src/routes/layout.tsx`) like so:
+
+```tsx
+import { component$, Slot } from "@builder.io/qwik";
+import type { RequestHandler } from "@builder.io/qwik-city";
+
+export const onGet: RequestHandler = async (request) => {
+  request.cacheControl({
+    // Always serve a cached response by default, up to a week stale
+    staleWhileRevalidate: 60 * 60 * 24 * 7,
+    // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
+    maxAge: 5,
+  });
+};
+
+export default component$(() => {
+  return (
+    <main class="mx-auto max-w-[2200px] relative">
+      <Slot />
+    </main>
+  );
+});
+```
+
+With the above setup we will not only have better performance (pages are always served instantly from cache), but can have significantly decreased hosting costs, as our server (or edge functions) only need to run max once every 5 seconds per page.
+
+## `Request.cacheControl`
+
+Any method that takes a [request event](https://qwik.builder.io/docs/advanced/request-handling/#request-event) can call `request.cacheControl` to set the cache control headers for the response:
+
+```tsx
+import type { RequestHandler } from "@builder.io/qwik-city";
+
+export const onGet: RequestHandler = async (request) => {
+  request.cacheControl({
+    public: true,
+    maxAge: 5,
+    sMaxAge: 10,
+    staleWhileRevalidate: 60 * 60 * 24 * 365,
+  });
+};
+```
+
+You can see the full [API reference](https://qwik.builder.io/api/qwik-city-middleware-request-handler/) of options you can pass to `request.cacheControl`.

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -28,6 +28,7 @@
 - [Pages](/docs/(qwikcity)/pages/index.mdx)
 - [Endpoints](/docs/(qwikcity)/endpoints/index.mdx)
 - [server$](/docs/(qwikcity)/server$/index.mdx)
+- [Caching](/docs/(qwikcity)/caching/index.mdx)
 - [Env variables](/docs/(qwikcity)/env-variables/index.mdx)
 - [API reference](/docs/(qwikcity)/api/index.mdx)
 

--- a/packages/qwik-city/middleware/request-handler/cache-control.ts
+++ b/packages/qwik-city/middleware/request-handler/cache-control.ts
@@ -60,5 +60,8 @@ export function createCacheControl(cacheControl: CacheControl) {
   if (cacheControl.staleWhileRevalidate) {
     controls.push(`stale-while-revalidate=${cacheControl.staleWhileRevalidate}`);
   }
+  if (cacheControl.staleIfError) {
+    controls.push(`stale-if-error=${cacheControl.staleIfError}`);
+  }
   return controls.join(', ');
 }

--- a/packages/qwik-city/middleware/request-handler/types.ts
+++ b/packages/qwik-city/middleware/request-handler/types.ts
@@ -372,6 +372,11 @@ export interface CacheControlOptions {
    * The stale-while-revalidate response directive indicates that the cache could reuse a stale response while it revalidates it to a cache.
    */
   staleWhileRevalidate?: number;
+  
+  /**
+   * The stale-if-error response directive that indicates if a stale response can be used when there's an error from the origin.
+   */
+  staleIfError?: number;
 
   /**
    * The no-store response directive indicates that any caches of any kind (private or shared) should not store this response.

--- a/packages/qwik-city/middleware/request-handler/types.ts
+++ b/packages/qwik-city/middleware/request-handler/types.ts
@@ -372,7 +372,7 @@ export interface CacheControlOptions {
    * The stale-while-revalidate response directive indicates that the cache could reuse a stale response while it revalidates it to a cache.
    */
   staleWhileRevalidate?: number;
-  
+
   /**
    * The stale-if-error response directive that indicates if a stale response can be used when there's an error from the origin.
    */

--- a/starters/apps/basic/src/routes/layout.tsx
+++ b/starters/apps/basic/src/routes/layout.tsx
@@ -7,10 +7,10 @@ import Footer from '~/components/starter/footer/footer';
 
 import styles from './styles.css?inline';
 
-export const onGet: RequestHandler = async (request) => {
+export const onGet: RequestHandler = async ({ cacheControl }) => {
   // Control caching for this request for best performance and to reduce hosting costs:
   // https://qwik.builder.io/docs/caching/
-  request.cacheControl({
+  cacheControl({
     // Always serve a cached response by default, up to a week stale
     staleWhileRevalidate: 60 * 60 * 24 * 7,
     // Max once every 5 seconds, revalidate on the server to get a fresh version of this page

--- a/starters/apps/basic/src/routes/layout.tsx
+++ b/starters/apps/basic/src/routes/layout.tsx
@@ -1,10 +1,22 @@
 import { component$, Slot, useStyles$ } from '@builder.io/qwik';
 import { routeLoader$ } from '@builder.io/qwik-city';
+import type { RequestHandler } from '@builder.io/qwik-city';
 
 import Header from '~/components/starter/header/header';
 import Footer from '~/components/starter/footer/footer';
 
 import styles from './styles.css?inline';
+
+export const onGet: RequestHandler = async (request) => {
+  // Control caching for this request for best performance and to reduce hosting costs:
+  // https://qwik.builder.io/docs/caching/
+  request.cacheControl({
+    // Always serve a cached response by default, up to a week stale
+    staleWhileRevalidate: 60 * 60 * 24 * 7,
+    // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
+    maxAge: 5,
+  });
+};
 
 export const useServerTimeLoader = routeLoader$(() => {
   return {

--- a/starters/apps/documentation-site/src/routes/layout.tsx
+++ b/starters/apps/documentation-site/src/routes/layout.tsx
@@ -3,10 +3,10 @@ import Footer from '~/components/footer/footer';
 import Header from '~/components/header/header';
 import type { RequestHandler } from '@builder.io/qwik-city';
 
-export const onGet: RequestHandler = async (request) => {
+export const onGet: RequestHandler = async ({ cacheControl }) => {
   // Control caching for this request for best performance and to reduce hosting costs:
   // https://qwik.builder.io/docs/caching/
-  request.cacheControl({
+  cacheControl({
     // Always serve a cached response by default, up to a week stale
     staleWhileRevalidate: 60 * 60 * 24 * 7,
     // Max once every 5 seconds, revalidate on the server to get a fresh version of this page

--- a/starters/apps/documentation-site/src/routes/layout.tsx
+++ b/starters/apps/documentation-site/src/routes/layout.tsx
@@ -1,6 +1,18 @@
 import { component$, Slot } from '@builder.io/qwik';
 import Footer from '~/components/footer/footer';
 import Header from '~/components/header/header';
+import type { RequestHandler } from '@builder.io/qwik-city';
+
+export const onGet: RequestHandler = async (request) => {
+  // Control caching for this request for best performance and to reduce hosting costs:
+  // https://qwik.builder.io/docs/caching/
+  request.cacheControl({
+    // Always serve a cached response by default, up to a week stale
+    staleWhileRevalidate: 60 * 60 * 24 * 7,
+    // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
+    maxAge: 5,
+  });
+};
 
 export default component$(() => {
   return (

--- a/starters/apps/empty/src/routes/layout.tsx
+++ b/starters/apps/empty/src/routes/layout.tsx
@@ -1,10 +1,10 @@
 import { component$, Slot } from '@builder.io/qwik';
 import type { RequestHandler } from '@builder.io/qwik-city';
 
-export const onGet: RequestHandler = async (request) => {
+export const onGet: RequestHandler = async ({ cacheControl }) => {
   // Control caching for this request for best performance and to reduce hosting costs:
   // https://qwik.builder.io/docs/caching/
-  request.cacheControl({
+  cacheControl({
     // Always serve a cached response by default, up to a week stale
     staleWhileRevalidate: 60 * 60 * 24 * 7,
     // Max once every 5 seconds, revalidate on the server to get a fresh version of this page

--- a/starters/apps/empty/src/routes/layout.tsx
+++ b/starters/apps/empty/src/routes/layout.tsx
@@ -1,4 +1,16 @@
 import { component$, Slot } from '@builder.io/qwik';
+import type { RequestHandler } from '@builder.io/qwik-city';
+
+export const onGet: RequestHandler = async (request) => {
+  // Control caching for this request for best performance and to reduce hosting costs:
+  // https://qwik.builder.io/docs/caching/
+  request.cacheControl({
+    // Always serve a cached response by default, up to a week stale
+    staleWhileRevalidate: 60 * 60 * 24 * 7,
+    // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
+    maxAge: 5,
+  });
+};
 
 export default component$(() => {
   return <Slot />;


### PR DESCRIPTION
# Overview

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

This is a really useful cache-control directive to avoid unnecessary downtime - allowing the CDN to serve stale responses when your origin is down

Also added a doc on caching, and added default caching to our starters


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
