### PR TITLE
fix: prefetch urls with different search queries

### DIFF
--- a/packages/qwik-city/runtime/src/utils.ts
+++ b/packages/qwik-city/runtime/src/utils.ts
@@ -29,6 +29,11 @@ export const isSamePath = (a: SimpleURL, b: SimpleURL) =>
 export const isSamePathname = (a: SimpleURL, b: SimpleURL) => a.pathname === b.pathname;
 
 /**
+ * Checks only if the search query strings are the same for the URLs
+ */
+export const isSameSearchQuery = (a: SimpleURL, b: SimpleURL) => a.search === b.search;
+
+/**
  * Same origin, but different pathname (doesn't include search and hash)
  */
 export const isSameOriginDifferentPathname = (a: SimpleURL, b: SimpleURL) =>
@@ -71,7 +76,8 @@ export const getPrefetchDataset = (
 ) => {
   if (props.prefetch === true && clientNavPath) {
     const prefetchUrl = toUrl(clientNavPath, currentLoc.url);
-    if (!isSamePathname(prefetchUrl, toUrl('', currentLoc.url))) {
+    const currentUrl = toUrl('', currentLoc.url);
+    if (!isSamePathname(prefetchUrl, currentUrl) || !isSameSearchQuery(prefetchUrl, currentUrl)) {
       return '';
     }
   }


### PR DESCRIPTION
# Overview

# What is it?

- [X] Feature / enhancement
- [X] Bug
- [ ] Docs / tests / types / typos

# Description

Link components don't prefetch URLs with different search queries but matching pathnames.
Since search queries are used by loaders to fetch data, we should prefetch URLs when the search changes.

# Use cases and why

- 1. When a single URL page has multiple possible filters or tabs that change the search parameters but not the pathname, it would be great to have these prefetch

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
