### PR TITLE
fix: Social and Vendor are production only components

### DIFF
--- a/packages/docs/src/components/router-head/router-head.tsx
+++ b/packages/docs/src/components/router-head/router-head.tsx
@@ -86,8 +86,6 @@ export const RouterHead = component$(() => {
           <Vendor />
         </>
       )}
-      <Social title={title} description={description} href={url.href} ogImage={imageUrl.value} />
-      <Vendor />
       {head.meta.map((m) => (
         <meta {...m} />
       ))}


### PR DESCRIPTION
# Overview

`Social` and `Vendor` should be production only.

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I think @mrhoodz just forgot to delete those lines for debugging in this PR https://github.com/BuilderIO/qwik/pull/4579 (great work btw 😍).

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
