### PR TITLE
feat(qwik): encode the manifest hash into the container.

### DIFF
--- a/packages/docs/src/routes/api/qwik-optimizer/api.json
+++ b/packages/docs/src/routes/api/qwik-optimizer/api.json
@@ -386,7 +386,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface QwikManifest \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [bundles](#) |  | { \\[fileName: string\\]: [QwikBundle](#qwikbundle)<!-- -->; } |  |\n|  [injections?](#) |  | [GlobalInjections](#globalinjections)<!-- -->\\[\\] | _(Optional)_ |\n|  [mapping](#) |  | { \\[symbolName: string\\]: string; } |  |\n|  [options?](#) |  | { target?: string; buildMode?: string; entryStrategy?: { \\[key: string\\]: any; }; } | _(Optional)_ |\n|  [platform?](#) |  | { \\[name: string\\]: string; } | _(Optional)_ |\n|  [symbols](#) |  | { \\[symbolName: string\\]: [QwikSymbol](#qwiksymbol)<!-- -->; } |  |\n|  [version](#) |  | string |  |",
+      "content": "```typescript\nexport interface QwikManifest \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [bundles](#) |  | { \\[fileName: string\\]: [QwikBundle](#qwikbundle)<!-- -->; } |  |\n|  [injections?](#) |  | [GlobalInjections](#globalinjections)<!-- -->\\[\\] | _(Optional)_ |\n|  [manifestHash](#) |  | string |  |\n|  [mapping](#) |  | { \\[symbolName: string\\]: string; } |  |\n|  [options?](#) |  | { target?: string; buildMode?: string; entryStrategy?: { \\[key: string\\]: any; }; } | _(Optional)_ |\n|  [platform?](#) |  | { \\[name: string\\]: string; } | _(Optional)_ |\n|  [symbols](#) |  | { \\[symbolName: string\\]: [QwikSymbol](#qwiksymbol)<!-- -->; } |  |\n|  [version](#) |  | string |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/optimizer/src/types.ts",
       "mdFile": "qwik.qwikmanifest.md"
     },

