### PR TITLE
feat: allow overriding preventDefault for modifier keys

### DIFF
--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -14,6 +14,7 @@ export const Link = component$<LinkProps>((props) => {
   const clientNavPath = untrack(() => getClientNavPath(linkProps, loc));
   const prefetchDataset = untrack(() => getPrefetchDataset(props, clientNavPath, loc));
   linkProps['preventdefault:click'] = !!clientNavPath;
+  linkProps['allowmodifiers'] = !!clientNavPath;
   linkProps.href = clientNavPath || originalHref;
   const onPrefetch =
     prefetchDataset != null
@@ -21,9 +22,8 @@ export const Link = component$<LinkProps>((props) => {
           prefetchLinkResources(elm as HTMLAnchorElement, ev.type === 'qvisible')
         )
       : undefined;
-  const handleClick = event$(async (_: any, elm: HTMLAnchorElement) => {
-    if (!elm.hasAttribute('preventdefault:click')) {
-      // Do not enter the nav pipeline if this is not a clientNavPath.
+  const handleClick = event$(async (event: any, elm: HTMLAnchorElement) => {
+    if (!(event as PointerEvent).defaultPrevented) {
       return;
     }
 

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -186,6 +186,11 @@ export interface QwikProps<T extends Element> extends PreventDefault<T> {
   ref?: Ref<T> | undefined;
 
   /**
+   * Allow modifier keys (ctrl, meta, shift, alt) to override preventdefault.
+   */
+  allowmodifiers?: boolean;
+
+  /**
    * Corresponding slot name used to project the element into.
    */
   'q:slot'?: string;

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -52,7 +52,17 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
   const dispatch = async (element: Element, onPrefix: string, ev: Event, eventName = ev.type) => {
     const attrName = 'on' + onPrefix + ':' + eventName;
     if (element.hasAttribute('preventdefault:' + eventName)) {
-      ev.preventDefault();
+      if (
+        !element.hasAttribute('allowmodifiers') ||
+        !(
+          (ev as MouseEvent).ctrlKey ||
+          (ev as MouseEvent).metaKey ||
+          (ev as MouseEvent).shiftKey ||
+          (ev as MouseEvent).altKey
+        )
+      ) {
+        ev.preventDefault();
+      }
     }
     const ctx = (element as any)['_qc_'] as QContext | undefined;
     const qrls = ctx?.li.filter((li) => li[0] === attrName);


### PR DESCRIPTION
# Overview

In response to this issue: https://github.com/BuilderIO/qwik/issues/3871

The only place to preventDefault or not is in the loader, unfortunately this makes it impossible to preventDefault on anchors while also letting users use browser-native modifier keys (ctrl, shift, alt) to open new tabs, etc on these same links.

This impl. adds an attribute at the same level as `preventdefault:*` that allows overriding it for modifier keys. The reason for this is to allow devs to still preventDefault even on these modifier keys.

Given the widespread use of `preventdefault` and the niche use of modifier keys, I think keeping this check as false by default and opt-in only when needed makes more sense.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
