### PR TITLE
cli: move next steps instructions to appear last

### DIFF
--- a/packages/create-qwik/create-app.ts
+++ b/packages/create-qwik/create-app.ts
@@ -61,16 +61,6 @@ export function logCreateAppResult(
   }
   outString.push(``);
 
-  outString.push(`🐰 ${cyan(`Next steps:`)}`);
-  if (!isCwdDir) {
-    outString.push(`   cd ${relativeProjectPath}`);
-  }
-  if (!ranInstall) {
-    outString.push(`   ${pkgManager} install`);
-  }
-  outString.push(`   ${pkgManager} start`);
-  outString.push(``);
-
   const qwikAdd = pkgManager !== 'npm' ? `${pkgManager} qwik add` : `npm run qwik add`;
   outString.push(`🤍 ${cyan('Integrations? Add Netlify, Cloudflare, Tailwind...')}`);
   outString.push(`   ${qwikAdd}`);
@@ -80,6 +70,16 @@ export function logCreateAppResult(
 
   outString.push(`👀 ${cyan('Presentations, Podcasts and Videos:')}`);
   outString.push(`   https://qwik.builder.io/media/`);
+  outString.push(``);
+
+  outString.push(`🐰 ${cyan(`Next steps:`)}`);
+  if (!isCwdDir) {
+    outString.push(`   cd ${relativeProjectPath}`);
+  }
+  if (!ranInstall) {
+    outString.push(`   ${pkgManager} install`);
+  }
+  outString.push(`   ${pkgManager} start`);
   outString.push(``);
 
   return outString.join('\n');


### PR DESCRIPTION
# Overview

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Move around next steps display.

# Use cases and why

Once installation finishes, it is more likely one would read back bottom to top. Makes more sense displaying this in the end.

![image](https://github.com/BuilderIO/qwik/assets/6682981/bc7259c5-b37b-4012-955a-6e26eabce4d2)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
