### PR TITLE
chore: array index can be typed as number

### DIFF
--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -263,7 +263,7 @@ export const resumeContainer = (containerEl: Element) => {
 
 const reviveSubscriptions = (
   value: any,
-  i: any,
+  i: number,
   objsSubs: any[],
   getObject: GetObject,
   containerState: ContainerState,

--- a/packages/qwik/src/core/container/serializers.ts
+++ b/packages/qwik/src/core/container/serializers.ts
@@ -489,7 +489,7 @@ const serializers: Serializer<any>[] = [
   QRLSerializer, ////////////// \u0002
   SignalSerializer, /////////// \u0012
   SignalWrapperSerializer, //// \u0013
-  TaskSerializer, //////////// \u0003
+  TaskSerializer, ///////////// \u0003
   ResourceSerializer, ///////// \u0004
   URLSerializer, ////////////// \u0005
   DateSerializer, ///////////// \u0006


### PR DESCRIPTION
# Overview

Just update the array index type and align the comments for serializer.

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