--- a/packages/docs/src/routes/api/qwik-optimizer/index.md
+++ b/packages/docs/src/routes/api/qwik-optimizer/index.md
@@ -377,15 +377,16 @@ export interface QwikBundle
 export interface QwikManifest
 ```
 
-| Property         | Modifiers | Type                                                                              | Description  |
-| ---------------- | --------- | --------------------------------------------------------------------------------- | ------------ |
-| [bundles](#)     |           | { [fileName: string]: [QwikBundle](#qwikbundle); }                                |              |
-| [injections?](#) |           | [GlobalInjections](#globalinjections)[]                                           | _(Optional)_ |
-| [mapping](#)     |           | { [symbolName: string]: string; }                                                 |              |
-| [options?](#)    |           | { target?: string; buildMode?: string; entryStrategy?: { [key: string]: any; }; } | _(Optional)_ |
-| [platform?](#)   |           | { [name: string]: string; }                                                       | _(Optional)_ |
-| [symbols](#)     |           | { [symbolName: string]: [QwikSymbol](#qwiksymbol); }                              |              |
-| [version](#)     |           | string                                                                            |              |
+| Property          | Modifiers | Type                                                                              | Description  |
+| ----------------- | --------- | --------------------------------------------------------------------------------- | ------------ |
+| [bundles](#)      |           | { [fileName: string]: [QwikBundle](#qwikbundle); }                                |              |
+| [injections?](#)  |           | [GlobalInjections](#globalinjections)[]                                           | _(Optional)_ |
+| [manifestHash](#) |           | string                                                                            |              |
+| [mapping](#)      |           | { [symbolName: string]: string; }                                                 |              |
+| [options?](#)     |           | { target?: string; buildMode?: string; entryStrategy?: { [key: string]: any; }; } | _(Optional)_ |
+| [platform?](#)    |           | { [name: string]: string; }                                                       | _(Optional)_ |
+| [symbols](#)      |           | { [symbolName: string]: [QwikSymbol](#qwiksymbol); }                              |              |
+| [version](#)      |           | string                                                                            |              |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/optimizer/src/types.ts)
 

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -1282,7 +1282,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface RenderSSROptions \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [base?](#) |  | string | _(Optional)_ |\n|  [beforeClose?](#) |  | (contexts: QContext\\[\\], containerState: ContainerState, containsDynamic: boolean, textNodes: Map&lt;string, string&gt;) =&gt; Promise&lt;[JSXNode](#jsxnode)<!-- -->&gt; | _(Optional)_ |\n|  [beforeContent?](#) |  | [JSXNode](#jsxnode)<!-- -->&lt;string&gt;\\[\\] | _(Optional)_ |\n|  [containerAttributes](#) |  | Record&lt;string, string&gt; |  |\n|  [containerTagName](#) |  | string |  |\n|  [serverData?](#) |  | Record&lt;string, any&gt; | _(Optional)_ |\n|  [stream](#) |  | [StreamWriter](#streamwriter) |  |",
+      "content": "```typescript\nexport interface RenderSSROptions \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [base?](#) |  | string | _(Optional)_ |\n|  [beforeClose?](#) |  | (contexts: QContext\\[\\], containerState: ContainerState, containsDynamic: boolean, textNodes: Map&lt;string, string&gt;) =&gt; Promise&lt;[JSXNode](#jsxnode)<!-- -->&gt; | _(Optional)_ |\n|  [beforeContent?](#) |  | [JSXNode](#jsxnode)<!-- -->&lt;string&gt;\\[\\] | _(Optional)_ |\n|  [containerAttributes](#) |  | Record&lt;string, string&gt; |  |\n|  [containerTagName](#) |  | string |  |\n|  [manifestHash](#) |  | string |  |\n|  [serverData?](#) |  | Record&lt;string, any&gt; | _(Optional)_ |\n|  [stream](#) |  | [StreamWriter](#streamwriter) |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/ssr/render-ssr.ts",
       "mdFile": "qwik.renderssroptions.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -1509,6 +1509,7 @@ export interface RenderSSROptions
 | [beforeContent?](#)      |           | [JSXNode](#jsxnode)&lt;string&gt;[]                                                                                                                             | _(Optional)_ |
 | [containerAttributes](#) |           | Record&lt;string, string&gt;                                                                                                                                    |              |
 | [containerTagName](#)    |           | string                                                                                                                                                          |              |
+| [manifestHash](#)        |           | string                                                                                                                                                          |              |
 | [serverData?](#)         |           | Record&lt;string, any&gt;                                                                                                                                       | _(Optional)_ |
 | [stream](#)              |           | [StreamWriter](#streamwriter)                                                                                                                                   |              |
 

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -189,6 +189,7 @@ export function ssrDevMiddleware(ctx: BuildContext, server: ViteDevServer) {
           Object.assign(serverRequestEv.platform, ctx.opts.platform);
 
           const manifest: QwikManifest = {
+            manifestHash: '',
             symbols: {},
             mapping: {},
             bundles: {},

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -742,6 +742,8 @@ export interface RenderSSROptions {
     // (undocumented)
     containerTagName: string;
     // (undocumented)
+    manifestHash: string;
+    // (undocumented)
     serverData?: Record<string, any>;
     // (undocumented)
     stream: StreamWriter;

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -77,6 +77,7 @@ export interface RenderSSROptions {
     containsDynamic: boolean,
     textNodes: Map<string, string>
   ) => Promise<JSXNode>;
+  manifestHash: string;
 }
 
 export interface SSRContext {
@@ -163,6 +164,7 @@ export const _renderSSR = async (node: JSXNode, opts: RenderSSROptions) => {
     'q:render': qRender,
     'q:base': opts.base,
     'q:locale': opts.serverData?.locale,
+    'q:manifest-hash': opts.manifestHash,
   };
   const children = root === 'html' ? [node] : [headNodes, node];
   if (root !== 'html') {

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -24,7 +24,7 @@ const renderSSRSuite = suite('renderSSR');
 renderSSRSuite('render attributes', async () => {
   await testSSR(
     <body id="stuff" aria-required="true" role=""></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body id="stuff" aria-required="true" role></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body id="stuff" aria-required="true" role></body></html>'
   );
 });
 
@@ -39,7 +39,7 @@ renderSSRSuite('render aria value', async () => {
       aria-hidden={undefined}
     ></body>,
     `
-        <html q:container="paused" q:version="dev" q:render="ssr-dev">
+        <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
           <body id="stuff" aria-required="true" aria-busy="false" role preventdefault:click=""></body>
         </html>
         `
@@ -49,7 +49,7 @@ renderSSRSuite('render aria value', async () => {
 renderSSRSuite('render className', async () => {
   await testSSR(
     <body class="stuff"></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body class="stuff"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body class="stuff"></body></html>'
   );
 });
 
@@ -154,7 +154,7 @@ renderSSRSuite('render class', async () => {
         'm-0 p-2': true,
       }}
     ></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body class="stuff m-0 p-2"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body class="stuff m-0 p-2"></body></html>'
   );
 
   const Test = component$(() => {
@@ -166,7 +166,7 @@ renderSSRSuite('render class', async () => {
     <body>
       <Test />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <div class="myClass" q:id="1"></div>
@@ -179,7 +179,7 @@ renderSSRSuite('render class', async () => {
     <body
       class={['stuff', '', 'm-0 p-2', null, { active: 1 }, undefined, [{ container: 'yup' }]]}
     ></body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body class="stuff m-0 p-2 active container"></body>
     </html>`
   );
@@ -188,7 +188,7 @@ renderSSRSuite('render class', async () => {
 renderSSRSuite('render contentEditable', async () => {
   await testSSR(
     <body contentEditable="true"></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body contentEditable="true"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body contentEditable="true"></body></html>'
   );
 });
 
@@ -200,7 +200,7 @@ renderSSRSuite('render draggable', async () => {
       <div draggable={undefined}></div>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <div draggable="true"></div>
         <div draggable="false"></div>
@@ -217,7 +217,7 @@ renderSSRSuite('render <textarea>', async () => {
       <textarea value="some text"></textarea>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <textarea>some text</textarea>
       </body>
@@ -234,7 +234,7 @@ renderSSRSuite('render spellcheck', async () => {
       <div spellcheck={undefined}></div>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <div spellcheck="true"></div>
         <div spellcheck="false"></div>
@@ -258,7 +258,7 @@ renderSSRSuite('render styles', async () => {
       }}
     ></body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body style="
           padding-top: 10px;
           padding-bottom: 10px;
@@ -276,7 +276,7 @@ renderSSRSuite('render fake click handler', async () => {
   const Div = 'body' as any;
   await testSSR(
     <Div on:click="true" onScroll="text"></Div>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body on:click="true" onScroll="text"></body>
     </html>`
   );
@@ -287,7 +287,7 @@ renderSSRSuite('self closing elements', async () => {
     <body>
       <input></input>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <input>
       </body>
@@ -298,27 +298,27 @@ renderSSRSuite('self closing elements', async () => {
 renderSSRSuite('single simple children', async () => {
   await testSSR(
     <body>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body>hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body>hola</body></html>'
   );
   await testSSR(
     <body>{0}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body>0</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body>0</body></html>'
   );
   await testSSR(
     <body>{true}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
   );
   await testSSR(
     <body>{false}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
   );
   await testSSR(
     <body>{null}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
   );
   await testSSR(
     <body>{undefined}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
   );
 });
 
@@ -329,7 +329,7 @@ renderSSRSuite('valid phrasing content', async () => {
         <del>Del</del>
       </p>
     </body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body><p><del>Del</del></p></body>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><p><del>Del</del></p></body>'
   );
   await testSSR(
     <body>
@@ -340,7 +340,7 @@ renderSSRSuite('valid phrasing content', async () => {
         </select>
       </p>
     </body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body><p><select><option>A</option><option>B</option></select></p></body>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><p><select><option>A</option><option>B</option></select></p></body>'
   );
   await testSSR(
     <body>
@@ -348,7 +348,7 @@ renderSSRSuite('valid phrasing content', async () => {
         <link rel="example" />
       </p>
     </body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body><p><link rel="example"/></p></body>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><p><link rel="example"/></p></body>'
   );
   await testSSR(
     <body>
@@ -359,7 +359,7 @@ renderSSRSuite('valid phrasing content', async () => {
         <img useMap="#my-map" src="/example.png" alt="Example" />
       </p>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <p>
           <map name="my-map">
@@ -383,7 +383,7 @@ renderSSRSuite('valid phrasing content', async () => {
         </svg>
       </p>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <p>
           <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -408,7 +408,7 @@ renderSSRSuite('valid phrasing content', async () => {
         </math>
       </p>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <p>
           <math>
@@ -429,51 +429,51 @@ renderSSRSuite('valid phrasing content', async () => {
 renderSSRSuite('events', async () => {
   await testSSR(
     <body onClick$={() => console.warn('hol')}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body on:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body onClick$={[undefined, $(() => console.warn('hol'))]}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body on:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body onClick$={[undefined, [$(() => console.warn('hol'))]]}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body on:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body document:onClick$={() => console.warn('hol')}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body on-document:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on-document:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body window:onClick$={() => console.warn('hol')}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body on-window:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on-window:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body>
       <input onInput$={() => console.warn('hol')} />
     </body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body><input on:input="/runtimeQRL#_"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><input on:input="/runtimeQRL#_"></body></html>'
   );
 });
 
 renderSSRSuite('innerHTML', async () => {
   await testSSR(
     <body dangerouslySetInnerHTML="<p>hola</p>"></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body q:key="innerhtml"><p>hola</p></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body q:key="innerhtml"><p>hola</p></body></html>'
   );
   await testSSR(
     <body dangerouslySetInnerHTML=""></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body q:key="innerhtml"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body q:key="innerhtml"></body></html>'
   );
   const Div = 'body' as any;
   await testSSR(
     <Div dangerouslySetInnerHTML={0}></Div>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body q:key="innerhtml">0</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body q:key="innerhtml">0</body></html>'
   );
   await testSSR(
     <body>
       <script dangerouslySetInnerHTML="() => null"></script>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <script q:key="innerhtml">
           () => null
@@ -488,7 +488,7 @@ renderSSRSuite('single complex children', async () => {
     <div>
       <p>hola</p>
     </div>,
-    '<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦"><div><p>hola</p></div></container>',
+    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦"><div><p>hola</p></div></container>',
     {
       containerTagName: 'container',
     }
@@ -498,7 +498,7 @@ renderSSRSuite('single complex children', async () => {
       hola {2}
       <p>hola</p>
     </div>,
-    '<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦"><div>hola 2<p>hola</p></div></container>',
+    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦"><div>hola 2<p>hola</p></div></container>',
     {
       containerTagName: 'container',
     }
@@ -517,7 +517,7 @@ renderSSRSuite('single multiple children', async () => {
       <li>7</li>
       <li>8</li>
     </ul>,
-    '<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦"><ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li><li>6</li><li>7</li><li>8</li></ul></container>',
+    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦"><ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li><li>6</li><li>7</li><li>8</li></ul></container>',
     {
       containerTagName: 'container',
     }
@@ -529,7 +529,7 @@ renderSSRSuite('sanity', async () => {
     <body>
       <div>{`.rule > thing{}`}</div>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <div>.rule &gt; thing{}</div>
       </body>
@@ -559,7 +559,7 @@ renderSSRSuite('using fragment', async () => {
       </>
       <li>8</li>
     </ul>,
-    '<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦"><ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li><li>6</li><li>7</li><li>8</li></ul></container>',
+    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦"><ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li><li>6</li><li>7</li><li>8</li></ul></container>',
     {
       containerTagName: 'container',
     }
@@ -569,11 +569,11 @@ renderSSRSuite('using fragment', async () => {
 renderSSRSuite('using promises', async () => {
   await testSSR(
     <body>{Promise.resolve('hola')}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body><!--qkssr-f-->hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><!--qkssr-f-->hola</body></html>'
   );
   await testSSR(
     <body>{Promise.resolve(<p>hola</p>)}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body><!--qkssr-f--><p>hola</p></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><!--qkssr-f--><p>hola</p></body></html>'
   );
 
   await testSSR(
@@ -588,7 +588,7 @@ renderSSRSuite('using promises', async () => {
       ))}
     </ul>,
     [
-      '<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">',
+      '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">',
       '<ul>',
       '<!--qkssr-f-->',
       '<li>',
@@ -630,7 +630,7 @@ renderSSRSuite('mixed children', async () => {
       ))}
     </ul>,
     `
-        <container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+        <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
         <ul>
         <li>0</li>
         <li>1</li>
@@ -658,7 +658,7 @@ renderSSRSuite('DelayResource', async () => {
         <DelayResource text="thing" delay={10} />
       </ul>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
     <body>
       <ul>
         <!--qv q:id=0 q:key=sX:-->
@@ -684,7 +684,7 @@ renderSSRSuite('using promises with DelayResource', async () => {
         <DelayResource text="thing" delay={500} />
       </ul>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
       <ul>
         <!--qkssr-f-->
@@ -702,7 +702,7 @@ renderSSRSuite('using promises with DelayResource', async () => {
 renderSSRSuite('using component', async () => {
   await testSSR(
     <MyCmp />,
-    `<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <section><div>MyCmp{}</div></section>
       <!--/qv-->
@@ -718,7 +718,7 @@ renderSSRSuite('using component with key', async () => {
     <body>
       <MyCmp key="hola" />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:hola-->
         <section><div>MyCmp{}</div></section>
@@ -733,7 +733,7 @@ renderSSRSuite('using element with key', async () => {
     <body>
       <div key="hola" />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <div q:key="hola"></div>
       </body>
@@ -746,7 +746,7 @@ renderSSRSuite('using element with key containing double quotes', async () => {
     <body>
       <div key={'"hola"'} />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <div q:key="&quot;hola&quot;"></div>
       </body>
@@ -768,7 +768,7 @@ renderSSRSuite('using component props', async () => {
       stuff
     </MyCmp>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <section>
         <div>MyCmp{"id":"12","host:prop":"attribute","innerHTML":"123","dangerouslySetInnerHTML":"432","onClick":"lazy.js","prop":"12"}</div>
@@ -789,7 +789,7 @@ renderSSRSuite('using component project content', async () => {
       <div>slot</div>
     </MyCmp>,
     `
-  <container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+  <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
     <!--qv q:id=0 q:key=sX:-->
     <section><div>MyCmp{}</div></section>
     <q:template q:slot hidden aria-hidden="true"><div>slot</div></q:template>
@@ -807,7 +807,7 @@ renderSSRSuite('using complex component', async () => {
     <body>
       <MyCmpComplex></MyCmpComplex>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <div on:click="/runtimeQRL#_" q:id="1">
@@ -824,7 +824,7 @@ renderSSRSuite('using complex component with slot', async () => {
   await testSSR(
     <MyCmpComplex>Hola</MyCmpComplex>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <div on:click="/runtimeQRL#_" q:id="1">
         <button on:click="/runtimeQRL#_">Click</button>
@@ -849,7 +849,7 @@ renderSSRSuite('<head>', async () => {
       </>
     </head>,
     `
-  <html q:container="paused" q:version="dev" q:render="ssr-dev">
+  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
     <head q:head>
       <title q:head>hola</title>
       <meta q:head>
@@ -872,7 +872,7 @@ renderSSRSuite('named slots', async () => {
       default
     </NamedSlot>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <div>
         <!--qv q:s q:sref=0 q:key=start-->
@@ -906,7 +906,7 @@ renderSSRSuite('nested slots', async () => {
       </SimpleSlot>
     </SimpleSlot>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
         <div id="root">
           Before root
@@ -945,7 +945,7 @@ renderSSRSuite('mixes slots', async () => {
   await testSSR(
     <MixedSlot>Content</MixedSlot>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <!--qv q:id=1 q:key=sX:-->
         <div id="1">Before 1
@@ -969,7 +969,7 @@ renderSSRSuite('component RenderSignals()', async () => {
   await testSSR(
     <RenderSignals />,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <!--qv q:id=0 q:key=sX:-->
       <head q:head>
         <title q:head>value</title>
@@ -990,7 +990,7 @@ renderSSRSuite('component useContextProvider()', async () => {
     <Context>
       <ContextConsumer />
     </Context>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <!--qv q:id=0 q:key=sX:-->
         <!--qv q:s q:sref=0 q:key=-->
           <!--qv q:id=1 q:key=sX:-->hello bye<!--/qv-->
@@ -1011,7 +1011,7 @@ renderSSRSuite('component slotted context', async () => {
       </VariadicContext>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <!--qv q:id=1 q:key=sX:-->
@@ -1052,7 +1052,7 @@ renderSSRSuite('component useOn()', async () => {
     <body>
       <Events />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
       <!--qv q:id=0 q:key=sX:-->
       <div on:click="/runtimeQRL#_\n/runtimeQRL#_" on-window:click="/runtimeQRL#_" on-document:click="/runtimeQRL#_"></div>
@@ -1068,7 +1068,7 @@ renderSSRSuite('component useOn([array])', async () => {
       <UseOnMultiple />
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <div on:click="/runtimeQRL#_\n/runtimeQRL#_"
@@ -1091,7 +1091,7 @@ renderSSRSuite('component useStyles()', async () => {
         <Styles />
       </body>
     </>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
           <style q:style="17nc-0" hidden>.host {color: red}</style>
@@ -1114,7 +1114,7 @@ renderSSRSuite('component useStylesScoped()', async () => {
       </body>
     </>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:sstyle=⭐️1d-0|⭐️1e-1 q:id=0 q:key=sX:-->
         <style q:style="1d-0" hidden>
@@ -1170,7 +1170,7 @@ renderSSRSuite('component useStylesScoped() + slot', async () => {
       <RootStyles></RootStyles>
     </>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <!--qv q:sstyle=⭐️lkei4s-0 q:id=0 q:key=sX:-->
       <body class="⭐️lkei4s-0">
         <!--qv q:sstyle=⭐️tdblg1-0 q:id=1 q:key=sX:-->
@@ -1198,7 +1198,7 @@ renderSSRSuite('component useStylesScoped() + slot', async () => {
 renderSSRSuite('component useBrowserVisibleTask()', async () => {
   await testSSR(
     <UseClientEffect />,
-    `<container q:container="paused" q:version="dev" q:render="ssr-dev" class="qc📦">
+    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
         <div on:qvisible="/runtimeQRL#_[0]
 /runtimeQRL#_[1]" q:id="1"></div>
@@ -1216,7 +1216,7 @@ renderSSRSuite('component useBrowserVisibleTask() without elements', async () =>
       <UseEmptyClientEffect />
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         Hola
@@ -1235,7 +1235,7 @@ renderSSRSuite('component useBrowserVisibleTask() inside <head>', async () => {
       <UseClientEffect as="style" />
     </head>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <head q:head>
         <!--qv q:id=0 q:key=sX:-->
         Hola
@@ -1254,7 +1254,7 @@ renderSSRSuite('nested html', async () => {
     <>
       <body></body>
     </>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev"><body></body></html>`
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>`
   );
 });
 
@@ -1264,7 +1264,7 @@ renderSSRSuite('root html component', async () => {
       <link></link>
     </HeadCmp>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <!--qv q:id=0 q:key=sX:-->
       <head on-document:qinit="/runtimeQRL#_[0]" q:id="1" q:head>
         <title q:head>hola</title>
@@ -1285,7 +1285,7 @@ renderSSRSuite('containerTagName', async () => {
       <UseClientEffect></UseClientEffect>
       <section></section>
     </>,
-    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="/manu/folder" class="qc📦">
+    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="/manu/folder" q:manifest-hash="test" class="qc📦">
       <link rel="stylesheet" href="/global.css">
       <!--qv q:id=0 q:key=sX:-->
         <style q:style="17nc-0" hidden>.host {color: red}</style>
@@ -1311,7 +1311,7 @@ renderSSRSuite('containerAttributes', async () => {
       <body></body>
     </>,
     `
-    <html prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
      <body></body>
     </html>
     `,
@@ -1326,7 +1326,7 @@ renderSSRSuite('containerAttributes', async () => {
       <div></div>
     </>,
     `
-    <app prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev" class='qc📦 thing'>
+    <app prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class='qc📦 thing'>
      <div></div>
     </app>
     `,
@@ -1346,7 +1346,7 @@ renderSSRSuite('custom q:render', async () => {
       <body></body>
     </>,
     `
-    <html q:render="static-ssr-dev" q:container="paused" q:version="dev">
+    <html q:render="static-ssr-dev" q:container="paused" q:version="dev" q:manifest-hash="test">
      <body></body>
     </html>
     `,
@@ -1361,7 +1361,7 @@ renderSSRSuite('custom q:render', async () => {
       <body></body>
     </>,
     `
-    <html q:render="ssr-dev" q:container="paused" q:version="dev">
+    <html q:render="ssr-dev" q:container="paused" q:version="dev" q:manifest-hash="test">
      <body></body>
     </html>
     `,
@@ -1390,7 +1390,7 @@ renderSSRSuite('ssr marks', async () => {
         <li>3</li>
       ))}
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qkssr-f-->
         <li>1</li>
@@ -1413,7 +1413,7 @@ renderSSRSuite('ssr raw', async () => {
       <SSRRaw data="<div>hello</div>" />
     </body>,
     `
-  <html q:container="paused" q:version="dev" q:render="ssr-dev">
+  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
     <body>
       <div>hello</div>
     </body>
@@ -1427,7 +1427,7 @@ renderSSRSuite('html fragment', async () => {
       <HTMLFragment dangerouslySetInnerHTML="<div>hello</div>" />
     </body>,
     `
-  <html q:container="paused" q:version="dev" q:render="ssr-dev">
+  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
     <body>
       <!--qv-->
       <div>hello</div>
@@ -1449,7 +1449,7 @@ renderSSRSuite('html slot', async () => {
       </body>
     </HtmlContext>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="/manu/folder">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="/manu/folder" q:manifest-hash="test">
       <!--qv q:id=0 q:key=sX:-->
       <!--qv q:s q:sref=0 q:key=-->
       <head q:head>
@@ -1480,7 +1480,7 @@ renderSSRSuite('null component', async () => {
     <>
       <NullCmp />
     </>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev"><!--qv q:id=0 q:key=sX:--><!--/qv--></html>`
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><!--qv q:id=0 q:key=sX:--><!--/qv--></html>`
   );
 });
 
@@ -1490,7 +1490,7 @@ renderSSRSuite('cleanse attribute name', async () => {
   };
   await testSSR(
     <body {...o}></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
   );
 });
 
@@ -1500,7 +1500,7 @@ renderSSRSuite('cleanse class attribute', async () => {
   };
   await testSSR(
     <body {...o}></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body class="&quot;><script>alert(&quot;ಠ~ಠ&quot;)</script>"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body class="&quot;><script>alert(&quot;ಠ~ಠ&quot;)</script>"></body></html>'
   );
 });
 
@@ -1510,7 +1510,7 @@ renderSSRSuite('class emoji valid', async () => {
   };
   await testSSR(
     <body {...o}></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev"><body class="package📦"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body class="package📦"></body></html>'
   );
 });
 
@@ -1522,7 +1522,7 @@ renderSSRSuite('issue 4283', async () => {
       </Issue4283>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <!--qv q:id=1 q:key=sX:-->
@@ -1837,6 +1837,7 @@ async function testSSR(
     stream,
     containerTagName: 'html',
     containerAttributes: {},
+    manifestHash: 'test',
     ...opts,
   });
   if (typeof expected === 'string') {

--- a/packages/qwik/src/core/util/hash_code.ts
+++ b/packages/qwik/src/core/util/hash_code.ts
@@ -1,7 +1,4 @@
 export const hashCode = (text: string, hash: number = 0) => {
-  if (text.length === 0) {
-    return hash;
-  }
   for (let i = 0; i < text.length; i++) {
     const chr = text.charCodeAt(i);
     hash = (hash << 5) - hash + chr;

--- a/packages/qwik/src/optimizer/src/api.md
+++ b/packages/qwik/src/optimizer/src/api.md
@@ -204,6 +204,8 @@ export interface QwikManifest {
     // (undocumented)
     injections?: GlobalInjections[];
     // (undocumented)
+    manifestHash: string;
+    // (undocumented)
     mapping: {
         [symbolName: string]: string;
     };

--- a/packages/qwik/src/optimizer/src/manifest.ts
+++ b/packages/qwik/src/optimizer/src/manifest.ts
@@ -251,6 +251,7 @@ export function generateManifestFromBundles(
   opts: NormalizedQwikPluginOptions
 ) {
   const manifest: QwikManifest = {
+    manifestHash: '',
     symbols: {},
     mapping: {},
     bundles: {},

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -17,6 +17,7 @@ import type {
 } from '../types';
 import { createLinter, type QwikLinter } from './eslint-plugin';
 import type { Rollup } from 'vite';
+import { hashCode } from '../../../core/util/hash_code';
 
 const REG_CTX_NAME = ['server'];
 
@@ -703,6 +704,8 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
             .sort();
         }
       }
+
+      manifest.manifestHash = hashCode(JSON.stringify(manifest));
 
       return manifest;
     };

--- a/packages/qwik/src/optimizer/src/plugins/plugin.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.unit.ts
@@ -160,7 +160,13 @@ test('manifestOutput', async () => {
 
 test('manifestInput', async () => {
   const plugin = await mockPlugin();
-  const manifestInput: QwikManifest = { mapping: {}, symbols: {}, bundles: {}, version: '1' };
+  const manifestInput: QwikManifest = {
+    manifestHash: '',
+    mapping: {},
+    symbols: {},
+    bundles: {},
+    version: '1',
+  };
   const opts = plugin.normalizeOptions({ manifestInput });
   equal(opts.manifestInput, manifestInput);
 });

--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -88,6 +88,7 @@ export async function configureDevServer(
 
         if (typeof render === 'function') {
           const manifest: QwikManifest = {
+            manifestHash: '',
             symbols: {},
             mapping: {},
             bundles: {},

--- a/packages/qwik/src/optimizer/src/types.ts
+++ b/packages/qwik/src/optimizer/src/types.ts
@@ -259,6 +259,7 @@ export interface SmartEntryStrategy {
  * @public
  */
 export interface QwikManifest {
+  manifestHash: string;
   symbols: { [symbolName: string]: QwikSymbol };
   mapping: { [symbolName: string]: string };
   bundles: { [fileName: string]: QwikBundle };

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -217,6 +217,7 @@ export async function renderToStream(
       snapshotTime = snapshotTimer();
       return jsx(Fragment, { children });
     },
+    manifestHash: resolvedManifest?.manifest.manifestHash || 'dev',
   });
 
   // End of container


### PR DESCRIPTION
# Overview

In order for Insight to correctly keep statistics on the symbols, it needs to know when a new build is deployed. This change embeds the manifest hash into the container. Insights will than be able to send this information to the server for analysis. 


<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
