### PR TITLE
fix: monaco editor ts typing issue

### DIFF
--- a/packages/docs/src/repl/monaco.tsx
+++ b/packages/docs/src/repl/monaco.tsx
@@ -199,6 +199,7 @@ export const addQwikLibs = async (version: string) => {
   const deps = await loadDeps(version);
   deps.forEach((dep) => {
     if (dep && typeof dep.code === 'string' && typeof dep.path === 'string') {
+      console.log('addExtraLib', dep);
       typescriptDefaults.addExtraLib(dep.code, `file://${dep.path}`);
     }
   });
@@ -328,7 +329,7 @@ const getCdnUrl = (pkgName: string, pkgVersion: string, pkgPath: string) => {
   return `https://cdn.jsdelivr.net/npm/${pkgName}@${pkgVersion}${pkgPath}`;
 };
 
-const MONACO_VERSION = '0.33.0';
+const MONACO_VERSION = '0.39.0';
 const MONACO_VS_URL = getCdnUrl('monaco-editor', MONACO_VERSION, '/min/vs');
 const MONACO_LOADER_URL = `${MONACO_VS_URL}/loader.js`;
 


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description
On http://localhost:3000/tutorial/understanding/capturing/ there is a TS error because of the props typings which does not use a generic. The same code is fine within a native qwik app.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
