### PR TITLE
docs(request-handling): cookie has method

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/advanced/request-handling/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/advanced/request-handling/index.mdx
@@ -120,5 +120,5 @@ cookie.delete('my-cookie', { domain: 'https://qwik.builder.io', path: '/docs/' }
 A convenience method which returns true or false based on the presence of the provided key in cookie.
 
 ```tsx
-!!cookie.get('my-cookie');
+cookie.has('my-cookie');
 ```


### PR DESCRIPTION
I just changed the shortcut to cast get to boolean to the has method

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
