### PR TITLE
fix: renderToString mode is always ignored and returns an empty page

### DIFF
--- a/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
@@ -441,7 +441,7 @@ export function renderQwikMiddleware(render: Render) {
         status: status !== 200 ? status : 200,
         href: getPathname(requestEv.url, trailingSlash),
       };
-      if ((typeof result as any as RenderToStringResult).html === 'string') {
+      if (typeof (result as any as RenderToStringResult).html === 'string') {
         // render result used renderToString(), so none of it was streamed
         // write the already completed html to the stream
         await stream.write((result as any as RenderToStringResult).html);


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

After changing the entry.ssr.tsx to:
```
export default function (opts: RenderToStringOptions) {
    const result = renderToString(<Root />, {
```
the application always returns an empty page when served from express server.

# Checklist:

- [ x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
