### PR TITLE
refactor: early return when the resource is done

### DIFF
--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -596,26 +596,24 @@ export const runResource = <T>(
   let done = false;
 
   const setState = (resolved: boolean, value: any) => {
-    if (!done) {
-      done = true;
-      if (resolved) {
-        done = true;
-        resource.loading = false;
-        resource._state = 'resolved';
-        resource._resolved = value;
-        resource._error = undefined;
-
-        resolve(value);
-      } else {
-        done = true;
-        resource.loading = false;
-        resource._state = 'rejected';
-        resource._error = value;
-        reject(value);
-      }
-      return true;
+    if (done) {
+      return false;
     }
-    return false;
+    done = true;
+    
+    resource.loading = false;  
+    if (resolved) {
+      resource._state = 'resolved';
+      resource._resolved = value;
+      resource._error = undefined;
+      resolve(value);
+    } else {
+      resource._state = 'rejected';
+      resource._error = value;
+      reject(value);
+    }
+
+    return true;
   };
 
   // Execute mutation inside empty invocation
@@ -635,10 +633,10 @@ export const runResource = <T>(
 
   const promise = safeCall(
     () => then(waitOn, () => taskFn(opts)),
-    (value) => {
+    (value: T) => {
       setState(true, value);
     },
-    (reason) => {
+    (reason: any) => {
       setState(false, reason);
     }
   );


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

I found it easier to read if we do early return when the done is true. And we can also remove the code for assigning `done = true` inside the `if resolved` and `if rejected` conditions. 

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
