### PR TITLE
fix: allow undefined ref prop

### DIFF
--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -416,7 +416,9 @@ export const diffVnode = (
         let newValue = props[prop];
         if (prop === 'ref') {
           assertElement(elm);
-          setRef(newValue, elm);
+          if (newValue !== undefined) {
+            setRef(newValue, elm);
+          }
           continue;
         }
 
@@ -997,7 +999,9 @@ export const setProperties = (
     let newValue = newProps[prop];
     if (prop === 'ref') {
       assertElement(elm);
-      setRef(newValue, elm);
+      if (newValue !== undefined) {
+        setRef(newValue, elm);
+      }
       continue;
     }
 

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -573,8 +573,10 @@ const renderNode = (
     for (const prop in props) {
       let value = props[prop];
       if (prop === 'ref') {
-        setRef(value, elm);
-        hasRef = true;
+        if (value !== undefined) {
+          setRef(value, elm);
+          hasRef = true;
+        }
         continue;
       }
       if (isOnProp(prop)) {

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -92,6 +92,7 @@ export const RenderChildren = component$(() => {
       <Issue3702 />
       <Issue3795 />
       <Issue4029 />
+      <Issue4346 />
       <SkipRenderTest />
       <SSRRawTest />
       <HTMLFragmentTest />
@@ -823,6 +824,20 @@ export const Issue4292 = component$(() => {
       >
         <div>Hello, World!</div>
       </TestB>
+    </>
+  );
+});
+
+export const Issue4346 = component$(() => {
+  const toggle = useSignal(true);
+  const ref = useSignal<HTMLDivElement>();
+
+  return (
+    <>
+      <div id="issue-4346-result" ref={toggle.value ? ref : undefined}>
+        {toggle.value ? 'Hello' : 'world'}
+      </div>
+      <button id="issue-4346-toggle" onClick$={() => (toggle.value = false)}></button>
     </>
   );
 });

--- a/starters/e2e/e2e.render.spec.ts
+++ b/starters/e2e/e2e.render.spec.ts
@@ -466,4 +466,12 @@ test.describe('render', () => {
     await ref.click();
     await expect(ref).not.toHaveText('data');
   });
+
+  test('issue4346', async ({ page }) => {
+    const result = page.locator('#issue-4346-result');
+    const toggle = page.locator('#issue-4346-toggle');
+    await expect(result).toHaveText('Hello');
+    await toggle.click();
+    await expect(result).toHaveText('world');
+  });
 });


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Allow undefined to be passed into ref props.

Fixes https://github.com/BuilderIO/qwik/issues/4346

If this is not how you would approach this problem @manucorporat, let me know! But hopefully this is a quick win.


# Use cases and why

Please see the linked issue above for a use case example

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
