### PR TITLE
Reorganize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,13 +5,13 @@
 
 # Dependencies
 *.node
+*.log
 /.pnpm-store/
 /.yarn/
 !/.yarn/releases
 /node_modules/
 
 # Application
-*.log
 /dist-dev/
 /etc/
 /lib/

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,29 @@
-.history
-.vscode/settings.json
-dist
-lib
-dist-dev
-node_modules
-tsc-out
-external
-*.
-**/*.log
-etc
-temp
-tsdoc-metadata.json
-**/.DS_Store
-src/napi/package-*
-target
-!/packages/docs/src/routes/demo/events/target
-*.node
-todo-express/
-qwik-app/
-**/server/
-.idea
-.eslintcache
+# Keep "OS" and "IDE and local environment" ignores on your local machine in user home
+# git config --global core.excludesFile ~/.gitignore
+# https://git-scm.com/docs/gitignore
+/.vscode/settings.json
 
-# Yarn
-.yarn/*
-!.yarn/releases
-.pnpm-store/*
+# Dependencies
+*.node
+/.pnpm-store/
+/.yarn/
+!/.yarn/releases
+/node_modules/
+
+# Application
+*.log
+.eslintcache
+/dist-dev/
+/etc/
+/lib/
+/external/
+/packages/qwik/src/napi/package-*
+/qwik-app/
+/server/
+/target/
+/temp/
+/todo-express/
+/tsdoc-metadata.json
+
+# Distribution
+/packages/qwik/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 
 # Application
 *.log
-.eslintcache
 /dist-dev/
 /etc/
 /lib/
@@ -24,6 +23,9 @@
 /temp/
 /todo-express/
 /tsdoc-metadata.json
+
+# Tests
+.eslintcache
 
 # Distribution
 /packages/qwik/dist/


### PR DESCRIPTION
# Overview

Organize git ignores in to categories.

[_source_](https://github.com/szepeviktor/debian-server-tools/blob/9abca88bda2b3805a7be0c9a535966d775da8d5f/.gitignore#L6-L12)

I'm highly unsure whether anchoring is correct and I've put ignores in the correct category.
Mainly in case of `/target/` and `**/server/`
Please help me.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

We could provide example `~/.gitignore` contents in CONTRIBUTING.md

```gitignore
# OS
.DS_Store
Thumbs.db

# IDE and local environment
/.history/
/.idea/
*. or .* ?
```

This is because one project cannot cover every OS, every IDE, every local env.
Please see https://git-scm.com/docs/gitignore
