### PR TITLE
docs(adding content security policy to the advanced topics)

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/advanced/content-security-policy/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/advanced/content-security-policy/index.mdx
@@ -1,0 +1,103 @@
+---
+title: Content Security Policy
+contributors:
+  - tzdesign
+---
+
+# Content Security Policy
+
+## What is CSP?
+
+[Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross-Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft, to site defacement, to malware distribution.
+
+## Steps to integrate
+
+### Add a route plugin
+
+To add the middleware plugin to your application, simply add a file named ```plugin@your-plugin-name.ts``` to the routes folder. 
+This file will be loaded with every request, allowing you to add headers, modify the response, and more.
+
+```bash  {3} /plugin@csp\.ts/ title="Add the plugin"
+src/
+└── routes/
+    ├── plugin@csp.ts         # The plugin which runs on every request (route middleware)
+    ├── contact/
+    │   └── index.mdx         # https://example.com/contact
+    ├── about/
+    │   └── index.md          # https://example.com/about
+    ├── index.mdx             # https://example.com/
+    │
+    └── layout.tsx            # This layout is used for all pages
+```
+
+```typescript title="src/routes/plugin@csp.ts"
+import type { RequestHandler } from "@builder.io/qwik-city";
+
+export const onRequest: RequestHandler = event => {
+  const nonce = Date.now().toString(36); // Your custom nonce logic here
+  event.sharedMap.set("@nonce", nonce);
+  const csp = [
+    `default-src 'self' 'unsafe-inline'`,
+    `font-src 'self'`,
+    `img-src 'self' 'unsafe-inline' data:`,
+    `script-src 'strict-dynamic' 'unsafe-inline' 'nonce-${nonce}'`,
+    `style-src 'self' 'unsafe-inline'`,
+    `frame-src 'self' 'nonce-${nonce}'`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+  ];
+
+  event.headers.set("Content-Security-Policy", csp.join("; "));
+};
+```
+
+### Add it to the service worker as well
+
+```tsx {12,22} /nonce/ title="src/root.ts"
+import { component$, useServerData } from "@builder.io/qwik";
+import {
+  QwikCityProvider,
+  RouterOutlet,
+  ServiceWorkerRegister,
+} from "@builder.io/qwik-city";
+import { RouterHead } from "./components/router-head/router-head";
+
+import "./global.css";
+
+export default component$(() => {
+  const nonce = useServerData<string | undefined>("nonce");
+  return (
+    <QwikCityProvider>
+      <head>
+        <meta charSet="utf-8" />
+        <link rel="manifest" href="/manifest.json" />
+        <RouterHead />
+      </head>
+      <body lang="en">
+        <RouterOutlet />
+        <ServiceWorkerRegister nonce={nonce} />
+      </body>
+    </QwikCityProvider>
+  );
+});
+```
+
+### Custom scripts
+
+If you have custom script tags that you need to add the nonce to, you can use the `useServerData` hook to get the nonce from the server and add it to your script tags.
+
+```tsx {2,5} /nonce/ title="src/components/some-component.tsx"
+export default component$(() => {
+  const nonce = useServerData<string | undefined>("nonce");
+  return (
+    <div>
+      <script nonce={nonce}>alert("Hello world")</script>
+    </div>
+  );
+});
+```
+
+
+## Validate your CSP
+
+There is a great tool to validate your CSP: [https://csp-evaluator.withgoogle.com/](https://csp-evaluator.withgoogle.com/)

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -99,6 +99,7 @@
 - [Static Assets](/docs/(qwikcity)/advanced/static-assets/index.mdx)
 - [Sitemaps](/docs/(qwikcity)/advanced/sitemaps/index.mdx)
 - [ESLint-Rules](/docs/(qwik)/advanced/eslint/index.mdx)
+- [Content Security Policy](/docs/(qwik)/advanced/content-security-policy/index.mdx)
 
 ## Reference
 


### PR DESCRIPTION
docs advanced » content security policy

I added information about CSP and how to integrate it with qwik. Added code examples and routing structure for middleware (plugins)

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Adding information how to add content-security-policy to a qwik application using middleware (plugin)

# Use cases and why

Every large website with security in mind will need to add CSP.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
