### PR TITLE
fix(deno middleware): serve static assets in Deno middleware as binary data

### DIFF
--- a/@types/deno.d.ts
+++ b/@types/deno.d.ts
@@ -7,6 +7,7 @@ declare module 'https://deno.land/std/path/mod.ts' {
 declare const Deno: {
   env: any;
   readTextFile(path: string): Promise<string>;
+  readFile(path: string): Promise<Uint8Array>;
   version: {
     deno: string;
   };

--- a/packages/qwik-city/middleware/deno/index.ts
+++ b/packages/qwik-city/middleware/deno/index.ts
@@ -109,7 +109,7 @@ export function createQwikCity(opts: QwikCityDenoOptions) {
     }
     return {
       filePath,
-      content: await Deno.readTextFile(filePath),
+      content: await Deno.readFile(filePath),
     };
   };
 


### PR DESCRIPTION
# Overview

Fixes https://github.com/BuilderIO/qwik/issues/4345

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

- 1. Safari didn't show images.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
