### PR TITLE
fix: the property parameter can be symbol

### DIFF
--- a/packages/qwik/src/core/state/store.ts
+++ b/packages/qwik/src/core/state/store.ts
@@ -196,7 +196,7 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
     return true;
   }
 
-  has(target: TargetType, property: string | symbol) {
+  has(target: TargetType, property: string | symbol): boolean {
     if (property === QOjectTargetSymbol) {
       return true;
     }
@@ -234,7 +234,10 @@ export class ReadWriteProxyHandler implements ProxyHandler<TargetType> {
     });
   }
 
-  getOwnPropertyDescriptor(target: TargetType, prop: string) {
+  getOwnPropertyDescriptor(
+    target: TargetType,
+    prop: string | symbol
+  ): PropertyDescriptor | undefined {
     if (isArray(target) || typeof prop === 'symbol') {
       return Object.getOwnPropertyDescriptor(target, prop);
     }


### PR DESCRIPTION
# Overview

- Change the type for `prop` param of `getOwnPropertyDescriptor` method.
- Add return types for `getOwnPropertyDescriptor` and `has` methods.

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

I think `getOwnPropertyDescriptor`'s prop parameter can also be symbol type since we're checking:

```ts
typeof prop === 'symbol'
```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
