### PR TITLE
fix(qwik-core): reuse Invoke Context between grouped tasks

### DIFF
--- a/packages/qwik/src/core/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/qrl/qrl-class.ts
@@ -146,7 +146,7 @@ export const createQRL = <TYPE>(
             context.$event$ = this as Event;
           }
           emitUsedSymbol(symbol, context.$element$, start);
-          if (maybeAsync && isServerPlatform()) {
+          if (maybeAsync) {
             return asyncInvoke.call(this, context, f, ...(args as Parameters<typeof f>));
           }
           return invoke.call(this, context, f, ...(args as Parameters<typeof f>));

--- a/packages/qwik/src/core/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/qrl/qrl-class.ts
@@ -146,7 +146,7 @@ export const createQRL = <TYPE>(
             context.$event$ = this as Event;
           }
           emitUsedSymbol(symbol, context.$element$, start);
-          if (maybeAsync) {
+          if (maybeAsync && isServerPlatform()) {
             return asyncInvoke.call(this, context, f, ...(args as Parameters<typeof f>));
           }
           return invoke.call(this, context, f, ...(args as Parameters<typeof f>));

--- a/packages/qwik/src/core/render/execute-component.ts
+++ b/packages/qwik/src/core/render/execute-component.ts
@@ -54,7 +54,7 @@ export const executeComponent = (
 
   // Resolve render function
   componentQRL.$setContainer$(rCtx.$static$.$containerState$.$containerEl$);
-  const componentFn = componentQRL.getFn(iCtx);
+  const componentFn = componentQRL.getFn(false, iCtx);
 
   return safeCall(
     () => componentFn(props),

--- a/packages/qwik/src/core/render/execute-component.ts
+++ b/packages/qwik/src/core/render/execute-component.ts
@@ -54,7 +54,7 @@ export const executeComponent = (
 
   // Resolve render function
   componentQRL.$setContainer$(rCtx.$static$.$containerState$.$containerEl$);
-  const componentFn = componentQRL.getFn(false, iCtx);
+  const componentFn = componentQRL.getFn(iCtx);
 
   return safeCall(
     () => componentFn(props),

--- a/packages/qwik/src/core/use/use-core.ts
+++ b/packages/qwik/src/core/use/use-core.ts
@@ -17,7 +17,7 @@ import {
 } from '../util/markers';
 import { isPromise, safeCall } from '../util/promises';
 import { seal } from '../util/qdev';
-import { isArray, ValueOrPromise } from '../util/types';
+import { isArray, type ValueOrPromise } from '../util/types';
 import { setLocale } from './use-locale';
 import type { Subscriber } from '../state/common';
 import type { Signal } from '../state/signal';

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -531,9 +531,13 @@ export const runResource = <T>(
   const iCtx = newInvokeContext(rCtx.$static$.$locale$, el, undefined, TaskEvent);
   const { $subsManager$: subsManager } = containerState;
   iCtx.$renderCtx$ = rCtx;
-  const taskFn = task.$qrl$.getFn(iCtx, () => {
-    subsManager.$clearSub$(task);
-  });
+  const taskFn = task.$qrl$.getFn(
+    iCtx,
+    () => {
+      subsManager.$clearSub$(task);
+    },
+    isServerPlatform()
+  );
 
   const cleanups: (() => void)[] = [];
   const resource = task.$state$;
@@ -660,9 +664,13 @@ export const runTask = (
   const iCtx = newInvokeContext(rCtx.$static$.$locale$, hostElement, undefined, TaskEvent);
   iCtx.$renderCtx$ = rCtx;
   const { $subsManager$: subsManager } = containerState;
-  const taskFn = task.$qrl$.getFn(iCtx, () => {
-    subsManager.$clearSub$(task);
-  }) as TaskFn;
+  const taskFn = task.$qrl$.getFn(
+    iCtx,
+    () => {
+      subsManager.$clearSub$(task);
+    },
+    isServerPlatform()
+  ) as TaskFn;
   const track: Tracker = (obj: (() => unknown) | object | Signal, prop?: string) => {
     if (isFunction(obj)) {
       const ctx = newInvokeContext();
@@ -721,9 +729,13 @@ export const runComputed = (
   iCtx.$renderCtx$ = rCtx;
 
   const { $subsManager$: subsManager } = containerState;
-  const taskFn = task.$qrl$.getFn(iCtx, () => {
-    subsManager.$clearSub$(task);
-  }) as ComputedFn<unknown>;
+  const taskFn = task.$qrl$.getFn(
+    iCtx,
+    () => {
+      subsManager.$clearSub$(task);
+    },
+    isServerPlatform()
+  ) as ComputedFn<unknown>;
 
   return safeCall(
     taskFn,

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -984,8 +984,6 @@ export const MultipleServerFunctionsInvokedInTask = component$(() => {
   useTask$(async () => {
     methods.a = await serverFunctionA();
     methods.b = await serverFunctionB();
-
-    console.log({ requestMethodOne: methods.a, requestMethodTwo: methods.b });
   });
 
   return (

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -17,6 +17,7 @@ import {
 } from "@builder.io/qwik";
 import { delay } from "../streaming/demo";
 import { isServer } from "@builder.io/qwik/build";
+import { server$ } from "@builder.io/qwik-city";
 
 export const Render = component$(() => {
   const rerender = useSignal(0);
@@ -106,6 +107,7 @@ export const RenderChildren = component$<{ v: number }>(({ v }) => {
       <Issue4455 />
       <Issue5266 />
       <DynamicButton id="dynamic-button" />;
+      <MultipleServerFunctionsInvokedInTask />
     </>
   );
 });
@@ -970,3 +972,26 @@ export const DynamicButton = component$<any>(
     );
   },
 );
+const serverFunctionA = server$(async function a() {
+  return this.method;
+});
+const serverFunctionB = server$(async function b() {
+  return this.method;
+});
+
+export const MultipleServerFunctionsInvokedInTask = component$(() => {
+  const methods = useStore<{ a: string; b: string }>({ a: "", b: "" });
+  useTask$(async () => {
+    methods.a = await serverFunctionA();
+    methods.b = await serverFunctionB();
+
+    console.log({ requestMethodOne: methods.a, requestMethodTwo: methods.b });
+  });
+
+  return (
+    <div id="methods">
+      {methods.a}
+      {methods.b}
+    </div>
+  );
+});

--- a/starters/apps/qwikcity-test/src/routes/(common)/server-func/resource/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/server-func/resource/index.tsx
@@ -1,0 +1,41 @@
+import { component$, useResource$, Resource } from "@builder.io/qwik";
+import { server$ } from "@builder.io/qwik-city";
+
+const serverFunctionA = server$(async function a() {
+  return this.pathname + "a";
+});
+
+const serverFunctionB = server$(async function b() {
+  return this.pathname + "b";
+});
+
+const serverFunctionC = server$(async function c() {
+  return this.pathname + "c";
+});
+
+const ResourceServerFns = component$(() => {
+  const resource = useResource$(async () => {
+    const resultA = await serverFunctionA();
+    const resultB = await serverFunctionB();
+    const resultC = await serverFunctionC();
+
+    return { resultA, resultB, resultC };
+  });
+
+  return (
+    <div>
+      <Resource
+        value={resource}
+        onResolved={({ resultA, resultB, resultC }) => (
+          <>
+            <p id="a">{resultA}</p>
+            <p id="b">{resultB} </p>
+            <p id="c">{resultC}</p>
+          </>
+        )}
+      />
+    </div>
+  );
+});
+
+export default ResourceServerFns;

--- a/starters/e2e/e2e.render.spec.ts
+++ b/starters/e2e/e2e.render.spec.ts
@@ -500,6 +500,11 @@ test.describe("render", () => {
       await button.click();
       await expect(tag).toHaveAttribute("data-v", "bar");
     });
+
+    test("Multiple server functions should use the same context when invoked from useTask$", async ({ page }) => {
+      const methodsContainer = page.locator("#methods");
+      await expect(methodsContainer).toContainText("GETGET")
+    });
   }
 
   tests();

--- a/starters/e2e/e2e.render.spec.ts
+++ b/starters/e2e/e2e.render.spec.ts
@@ -501,9 +501,11 @@ test.describe("render", () => {
       await expect(tag).toHaveAttribute("data-v", "bar");
     });
 
-    test("Multiple server functions should use the same context when invoked from useTask$", async ({ page }) => {
+    test("Multiple server functions should use the same context when invoked from useTask$", async ({
+      page,
+    }) => {
       const methodsContainer = page.locator("#methods");
-      await expect(methodsContainer).toContainText("GETGET")
+      await expect(methodsContainer).toContainText("GETGET");
     });
   }
 

--- a/starters/e2e/qwikcity/server.spec.ts
+++ b/starters/e2e/qwikcity/server.spec.ts
@@ -52,7 +52,7 @@ test.describe("server$ inside resource", () => {
         await expect(result).toHaveText([
           "/qwikcity-test/server-func/resource/" + letter,
         ]);
-      })
+      }),
     );
   });
 });

--- a/starters/e2e/qwikcity/server.spec.ts
+++ b/starters/e2e/qwikcity/server.spec.ts
@@ -40,3 +40,19 @@ test.describe("server$", () => {
     await expect(logs).toHaveText("01234");
   });
 });
+
+test.describe("server$ inside resource", () => {
+  test("All functions have reference to requestevent", async ({ page }) => {
+    await page.goto("/qwikcity-test/server-func/resource");
+
+    await Promise.all(
+      ["a", "b", "c"].map(async (letter) => {
+        const result = await page.locator(`#${letter}`);
+
+        await expect(result).toHaveText([
+          "/qwikcity-test/server-func/resource/" + letter,
+        ]);
+      })
+    );
+  });
+});


### PR DESCRIPTION
# Overview

When multiple `server$` functions are called from a `useResource$` hook, the invocation's context is dropped by `useResource` after the first function resolved.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

fixes #4417

# Use cases and why

One would expect they can write and use separate `server$` functions, and reuse them inside a single `<Resource />` 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
