### PR TITLE
fix: 'Numberish' type used for width/height didn't allow %

### DIFF
--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -2,7 +2,7 @@ import type { Signal } from '../../../state/signal';
 import type { DOMAttributes, ClassList } from './jsx-qwik-attributes';
 interface HTMLWebViewElement extends HTMLElement {}
 export type Booleanish = boolean | `${boolean}`;
-export type Numberish = number | `${number}`;
+export type Numberish = number | `${number}` | `${number}%`;
 
 /**
  * @public


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

The `Numberish` type which was used for heights and widths didn't allow for any % values like "100%"

# Use cases and why
The following should support the percentage value passed
![image](https://github.com/BuilderIO/qwik/assets/90424167/ec456093-d8f2-4482-9608-cc8f8b513665)

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
