### PR TITLE
fix: add missing nonce to popstate script

### DIFF
--- a/packages/qwik-city/runtime/src/router-outlet-component.tsx
+++ b/packages/qwik-city/runtime/src/router-outlet-component.tsx
@@ -7,6 +7,7 @@ import {
   _IMMUTABLE,
   _jsxBranch,
   _jsxQ,
+  useServerData,
 } from '@builder.io/qwik';
 
 import { ContentInternalContext } from './contexts';
@@ -18,6 +19,7 @@ import popStateScript from './init-popstate.txt?raw';
 export const RouterOutlet = component$(() => {
   _jsxBranch();
 
+  const nonce = useServerData<string | undefined>('nonce');
   const { value } = useContext(ContentInternalContext);
   if (value && value.length > 0) {
     const contentsLen = value.length;
@@ -30,7 +32,7 @@ export const RouterOutlet = component$(() => {
     return (
       <>
         {cmp}
-        <script dangerouslySetInnerHTML={popStateScript}></script>
+        <script dangerouslySetInnerHTML={popStateScript} nonce={nonce}></script>
       </>
     );
   }


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests / types / typos

# Description

fixes https://github.com/BuilderIO/qwik/issues/4411

Add a missing nonce to a Qwik City script which prevents websites from running correctly.

This code is taken from https://github.com/BuilderIO/qwik/pull/4440, thanks @tzdesign @the-zimmermann. I'm adding this as a separate PR so that it can be merged in sooner without needing to review the changes to the docs, as this is an important fix, hopefully we can prioritise it.

# Use cases and why

- Qwik is broken without it

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
