### PR TITLE
fix: correct documentation URLs for rules created by ESLintUtils.RuleCreator

### DIFF
--- a/packages/eslint-plugin-qwik/src/jsxImg.ts
+++ b/packages/eslint-plugin-qwik/src/jsxImg.ts
@@ -1,7 +1,9 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESTree } from '@typescript-eslint/utils';
 import { QwikEslintExamples } from '../examples';
 
-const createRule = ESLintUtils.RuleCreator(() => 'https://qwik.builder.io/docs/advanced/dollar/');
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://qwik.builder.io/docs/advanced/eslint/#${name}`
+);
 
 export const jsxImg = createRule({
   defaultOptions: [],
@@ -12,7 +14,6 @@ export const jsxImg = createRule({
       description:
         'For performance reasons, always provide width and height attributes for <img> elements, it will help to prevent layout shifts.',
       recommended: 'warn',
-      url: 'https://qwik.builder.io/docs/advanced/eslint/#jsx-img',
     },
     fixable: 'code',
     schema: [],

--- a/packages/eslint-plugin-qwik/src/jsxImg.ts
+++ b/packages/eslint-plugin-qwik/src/jsxImg.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
 import { QwikEslintExamples } from '../examples';
 
 const createRule = ESLintUtils.RuleCreator(

--- a/packages/eslint-plugin-qwik/src/jsxNoScriptUrl.ts
+++ b/packages/eslint-plugin-qwik/src/jsxNoScriptUrl.ts
@@ -1,4 +1,4 @@
-import { TSESLint, ASTUtils } from '@typescript-eslint/utils';
+import { ASTUtils } from '@typescript-eslint/utils';
 import { QwikEslintExamples } from '../examples';
 const { getStaticValue } = ASTUtils;
 

--- a/packages/eslint-plugin-qwik/src/validLexicalScope.ts
+++ b/packages/eslint-plugin-qwik/src/validLexicalScope.ts
@@ -7,7 +7,9 @@ import redent from 'redent';
 import type { RuleContext } from '@typescript-eslint/utils/dist/ts-eslint';
 import { QwikEslintExamples } from '../examples';
 
-const createRule = ESLintUtils.RuleCreator(() => 'https://qwik.builder.io/docs/advanced/dollar/');
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://qwik.builder.io/docs/advanced/eslint/#${name}`
+);
 
 interface DetectorOptions {
   allowAny: boolean;
@@ -25,7 +27,6 @@ export const validLexicalScope = createRule({
       description:
         'Used the tsc typechecker to detect the capture of unserializable data in dollar ($) scopes.',
       recommended: 'error',
-      url: 'https://qwik.builder.io/docs/advanced/eslint/#valid-lexical-scope',
     },
 
     schema: [


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

![截圖 2023-06-26 下午1 41 44](https://github.com/BuilderIO/qwik/assets/16910748/71f90169-8701-4d96-828f-075c152cfb1f)

The documentation url for eslint rule should be `https://qwik.builder.io/docs/advanced/eslint/#{ruleName}` instead of `https://qwik.builder.io/docs/advanced/dollar/`. 

```ts
{
  // ...
  meta: {
    docs: {
      description: ""
      recommended: "warn",
      url: "https://example.com/rule/my-rule" // ❌ This is omitted in the `NamedCreateRuleMetaDocs` 
    },
}
```

Ref: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/utils/src/eslint-utils/RuleCreator.ts#L11

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Write an `img` tag without giving it specific `width` and `height` and find it caught by the `qwik/jsx-img` lint rule. Click the `eslint(qwik/jsx-img)` in the end of the error message should open the correct documentation, which is https://qwik.builder.io/docs/advanced/eslint/#jsx-img in this case.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
