### PR TITLE
fix(eslint): useMethod rule for regular functions

### DIFF
--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -109,6 +109,19 @@ export const HelloWorld = component$(async () => {
         
           });
           `,
+      `export const InsideTask = component$(() => {
+          const mySig = useSignal(0);
+          useTask$(async function initTask(){
+            if (isServer){
+              await fetch('/url');
+            }
+          })
+
+          useTask$(({track})=>{
+            track(()=> mySig.value);
+          })
+          return <div></div>;
+      });`,
     ],
     invalid: [
       {

--- a/packages/eslint-plugin-qwik/src/useMethodUsage.ts
+++ b/packages/eslint-plugin-qwik/src/useMethodUsage.ts
@@ -34,6 +34,12 @@ export const useMethodUsage: Rule.RuleModule = {
       'ArrowFunctionExpression:exit'(d) {
         stack.pop();
       },
+      FunctionExpression() {
+        stack.push({ await: false });
+      },
+      'FunctionExpression:exit'(d) {
+        stack.pop();
+      },
       AwaitExpression() {
         const last = stack[stack.length - 1];
         if (last) {


### PR DESCRIPTION
# Overview


# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

When using regular functions in tasks and async await, eslint would throw an error

For example in the following code: 
```
useTask$(async function myTask(){
  await fetch()
});

useTask$(function myTask2(){
  // ESLINT WOULD SHOW AN ERROR HERE 👈
});

```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
