### PR TITLE
click-to-component: release keys on alt+tab

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/click-to-component.html
+++ b/packages/qwik/src/optimizer/src/plugins/click-to-component.html
@@ -99,6 +99,15 @@
       { capture: true }
     );
 
+    window.addEventListener(
+      'blur',
+      (event) => {
+        window.__qwik_inspector_state.pressedKeys.clear();
+        updateOverlay();
+      },
+      { capture: true }
+    );
+
     document.addEventListener(
       'mouseover',
       (event) => {


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

When developing on windows/linux and using alt-tab to switch away from the chrome, the alt key state didn't clear.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
