### PR TITLE
fix(eslint): allow eslint to accept FunctionComponent inside lexical scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "build": "tsm scripts/index.ts --tsc --build --qwikcity --qwiklabs --api --platform-binding-wasm-copy",
     "build.cli": "tsm scripts/index.ts --cli --dev",
     "build.cli.prod": "tsm scripts/index.ts --cli",
+    "build.eslint": "tsm scripts/index.ts --eslint",
     "build.full": "tsm scripts/index.ts --tsc --build --supabaseauthhelpers --api --eslint --qwikcity --qwikworker --qwiklabs --qwikreact --qwikauth --cli --platform-binding --wasm",
     "build.only_javascript": "tsm scripts/index.ts --tsc --build --api",
     "build.platform": "tsm scripts/index.ts --platform-binding",

--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -360,7 +360,6 @@ export const RemoteApp = component$(({ name }: { name: string }) => {
               console.log(a);
             }}></div>;
           });`,
-
     `
   export interface PropFnInterface<ARGS extends any[], RET> {
     (...args: ARGS): Promise<RET>
@@ -386,7 +385,6 @@ export const RemoteApp = component$(({ name }: { name: string }) => {
     }}></div>;
   });
       `,
-    ``,
     `
 import { component$ } from "@builder.io/qwik";
 
@@ -427,6 +425,29 @@ export default component$(() => {
             useMethod(foo);
             return <div></div>
           });`,
+    `
+      import {Component, component$, useStore} from '@builder.io/qwik';
+      export const PopupManager = component$(() => {
+        const popup = useStore({
+            component: null as null | Component<any>,
+            props: null as any,
+            visible: false,
+            x: 0,
+            y: 0,
+        });
+        return (
+            <div
+                document:onMouseEnter$={(e) => {
+                popup.visible = true;
+            }}
+                document:onMouseLeave$={(e) => {
+                popup.visible = true;
+            }}
+            >
+            </div>
+        );
+      });
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-qwik/src/validLexicalScope.ts
+++ b/packages/eslint-plugin-qwik/src/validLexicalScope.ts
@@ -338,7 +338,8 @@ function _isTypeCapturable(
     if (
       symbolName === 'PropFnInterface' ||
       symbolName === 'RefFnInterface' ||
-      symbolName === 'bivarianceHack'
+      symbolName === 'bivarianceHack' ||
+      symbolName === 'FunctionComponent'
     ) {
       return;
     }


### PR DESCRIPTION
# Overview

Not sure if this is the right fix but this fixes linting issue with `FunctionComponent` type being a "callable" thus resulting in a linting error with message that says "not serializable" mentioned in issue https://github.com/BuilderIO/qwik/issues/4794

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality
