### PR TITLE
#4319 prevent Link from handling the same click event multiple times

### DIFF
--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -21,11 +21,12 @@ export const Link = component$<LinkProps>((props) => {
           prefetchLinkResources(elm as HTMLAnchorElement, ev.type === 'qvisible')
         )
       : undefined;
-  const handleClick = event$(async (_: any, elm: HTMLAnchorElement) => {
-    if (elm.href) {
+  const handleClick = event$(async (event: any, elm: HTMLAnchorElement) => {
+    if (elm.href && !event._qwik_nav_handled) {
       elm.setAttribute('aria-pressed', 'true');
       await nav(elm.href, reload);
       elm.removeAttribute('aria-pressed');
+      event._qwik_nav_handled = true;
     }
   });
   return (


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Prevents the Link component Click handler from handling the same event multiple times.
This may happen when a Link is updated due to the SPA navigation and the same DOM element reprocess the same click event with a different href.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
