### PR TITLE
fix(ssr): embed entry.ssr serverData to client document object

### DIFF
--- a/packages/qwik/src/core/use/use-env-data.ts
+++ b/packages/qwik/src/core/use/use-env-data.ts
@@ -15,5 +15,12 @@ export function useServerData<T, B = T>(key: string, defaultValue: B): T | B;
  */
 export function useServerData(key: string, defaultValue?: any) {
   const ctx = tryGetInvokeContext();
+  if (typeof document !== 'undefined') {
+    return (
+      ctx?.$renderCtx$?.$static$.$containerState$.$serverData$[key] ??
+      (document as any).serverData?.[key] ??
+      defaultValue
+    );
+  }
   return ctx?.$renderCtx$?.$static$.$containerState$.$serverData$[key] ?? defaultValue;
 }

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -213,6 +213,24 @@ export async function renderToStream(
         );
       }
 
+      // embed server-data in document obj
+      if (opts.serverData) {
+        const normalizedServerData: any = {};
+        const disallowedProperties = ['url', 'requestHeaders', 'nonce', 'qwikcity'];
+        for (const key of Object.keys(opts.serverData).filter(
+          (k) => !disallowedProperties.includes(k)
+        )) {
+          normalizedServerData[key] = opts.serverData[key];
+        }
+        const normalizedServerDataJson = JSON.stringify(normalizedServerData);
+        children.push(
+          jsx('script', {
+            dangerouslySetInnerHTML: `window.document.serverData=JSON.parse('${normalizedServerDataJson}')`,
+            nonce: opts.serverData?.nonce,
+          })
+        );
+      }
+
       collectRenderSymbols(renderSymbols, contexts);
       snapshotTime = snapshotTimer();
       return jsx(Fragment, { children });


### PR DESCRIPTION

useServerData was not returning serverData[key] on client render

fix #4506

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ X] Bug
- [ ] Docs / tests / types / typos

# Description

The `useServerData` hook was not returning a value when a key that was specified in `entry.ssr.tsx` `serverData` was passed as a parameter, when the component was rendered from client via qwik-city.

My fix is to include the normalized `serverData` from the SSR container state, into the `document` object on client, using a script tag that's rendered with SSR.

The `useServerData` hook is modified to search for the `document.serverData[key]` when the invoke context didn't include the value in `ctx?.$renderCtx$?.$static$.$containerState$.$serverData$[key]`.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Setup:
`entry.ssr.tsx`

```
export const SERVER_DATA = "serverDataKey";

export default function (opts: RenderToStreamOptions) {
  return renderToStream(<Root />, {
    manifest,
    ...opts,
    // Use container attributes to set attributes on the html tag.
    containerAttributes: {
      lang: "en-us",
      ...opts.containerAttributes,
    },
    serverData: {
      ...opts.serverData,
      [SERVER_DATA]: {
        test: "value",
      },
    },
  });
}
```

Expected: 

When clicking a `Link` tag, navigating to a component that calls `useServerData(SERVER_DATA)`,
the `{ test: "value" }` is returned.

Actual:

Returned `undefined`, as the serverData is read from the invoke context, which contains no `$renderCtx$` when is created in client side.

(the `$renderCtx$` contains the `$static$.$containerState$.$serverData$` data when exists)

# Checklist:

- [X ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality