### PR TITLE
feat: aria-current on Link component

### DIFF
--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -320,7 +320,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface LinkProps extends AnchorAttributes \n```\n**Extends:** AnchorAttributes\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [end?](#) |  | boolean | _(Optional)_ |\n|  [prefetch?](#) |  | boolean | _(Optional)_ |\n|  [reload?](#) |  | boolean | _(Optional)_ |",
+      "content": "```typescript\nexport interface LinkProps extends AnchorAttributes \n```\n**Extends:** AnchorAttributes\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [end?](#) |  | boolean | _(Optional)_ The end prop changes the matching logic for the aria-current attribute to only match to the \"end\" of the Link's href path. If the URL is longer than href, it will no longer be considered active.. |\n|  [prefetch?](#) |  | boolean | _(Optional)_ The prefetch prop tells Qwik to prefetch the code for the Link's destination. |\n|  [reload?](#) |  | boolean | _(Optional)_ The reload prop forces a reload of the current route when a Link is clicked, even if the current route is the same as the Link's destination. |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/link-component.tsx",
       "mdFile": "qwik-city.linkprops.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -320,7 +320,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface LinkProps extends AnchorAttributes \n```\n**Extends:** AnchorAttributes\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [prefetch?](#) |  | boolean | _(Optional)_ |\n|  [reload?](#) |  | boolean | _(Optional)_ |",
+      "content": "```typescript\nexport interface LinkProps extends AnchorAttributes \n```\n**Extends:** AnchorAttributes\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [end?](#) |  | boolean | _(Optional)_ |\n|  [prefetch?](#) |  | boolean | _(Optional)_ |\n|  [reload?](#) |  | boolean | _(Optional)_ |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/link-component.tsx",
       "mdFile": "qwik-city.linkprops.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -331,6 +331,7 @@ export interface LinkProps extends AnchorAttributes
 
 | Property       | Modifiers | Type    | Description  |
 | -------------- | --------- | ------- | ------------ |
+| [end?](#)      |           | boolean | _(Optional)_ |
 | [prefetch?](#) |           | boolean | _(Optional)_ |
 | [reload?](#)   |           | boolean | _(Optional)_ |
 

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -329,11 +329,11 @@ export interface LinkProps extends AnchorAttributes
 
 **Extends:** AnchorAttributes
 
-| Property       | Modifiers | Type    | Description  |
-| -------------- | --------- | ------- | ------------ |
-| [end?](#)      |           | boolean | _(Optional)_ |
-| [prefetch?](#) |           | boolean | _(Optional)_ |
-| [reload?](#)   |           | boolean | _(Optional)_ |
+| Property       | Modifiers | Type    | Description                                                                                                                                                                                                      |
+| -------------- | --------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [end?](#)      |           | boolean | _(Optional)_ The end prop changes the matching logic for the aria-current attribute to only match to the "end" of the Link's href path. If the URL is longer than href, it will no longer be considered active.. |
+| [prefetch?](#) |           | boolean | _(Optional)_ The prefetch prop tells Qwik to prefetch the code for the Link's destination.                                                                                                                       |
+| [reload?](#)   |           | boolean | _(Optional)_ The reload prop forces a reload of the current route when a Link is clicked, even if the current route is the same as the Link's destination.                                                       |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/link-component.tsx)
 

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -249,6 +249,8 @@ export const Link: Component<LinkProps>;
 //
 // @public (undocumented)
 export interface LinkProps extends AnchorAttributes {
+    // The end prop changes the matching logic for the aria-current attribute to only match to the "end" of the Link's href path. If the URL is longer than href, it will no longer be considered active.
+    end?: boolean;
     // (undocumented)
     prefetch?: boolean;
     // (undocumented)

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -249,11 +249,8 @@ export const Link: Component<LinkProps>;
 //
 // @public (undocumented)
 export interface LinkProps extends AnchorAttributes {
-    // The end prop changes the matching logic for the aria-current attribute to only match to the "end" of the Link's href path. If the URL is longer than href, it will no longer be considered active.
     end?: boolean;
-    // (undocumented)
     prefetch?: boolean;
-    // (undocumented)
     reload?: boolean;
 }
 

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -252,8 +252,6 @@ export interface LinkProps extends AnchorAttributes {
     // The end prop changes the matching logic for the aria-current attribute to only match to the "end" of the Link's href path. If the URL is longer than href, it will no longer be considered active.
     end?: boolean;
     // (undocumented)
-    end?: boolean;
-    // (undocumented)
     prefetch?: boolean;
     // (undocumented)
     reload?: boolean;

--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -84,7 +84,16 @@ type AnchorAttributes = QwikIntrinsicElements['a'];
  * @public
  */
 export interface LinkProps extends AnchorAttributes {
+  /**
+   * The prefetch prop tells Qwik to prefetch the code for the Link's destination.
+   */
   prefetch?: boolean;
+  /**
+   * The reload prop forces a reload of the current route when a Link is clicked, even if the current route is the same as the Link's destination.
+   */
   reload?: boolean;
+  /**
+   * The end prop changes the matching logic for the aria-current attribute to only match when current location pathname and href are identical. Otherwise, aria-current will match any location that starts with the href value.
+   */
   end?: boolean;
 }

--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -1,4 +1,4 @@
-import { component$, Slot, type QwikIntrinsicElements, untrack, event$ } from '@builder.io/qwik';
+import { component$, Slot, type QwikIntrinsicElements, untrack, event$, useComputed$ } from '@builder.io/qwik';
 import { getClientNavPath, getPrefetchDataset } from './utils';
 import { loadClientData } from './use-endpoint';
 import { useLocation, useNavigate } from './use-functions';
@@ -18,8 +18,8 @@ export const Link = component$<LinkProps>((props) => {
   const onPrefetch =
     prefetchDataset != null
       ? event$((ev: any, elm: HTMLAnchorElement) =>
-          prefetchLinkResources(elm as HTMLAnchorElement, ev.type === 'qvisible')
-        )
+        prefetchLinkResources(elm as HTMLAnchorElement, ev.type === 'qvisible')
+      )
       : undefined;
   const handleClick = event$(async (_: any, elm: HTMLAnchorElement) => {
     if (elm.href) {
@@ -28,9 +28,23 @@ export const Link = component$<LinkProps>((props) => {
       elm.removeAttribute('aria-pressed');
     }
   });
+  const ariaCurrent = useComputed$(() =>
+    Boolean(props.href) &&
+      (loc.url.pathname === props.href ||
+        (!props.end &&
+          loc.url.pathname.startsWith(props.href!) &&
+          loc.url.pathname.charAt(props.href!.length) === "/") ||
+        loc.prevUrl?.href === props.href ||
+        (!props.end &&
+          loc.prevUrl?.pathname.startsWith(props.href!) &&
+          loc.prevUrl?.pathname.charAt(props.href!.length) === "/"))
+      ? "page"
+      : undefined
+  )
   return (
     <a
       {...linkProps}
+      aria-current={ariaCurrent.value}
       onClick$={[onClick$, handleClick]}
       data-prefetch={prefetchDataset}
       onMouseOver$={onPrefetch}
@@ -69,4 +83,5 @@ type AnchorAttributes = QwikIntrinsicElements['a'];
 export interface LinkProps extends AnchorAttributes {
   prefetch?: boolean;
   reload?: boolean;
+  end?: boolean;
 }

--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -1,4 +1,11 @@
-import { component$, Slot, type QwikIntrinsicElements, untrack, event$, useComputed$ } from '@builder.io/qwik';
+import {
+  component$,
+  Slot,
+  type QwikIntrinsicElements,
+  untrack,
+  event$,
+  useComputed$,
+} from '@builder.io/qwik';
 import { getClientNavPath, getPrefetchDataset } from './utils';
 import { loadClientData } from './use-endpoint';
 import { useLocation, useNavigate } from './use-functions';
@@ -18,8 +25,8 @@ export const Link = component$<LinkProps>((props) => {
   const onPrefetch =
     prefetchDataset != null
       ? event$((ev: any, elm: HTMLAnchorElement) =>
-        prefetchLinkResources(elm as HTMLAnchorElement, ev.type === 'qvisible')
-      )
+          prefetchLinkResources(elm as HTMLAnchorElement, ev.type === 'qvisible')
+        )
       : undefined;
   const handleClick = event$(async (_: any, elm: HTMLAnchorElement) => {
     if (elm.href) {
@@ -30,13 +37,13 @@ export const Link = component$<LinkProps>((props) => {
   });
   const ariaCurrent = useComputed$(() =>
     Boolean(props.href) &&
-      (loc.url.pathname === props.href ||
-        (!props.end &&
-          loc.url.pathname.startsWith(props.href!) &&
-          loc.url.pathname.charAt(props.href!.length) === "/"))
-      ? "page"
+    (loc.url.pathname === props.href ||
+      (!props.end &&
+        loc.url.pathname.startsWith(props.href!) &&
+        loc.url.pathname.charAt(props.href!.length) === '/'))
+      ? 'page'
       : undefined
-  )
+  );
   return (
     <a
       {...linkProps}

--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -33,11 +33,7 @@ export const Link = component$<LinkProps>((props) => {
       (loc.url.pathname === props.href ||
         (!props.end &&
           loc.url.pathname.startsWith(props.href!) &&
-          loc.url.pathname.charAt(props.href!.length) === "/") ||
-        loc.prevUrl?.href === props.href ||
-        (!props.end &&
-          loc.prevUrl?.pathname.startsWith(props.href!) &&
-          loc.prevUrl?.pathname.charAt(props.href!.length) === "/"))
+          loc.url.pathname.charAt(props.href!.length) === "/"))
       ? "page"
       : undefined
   )


### PR DESCRIPTION
# Overview

fixes: #4041

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

This pull request introduces a new feature that adds support for aria-current on the Link component. The aria-current attribute is a helpful accessibility feature that allows screen readers and other assistive technologies to indicate the current active link to users.

this is inspired by the `NavLink` component of react-router v6
https://github.com/remix-run/react-router/blob/main/packages/react-router-dom/index.tsx#L644

# Use cases and why

With this enhancement, when the Link component is rendered as the active link, the aria-current="page" attribute will be automatically applied, providing better accessibility and usability for users navigating through the application.

By incorporating aria-current support into the Link component, developers using Tailwind CSS or Unocss can easily style the active link state with `class="aria-[current=page]:bg-red"`

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
