### PR TITLE
Fix typo in MDX example code

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/mdx/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/mdx/index.mdx
@@ -174,7 +174,7 @@ import { useDocumentHead } from '@builder.io/qwik-city';
 export const Tags = component$(() => {
   const { frontmatter } = useDocumentHead();
   
-  if (frontmatter.tags.length) {
+  if (frontmatter.tags.length === 0) {
     return;
   }
   


### PR DESCRIPTION
# Overview

Fix a minor bug in example code.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

Fix a minor bug in example code. Some people prefer a `!`, but `=== 0` is more explicit.