### PR TITLE
docs: Fix typo at caching index.mdx page

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/caching/index.mdx
@@ -53,7 +53,7 @@ export const onGet: RequestHandler = async ({ cacheControl }) => {
 };
 ```
 
-You can also override this as well. For instance, perhaps you have a defualt caching at the root, but want to disable caching for a specific page, you can override this with nested layouts
+You can also override this as well. For instance, perhaps you have a default caching at the root, but want to disable caching for a specific page, you can override this with nested layouts
 
 ```tsx title="src/routes/dashboard/layout.tsx"
 import type { RequestHandler } from "@builder.io/qwik-city";


### PR DESCRIPTION
# What is it?

- [x] Docs / tests / types / typos

# Description

Just to fix a typo: `defualt` to `default` 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code