### PR TITLE
fix: perfect hash scroll

### DIFF
--- a/packages/qwik-city/runtime/src/client-navigate.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.ts
@@ -10,22 +10,15 @@ export const clientNavigate = (
   toURL: URL,
   replaceState = false
 ) => {
-  const samePath = isSamePath(fromURL, toURL);
-  const sameHash = fromURL.hash === toURL.hash;
+  if (navType !== 'popstate') {
+    const samePath = isSamePath(fromURL, toURL);
+    const sameHash = fromURL.hash === toURL.hash;
 
-  const newState = {
-    _qCityScroll: newScrollState(),
-  };
-
-  if (navType === 'popstate') {
-    if (samePath && toURL.hash && !sameHash && !history.state?._qCityScroll) {
-      // This is an anchor tag, upgrade state to include scroll.
-      const state = history.state || {};
-      state._qCityScroll = newState;
-      win.history.replaceState(state, '', toPath(toURL));
-    }
-  } else {
     if (!samePath || !sameHash) {
+      const newState = {
+        _qCityScroll: newScrollState(),
+      };
+
       if (replaceState) {
         win.history.replaceState(newState, '', toPath(toURL));
       } else {

--- a/packages/qwik-city/runtime/src/client-navigate.ts
+++ b/packages/qwik-city/runtime/src/client-navigate.ts
@@ -10,14 +10,22 @@ export const clientNavigate = (
   toURL: URL,
   replaceState = false
 ) => {
-  if (navType !== 'popstate') {
-    const samePath = isSamePath(fromURL, toURL);
-    const sameHash = fromURL.hash === toURL.hash;
-    if (!samePath || !sameHash) {
-      const newState = {
-        _qCityScroll: newScrollState(),
-      };
+  const samePath = isSamePath(fromURL, toURL);
+  const sameHash = fromURL.hash === toURL.hash;
 
+  const newState = {
+    _qCityScroll: newScrollState(),
+  };
+
+  if (navType === 'popstate') {
+    if (samePath && toURL.hash && !sameHash && !history.state?._qCityScroll) {
+      // This is an anchor tag, upgrade state to include scroll.
+      const state = history.state || {};
+      state._qCityScroll = newState;
+      win.history.replaceState(state, '', toPath(toURL));
+    }
+  } else {
+    if (!samePath || !sameHash) {
       if (replaceState) {
         win.history.replaceState(newState, '', toPath(toURL));
       } else {

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -54,6 +54,7 @@ import {
   currentScrollState,
   getScrollHistory,
   saveScrollHistory,
+  scrollToHashId,
   toLastPositionOnPopState,
 } from './scroll-restoration';
 
@@ -159,6 +160,10 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
     const lastDest = routeInternal.value.dest;
     const dest = path === undefined ? lastDest : toUrl(path, routeLocation.url);
     if (!forceReload && dest.href === lastDest.href) {
+      if (type === 'link' && dest.hash) {
+        scrollToHashId(dest.hash);
+      }
+
       return;
     }
     routeInternal.value = { type, dest, replaceState };

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -161,8 +161,12 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
     const dest = path === undefined ? lastDest : toUrl(path, routeLocation.url);
     if (!forceReload && dest.href === lastDest.href) {
       if (isBrowser) {
-        if (type === 'link' && dest.hash) {
-          scrollToHashId(dest.hash);
+        if (type === 'link') {
+          if (dest.hash) {
+            scrollToHashId(dest.hash);
+          } else {
+            window.scrollTo(0, 0);
+          }
         } else if (type === 'popstate') {
           // Re-enable scroll handler for anchor tag hashpops.
           (window as ClientHistoryWindow)._qCityScrollHandlerEnabled = true;

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -160,8 +160,13 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
     const lastDest = routeInternal.value.dest;
     const dest = path === undefined ? lastDest : toUrl(path, routeLocation.url);
     if (!forceReload && dest.href === lastDest.href) {
-      if (type === 'link' && dest.hash) {
-        scrollToHashId(dest.hash);
+      if (isBrowser) {
+        if (type === 'link' && dest.hash) {
+          scrollToHashId(dest.hash);
+        } else if (type === 'popstate') {
+          // Re-enable scroll handler for anchor tag hashpops.
+          (window as ClientHistoryWindow)._qCityScrollHandlerEnabled = true;
+        }
       }
 
       return;
@@ -318,6 +323,8 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
             });
 
             win.removeEventListener('popstate', win._qCityPopstateFallback!);
+
+            // TODO Fix Firefox anchor tag re-scroll. (doesn't trigger any events)
 
             // TODO Remove block after Navigation API PR.
             // Calling `history.replaceState` during `visibilitychange` in Chromium will nuke BFCache.

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -48,7 +48,7 @@ import type {
 } from './types';
 import { loadClientData } from './use-endpoint';
 import { useQwikCityEnv } from './use-functions';
-import { isSamePathname, toUrl } from './utils';
+import { isSameOrigin, isSamePath, isSamePathname, toUrl } from './utils';
 import { clientNavigate } from './client-navigate';
 import {
   currentScrollState,
@@ -340,11 +340,16 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
                 return;
               }
 
-              const target = (event.target as HTMLElement).closest('a[href^="#"]');
+              const target = (event.target as HTMLElement).closest('a[href*="#"]');
 
               if (target && !target.getAttribute('preventdefault:click')) {
-                event.preventDefault();
-                goto(target.getAttribute('href')!);
+                const prev = routeLocation.url;
+                const dest = toUrl(target.getAttribute('href')!, prev);
+                // Patch only same-page hash anchors.
+                if (isSameOrigin(dest, prev) && isSamePath(dest, prev)) {
+                  event.preventDefault();
+                  goto(target.getAttribute('href')!);
+                }
               }
             });
 

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -158,7 +158,11 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
       replaceState = false,
     } = typeof opt === 'object' ? opt : { forceReload: opt };
     const lastDest = routeInternal.value.dest;
-    const dest = path === undefined ? lastDest : toUrl(path, routeLocation.url);
+    let dest = path === undefined ? lastDest : toUrl(path, routeLocation.url);
+
+    // Remove empty # before sending them into Navigate, it introduces too many edgecases.
+    dest = !dest.hash && dest.href.endsWith('#') ? new URL(dest.href.slice(0, -1)) : dest;
+
     if (!forceReload && dest.href === lastDest.href) {
       if (isBrowser) {
         if (type === 'link') {
@@ -340,9 +344,7 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
 
               if (target && !target.getAttribute('preventdefault:click')) {
                 event.preventDefault();
-                const url = new URL(target.getAttribute('href')!, location as any);
-                // Remove empty #, we will re-scroll on same-page navigation in SPA anyway.
-                goto((url.hash && url.href) || url.href.slice(0, -1));
+                goto(target.getAttribute('href')!);
               }
             });
 

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -167,9 +167,6 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
           } else {
             window.scrollTo(0, 0);
           }
-        } else if (type === 'popstate') {
-          // Re-enable scroll handler for anchor tag hashpops.
-          (window as ClientHistoryWindow)._qCityScrollHandlerEnabled = true;
         }
       }
 

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -55,7 +55,10 @@ const scrollForHashChange = (fromUrl: URL, toUrl: URL): boolean => {
   return true;
 };
 
-const scrollToHashId = (hash: string) => {
+/**
+ * @alpha
+ */
+export const scrollToHashId = (hash: string) => {
   const elmId = hash.slice(1);
   const elm = document.getElementById(elmId);
   if (elm) {

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -16,10 +16,11 @@ export const toTopAlways: QRL<RestoreScroll> = $((_type, fromUrl, toUrl) => () =
  */
 export const toLastPositionOnPopState: QRL<RestoreScroll> = $(
   (type, fromUrl, toUrl, scrollState) => () => {
-    // Chromium & Firefox will always natively restore on popstate, only scroll to hash on regular navigate.
-    if (type === 'popstate' || !scrollForHashChange(fromUrl, toUrl)) {
+    // Chromium & Firefox will always natively restore on visited popstates.
+    // Always scroll to known state if available on pop. Otherwise, try hash scroll.
+    if ((type === 'popstate' && scrollState) || !scrollForHashChange(fromUrl, toUrl)) {
       let [scrollX, scrollY] = [0, 0];
-      if (type === 'popstate' && scrollState) {
+      if (scrollState) {
         scrollX = scrollState.scrollX;
         scrollY = scrollState.scrollY;
       }


### PR DESCRIPTION
# Overview

This is my last PR re. the actual scroll experience, I think it now provides a near flawless UX. This should be a good baseline for this release. Next PR will be restoring SPA/scroll after refresh/reloading/session restore, I think you can add that in a point release after, should be a transparent upgrade. cc @manucorporat 

This PR fixes some big issues around hash scrolling (and others) that were present for a long time:
- Browsers natively re-scroll to hashes always when clicked. Now they do here.
- Anchors (not Links) with same-page hashes have numerous issues that differ by browser when SPA is enabled, we introduce a new default when upgrading to SPA by patching these events to redirect these all into the Link pipeline.
- Links/anchors with empty hashes (and same-page Link) should always scroll to top. Now they do here.
- Empty hashstrings create many edgecase problems for SPA and differ by browser, Link already removes these from its href. We patch these out for all same-page hash anchors, and also useNavigate to prevent devs from breaking SPA.
- Empty hashes on anchors will not navigate to /# (instead to /), but they do scroll, so they are functionally the same.
- etc.

Prior to this PR the use of `<a href="#...">` anywhere in SPA would effectively break SPA state/UX.

This was quite the rabbit hole to fix. I don't have access to a Mac but I have tested these changes extensively in Chromium, Firefox, and WebKitGTK, I am confident that this covers most or all of the edgecases.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
