### PR TITLE
fix(vite): \n escaping in  vite plugin

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -667,7 +667,7 @@ export async function render(document, rootNode, opts) {
 
   if (!window.__qwikViteLog) {
     window.__qwikViteLog = true;
-    console.debug("%c⭐️ Qwik Client Mode","background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;","Do not use this mode in production!\n - No portion of the application is pre-rendered on the server\n - All of the application is running eagerly in the browser\n - Optimizer/Serialization/Deserialization code is not exercised!");
+    console.debug("%c⭐️ Qwik Client Mode","background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;","Do not use this mode in production!\\n - No portion of the application is pre-rendered on the server\\n - All of the application is running eagerly in the browser\\n - Optimizer/Serialization/Deserialization code is not exercised!");
   }
 }`;
 }


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

The code `\n` in the string is not properly escaped, resulting in incorrect syntax being output, which in vite results in the following build error, This will break the qwikify$ integration of the three-party framework

<img width="1345" alt="image" src="https://github.com/BuilderIO/qwik/assets/1720349/95daace3-0895-4e97-9be8-d4f33d0b45b8">



# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https:github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality 