### PR TITLE
fix: fix cookie parsing to allow invalid uri encoding

### DIFF
--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -52,6 +52,17 @@ const createSetCookieValue = (cookieName: string, cookieValue: string, options: 
   return c.join('; ');
 };
 
+function tryDecodeUriComponent(str: string) {
+  if (str.indexOf('%') === -1) {
+    return str;
+  }
+  try {
+    return decodeURIComponent(str);
+  } catch {
+    return str;
+  }
+}
+
 const parseCookieString = (cookieString: string | undefined | null) => {
   const cookie: Record<string, string> = {};
   if (typeof cookieString === 'string' && cookieString !== '') {
@@ -59,8 +70,8 @@ const parseCookieString = (cookieString: string | undefined | null) => {
     for (const cookieSegment of cookieSegments) {
       const separatorIndex = cookieSegment.indexOf('=');
       if (separatorIndex !== -1) {
-        cookie[decodeURIComponent(cookieSegment.slice(0, separatorIndex).trim())] =
-          decodeURIComponent(cookieSegment.slice(separatorIndex + 1).trim());
+        cookie[tryDecodeUriComponent(cookieSegment.slice(0, separatorIndex).trim())] =
+          tryDecodeUriComponent(cookieSegment.slice(separatorIndex + 1).trim());
       }
     }
   }

--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -53,9 +53,6 @@ const createSetCookieValue = (cookieName: string, cookieValue: string, options: 
 };
 
 function tryDecodeUriComponent(str: string) {
-  if (str.indexOf('%') === -1) {
-    return str;
-  }
   try {
     return decodeURIComponent(str);
   } catch {

--- a/packages/qwik-city/middleware/request-handler/cookie.unit.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.unit.ts
@@ -15,6 +15,7 @@ test('parses cookie', () => {
     a: 'hello=world',
     b: '25',
     c: '{"hello": "world"}',
+    d: '%badencoding',
   };
   const cookieString = Object.entries(cookieValues)
     .reduce((prev: string[], [key, value]) => {
@@ -28,10 +29,11 @@ test('parses cookie', () => {
   Object.entries(cookieValues).forEach(([key, value]) => {
     equal(cookie.get(key)?.value, value);
   });
-  equal(Object.keys(cookie.getAll()).length, 3);
+  equal(Object.keys(cookie.getAll()).length, 4);
   equal(cookie.getAll().a.value, 'hello=world');
   equal(cookie.getAll().b.number(), 25);
   equal(cookie.getAll().c.json(), { hello: 'world' });
+  equal(cookie.getAll().d.value, '%badencoding');
 });
 
 test('creates correct headers', () => {


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

Cookies with invalid URI encoding throws a `URIError: URI malformed` error and bails out of processing.

Cookie values do not need to be URL encoded. Looking at the `cookie` library used by `cookie-parser` and many others, they do a [`tryDecode`](https://github.com/jshttp/cookie/blob/master/index.js#L86) and return the raw value on failure to decode.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I updated the cookie parsing function to mimic this `tryDecode` functionality and added a test to validate that.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

A cookie header with `foo=%bar` should have a cookie with key `foo` have value `%bar` and the rest of the app should continue to function. Currently, it gets a `URIError: URI malformed` and bails with a server error.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
