### PR TITLE
fix: add .pnpm-store to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 .history
 .yarn
 .yarnrc.yml
+.pnpm-store
 pnpm-lock.yaml
 .mf
 dist


### PR DESCRIPTION
# Overview

Running fmt or lint will run prettier, if you have a `.pnpm-store` it will run through this and waste probably about 10x the amount of time/resources. (GitHub CI uses pnpm, probably wastes there as well)

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
