### PR TITLE
feat: frame-perfect and state-backed durable SPA scroll restoration

### DIFF
--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -460,7 +460,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface QwikCityProps \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [restoreScroll$?](#) |  | PropFunction&lt;RestoreScroll&gt; | _(Optional)_ |\n|  [viewTransition?](#) |  | boolean | <p>_(Optional)_ Enable the ViewTransition API</p><p>Default: <code>true</code></p> |",
+      "content": "```typescript\nexport interface QwikCityProps \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [viewTransition?](#) |  | boolean | <p>_(Optional)_ Enable the ViewTransition API</p><p>Default: <code>true</code></p> |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/qwik-city-component.tsx",
       "mdFile": "qwik-city.qwikcityprops.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -439,10 +439,9 @@ export interface QwikCityPlan
 export interface QwikCityProps
 ```
 
-| Property             | Modifiers | Type                              | Description                                                                        |
-| -------------------- | --------- | --------------------------------- | ---------------------------------------------------------------------------------- |
-| [restoreScroll$?](#) |           | PropFunction&lt;RestoreScroll&gt; | _(Optional)_                                                                       |
-| [viewTransition?](#) |           | boolean                           | <p>_(Optional)_ Enable the ViewTransition API</p><p>Default: <code>true</code></p> |
+| Property             | Modifiers | Type    | Description                                                                        |
+| -------------------- | --------- | ------- | ---------------------------------------------------------------------------------- |
+| [viewTransition?](#) |           | boolean | <p>_(Optional)_ Enable the ViewTransition API</p><p>Default: <code>true</code></p> |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/qwik-city-component.tsx)
 

--- a/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
@@ -242,61 +242,6 @@ The `QwikCityProvider` component initializes Qwik City in the existing document,
 This component is usually located at the very root of your application, in most of the starters you will find it in the `src/root.tsx` file:
 
 ```tsx title="src/root.tsx"
-import { QwikCityProvider, RouterOutlet } from '@builder.io/qwik-city';
-
-export default function Root() {
-  return (
-    <QwikCityProvider>
-      <head>
-        <meta charSet="utf-8" />
-      </head>
-      <body>
-        <RouterOutlet />
-      </body>
-    </QwikCityProvider>
-  );
-}
-```
-
-> `QwikCityProvider` does not render any DOM element, not even the matched route, it merely initializes Qwik City core logic, because of this reason, it should not be used more than once in the same app.
-
-## `<RouterOutlet>`
-
-The `RouterOutlet` component is responsible for rendering the matched route at a given moment, it uses internally the [`useContent()`](/docs/(qwikcity)/api/index.mdx#usecontent) and to render the current page, as well as all the nested layouts.
-
-This component is usually located as a child of `<body>`, in most of the starters you will find it in the `src/root.tsx` file (refer to the example in `QwikCityProvider`).
-
-It accepts an optional `restoreScroll$` prop that can be used to customize the scrolling behavior of SPAs. The function supplied to `restoreScroll$` is called with the following arguments upon navigation events:
-
-```ts
-type RestoreScroll = (
-  type: 'initial' | 'form' | 'link' | 'popstate';
-  fromUrl: URL;
-  toUrlSettled: Promise<URL>;
-) => void;
-```
-
-There are two built-in scroll restoration presets provided by QwikCity - `toTopAlways` and `toLastPositionOnPopState`.
-
-- `toTopAlways` (default), as the name suggested, always scrolls the page to the top of the window when navigating to new or previous pages.
-- `toLastPositionOnPopState` mimics how browsers handle MPA - scrolling the page to the top when navigating to a new page, but to the last-visited position when navigating with a `popstate` event (e.g. back/next button).
-
-> Note that both presets treat hash navigation as an exception and always scroll to the hashed element when it is available and specified in the URL.
-
-You can also implement your own scroll restoration logic by supplying a function with the above signature. The `toUrlSettled` promise allows you to wait for DOM updates to complete before setting scroll positions.
-
-```ts
-const restoreScroll: RestoreScroll = $(async (type, fromUrl, toUrlSettled) => {
-  // do something before navigation, e.g. saving current scroll position to sessionStorage
-  prepare(type, fromUrl);
-  // wait for final URL to be resolved and DOM to settle
-  const toUrl = await toUrlSettled;
-  // handle the actual scroll restoration
-  handleScroll(type, fromUrl, toUrl);
-});
-```
-
-```tsx title="src/routes.tsx"
 export default component$(() => {
   /**
    * The root of a QwikCity site always start with the <QwikCityProvider> component,
@@ -320,6 +265,49 @@ export default component$(() => {
   );
 });
 ```
+
+> `QwikCityProvider` does not render any DOM element, not even the matched route, it merely initializes Qwik City core logic, because of this reason, it should not be used more than once in the same app.
+
+It also accepts an optional `restoreScroll$` prop that can be used to customize the scrolling behavior of SPAs. The function supplied to `restoreScroll$` is called with the following arguments upon navigation events:
+
+```ts
+type RestoreScroll = (
+  type: 'initial' | 'form' | 'link' | 'popstate';
+  fromUrl: URL;
+  toUrl: URL;
+  records: ScrollRecord;
+) => () => void;
+```
+
+There are two built-in scroll restoration presets provided by QwikCity - `toTopAlways` and `toLastPositionOnPopState`.
+
+- `toTopAlways`, as the name suggests, always scrolls the page to the top of the window when navigating to new or previous pages.
+- `toLastPositionOnPopState` (default) mimics how browsers handle MPA - scrolling the page to the top when navigating to a new page, but to the last-visited position when navigating with a `popstate` event (e.g. back/next button).
+
+> Note that both presets treat hash navigation as an exception and always scroll to the hashed element when it is available and specified in the URL.
+
+You can also implement your own scroll restoration logic by supplying a function with the above signature, for example:
+
+```ts
+// TODO Adjust this example after finalize of SPA scroll restoration feature.
+const restoreScroll: RestoreScroll = $((type, fromUrl, toUrl, records) => {
+  // do something before navigation
+  prepare();
+
+  return () => {
+    // handle the actual scroll restoration
+    window.scrollTo(scrollX, scrollY);
+  }
+});
+```
+
+> Note that the returned inner void function is run synchronously with render, it is recommended to avoid expensive computations inside of it.
+
+## `<RouterOutlet>`
+
+The `RouterOutlet` component is responsible for rendering the matched route at a given moment, it uses internally the [`useContent()`](/docs/(qwikcity)/api/index.mdx#usecontent) and to render the current page, as well as all the nested layouts.
+
+This component is usually located as a child of `<body>`, in most of the starters you will find it in the `src/root.tsx` file (refer to the example in `QwikCityProvider`).
 
 ## `<Form>`
 

--- a/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
@@ -275,7 +275,7 @@ type RestoreScroll = (
   type: 'initial' | 'form' | 'link' | 'popstate';
   fromUrl: URL;
   toUrl: URL;
-  records: ScrollRecord;
+  scrollState?: ScrollState;
 ) => () => void;
 ```
 
@@ -289,19 +289,24 @@ There are two built-in scroll restoration presets provided by QwikCity - `toTopA
 You can also implement your own scroll restoration logic by supplying a function with the above signature, for example:
 
 ```ts
-// TODO Adjust this example after finalize of SPA scroll restoration feature.
-const restoreScroll: RestoreScroll = $((type, fromUrl, toUrl, records) => {
-  // do something before navigation
+const restoreScroll: QRL<RestoreScroll> = $((type, _fromUrl, _toUrl, scrollState) => {
+  // Do something before navigation:
   prepare();
 
   return () => {
-    // handle the actual scroll restoration
+    // Handle the actual scroll restoration:
+    let [scrollX, scrollY] = [0, 0];
+    if (type === 'popstate' && scrollState) {
+      scrollX = scrollState.scrollX;
+      scrollY = scrollState.scrollY;
+    }
     window.scrollTo(scrollX, scrollY);
   }
 });
 ```
 
-> Note that the returned inner void function is run synchronously with render, it is recommended to avoid expensive computations inside of it.
+> Note that the returned inner void function MUST run synchronously with render, it is recommended to avoid expensive computations inside of it.
+> The `scrollState` argument may be undefined when there is no scroll history, typically when type is not popstate, but also pops on custom `pushState`s.
 
 ## `<RouterOutlet>`
 

--- a/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
@@ -289,7 +289,7 @@ There are two built-in scroll restoration presets provided by QwikCity - `toTopA
 You can also implement your own scroll restoration logic by supplying a function with the above signature, for example:
 
 ```ts
-const restoreScroll: QRL<RestoreScroll> = $((type, _fromUrl, _toUrl, scrollState) => {
+const restoreScroll: QRL<RestoreScroll> = $((type, fromUrl, toUrl, scrollState) => {
   // Do something before navigation:
   prepare();
 

--- a/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
@@ -284,7 +284,7 @@ There are two built-in scroll restoration presets provided by QwikCity - `toTopA
 - `toTopAlways`, as the name suggests, always scrolls the page to the top of the window when navigating to new or previous pages.
 - `toLastPositionOnPopState` (default) mimics how browsers handle MPA - scrolling the page to the top when navigating to a new page, but to the last-visited position when navigating with a `popstate` event (e.g. back/next button).
 
-> Note that both presets treat hash navigation as an exception and always scroll to the hashed element when it is available and specified in the URL.
+> Note that browsers such as Chromium and Firefox natively scroll to hashes on regular navigation, popstates will ALWAYS restore. The `toLastPositionOnPopState` preset will replicate this behavior, while `toTopAlways` will always scroll to hashes.
 
 You can also implement your own scroll restoration logic by supplying a function with the above signature, for example:
 
@@ -306,7 +306,8 @@ const restoreScroll: QRL<RestoreScroll> = $((type, fromUrl, toUrl, scrollState) 
 ```
 
 > Note that the returned inner void function MUST run synchronously with render, it is recommended to avoid expensive computations inside of it.
-> The `scrollState` argument may be undefined when there is no scroll history, typically when type is not popstate, but also pops on custom `pushState`s.
+
+> The `scrollState` argument may be undefined when there is no scroll history, typically when type is not popstate, but also pops on custom `pushState`.
 
 ## `<RouterOutlet>`
 

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -220,9 +220,6 @@ export interface FormSubmitSuccessDetail<T> {
     value: T;
 }
 
-// @alpha (undocumented)
-export const getHistoryId: () => string;
-
 // @public (undocumented)
 export const globalAction$: ActionConstructor;
 
@@ -343,10 +340,10 @@ export { RequestHandler }
 // @public (undocumented)
 export type ResolvedDocumentHead = Required<DocumentHeadValue>;
 
-// Warning: (ae-forgotten-export) The symbol "ScrollRecord" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ScrollState" needs to be exported by the entry point index.d.ts
 //
 // @alpha (undocumented)
-export type RestoreScroll = (navigationType: NavigationType, fromUrl: URL, toUrl: URL, records: ScrollRecord) => () => void;
+export type RestoreScroll = (navigationType: NavigationType, fromUrl: URL, toUrl: URL, scrollState?: ScrollState) => () => void;
 
 // @public (undocumented)
 export const routeAction$: ActionConstructor;

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -10,7 +10,6 @@ import { CookieOptions } from '@builder.io/qwik-city/middleware/request-handler'
 import { CookieValue } from '@builder.io/qwik-city/middleware/request-handler';
 import { DeferReturn } from '@builder.io/qwik-city/middleware/request-handler';
 import { JSXNode } from '@builder.io/qwik';
-import { PropFunction } from '@builder.io/qwik';
 import { QRL } from '@builder.io/qwik';
 import { QwikIntrinsicElements } from '@builder.io/qwik';
 import { QwikJSX } from '@builder.io/qwik';
@@ -321,10 +320,8 @@ export interface QwikCityPlan {
 
 // @public (undocumented)
 export interface QwikCityProps {
-    // Warning: (ae-incompatible-release-tags) The symbol "restoreScroll$" is marked as @public, but its signature references "RestoreScroll" which is marked as @alpha
-    //
-    // (undocumented)
-    restoreScroll$?: PropFunction<RestoreScroll>;
+    // @alpha
+    restoreScroll$?: RestoreScroll;
     viewTransition?: boolean;
 }
 

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -349,7 +349,7 @@ export type ResolvedDocumentHead = Required<DocumentHeadValue>;
 // Warning: (ae-forgotten-export) The symbol "ScrollRecord" needs to be exported by the entry point index.d.ts
 //
 // @alpha (undocumented)
-export type RestoreScroll = (navigationType: NavigationType, fromUrl: URL, toUrl: URL, records: ScrollRecord) => void | Promise<void>;
+export type RestoreScroll = (navigationType: NavigationType, fromUrl: URL, toUrl: URL, records: ScrollRecord) => () => void;
 
 // @public (undocumented)
 export const routeAction$: ActionConstructor;

--- a/packages/qwik-city/runtime/src/client-navigate.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.ts
@@ -1,8 +1,7 @@
 import { isBrowser } from '@builder.io/qwik/build';
 import type { QPrefetchData } from './service-worker/types';
-import type { NavigationType } from './types';
+import type { NavigationType, ScrollState } from './types';
 import { isSamePath, toPath } from './utils';
-import { emptyScrollState, type ScrollHistoryState } from './scroll-restoration';
 
 export const clientNavigate = (
   win: Window,
@@ -15,8 +14,8 @@ export const clientNavigate = (
     const samePath = isSamePath(fromURL, toURL);
     const sameHash = fromURL.hash === toURL.hash;
     if (!samePath || !sameHash) {
-      const newState: ScrollHistoryState = {
-        _qCityScroll: emptyScrollState(),
+      const newState = {
+        _qCityScroll: newScrollState(),
       };
 
       if (replaceState) {
@@ -27,6 +26,15 @@ export const clientNavigate = (
       }
     }
   }
+};
+
+export const newScrollState = (): ScrollState => {
+  return {
+    scrollX: 0,
+    scrollY: 0,
+    scrollWidth: 0,
+    scrollHeight: 0,
+  };
 };
 
 export const dispatchPrefetchEvent = (prefetchData: QPrefetchData) => {

--- a/packages/qwik-city/runtime/src/client-navigate.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.ts
@@ -15,15 +15,15 @@ export const clientNavigate = (
     const samePath = isSamePath(fromURL, toURL);
     const sameHash = fromURL.hash === toURL.hash;
     if (!samePath || !sameHash) {
-      const state: ScrollHistoryState = {
+      const newState: ScrollHistoryState = {
         _qCityScroll: emptyScrollState(),
       };
 
       if (replaceState) {
-        win.history.replaceState(state, '', toPath(toURL));
+        win.history.replaceState(newState, '', toPath(toURL));
       } else {
         // push to history for path or hash changes
-        win.history.pushState(state, '', toPath(toURL));
+        win.history.pushState(newState, '', toPath(toURL));
       }
     }
   }

--- a/packages/qwik-city/runtime/src/client-navigate.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.ts
@@ -2,6 +2,7 @@ import { isBrowser } from '@builder.io/qwik/build';
 import type { QPrefetchData } from './service-worker/types';
 import type { NavigationType } from './types';
 import { isSamePath, toPath } from './utils';
+import { emptyScrollState, type ScrollHistoryState } from './scroll-restoration';
 
 export const clientNavigate = (
   win: Window,
@@ -10,34 +11,23 @@ export const clientNavigate = (
   toURL: URL,
   replaceState = false
 ) => {
-  if (navType === 'popstate') {
-    clientHistoryState.id = win.history.state?.id ?? 0;
-  } else {
+  if (navType !== 'popstate') {
     const samePath = isSamePath(fromURL, toURL);
     const sameHash = fromURL.hash === toURL.hash;
     if (!samePath || !sameHash) {
+      const state: ScrollHistoryState = {
+        _qCityScroll: emptyScrollState(),
+      };
+
       if (replaceState) {
-        win.history.replaceState({ id: ++clientHistoryState.id }, '', toPath(toURL));
+        win.history.replaceState(state, '', toPath(toURL));
       } else {
         // push to history for path or hash changes
-        win.history.pushState({ id: ++clientHistoryState.id }, '', toPath(toURL));
+        win.history.pushState(state, '', toPath(toURL));
       }
     }
   }
 };
-
-const clientHistoryState = { id: 0 };
-
-/**
- * @alpha
- * @returns A unique opaque id representing the current client history entry
- */
-export const getHistoryId = () => '' + clientHistoryState.id;
-
-/**
- * @internal
- */
-export const resetHistoryId = () => (clientHistoryState.id = 0);
 
 export const dispatchPrefetchEvent = (prefetchData: QPrefetchData) => {
   if (isBrowser) {

--- a/packages/qwik-city/runtime/src/client-navigate.unit.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.unit.ts
@@ -1,146 +1,144 @@
-// import { suite } from 'uvu';
-// import { equal } from 'uvu/assert';
-// import { clientNavigate } from './client-navigate';
+import { suite } from 'uvu';
+import { equal } from 'uvu/assert';
+import { clientNavigate } from './client-navigate';
+import { emptyScrollState } from './scroll-restoration';
+import { deepEqual } from 'assert';
 
-// const navTest = suite('clientNavigate');
+const navTest = suite('clientNavigate');
 
-// navTest('update id for pushState and popState', () => {
-//   const [win, urlOf] = createTestWindow('http://qwik.dev/');
-//   equal(win.history.state, null);
-//   equal(getHistoryId(), '0');
+navTest('initialize and push empty scroll history state on navigate', () => {
+  const [win, urlOf] = createTestWindow('http://qwik.dev/');
+  equal(win.history.state, null);
 
-//   clientNavigate(win, 'link', urlOf('/'), urlOf('/page-a'));
-//   equal(win.history.state, { id: 1 });
-//   equal(getHistoryId(), '1');
+  const scrollState = emptyScrollState();
 
-//   clientNavigate(win, 'link', urlOf('/'), urlOf('/page-b'));
-//   equal(win.history.state, { id: 2 });
-//   equal(getHistoryId(), '2');
+  clientNavigate(win, 'link', urlOf('/'), urlOf('/page-a'));
+  deepEqual(win.history.state, { _qCityScroll: scrollState });
 
-//   win.history.popState(-1);
-//   clientNavigate(win, 'popstate', urlOf('/page-b'), urlOf('/page-a'));
-//   equal(win.history.state, { id: 1 });
-//   equal(getHistoryId(), '1');
+  clientNavigate(win, 'link', urlOf('/page-a'), urlOf('/page-b'));
+  deepEqual(win.history.state, { _qCityScroll: scrollState });
 
-//   win.history.popState(-1);
-//   clientNavigate(win, 'popstate', urlOf('/page-a'), urlOf('/'));
-//   equal(win.history.state, null);
-//   equal(getHistoryId(), '0');
+  win.history.popState(-1);
+  clientNavigate(win, 'popstate', urlOf('/page-b'), urlOf('/page-a'));
+  deepEqual(win.history.state, { _qCityScroll: scrollState });
 
-//   equal(win.events(), []);
-// });
+  win.history.popState(-1);
+  clientNavigate(win, 'popstate', urlOf('/page-a'), urlOf('/'));
+  // This will be null, upgrading state only happens in QwikCityProvider.
+  // ClientNavigate only pushes new empty states for the scroll handler to use.
+  equal(win.history.state, null);
 
-// navTest('pushState for different routes', () => {
-//   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
-//   equal(win.history.state, null);
-//   equal(getHistoryId(), '0');
+  equal(win.events(), []);
+});
 
-//   clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-b?search=123'));
-//   equal(win.history.state, { id: 1 });
-//   equal(getHistoryId(), '1');
+navTest('pushState for different routes', () => {
+  const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
+  equal(win.history.state, null);
 
-//   clientNavigate(win, 'link', urlOf('/page-b?search=123'), urlOf('/page-b?param=456'));
-//   equal(win.history.state, { id: 2 });
-//   equal(getHistoryId(), '2');
+  const scrollState = emptyScrollState();
 
-//   equal(win.events(), []);
-// });
+  clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-b?search=123'));
+  deepEqual(win.history.state, { _qCityScroll: scrollState });
 
-// navTest('when passing replaceState', () => {
-//   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
-//   equal(win.history.state, null);
-//   equal(getHistoryId(), '0');
+  clientNavigate(win, 'link', urlOf('/page-b?search=123'), urlOf('/page-b?param=456'));
+  deepEqual(win.history.state, { _qCityScroll: scrollState });
 
-//   const length = win.history.length;
-//   clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-a?search=456'), true);
-//   equal(win.history.state, { id: 1 });
-//   equal(getHistoryId(), '1');
-//   equal(win.history.length, length);
-// });
+  equal(win.events(), []);
+});
 
-// navTest('pushState for different hash', () => {
-//   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123#hash-1');
-//   equal(win.history.state, null);
-//   equal(getHistoryId(), '0');
+navTest('when passing replaceState', () => {
+  const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
+  equal(win.history.state, null);
 
-//   clientNavigate(
-//     win,
-//     'link',
-//     urlOf('/page-a?search=123#hash-1'),
-//     urlOf('/page-b?search=123#hash-2')
-//   );
-//   equal(win.history.state, { id: 1 });
-//   equal(getHistoryId(), '1');
-//   equal(win.events(), []);
+  const scrollState = emptyScrollState();
 
-//   clientNavigate(
-//     win,
-//     'link',
-//     urlOf('/page-b?search=123#hash-2'),
-//     urlOf('/page-b?search=123#hash-3')
-//   );
-//   equal(win.history.state, { id: 2 });
-//   equal(getHistoryId(), '2');
-// });
+  const length = win.history.length;
+  clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-a?search=456'), true);
+  deepEqual(win.history.state, { _qCityScroll: scrollState });
+  equal(win.history.length, length);
+});
 
-// function createTestWindow<T>(href: string): [testWindow: TestWindow, urlOf: (path: string) => URL] {
-//   resetHistoryId();
-//   const events: Event[] = [];
-//   const historyEntries: { url: URL; state: T | null }[] = [{ url: new URL(href), state: null }];
-//   let index = 0;
+navTest('pushState for different hash', () => {
+  const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123#hash-1');
+  equal(win.history.state, null);
 
-//   return [
-//     {
-//       HashChangeEvent: class {
-//         type: 'hashchange';
-//         newURL: string;
-//         oldURL: string;
-//         constructor(type: 'hashchange', { newURL, oldURL }: { newURL: string; oldURL: string }) {
-//           this.type = type;
-//           this.newURL = newURL;
-//           this.oldURL = oldURL;
-//         }
-//       },
-//       events() {
-//         return events;
-//       },
-//       get location() {
-//         return historyEntries[index].url;
-//       },
-//       dispatchEvent: (event: Event) => events.push(event),
-//       history: {
-//         popState: (delta: number) => {
-//           const newIndex = index + delta;
-//           if (newIndex < 0 || newIndex > historyEntries.length - 1) {
-//             throw new Error(
-//               `Invalid change to history position. current: ${index}, delta: ${delta}, length: ${historyEntries.length}`
-//             );
-//           }
-//           index = newIndex;
-//         },
-//         pushState: (state: any, _: string, path: string) => {
-//           ++index;
-//           historyEntries.push({ url: new URL(path, href), state });
-//         },
-//         replaceState: (state: any, _: string, path: string) => {
-//           historyEntries.splice(historyEntries.length - 1, 1, { url: new URL(path, href), state });
-//           return historyEntries;
-//         },
-//         get length() {
-//           return historyEntries.length;
-//         },
-//         get state() {
-//           return historyEntries[index].state;
-//         },
-//       },
-//     } as any,
-//     (path: string) => new URL(path, href),
-//   ];
-// }
+  const scrollState = emptyScrollState();
 
-// interface TestWindow extends Window {
-//   events: () => Event[];
-//   history: History & { popState: (delta: number) => void };
-// }
+  clientNavigate(
+    win,
+    'link',
+    urlOf('/page-a?search=123#hash-1'),
+    urlOf('/page-b?search=123#hash-2')
+  );
+  deepEqual(win.history.state, { _qCityScroll: scrollState });
+  equal(win.events(), []);
 
-// navTest.run();
+  clientNavigate(
+    win,
+    'link',
+    urlOf('/page-b?search=123#hash-2'),
+    urlOf('/page-b?search=123#hash-3')
+  );
+  deepEqual(win.history.state, { _qCityScroll: scrollState });
+});
+
+function createTestWindow<T>(href: string): [testWindow: TestWindow, urlOf: (path: string) => URL] {
+  const events: Event[] = [];
+  const historyEntries: { url: URL; state: T | null }[] = [{ url: new URL(href), state: null }];
+  let index = 0;
+
+  return [
+    {
+      HashChangeEvent: class {
+        type: 'hashchange';
+        newURL: string;
+        oldURL: string;
+        constructor(type: 'hashchange', { newURL, oldURL }: { newURL: string; oldURL: string }) {
+          this.type = type;
+          this.newURL = newURL;
+          this.oldURL = oldURL;
+        }
+      },
+      events() {
+        return events;
+      },
+      get location() {
+        return historyEntries[index].url;
+      },
+      dispatchEvent: (event: Event) => events.push(event),
+      history: {
+        popState: (delta: number) => {
+          const newIndex = index + delta;
+          if (newIndex < 0 || newIndex > historyEntries.length - 1) {
+            throw new Error(
+              `Invalid change to history position. current: ${index}, delta: ${delta}, length: ${historyEntries.length}`
+            );
+          }
+          index = newIndex;
+        },
+        pushState: (state: any, _: string, path: string) => {
+          ++index;
+          historyEntries.push({ url: new URL(path, href), state });
+        },
+        replaceState: (state: any, _: string, path: string) => {
+          historyEntries.splice(historyEntries.length - 1, 1, { url: new URL(path, href), state });
+          return historyEntries;
+        },
+        get length() {
+          return historyEntries.length;
+        },
+        get state() {
+          return historyEntries[index].state;
+        },
+      },
+    } as any,
+    (path: string) => new URL(path, href),
+  ];
+}
+
+interface TestWindow extends Window {
+  events: () => Event[];
+  history: History & { popState: (delta: number) => void };
+}
+
+navTest.run();

--- a/packages/qwik-city/runtime/src/client-navigate.unit.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.unit.ts
@@ -1,146 +1,146 @@
-import { suite } from 'uvu';
-import { equal } from 'uvu/assert';
-import { resetHistoryId, getHistoryId, clientNavigate } from './client-navigate';
+// import { suite } from 'uvu';
+// import { equal } from 'uvu/assert';
+// import { clientNavigate } from './client-navigate';
 
-const navTest = suite('clientNavigate');
+// const navTest = suite('clientNavigate');
 
-navTest('update id for pushState and popState', () => {
-  const [win, urlOf] = createTestWindow('http://qwik.dev/');
-  equal(win.history.state, null);
-  equal(getHistoryId(), '0');
+// navTest('update id for pushState and popState', () => {
+//   const [win, urlOf] = createTestWindow('http://qwik.dev/');
+//   equal(win.history.state, null);
+//   equal(getHistoryId(), '0');
 
-  clientNavigate(win, 'link', urlOf('/'), urlOf('/page-a'));
-  equal(win.history.state, { id: 1 });
-  equal(getHistoryId(), '1');
+//   clientNavigate(win, 'link', urlOf('/'), urlOf('/page-a'));
+//   equal(win.history.state, { id: 1 });
+//   equal(getHistoryId(), '1');
 
-  clientNavigate(win, 'link', urlOf('/'), urlOf('/page-b'));
-  equal(win.history.state, { id: 2 });
-  equal(getHistoryId(), '2');
+//   clientNavigate(win, 'link', urlOf('/'), urlOf('/page-b'));
+//   equal(win.history.state, { id: 2 });
+//   equal(getHistoryId(), '2');
 
-  win.history.popState(-1);
-  clientNavigate(win, 'popstate', urlOf('/page-b'), urlOf('/page-a'));
-  equal(win.history.state, { id: 1 });
-  equal(getHistoryId(), '1');
+//   win.history.popState(-1);
+//   clientNavigate(win, 'popstate', urlOf('/page-b'), urlOf('/page-a'));
+//   equal(win.history.state, { id: 1 });
+//   equal(getHistoryId(), '1');
 
-  win.history.popState(-1);
-  clientNavigate(win, 'popstate', urlOf('/page-a'), urlOf('/'));
-  equal(win.history.state, null);
-  equal(getHistoryId(), '0');
+//   win.history.popState(-1);
+//   clientNavigate(win, 'popstate', urlOf('/page-a'), urlOf('/'));
+//   equal(win.history.state, null);
+//   equal(getHistoryId(), '0');
 
-  equal(win.events(), []);
-});
+//   equal(win.events(), []);
+// });
 
-navTest('pushState for different routes', () => {
-  const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
-  equal(win.history.state, null);
-  equal(getHistoryId(), '0');
+// navTest('pushState for different routes', () => {
+//   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
+//   equal(win.history.state, null);
+//   equal(getHistoryId(), '0');
 
-  clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-b?search=123'));
-  equal(win.history.state, { id: 1 });
-  equal(getHistoryId(), '1');
+//   clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-b?search=123'));
+//   equal(win.history.state, { id: 1 });
+//   equal(getHistoryId(), '1');
 
-  clientNavigate(win, 'link', urlOf('/page-b?search=123'), urlOf('/page-b?param=456'));
-  equal(win.history.state, { id: 2 });
-  equal(getHistoryId(), '2');
+//   clientNavigate(win, 'link', urlOf('/page-b?search=123'), urlOf('/page-b?param=456'));
+//   equal(win.history.state, { id: 2 });
+//   equal(getHistoryId(), '2');
 
-  equal(win.events(), []);
-});
+//   equal(win.events(), []);
+// });
 
-navTest('when passing replaceState', () => {
-  const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
-  equal(win.history.state, null);
-  equal(getHistoryId(), '0');
+// navTest('when passing replaceState', () => {
+//   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
+//   equal(win.history.state, null);
+//   equal(getHistoryId(), '0');
 
-  const length = win.history.length;
-  clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-a?search=456'), true);
-  equal(win.history.state, { id: 1 });
-  equal(getHistoryId(), '1');
-  equal(win.history.length, length);
-});
+//   const length = win.history.length;
+//   clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-a?search=456'), true);
+//   equal(win.history.state, { id: 1 });
+//   equal(getHistoryId(), '1');
+//   equal(win.history.length, length);
+// });
 
-navTest('pushState for different hash', () => {
-  const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123#hash-1');
-  equal(win.history.state, null);
-  equal(getHistoryId(), '0');
+// navTest('pushState for different hash', () => {
+//   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123#hash-1');
+//   equal(win.history.state, null);
+//   equal(getHistoryId(), '0');
 
-  clientNavigate(
-    win,
-    'link',
-    urlOf('/page-a?search=123#hash-1'),
-    urlOf('/page-b?search=123#hash-2')
-  );
-  equal(win.history.state, { id: 1 });
-  equal(getHistoryId(), '1');
-  equal(win.events(), []);
+//   clientNavigate(
+//     win,
+//     'link',
+//     urlOf('/page-a?search=123#hash-1'),
+//     urlOf('/page-b?search=123#hash-2')
+//   );
+//   equal(win.history.state, { id: 1 });
+//   equal(getHistoryId(), '1');
+//   equal(win.events(), []);
 
-  clientNavigate(
-    win,
-    'link',
-    urlOf('/page-b?search=123#hash-2'),
-    urlOf('/page-b?search=123#hash-3')
-  );
-  equal(win.history.state, { id: 2 });
-  equal(getHistoryId(), '2');
-});
+//   clientNavigate(
+//     win,
+//     'link',
+//     urlOf('/page-b?search=123#hash-2'),
+//     urlOf('/page-b?search=123#hash-3')
+//   );
+//   equal(win.history.state, { id: 2 });
+//   equal(getHistoryId(), '2');
+// });
 
-function createTestWindow<T>(href: string): [testWindow: TestWindow, urlOf: (path: string) => URL] {
-  resetHistoryId();
-  const events: Event[] = [];
-  const historyEntries: { url: URL; state: T | null }[] = [{ url: new URL(href), state: null }];
-  let index = 0;
+// function createTestWindow<T>(href: string): [testWindow: TestWindow, urlOf: (path: string) => URL] {
+//   resetHistoryId();
+//   const events: Event[] = [];
+//   const historyEntries: { url: URL; state: T | null }[] = [{ url: new URL(href), state: null }];
+//   let index = 0;
 
-  return [
-    {
-      HashChangeEvent: class {
-        type: 'hashchange';
-        newURL: string;
-        oldURL: string;
-        constructor(type: 'hashchange', { newURL, oldURL }: { newURL: string; oldURL: string }) {
-          this.type = type;
-          this.newURL = newURL;
-          this.oldURL = oldURL;
-        }
-      },
-      events() {
-        return events;
-      },
-      get location() {
-        return historyEntries[index].url;
-      },
-      dispatchEvent: (event: Event) => events.push(event),
-      history: {
-        popState: (delta: number) => {
-          const newIndex = index + delta;
-          if (newIndex < 0 || newIndex > historyEntries.length - 1) {
-            throw new Error(
-              `Invalid change to history position. current: ${index}, delta: ${delta}, length: ${historyEntries.length}`
-            );
-          }
-          index = newIndex;
-        },
-        pushState: (state: any, _: string, path: string) => {
-          ++index;
-          historyEntries.push({ url: new URL(path, href), state });
-        },
-        replaceState: (state: any, _: string, path: string) => {
-          historyEntries.splice(historyEntries.length - 1, 1, { url: new URL(path, href), state });
-          return historyEntries;
-        },
-        get length() {
-          return historyEntries.length;
-        },
-        get state() {
-          return historyEntries[index].state;
-        },
-      },
-    } as any,
-    (path: string) => new URL(path, href),
-  ];
-}
+//   return [
+//     {
+//       HashChangeEvent: class {
+//         type: 'hashchange';
+//         newURL: string;
+//         oldURL: string;
+//         constructor(type: 'hashchange', { newURL, oldURL }: { newURL: string; oldURL: string }) {
+//           this.type = type;
+//           this.newURL = newURL;
+//           this.oldURL = oldURL;
+//         }
+//       },
+//       events() {
+//         return events;
+//       },
+//       get location() {
+//         return historyEntries[index].url;
+//       },
+//       dispatchEvent: (event: Event) => events.push(event),
+//       history: {
+//         popState: (delta: number) => {
+//           const newIndex = index + delta;
+//           if (newIndex < 0 || newIndex > historyEntries.length - 1) {
+//             throw new Error(
+//               `Invalid change to history position. current: ${index}, delta: ${delta}, length: ${historyEntries.length}`
+//             );
+//           }
+//           index = newIndex;
+//         },
+//         pushState: (state: any, _: string, path: string) => {
+//           ++index;
+//           historyEntries.push({ url: new URL(path, href), state });
+//         },
+//         replaceState: (state: any, _: string, path: string) => {
+//           historyEntries.splice(historyEntries.length - 1, 1, { url: new URL(path, href), state });
+//           return historyEntries;
+//         },
+//         get length() {
+//           return historyEntries.length;
+//         },
+//         get state() {
+//           return historyEntries[index].state;
+//         },
+//       },
+//     } as any,
+//     (path: string) => new URL(path, href),
+//   ];
+// }
 
-interface TestWindow extends Window {
-  events: () => Event[];
-  history: History & { popState: (delta: number) => void };
-}
+// interface TestWindow extends Window {
+//   events: () => Event[];
+//   history: History & { popState: (delta: number) => void };
+// }
 
-navTest.run();
+// navTest.run();

--- a/packages/qwik-city/runtime/src/client-navigate.unit.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.unit.ts
@@ -1,7 +1,6 @@
 import { suite } from 'uvu';
 import { equal } from 'uvu/assert';
-import { clientNavigate } from './client-navigate';
-import { emptyScrollState } from './scroll-restoration';
+import { clientNavigate, newScrollState } from './client-navigate';
 import { deepEqual } from 'assert';
 
 const navTest = suite('clientNavigate');
@@ -10,7 +9,7 @@ navTest('initialize and push empty scroll history state on navigate', () => {
   const [win, urlOf] = createTestWindow('http://qwik.dev/');
   equal(win.history.state, null);
 
-  const scrollState = emptyScrollState();
+  const scrollState = newScrollState();
 
   clientNavigate(win, 'link', urlOf('/'), urlOf('/page-a'));
   deepEqual(win.history.state, { _qCityScroll: scrollState });
@@ -35,7 +34,7 @@ navTest('pushState for different routes', () => {
   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
   equal(win.history.state, null);
 
-  const scrollState = emptyScrollState();
+  const scrollState = newScrollState();
 
   clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-b?search=123'));
   deepEqual(win.history.state, { _qCityScroll: scrollState });
@@ -50,7 +49,7 @@ navTest('when passing replaceState', () => {
   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123');
   equal(win.history.state, null);
 
-  const scrollState = emptyScrollState();
+  const scrollState = newScrollState();
 
   const length = win.history.length;
   clientNavigate(win, 'link', urlOf('/page-a?search=123'), urlOf('/page-a?search=456'), true);
@@ -62,7 +61,7 @@ navTest('pushState for different hash', () => {
   const [win, urlOf] = createTestWindow('http://qwik.dev/page-a?search=123#hash-1');
   equal(win.history.state, null);
 
-  const scrollState = emptyScrollState();
+  const scrollState = newScrollState();
 
   clientNavigate(
     win,

--- a/packages/qwik-city/runtime/src/index.ts
+++ b/packages/qwik-city/runtime/src/index.ts
@@ -53,7 +53,6 @@ export {
 } from './qwik-city-component';
 export { type LinkProps, Link } from './link-component';
 export { toTopAlways, toLastPositionOnPopState } from './scroll-restoration';
-export { getHistoryId } from './client-navigate';
 export { ServiceWorkerRegister } from './sw-component';
 export { useDocumentHead, useLocation, useContent, useNavigate } from './use-functions';
 export { routeAction$, routeActionQrl } from './server-functions';

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -13,7 +13,6 @@ import {
   _weakSerialize,
   useStyles$,
   _waitUntilRendered,
-  type PropFunction,
 } from '@builder.io/qwik';
 import { isBrowser, isServer } from '@builder.io/qwik/build';
 import * as qwikCity from '@qwik-city-plan';
@@ -85,7 +84,13 @@ export interface QwikCityProps {
    */
   viewTransition?: boolean;
 
-  restoreScroll$?: PropFunction<RestoreScroll>;
+  /**
+   * @alpha
+   * Scroll restoration logic for SPA navigation.
+   * 
+   * Default: `toLastPositionOnPopState`
+   */
+  restoreScroll$?: RestoreScroll;
 }
 
 /**

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -340,7 +340,7 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
           clearTimeout(win._qCityScrollDebounceTimeout);
           if (navType !== 'popstate') {
             // Save the final scroll state before pushing new state.
-            // Also upgrades/replaces null state with scroll pos on first nav.
+            // Upgrades/replaces state with scroll pos on nav as needed.
             const scrollState = currentScrollState(document.documentElement);
             saveScrollHistory(scrollState, true);
           }

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -325,6 +325,7 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
                 win._qCityScrollDebounceTimeout = setTimeout(() => {
                   const scrollState = currentScrollState(document.documentElement);
                   saveScrollHistory(scrollState);
+                  // Needed for e2e debounceDetector.
                   win._qCityScrollDebounceTimeout = undefined;
                 }, 200);
               },

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -302,6 +302,18 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
             // only add event listener once
             win._qCityHistory = 1;
 
+            win.addEventListener('popstate', () => {
+              // Disable scroll handler eagerly to prevent overwriting history.state.
+              win._qCityScrollHandlerEnabled = false;
+              clearTimeout(win._qCityScrollDebounceTimeout);
+
+              return goto(location.href, {
+                type: 'popstate',
+              });
+            });
+
+            win.removeEventListener('popstate', win._qCityPopstateFallback!);
+
             win.addEventListener(
               'scroll',
               () => {
@@ -318,18 +330,6 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
               },
               { passive: true }
             );
-
-            win.addEventListener('popstate', () => {
-              // Disable scroll handler eagerly to prevent overwriting history.state.
-              win._qCityScrollHandlerEnabled = false;
-              clearTimeout(win._qCityScrollDebounceTimeout);
-
-              return goto(location.href, {
-                type: 'popstate',
-              });
-            });
-
-            win.removeEventListener('popstate', win._qCityPopstateFallback!);
 
             if (history.scrollRestoration) {
               history.scrollRestoration = 'manual';

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -87,7 +87,7 @@ export interface QwikCityProps {
   /**
    * @alpha
    * Scroll restoration logic for SPA navigation.
-   * 
+   *
    * Default: `toLastPositionOnPopState`
    */
   restoreScroll$?: RestoreScroll;

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -284,6 +284,10 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
             });
 
             win.removeEventListener('popstate', win._qCityPopstateFallback!);
+
+            if (history.scrollRestoration) {
+              history.scrollRestoration = 'manual';
+            }
           }
           const navId = getHistoryId();
           const scrollRecord = getOrInitializeScrollRecord();

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -313,6 +313,7 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
                 win._qCityScrollDebounceTimeout = setTimeout(() => {
                   const scrollState = currentScrollState(document.documentElement);
                   saveScrollHistory(scrollState);
+                  win._qCityScrollDebounceTimeout = undefined;
                 }, 200);
               },
               { passive: true }

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -16,8 +16,8 @@ export const toTopAlways: QRL<RestoreScroll> = $((_type, fromUrl, toUrl) => () =
  */
 export const toLastPositionOnPopState: QRL<RestoreScroll> = $(
   (type, fromUrl, toUrl, scrollState) => () => {
-    if (!scrollForHashChange(fromUrl, toUrl)) {
-      // retrieve scroll position for popstate navigation
+    // Chromium & Firefox will always natively restore on popstate, only scroll to hash on regular navigate.
+    if (type === 'popstate' || !scrollForHashChange(fromUrl, toUrl)) {
       let [scrollX, scrollY] = [0, 0];
       if (type === 'popstate' && scrollState) {
         scrollX = scrollState.scrollX;

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -68,18 +68,6 @@ const scrollToHashId = (hash: string) => {
 /**
  * @alpha
  */
-export const emptyScrollState = (): ScrollState => {
-  return {
-    scrollX: 0,
-    scrollY: 0,
-    scrollWidth: 0,
-    scrollHeight: 0,
-  };
-};
-
-/**
- * @alpha
- */
 export const currentScrollState = (elm: Element): ScrollState => {
   return {
     scrollX: elm.scrollLeft,

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -84,8 +84,8 @@ export const emptyScrollState = (): ScrollState => {
  */
 export const currentScrollState = (elm: Element): ScrollState => {
   return {
-    scrollX: window.scrollX,
-    scrollY: window.scrollY,
+    scrollX: elm.scrollLeft,
+    scrollY: elm.scrollTop,
     scrollWidth: Math.max(elm.scrollWidth, elm.clientWidth),
     scrollHeight: Math.max(elm.scrollHeight, elm.clientHeight),
   };

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -7,15 +7,11 @@ import { getHistoryId } from './client-navigate';
  * @alpha
  */
 export const toTopAlways: QRL<RestoreScroll> = $(async (_type, fromUrl, toUrlSettled) => {
-  nativeScrollRestoration.disable();
-
   // wait for url to settled
   const toUrl = await toUrlSettled;
   if (!scrollForHashChange(fromUrl, toUrl)) {
     window.scrollTo(0, 0);
   }
-
-  nativeScrollRestoration.enable();
 });
 
 /**
@@ -23,7 +19,6 @@ export const toTopAlways: QRL<RestoreScroll> = $(async (_type, fromUrl, toUrlSet
  */
 export const toLastPositionOnPopState: QRL<RestoreScroll> = $(
   (type, fromUrl, toUrlSettled, scrollRecord) => {
-    nativeScrollRestoration.disable();
     flushScrollRecordToStorage(scrollRecord);
 
     // wait for url to settled
@@ -40,23 +35,8 @@ export const toLastPositionOnPopState: QRL<RestoreScroll> = $(
       }
       window.scrollTo(scrollX, scrollY);
     }
-
-    nativeScrollRestoration.enable();
   }
 );
-
-const nativeScrollRestoration = {
-  backup: 'auto' as ScrollRestoration,
-  disable() {
-    // back up browser scroll restoration setting and override it to manual
-    nativeScrollRestoration.backup = history.scrollRestoration;
-    history.scrollRestoration = 'manual';
-  },
-  enable() {
-    // revert scroll restoration to original value
-    history.scrollRestoration = nativeScrollRestoration.backup;
-  },
-};
 
 const QWIK_CITY_SCROLL_RECORD = '_qCityScroll';
 

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -6,9 +6,7 @@ import { getHistoryId } from './client-navigate';
 /**
  * @alpha
  */
-export const toTopAlways: QRL<RestoreScroll> = $(async (_type, fromUrl, toUrlSettled) => {
-  // wait for url to settled
-  const toUrl = await toUrlSettled;
+export const toTopAlways: QRL<RestoreScroll> = $((_type, fromUrl, toUrl) => () => {
   if (!scrollForHashChange(fromUrl, toUrl)) {
     window.scrollTo(0, 0);
   }
@@ -18,11 +16,9 @@ export const toTopAlways: QRL<RestoreScroll> = $(async (_type, fromUrl, toUrlSet
  * @alpha
  */
 export const toLastPositionOnPopState: QRL<RestoreScroll> = $(
-  (type, fromUrl, toUrlSettled, scrollRecord) => {
+  (type, fromUrl, toUrl, scrollRecord) => () => {
     flushScrollRecordToStorage(scrollRecord);
 
-    // wait for url to settled
-    const toUrl = toUrlSettled;
     if (!scrollForHashChange(fromUrl, toUrl)) {
       // retrieve scroll position for popstate navigation
       let [scrollX, scrollY] = [0, 0];

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -19,11 +19,9 @@ export const toLastPositionOnPopState: QRL<RestoreScroll> = $(
     if (!scrollForHashChange(fromUrl, toUrl)) {
       // retrieve scroll position for popstate navigation
       let [scrollX, scrollY] = [0, 0];
-      if (type === 'popstate') {
-        if (scrollState) {
-          scrollX = scrollState.scrollX || 0;
-          scrollY = scrollState.scrollY || 0;
-        }
+      if (type === 'popstate' && scrollState) {
+        scrollX = scrollState.scrollX;
+        scrollY = scrollState.scrollY;
       }
       window.scrollTo(scrollX, scrollY);
     }

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -82,17 +82,12 @@ export type RouteStateInternal = {
 /**
  * @alpha
  */
-export type ScrollState = [
-  scrollX: number,
-  scrollY: number,
-  scrollWidth: number,
-  scrollHeight: number
-];
-
-/**
- * @alpha
- */
-export type ScrollRecord = Record<string, ScrollState>;
+export type ScrollState = {
+  scrollX: number;
+  scrollY: number;
+  scrollWidth: number;
+  scrollHeight: number;
+};
 
 /**
  * @alpha
@@ -101,7 +96,7 @@ export type RestoreScroll = (
   navigationType: NavigationType,
   fromUrl: URL,
   toUrl: URL,
-  records: ScrollRecord
+  scrollState?: ScrollState
 ) => () => void;
 
 /**

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -102,7 +102,7 @@ export type RestoreScroll = (
   fromUrl: URL,
   toUrl: URL,
   records: ScrollRecord
-) => void | Promise<void>;
+) => () => void;
 
 /**
  * @public

--- a/packages/qwik/src/core/render/dom/notify-render.ts
+++ b/packages/qwik/src/core/render/dom/notify-render.ts
@@ -1,5 +1,5 @@
 import { assertDefined, assertTrue } from '../../error/assert';
-import { executeContextWithTransition, IS_HEAD, IS_SVG, SVG_NS } from './visitor';
+import { executeContextWithScrollAndTransition, IS_HEAD, IS_SVG, SVG_NS } from './visitor';
 import { getDocument } from '../../util/dom';
 import { logError, logWarn } from '../../util/log';
 import { getWrappingContainer } from '../../use/use-core';
@@ -191,7 +191,7 @@ const renderMarked = async (containerState: ContainerState): Promise<void> => {
       return;
     }
 
-    await executeContextWithTransition(staticCtx);
+    await executeContextWithScrollAndTransition(staticCtx);
     printRenderStats(staticCtx);
     return postRendering(containerState, rCtx);
   } catch (err) {

--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -1120,7 +1120,9 @@ export const executeContextWithScrollAndTransition = async (ctx: RenderStaticCon
   }
   // fallback
   executeDOMRender(ctx);
-  if (isBrowser) restoreScroll();
+  if (isBrowser) {
+    restoreScroll();
+  }
 };
 
 export const directAppendChild = (parent: QwikElement, child: Node | VirtualElement) => {

--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -1097,19 +1097,30 @@ export const cleanupTree = (
   }
 };
 
-export const executeContextWithTransition = async (ctx: RenderStaticContext) => {
+const restoreScroll = () => {
+  if (document.__q_scroll_restore__) {
+    document.__q_scroll_restore__();
+    document.__q_scroll_restore__ = undefined;
+  }
+};
+
+export const executeContextWithScrollAndTransition = async (ctx: RenderStaticContext) => {
   // try to use `document.startViewTransition`
   if (isBrowser && !qTest) {
     if (document.__q_view_transition__) {
       document.__q_view_transition__ = undefined;
       if (document.startViewTransition) {
-        await document.startViewTransition(() => executeDOMRender(ctx)).finished;
+        await document.startViewTransition(() => {
+          executeDOMRender(ctx);
+          restoreScroll();
+        }).finished;
         return;
       }
     }
   }
   // fallback
   executeDOMRender(ctx);
+  if (isBrowser) restoreScroll();
 };
 
 export const directAppendChild = (parent: QwikElement, child: Node | VirtualElement) => {

--- a/packages/qwik/src/core/render/types.ts
+++ b/packages/qwik/src/core/render/types.ts
@@ -37,7 +37,7 @@ export interface RenderStaticContext {
  */
 export interface RenderContext2 {}
 
-// Polyfills for ViewTransition API
+// Polyfills for ViewTransition API & scroll restoration
 declare global {
   interface ViewTransition {
     ready: Promise<void>;
@@ -49,5 +49,6 @@ declare global {
   interface Document {
     startViewTransition?: (callback: () => void | Promise<void>) => ViewTransition;
     __q_view_transition__?: true | undefined;
+    __q_scroll_restore__?: (() => void) | undefined;
   }
 }

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -5,6 +5,7 @@ import {
   getWindowScrollXY,
   linkNavigate,
   load,
+  scrollDebounceDetector,
   scrollDetector,
   scrollTo,
 } from './util.js';
@@ -99,6 +100,12 @@ test.describe('actions', () => {
 
         const scrollHeightShort = await getScrollHeight(page);
         await scrollTo(page, 0, scrollHeightShort);
+
+        // QwikCity relies on a debounced scroll handler to save scroll position.
+        // Once a popstate occurs we cannot update scroll position.
+        // We must wait for the debounce to trigger before popping.
+        await page.waitForTimeout(50);
+        await scrollDebounceDetector(page);
 
         const scrollDetector2 = scrollDetector(page);
         await page.goBack();

--- a/starters/e2e/qwikcity/util.ts
+++ b/starters/e2e/qwikcity/util.ts
@@ -124,6 +124,19 @@ export async function scrollDetector(page: Page) {
   );
 }
 
+export async function scrollDebounceDetector(page: Page) {
+  await page.evaluate(() => {
+    return new Promise<void>((resolve) => {
+      const checkInterval = setInterval(() => {
+        if (!window['_qCityScrollDebounceTimeout']) {
+          clearInterval(checkInterval);
+          resolve();
+        }
+      }, 50);
+    });
+  });
+}
+
 export function locator(ctx: TestContext, selector: string) {
   const page = getPage(ctx);
   return page.locator(selector);


### PR DESCRIPTION
# Overview

_**Update:** Included the durable scroll history changes because they required changes to scroll restoration API. The next PR to address SPA context recovery should be a transparent upgrade (no API changes) that can be merged post-release if it's not done/agreed upon before next week._

As mentioned here (https://github.com/BuilderIO/qwik/pull/3244#issuecomment-1551719502), this PR correctly implements the following:

- Properly disables the built-in browser scroll restoration when SPA is enabled.
    - It needs to be disabled during SPA, otherwise you will get pre-scrolling.
- Makes the manual scroll restoration synchronous with render.
  - Async has problems with potential for draws between render and when the event loop gets around to the scroll restore.
  - Simple, implemented in the same way alongside the View Transition.
- Makes the scroll history durable by storing it directly in history state instead of session storage.
  - This is a must to eventually recover scroll states on resuming sessions (desktop, mobile). Browsers natively recover MPA scroll sessions by storing scroll positions in the tab history. With session storage, it becomes impossible to replicate MPA.
  - Mobile browsers specifically can lose session storage very easily resulting in the loss of all scroll history.
  - Because state cannot be updated after a pop, it requires a scroll handler to be added when upgrading to SPA, but we are very careful to debounce reasonably here. Performance impact should be negligible.

The navigation API shipped live in Chromium 102+, in a future PR I can implement this to simplify SPA navigation/scroll in browsers that support it and leave the state-backed SPA as a fallback.

_**Note:** This PR does **not** address these issues:_

- Complete loss of SPA ctx on refresh and bfcache clear.
- Complete loss of scroll restore when losing SPA as above.

These will be addressed in a follow-up PR to make SPA navigation recoverable and function nearly identically to MPA in all circumstances, you should not be able to tell the difference.

# What is it?

- [x] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
