### PR TITLE
fix(use-on.ts): fixed useOn methods to pass correct eventName to _useOn

### DIFF
--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -1062,6 +1062,28 @@ renderSSRSuite('component useOn()', async () => {
   );
 });
 
+renderSSRSuite('component useOn([array])', async () => {
+  await testSSR(
+    <body>
+      <UseOnMultiple />
+    </body>,
+    `
+    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+      <body>
+        <!--qv q:id=0 q:key=sX:-->
+        <div on:click="/runtimeQRL#_\n/runtimeQRL#_"
+          on:scroll="/runtimeQRL#_"
+          on-window:click="/runtimeQRL#_"
+          on-window:scroll="/runtimeQRL#_"
+          on-document:click="/runtimeQRL#_"
+          on-document:scroll="/runtimeQRL#_"
+        ></div>
+        <!--/qv-->
+      </body>
+    </html>`
+  );
+});
+
 renderSSRSuite('component useStyles()', async () => {
   await testSSR(
     <>
@@ -1594,6 +1616,23 @@ export const Events = component$(() => {
   useOnDocument(
     'click',
     $(() => console.warn('document:click'))
+  );
+
+  return <div onClick$={() => console.warn('scroll')}></div>;
+});
+
+export const UseOnMultiple = component$(() => {
+  useOn(
+    ['click', 'scroll'],
+    $(() => console.warn('click or scroll'))
+  );
+  useOnWindow(
+    ['click', 'scroll'],
+    $(() => console.warn('window:click or scroll'))
+  );
+  useOnDocument(
+    ['click', 'scroll'],
+    $(() => console.warn('document:click or scroll'))
   );
 
   return <div onClick$={() => console.warn('scroll')}></div>;

--- a/packages/qwik/src/core/use/use-on.ts
+++ b/packages/qwik/src/core/use/use-on.ts
@@ -22,7 +22,9 @@ import { type PascalCaseEventLiteralType } from '../render/jsx/types/jsx-qwik-ev
 export const useOn = (
   event: PascalCaseEventLiteralType | PascalCaseEventLiteralType[],
   eventQrl: QRL<(ev: Event) => void> | undefined
-) => _useOn(`on-${event}`, eventQrl);
+) => {
+  _useOn(createEventName(event, undefined), eventQrl);
+};
 
 // <docs markdown="../readme.md#useOnDocument">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
@@ -57,7 +59,9 @@ export const useOn = (
 export const useOnDocument = (
   event: PascalCaseEventLiteralType | PascalCaseEventLiteralType[],
   eventQrl: QRL<(ev: Event) => void> | undefined
-) => _useOn(`document:on-${event}`, eventQrl);
+) => {
+  _useOn(createEventName(event, 'document'), eventQrl);
+};
 
 // <docs markdown="../readme.md#useOnWindow">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
@@ -93,7 +97,20 @@ export const useOnDocument = (
 export const useOnWindow = (
   event: PascalCaseEventLiteralType | PascalCaseEventLiteralType[],
   eventQrl: QRL<(ev: Event) => void> | undefined
-) => _useOn(`window:on-${event}`, eventQrl);
+) => {
+  _useOn(createEventName(event, 'window'), eventQrl);
+};
+
+const createEventName = (
+  event: PascalCaseEventLiteralType | PascalCaseEventLiteralType[],
+  eventType: 'window' | 'document' | undefined
+) => {
+  const formattedEventType = eventType !== undefined ? eventType + ':' : '';
+  const res = Array.isArray(event)
+    ? event.map((e) => `${formattedEventType}on-${e}`)
+    : `${formattedEventType}on-${event}`;
+  return res;
+};
 
 const _useOn = (eventName: string | string[], eventQrl: QRL<(ev: Event) => void> | undefined) => {
   if (eventQrl) {


### PR DESCRIPTION

#4408

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

The issue was: when passing an array of events to the `useOnDocument` method, the events didn't work as expected in the browser.

### The useOnDocument method passes invalid param to \_useOn

```ts
export const useOnDocument = (
	event: PascalCaseEventLiteralType | PascalCaseEventLiteralType[],
	eventQrl: QRL<(ev: Event) => void> | undefined
) => {
	_useOn(`document:on-${event}`, eventQrl);
};
```

The problem is that the `${event}` is translated into `e1,e2` when the event is `[e1,e2]`.

Replication in js:

```js
const event = ['e1', 'e2'];
const res = `document:on-${event}`;
console.log(res); // document:on-e1,e2
```

The solution is to change the `event` parameter to pass an array of event names, instead of the malformed event string.

This is achieved by changing the creation of the eventName parameter that is passed to the method `useOn`:

```ts
export const useOn = (
	event: PascalCaseEventLiteralType | PascalCaseEventLiteralType[],
	eventQrl: QRL<(ev: Event) => void> | undefined
) => {
	const eventName = Array.isArray(event)
		? event.map((e) => `document:on-${e}`)
		: `document:on-${event}`;
	_useOn(eventName, eventQrl);
};
```

I added a method to the module which is reusable within the `useOn` methods in the module, and it solves the bug.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
