### PR TITLE
chore: fix \\n is pure text in console

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/perf-warning.html
+++ b/packages/qwik/src/optimizer/src/plugins/perf-warning.html
@@ -4,7 +4,7 @@
     console.debug(
       '%c⭐️ Qwik Dev SSR Mode',
       'background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;',
-      "App is running in SSR development mode!\\n - Additional JS is loaded by Vite for debugging and live reloading\\n - Rendering performance might not be optimal\\n - Delayed interactivity because prefetching is disabled\\n - Vite dev bundles do not represent production output\\n\\nProduction build can be tested running 'npm run preview'"
+      "App is running in SSR development mode!\n - Additional JS is loaded by Vite for debugging and live reloading\n - Rendering performance might not be optimal\n - Delayed interactivity because prefetching is disabled\n - Vite dev bundles do not represent production output\n\nProduction build can be tested running 'npm run preview'"
     );
   }
 </script>

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -1,4 +1,5 @@
-import type { Plugin as VitePlugin, UserConfig, ViteDevServer } from 'vite';
+import type { UserConfig, ViteDevServer, Plugin as VitePlugin } from 'vite';
+import { QWIK_LOADER_DEFAULT_DEBUG, QWIK_LOADER_DEFAULT_MINIFIED } from '../scripts';
 import type {
   EntryStrategy,
   GlobalInjections,
@@ -8,29 +9,28 @@ import type {
   QwikManifest,
   TransformModule,
 } from '../types';
-import {
-  createPlugin,
-  type NormalizedQwikPluginOptions,
-  parseId,
-  type QwikBuildMode,
-  type QwikPluginOptions,
-  type QwikBuildTarget,
-  QWIK_CORE_ID,
-  Q_MANIFEST_FILENAME,
-  QWIK_CLIENT_MANIFEST_ID,
-  QWIK_BUILD_ID,
-  type QwikPackages,
-  QWIK_JSX_RUNTIME_ID,
-  CLIENT_OUT_DIR,
-  QWIK_JSX_DEV_RUNTIME_ID,
-  SSR_OUT_DIR,
-  QWIK_CORE_SERVER,
-} from './plugin';
-import { createRollupError, normalizeRollupOutputOptions } from './rollup';
-import { configureDevServer, configurePreviewServer, VITE_DEV_CLIENT_QS } from './vite-server';
-import { QWIK_LOADER_DEFAULT_DEBUG, QWIK_LOADER_DEFAULT_MINIFIED } from '../scripts';
 import { versions } from '../versions';
 import { getImageSizeServer } from './image-size-server';
+import {
+  CLIENT_OUT_DIR,
+  QWIK_BUILD_ID,
+  QWIK_CLIENT_MANIFEST_ID,
+  QWIK_CORE_ID,
+  QWIK_CORE_SERVER,
+  QWIK_JSX_DEV_RUNTIME_ID,
+  QWIK_JSX_RUNTIME_ID,
+  Q_MANIFEST_FILENAME,
+  SSR_OUT_DIR,
+  createPlugin,
+  parseId,
+  type NormalizedQwikPluginOptions,
+  type QwikBuildMode,
+  type QwikBuildTarget,
+  type QwikPackages,
+  type QwikPluginOptions,
+} from './plugin';
+import { createRollupError, normalizeRollupOutputOptions } from './rollup';
+import { VITE_DEV_CLIENT_QS, configureDevServer, configurePreviewServer } from './vite-server';
 
 const DEDUPE = [QWIK_CORE_ID, QWIK_JSX_RUNTIME_ID, QWIK_JSX_DEV_RUNTIME_ID];
 
@@ -661,7 +661,7 @@ export async function render(document, rootNode, opts) {
 
   if (!window.__qwikViteLog) {
     window.__qwikViteLog = true;
-    console.debug("%c⭐️ Qwik Client Mode","background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;","Do not use this mode in production!\\n - No portion of the application is pre-rendered on the server\\n - All of the application is running eagerly in the browser\\n - Optimizer/Serialization/Deserialization code is not exercised!");
+    console.debug("%c⭐️ Qwik Client Mode","background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;","Do not use this mode in production!\n - No portion of the application is pre-rendered on the server\n - All of the application is running eagerly in the browser\n - Optimizer/Serialization/Deserialization code is not exercised!");
   }
 }`;
 }


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

I found typo error in console.debug when use `\\n` console is read \n as pure string.
So, I change `\\n` to `\n`

## Screenshots

![image](https://github.com/BuilderIO/qwik/assets/57122180/1ca498c0-e32f-43a2-a227-bad164e7050e)

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
