### PR TITLE
docs: Update deprecation information about the basePathname

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
@@ -61,7 +61,7 @@ The URL `origin`, which is a combination of the scheme (protocol) and hostname (
 
 The `origin` is used to provide a full URL during Static Site Generation (SSG), and to simulate a complete URL rather than just the `pathname`. For example, in order to render a correct canonical tag URL or URLs within the `sitemap.xml`, the `origin` must be provided too.
 
-If the site also starts with a pathname other than `/`, please use the `basePathname` option in the Qwik City config options.
+If the site also starts with a pathname other than `/`, please use the `base` option in the Vite config options (the `basePathname` option in the Qwik City config options is deprecated).
 
 #### `outDir`
 


### PR DESCRIPTION
The `basePathname` was deprecated among Qwik City configuration options, in favor of `base` in the Vite configuration options but the docs have no information about it yet.

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

The `basePathname` was deprecated among Qwik City configuration options, in favor of `base` in the Vite configuration options but the docs have no information about it yet.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
