### PR TITLE
docs: useOn suggestion

### DIFF
--- a/packages/docs/src/routes/tutorial/hooks/use-on/index.mdx
+++ b/packages/docs/src/routes/tutorial/hooks/use-on/index.mdx
@@ -9,4 +9,4 @@ Use `useOn()` / `useOnDocument()` / `useOnWindow()` to programmatically set up l
 
 ### Example
 
-The example on the right shows how to use `useOn()` method. Duplicate the code to explore how to use `useOnDocument()` / `useOnWindow()` and how they behave differently.
+The example on the right shows how to use `useOn()` method. Duplicate the code to explore how to use `useOnDocument()` / `useOnWindow()` and how they behave differently..


### PR DESCRIPTION
# DON'T MERGE
useOn/useOnWindow/useOnDocument are here located under "Lifecycle Hooks", but they also exist under "Events". In my opinion it's not necessary to have both and they fit better under events as they don't seem related to the component lifecycle, but rather give access to env-specific APIs to make attaching event handlers easier.

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
