### PR TITLE
fix(qwik-city buildtime): make generated file ids unique

### DIFF
--- a/packages/qwik-city/buildtime/build-endpoints.unit.ts
+++ b/packages/qwik-city/buildtime/build-endpoints.unit.ts
@@ -5,14 +5,14 @@ const test = testAppSuite('Build Endpoints');
 
 test('endpoint', ({ assertRoute }) => {
   const r = assertRoute('/api/data.json');
-  equal(r.id, 'CommonApiData');
+  equal(r.id, 'CommonApiDataRoute');
   equal(r.pattern, /^\/api\/data\.json\/?$/);
   equal(r.paramNames.length, 0);
 });
 
 test('endpoint w/ params', ({ assertRoute }) => {
   const r = assertRoute('/api/[org]/[user].json');
-  equal(r.id, 'CommonApiOrgUser');
+  equal(r.id, 'CommonApiOrgUserRoute');
   equal(r.pattern, /^\/api\/([^/]+?)\/([^/]+?)\.json\/?$/);
   equal(r.paramNames.length, 2);
   equal(r.paramNames[0], 'org');

--- a/packages/qwik-city/buildtime/build-pages.unit.ts
+++ b/packages/qwik-city/buildtime/build-pages.unit.ts
@@ -5,7 +5,7 @@ const test = testAppSuite('Build Pages');
 
 test('layoutStop file', ({ assertRoute }) => {
   const r = assertRoute('/mit/');
-  assert.equal(r.id, 'CommonMit');
+  assert.equal(r.id, 'CommonMitRoute');
   assert.equal(r.pattern, /^\/mit\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts.length, 0);
@@ -13,7 +13,7 @@ test('layoutStop file', ({ assertRoute }) => {
 
 test('pathless directory', ({ assertRoute }) => {
   const r = assertRoute('/sign-in/');
-  assert.equal(r.id, 'CommonAuthSignin');
+  assert.equal(r.id, 'CommonAuthSigninRoute');
   assert.equal(r.pattern, /^\/sign-in\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts.length, 3);
@@ -26,7 +26,7 @@ test('index file w/ nested named layout, in directory w/ nested named layout', (
   assertRoute,
 }) => {
   const r = assertRoute('/api/');
-  assert.equal(r.id, 'CommonApiIndexapi');
+  assert.equal(r.id, 'CommonApiIndexapiRoute');
   assert.equal(r.pattern, /^\/api\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts[0].id, 'Layout');
@@ -40,7 +40,7 @@ test('index file w/ nested named layout, in directory w/ nested named layout', (
 
 test('index file w/out named layout, in directory w/ named layout', ({ assertRoute }) => {
   const r = assertRoute('/dashboard/');
-  assert.equal(r.id, 'Dashboard');
+  assert.equal(r.id, 'DashboardRoute');
   assert.equal(r.pattern, /^\/dashboard\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts[0].id, 'Layout');
@@ -50,7 +50,7 @@ test('index file w/out named layout, in directory w/ named layout', ({ assertRou
 
 test('index file in directory w/ nested named layout file', ({ assertRoute }) => {
   const r = assertRoute('/dashboard/profile/');
-  assert.equal(r.id, 'DashboardProfile');
+  assert.equal(r.id, 'DashboardProfileRoute');
   assert.equal(r.pattern, /^\/dashboard\/profile\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts[0].id, 'Layout');
@@ -60,7 +60,7 @@ test('index file in directory w/ nested named layout file', ({ assertRoute }) =>
 
 test('index file in directory w/ top named layout file', ({ assertRoute }) => {
   const r = assertRoute('/dashboard/settings/');
-  assert.equal(r.id, 'DashboardSettings');
+  assert.equal(r.id, 'DashboardSettingsRoute');
   assert.equal(r.pattern, /^\/dashboard\/settings\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts[0].id, 'Layout');
@@ -72,7 +72,7 @@ test('params route, index file w/out named layout, in directory w/ top layout di
   assertRoute,
 }) => {
   const r = assertRoute('/docs/[category]/[id]/');
-  assert.equal(r.id, 'DocsCategoryId');
+  assert.equal(r.id, 'DocsCategoryIdRoute');
   assert.equal(r.pattern, /^\/docs\/([^/]+?)\/([^/]+?)\/?$/);
   assert.equal(r.paramNames.length, 2);
   assert.equal(r.paramNames[0], 'category');
@@ -85,7 +85,7 @@ test('markdown index file w/out named layout, in directory w/ top layout directo
   assertRoute,
 }) => {
   const r = assertRoute('/docs/overview/');
-  assert.equal(r.id, 'DocsOverview');
+  assert.equal(r.id, 'DocsOverviewRoute');
   assert.equal(r.pattern, /^\/docs\/overview\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts[0].id, 'Layout');
@@ -96,7 +96,7 @@ test('markdown file w/out named layout, in directory w/ top layout directory', (
   assertRoute,
 }) => {
   const r = assertRoute('/docs/getting-started/');
-  assert.equal(r.id, 'DocsGettingstarted');
+  assert.equal(r.id, 'DocsGettingstartedRoute');
   assert.equal(r.pattern, /^\/docs\/getting-started\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts[0].id, 'Layout');
@@ -105,7 +105,7 @@ test('markdown file w/out named layout, in directory w/ top layout directory', (
 
 test('index file w/out named layout, in directory w/ top layout directory', ({ assertRoute }) => {
   const r = assertRoute('/docs/');
-  assert.equal(r.id, 'Docs');
+  assert.equal(r.id, 'DocsRoute');
   assert.equal(r.pattern, /^\/docs\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts[0].id, 'Layout');
@@ -116,7 +116,7 @@ test('index file w/out named layout, in directory w/ top layout directory', ({ a
 
 test('named file w/out named layout, in directory w/ layout directory', ({ assertRoute }) => {
   const r = assertRoute('/about-us/');
-  assert.equal(r.id, 'CommonAboutus');
+  assert.equal(r.id, 'CommonAboutusRoute');
   assert.equal(r.pattern, /^\/about-us\/?$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.layouts[0].id, 'Layout');
@@ -126,14 +126,14 @@ test('named file w/out named layout, in directory w/ layout directory', ({ asser
 
 test('named tsx file', ({ assertRoute }) => {
   const r = assertRoute('/about-us/');
-  assert.equal(r.id, 'CommonAboutus');
+  assert.equal(r.id, 'CommonAboutusRoute');
   assert.equal(r.pattern, /^\/about-us\/?$/);
   assert.equal(r.paramNames.length, 0);
 });
 
 test('root index', ({ assertRoute }) => {
   const r = assertRoute('/');
-  assert.equal(r.id, 'Common');
+  assert.equal(r.id, 'CommonRoute');
   assert.equal(r.pattern, /^\/$/);
   assert.equal(r.paramNames.length, 0);
   assert.equal(r.paramNames.length, 0);

--- a/packages/qwik-city/buildtime/routing/resolve-source-file.ts
+++ b/packages/qwik-city/buildtime/routing/resolve-source-file.ts
@@ -156,7 +156,7 @@ export function resolveRoute(
   }
 
   const buildRoute: BuildRoute = {
-    id: createFileId(opts.routesDir, filePath),
+    id: createFileId(opts.routesDir, filePath, 'Route'),
     filePath,
     pathname,
     layouts: layouts.reverse(),
@@ -170,7 +170,7 @@ export function resolveRoute(
 export function resolveServerPlugin(opts: NormalizedPluginOptions, sourceFile: RouteSourceFile) {
   const filePath = sourceFile.filePath;
   const buildRoute: BuildServerPlugin = {
-    id: createFileId(opts.serverPluginsDir, filePath),
+    id: createFileId(opts.serverPluginsDir, filePath, 'Plugin'),
     filePath,
     ext: sourceFile.ext,
   };
@@ -182,7 +182,7 @@ function resolveEntry(opts: NormalizedPluginOptions, sourceFile: RouteSourceFile
   const chunkFileName = pathname.slice(opts.basePathname.length);
 
   const buildEntry: BuildEntry = {
-    id: createFileId(opts.routesDir, sourceFile.filePath),
+    id: createFileId(opts.routesDir, sourceFile.filePath, 'Route'),
     filePath: sourceFile.filePath,
     chunkFileName,
     ...parseRoutePathname(opts.basePathname, pathname),
@@ -197,7 +197,7 @@ function resolveServiceWorkerEntry(opts: NormalizedPluginOptions, sourceFile: Ro
   const chunkFileName = pathname.slice(opts.basePathname.length);
 
   const buildEntry: BuildEntry = {
-    id: createFileId(opts.routesDir, sourceFile.filePath),
+    id: createFileId(opts.routesDir, sourceFile.filePath, 'ServiceWorker'),
     filePath: sourceFile.filePath,
     chunkFileName,
     ...parseRoutePathname(opts.basePathname, pathname),

--- a/packages/qwik-city/buildtime/routing/sort-routes.unit.ts
+++ b/packages/qwik-city/buildtime/routing/sort-routes.unit.ts
@@ -46,7 +46,7 @@ test('routeSortCompare', () => {
 function route(r: TestRoute) {
   const pathname = r.pathname || '/';
   const route: BuildRoute = {
-    id: createFileId('', pathname),
+    id: createFileId('', pathname, 'Route'),
     filePath: pathname,
     pathname,
     ext: '.tsx',

--- a/packages/qwik-city/buildtime/routing/walk-server-plugins.ts
+++ b/packages/qwik-city/buildtime/routing/walk-server-plugins.ts
@@ -22,7 +22,7 @@ export async function walkServerPlugins(opts: NormalizedPluginOptions) {
 
       if (isModuleExt(ext) && isPluginModule(extlessName)) {
         sourceFiles.push({
-          id: createFileId(opts.serverPluginsDir, itemPath),
+          id: createFileId(opts.serverPluginsDir, itemPath, 'Plugin'),
           filePath: itemPath,
           ext,
         });

--- a/packages/qwik-city/utils/fs.ts
+++ b/packages/qwik-city/utils/fs.ts
@@ -87,7 +87,18 @@ export function normalizePathSlash(path: string) {
   return path;
 }
 
-export function createFileId(routesDir: string, fsPath: string) {
+/**
+ * Creates an id for the module, based on its path.
+ *
+ * @param routesDir
+ * @param fsPath
+ * @param explicitFileType Add to avoid collisions between different types of modules. `Menu` and `Layout` files are named based on their path (eg. /routes/about/menu.md => AboutMenu)
+ */
+export function createFileId(
+  routesDir: string,
+  fsPath: string,
+  explicitFileType?: 'Route' | 'Plugin' | 'ServiceWorker'
+) {
   const ids: string[] = [];
 
   for (let i = 0; i < 25; i++) {
@@ -112,7 +123,10 @@ export function createFileId(routesDir: string, fsPath: string) {
     ids.shift();
   }
 
-  return ids.reverse().join('');
+  return ids
+    .reverse()
+    .join('')
+    .concat(explicitFileType || '');
 }
 
 const PAGE_MODULE_EXTS: { [type: string]: boolean } = {

--- a/packages/qwik-city/utils/fs.unit.ts
+++ b/packages/qwik-city/utils/fs.unit.ts
@@ -160,32 +160,38 @@ test('removeExtension', () => {
 
 test('createFileId, Page dir/index.tsx', () => {
   const path = normalizePath(join(routesDir, 'docs', 'index.tsx'));
-  const p = createFileId(routesDir, path);
-  equal(p, 'Docs');
+  const p = createFileId(routesDir, path, 'Route');
+  equal(p, 'DocsRoute');
 });
 
 test('createFileId, Page about-us.tsx', () => {
   const path = normalizePath(join(routesDir, 'about-us', 'index.tsx'));
-  const p = createFileId(routesDir, path);
-  equal(p, 'Aboutus');
+  const p = createFileId(routesDir, path, 'Route');
+  equal(p, 'AboutusRoute');
 });
 
 test('createFileId, Endpoint, api/[user]/index.ts', () => {
   const path = normalizePath(join(routesDir, 'api', '[user]', 'index.ts'));
-  const p = createFileId(routesDir, path);
-  equal(p, 'ApiUser');
+  const p = createFileId(routesDir, path, 'Route');
+  equal(p, 'ApiUserRoute');
 });
 
 test('createFileId, Endpoint, data.json.ts', () => {
   const path = normalizePath(join(routesDir, 'api', 'data.json', 'index.ts'));
-  const p = createFileId(routesDir, path);
-  equal(p, 'ApiData');
+  const p = createFileId(routesDir, path, 'Route');
+  equal(p, 'ApiDataRoute');
 });
 
 test('createFileId, Layout', () => {
   const path = normalizePath(join(routesDir, 'dashboard', 'settings', 'layout.tsx'));
   const p = createFileId(routesDir, path);
   equal(p, 'DashboardSettingsLayout');
+});
+
+test('createFileId, Menu', () => {
+  const path = normalizePath(join(routesDir, 'settings', 'menu.mdx'));
+  const p = createFileId(routesDir, path);
+  equal(p, 'SettingsMenu');
 });
 
 [


### PR DESCRIPTION
By appending type to the id generated from the path - except for menus and layouts, because they already contain their type based on the file names.

fix #4504

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Generated module identifiers were not unique. If you defined a `/menu` route and a `menu.md` for the root, the build failed. The same could occur with layouts. If you had my `/my/layout` route and a layout defined for `/my`, the build would fail.

# Use cases and why

While this is an edge case, and there is a workaround described in the ticket, we can save some other devs from headaches.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
