### PR TITLE
feat(server-functions): routeAction$ validation based on RequestEvent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,7 @@ To use your build in your project, follow these steps:
    ```shell
    pnpm link.dist.npm
    ```
+
    or
 
    ```shell
@@ -201,6 +202,7 @@ To use your build in your project, follow these steps:
     pnpm install
     pnpm link --global @builder.io/qwik @builder.io/qwik-city
    ```
+
    or
 
    ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,11 @@ To use your build in your project, follow these steps:
    ```shell
    pnpm link.dist.npm
    ```
+   or
+
+   ```shell
+   pnpm link.dist.yarn
+   ```
 
 2. Inside the root of your project run:
 
@@ -195,6 +200,12 @@ To use your build in your project, follow these steps:
    ```shell
     pnpm install
     pnpm link --global @builder.io/qwik @builder.io/qwik-city
+   ```
+   or
+
+   ```shell
+    yarn install
+    yarn link @builder.io/qwik @builder.io/qwik-city
    ```
 
 If you can't use package linking (npm link) just copy the contents of `package/qwik/dist` into your projects' `node_modules/@builder.io/qwik` folder.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "commit": "git-cz",
     "link.dist": "cd packages/qwik/dist && pnpm link --global && cd ../../qwik-city/lib && pnpm link --global && cd ../../eslint-plugin-qwik/dist && pnpm link --global && cd ../../qwik-react && pnpm link --global",
     "link.dist.npm": "cd packages/qwik/dist && npm link && cd ../../qwik-city/lib && npm link && cd ../../eslint-plugin-qwik/dist && npm link && cd ../../qwik-react && npm link",
+    "link.dist.yarn": "cd packages/qwik/dist && yarn link && cd ../../qwik-city/lib && yarn link && cd ../../eslint-plugin-qwik/dist && yarn link && cd ../../qwik-react && yarn link",
     "cli": "pnpm build.cli && node packages/create-qwik/dist/create-qwik.cjs && tsm scripts/validate-cli.ts --copy-local-qwik-dist",
     "cli.validate": "tsm scripts/validate-cli.ts",
     "cli.qwik": "pnpm build.cli && node packages/qwik/dist/qwik.cjs",

--- a/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
@@ -11,6 +11,7 @@ contributors:
   - thejackshelton
   - adnanebrahimi
   - mhevery
+  - tzdesign
 ---
 
 # `routeAction$()`
