### PR TITLE
Fix typo in docs URL

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/qwikcity/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/qwikcity/index.mdx
@@ -16,7 +16,7 @@ contributors:
 While Qwik focuses on Component API, Qwik City contains API to support the component with common server focused features:
 - [routing](/docs/routing/): Define your application routes with directory based routing. (Supports both MPA and SPA routing models.)
 - [pages](/docs/pages): Render application pages, the main feature of an application.
-- [layouts](/docs/layouts/): Define common shared page layouts to be reused across pages.
+- [layouts](/docs/layout/): Define common shared page layouts to be reused across pages.
 - [loaders](/docs/route-loader/): Fetch data on the server to be used by the component.
 - [actions](/docs/action/): Provide a way for the component to request the server to perform an action.
 - [endpoints](/docs/endpoints/): A way to define data endpoints for your RESTful API, GraphQL API, JSON, XML or reverse proxy.


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

`/docs/layouts/` leads to a 404 not found page, the actual page is on `/docs/layout/`

# Use cases and why

`/docs/layouts/` has an extra `s` character.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
