### PR TITLE
fix(parse-pathname): path segment encoding

### DIFF
--- a/packages/qwik-city/buildtime/routing/parse-pathname.ts
+++ b/packages/qwik-city/buildtime/routing/parse-pathname.ts
@@ -46,7 +46,8 @@ export function parseRoutePathname(basePathname: string, pathname: string): Pars
               }
 
               return (
-                content // allow users to specify characters on the file system in an encoded manner
+                encodeURIComponent(content)
+                  // allow users to specify characters on the file system in an encoded manner
                   .normalize()
                   // We use [ and ] to denote parameters, so users must encode these on the file
                   // system to match against them. We don't decode all characters since others
@@ -61,7 +62,7 @@ export function parseRoutePathname(basePathname: string, pathname: string): Pars
                   .replace(/\?/g, '%3F')
                   // escape characters that have special meaning in regex
                   .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-              ); // TODO handle encoding
+              );
             })
             .join('')
         );

--- a/packages/qwik-city/buildtime/routing/parse-pathname.unit.ts
+++ b/packages/qwik-city/buildtime/routing/parse-pathname.unit.ts
@@ -63,6 +63,11 @@ const tests = {
     pattern: /^\/xyz\/abc\.dot\/?$/,
     paramNames: [],
   },
+  '/xyz/%D8%B9%D8%B1%D8%A8%D9%8A/': {
+    basePathname: '/',
+    pattern: /^\/xyz\/%D8%B9%D8%B1%D8%A8%D9%8A\/?$/,
+    paramNames: [],
+  },
 };
 
 for (const [key, t] of Object.entries(tests)) {

--- a/starters/apps/qwikcity-test/src/routes/issue3438/عربي/index.mdx
+++ b/starters/apps/qwikcity-test/src/routes/issue3438/عربي/index.mdx
@@ -1,0 +1,1 @@
+Test arabic route


### PR DESCRIPTION
fix #3438

# Overview


# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Add path segment encoding

# Use cases and why

Currently any non-latin letters are not supported in routes. This fix add path segment encoding to enable support for non-latin letters.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
