### PR TITLE
repl: default to 1.1.5 until 1.2.x works

### DIFF
--- a/packages/docs/src/repl/repl-version.ts
+++ b/packages/docs/src/repl/repl-version.ts
@@ -58,6 +58,8 @@ export const getReplVersion = async (version: string | undefined) => {
 
     if (!version || !npmData.versions.includes(version)) {
       version = npmData.tags.latest;
+      // TEMPORARY: use 1.1.5 until 1.2 works
+      version = '1.1.5';
     }
   }
 


### PR DESCRIPTION
This sets the version of Qwik used by the repl service worker to 1.1.5 until 1.2 is fixed