@@ -235,6 +236,44 @@ export default component$(() => {
 When submitting data to a `routeAction()`, the data is validated against the Zod schema. If the data is invalid, the action will put the validation error in the `routeAction.value` property.
 
 Please refer to the [Zod documentation](https://zod.dev/) for more information on how to use Zod schemas.
+
+
+### Advanced event based validation
+
+The constructor of ```zod$``` can also take a function, as the first argument is zod itself, so you can use this directly to build the schema. 
+The second parameter is the RequestEvent to construct an event-based zod schema.
+Especially in combination with ```refine``` and ```superDefine``` in zod, the only limit is your imagination.
+
+
+```tsx {5-5} /ev/#a  title="Advanced event based validation"
+export const useAddUser = routeAction$(
+  async (user) => {
+    // The "user" is still strongly typed, but firstname 
+    // is now optional: { firstName?: string | undefined, lastName: string }
+    const userID = await db.users.add({
+      firstName: user.firstName,
+      lastName: user.lastName,
+    });
+    return {
+      success: true,
+      userID,
+    };
+  },
+  // Zod schema is used to validate that the FormData includes "firstName" and "lastName"
+  zod$((z, ev) => {
+    // The first name is optional if the url contains the query parameter "firstname=optional"
+    const firstName =
+      ev.url.searchParams.get("firstname") === "optional"
+        ? z.string().optional()
+        : z.string().nonempty();
+
+    return z.object({
+      firstName,
+      lastName: z.string(),
+    });
+  })
+);
+```
 
 ## HTTP request and response
 

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -450,11 +450,11 @@ export interface ZodConstructor {
     // (undocumented)
     <T extends zod.ZodRawShape>(schema: T): TypedDataValidator<zod.ZodObject<T>>;
     // (undocumented)
-    <T extends zod.ZodRawShape>(schema: (z: typeof zod) => T): TypedDataValidator<zod.ZodObject<T>>;
+    <T extends zod.ZodRawShape>(schema: (z: typeof zod, ev: RequestEvent) => T): TypedDataValidator<zod.ZodObject<T>>;
     // (undocumented)
     <T extends zod.Schema>(schema: T): TypedDataValidator<T>;
     // (undocumented)
-    <T extends zod.Schema>(schema: (z: typeof zod) => T): TypedDataValidator<T>;
+    <T extends zod.Schema>(schema: (z: typeof zod, ev: RequestEvent) => T): TypedDataValidator<T>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ZodConstructorQRL" needs to be exported by the entry point index.d.ts

--- a/packages/qwik-city/runtime/src/server-functions.ts
+++ b/packages/qwik-city/runtime/src/server-functions.ts
@@ -231,24 +231,51 @@ export const validatorQrl = ((
 export const validator$: ValidatorConstructor = /*#__PURE__*/ implicit$FirstArg(validatorQrl);
 
 /**
+ * The common type to use with zod$.
+ * @private
+ */
+export type ZodQRLInput = z.ZodRawShape | z.Schema | ((z: typeof import('zod').z) => z.ZodRawShape);
+
+/**
+ * The advanced type to use with zod$. I need to use an object here, because TypeScript can't differentiate between two function signatures.
+ * @private
+ */
+export type ZodQRLAdvancedInput = {
+  validate: (event: RequestEvent, inputData: unknown) => z.Schema;
+};
+
+/**
+ * Differentiate between ZodQRLInput and ZodQRLAdvancedInput
+ *
+ * @param obj is ZodQRLInput | ZodQRLAdvancedInput
+ * @private
+ */
+export function isZodQRLAdvancedInput(
+  obj: ZodQRLInput | ZodQRLAdvancedInput
+): obj is ZodQRLAdvancedInput {
+  return typeof obj === 'object' && 'validate' in obj && typeof obj.validate === 'function';
+}
+
+/**
  * @public
  */
-export const zodQrl = ((
-  qrl: QRL<z.ZodRawShape | z.Schema | ((z: typeof import('zod').z) => z.ZodRawShape)>
-): DataValidator => {
+export const zodQrl = ((qrl: QRL<ZodQRLInput | ZodQRLAdvancedInput>): DataValidator => {
   if (isServer) {
-    const schema: Promise<z.Schema> = qrl.resolve().then((obj) => {
-      if (typeof obj === 'function') {
-        obj = obj(z);
-      }
-      if (obj instanceof z.Schema) {
-        return obj;
-      } else {
-        return z.object(obj);
-      }
-    });
     return {
       async validate(ev, inputData) {
+        const schema: Promise<z.Schema> = qrl.resolve().then((obj) => {
+          if (typeof obj === 'function') {
+            obj = obj(z);
+          }
+          if (obj instanceof z.Schema) {
+            return obj;
+          } else if (isZodQRLAdvancedInput(obj)) {
+            return obj.validate(ev, inputData);
+          } else {
+            return z.object(obj);
+          }
+        });
+
         const data = inputData ?? (await ev.parseBody());
         const result = await (await schema).safeParseAsync(data);
         if (result.success) {

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -723,6 +723,9 @@ export interface ZodConstructor {
   <T extends zod.ZodRawShape>(schema: (z: typeof zod) => T): TypedDataValidator<zod.ZodObject<T>>;
   <T extends zod.Schema>(schema: T): TypedDataValidator<T>;
   <T extends zod.Schema>(schema: (z: typeof zod) => T): TypedDataValidator<T>;
+  <T extends zod.Schema>(schema: {
+    validate: (ev: RequestEvent, data: unknown) => T;
+  }): TypedDataValidator<T>;
 }
 
 /**

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -720,12 +720,11 @@ export interface ValidatorConstructorQRL {
  */
 export interface ZodConstructor {
   <T extends zod.ZodRawShape>(schema: T): TypedDataValidator<zod.ZodObject<T>>;
-  <T extends zod.ZodRawShape>(schema: (z: typeof zod) => T): TypedDataValidator<zod.ZodObject<T>>;
+  <T extends zod.ZodRawShape>(schema: (z: typeof zod, ev: RequestEvent) => T): TypedDataValidator<
+    zod.ZodObject<T>
+  >;
   <T extends zod.Schema>(schema: T): TypedDataValidator<T>;
-  <T extends zod.Schema>(schema: (z: typeof zod) => T): TypedDataValidator<T>;
-  <T extends zod.Schema>(schema: {
-    validate: (ev: RequestEvent, data: unknown) => T;
-  }): TypedDataValidator<T>;
+  <T extends zod.Schema>(schema: (z: typeof zod, ev: RequestEvent) => T): TypedDataValidator<T>;
 }
 
 /**

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -732,11 +732,13 @@ export interface ZodConstructor {
  */
 export interface ZodConstructorQRL {
   <T extends zod.ZodRawShape>(schema: QRL<T>): TypedDataValidator<zod.ZodObject<T>>;
-  <T extends zod.ZodRawShape>(schema: QRL<(zs: typeof zod) => T>): TypedDataValidator<
-    zod.ZodObject<T>
-  >;
+  <T extends zod.ZodRawShape>(
+    schema: QRL<(zs: typeof zod, ev: RequestEvent) => T>
+  ): TypedDataValidator<zod.ZodObject<T>>;
   <T extends zod.Schema>(schema: QRL<T>): TypedDataValidator<T>;
-  <T extends zod.Schema>(schema: QRL<(z: typeof zod) => T>): TypedDataValidator<T>;
+  <T extends zod.Schema>(
+    schema: QRL<(z: typeof zod, ev: RequestEvent) => T>
+  ): TypedDataValidator<T>;
 }
 
 export interface ServerFunction {


### PR DESCRIPTION
Passed the request event to the builder functions to make request event based designed zod schemas.

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

We have an e-commerce site with multiple shops that are powered by a single application. This has complex validation structures as a shop in Denmark has some fields as required type and for the international shop this type is optional. To determine the correct zodSchema we need the RequestEvent to work with. See the example below.

I have to admit that I am still in a relationship with ```yarn```, so I added the link option to it, if you don't mind.

```ts
export const useAddUser = routeAction$(
  async (user) => {
    // The "user" is still strongly typed, but firstname 
    // is now optional: { firstName?: string | undefined, lastName: string }
    const userID = await db.users.add({
      firstName: user.firstName,
      lastName: user.lastName,
    });
    return {
      success: true,
      userID,
    };
  },
  // Zod schema is used to validate that the FormData includes "firstName" and "lastName"
  zod$((z, ev) => {
    // The first name is optional if the url contains the query parameter "firstname=optional"
    const firstName =
      ev.url.searchParams.get("firstname") === "optional"
        ? z.string().optional()
        : z.string().nonempty();

    return z.object({
      firstName,
      lastName: z.string(),
    });
  })
);
```


# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- Return advanced schemas with superRefine based on RequestEventData
- Return dynamic zodSchemas based on routActions form data

# Questions

- How bad is it in terms of performance to move schema resolution to the validate function?
- Should this be another export like zodEvent$ with a simpler signature?


# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
