### PR TITLE
fix(compile): compile source code on windows os

### DIFF
--- a/scripts/qwik-city.ts
+++ b/scripts/qwik-city.ts
@@ -181,7 +181,20 @@ export async function buildQwikCity(config: BuildConfig) {
 }
 
 async function buildRuntime(config: BuildConfig) {
-  const result = await execa('pnpm', ['build'], {
+  const execOptions = {
+    win: {
+      manager: 'npm',
+      command: ['run', 'build'],
+    },
+    other: {
+      manager: 'pnpm',
+      command: ['build'],
+    },
+  };
+  const isWindows = process.platform.includes('win32');
+  const runOptions = isWindows ? execOptions.win : execOptions.other;
+
+  const result = await execa(runOptions.manager, runOptions.command, {
     stdout: 'inherit',
     cwd: config.srcQwikCityDir,
   });


### PR DESCRIPTION

![image](https://github.com/BuilderIO/qwik/assets/15802366/8e221a5a-9659-4527-bf06-134d8579aeb0)

hotfix to compile source code on windows

this issue is related to https://github.com/BuilderIO/qwik/issues/2515