### PR TITLE
Allow passing in loading and decoding attributes for images loaded using ?jsx

### DIFF
--- a/packages/qwik-city/buildtime/vite/image-jsx.ts
+++ b/packages/qwik-city/buildtime/vite/image-jsx.ts
@@ -87,9 +87,9 @@ export function imagePlugin(userOpts?: QwikCityVitePluginOptions): PluginOption[
               code.slice(0, index) +
               `
   import { _jsxQ } from '@builder.io/qwik';
-  const PROPS = {decoding: 'async', loading: 'lazy', srcSet, width, height};
+  const PROPS = {srcSet, width, height};
   export default function (props, key, _, dev) {
-    return _jsxQ('img', props, PROPS, undefined, 3, key, dev);
+    return _jsxQ('img', {...{decoding: 'async', loading: 'lazy'}, ...props}, PROPS, undefined, 3, key, dev);
   }`
             );
           } else if (extension === '.svg') {

--- a/starters/apps/qwikcity-test/src/routes/(common)/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/index.tsx
@@ -12,7 +12,7 @@ export default component$(() => {
     <div>
       <h1 onClick$={() => console.warn("hola")}>Welcome to Qwik City</h1>
       <p>The meta-framework for Qwik.</p>
-      <ImageJpeg id="image-jpeg" />
+      <ImageJpeg id="image-jpeg" loading="eager" decoding="auto" />
       <ImageSvg id="image-svg" />
       <ImageJpegResized id="image-avif" />
     </div>

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -346,6 +346,15 @@ test.describe("actions", () => {
         520
       );
 
+      await expect(page.locator("#image-jpeg")).toHaveJSProperty(
+        "loading",
+        "eager"
+      );
+      await expect(page.locator("#image-jpeg")).toHaveJSProperty(
+        "decoding",
+        "auto"
+      );
+
       await expect(page.locator("#image-avif")).toHaveJSProperty("width", 100);
       await expect(page.locator("#image-avif")).toHaveJSProperty("height", 100);
       await expect(page.locator("#image-avif")).toHaveJSProperty(


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Allow users to set 'loading' and/or 'decoding' attributes on the img tag generated when loading image using the 'qwik-city-image-jsx' plugin.

# Use cases and why

Some images like logos and primary information sources should not be deferred.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality
