### PR TITLE
docs: fix link to `speculative-module-fetching`

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/bundle/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/bundle/index.mdx
@@ -146,7 +146,7 @@ To collect symbol usage from a running application:
 
 Qwik apps employ a service worker to ensure that bundles are prefetched into the browser's cache and that any user interaction would result in a cache hit, hence no delay in interaction.
 
-See [Speculative Module Fetching](/docs/advanced/speculative-module-fetching/index.mdx).
+See [Speculative Module Fetching](/docs/(qwikcity)/advanced/speculative-module-fetching/index.mdx).
 
 ## Events
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

docs: fix link to `speculative-module-fetching`

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
