### PR TITLE
docs: fixed a typo in image link

### DIFF
--- a/packages/docs/src/routes/docs/integrations/image-optimization/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/image-optimization/index.mdx
@@ -82,7 +82,7 @@ export default component$(() => {
   const imageTransformer$ = $(
     ({ src, width, height }: ImageTransformerProps): string => {
       // Here you can set your favorite image loaders service
-      return `https://cdn.builder.io/api/v1/${src}?height=${height}&width=${width}}&format=webp&fit=fill`;
+      return `https://cdn.builder.io/api/v1/${src}?height=${height}&width=${width}&format=webp&fit=fill`;
     }
   );
 


### PR DESCRIPTION
# What is it?
- [x] Docs / tests / types / typos

# Description

Removed a double curly brace in the qwik-image example. 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [] Added new tests to cover the fix / functionality
