### PR TITLE
docs(mdx): fixed path to counter component

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/mdx/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/mdx/index.mdx
@@ -43,7 +43,8 @@ The above component will be rendered at `https://example.com/some/path`.
 ```bash
 src/
 ├── components/
-│   └──  counter.tsx
+|   └── counter
+│       └──  counter.tsx
 └── routes/
     └── some/
         └── path/


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

Both files under "Importing other components" state, that the `Counter` component should be under `components/counter/counter.tsx` but the directory structure does not reflect that.

# Use cases and why

/

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
