### PR TITLE
docs: fix example in Best Practices Guide

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/best-practices/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/best-practices/index.mdx
@@ -61,16 +61,16 @@ When using `useVisibleTask` to programmatically register events, we are download
 
 ```tsx title="Suboptimal implementation"
 // Don't do this!
-useVisibleTask$(() => {
+useVisibleTask$(({ cleanup }) => {
   const listener = (event) => {
     const mouseEvent = event as MouseEvent;
     console.log(mouseEvent.x, mouseEvent.y);
   };
   document.addEventListener('mousemove', listener);
 
-  return () => {
+  cleanup(() => {
     document.removeEventListener('mousemove', listener);
-  };
+  });
 });
 ```
 


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Fixed the example [here](https://qwik.builder.io/docs/guides/best-practices/#avoid-registering-dom-events-in-usevisibletask) where it does not correctly cleanup the event listenter.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
