### PR TITLE
fix: Link component `reload` functionality

### DIFF
--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -7,11 +7,12 @@ import { useLocation, useNavigate } from './use-functions';
  * @public
  */
 export const Link = component$<LinkProps>((props) => {
+  console.log('Link', props);
   const nav = useNavigate();
   const loc = useLocation();
   const originalHref = props.href;
   const { onClick$, reload, replaceState, scroll, ...linkProps } = (() => props)();
-  const clientNavPath = untrack(() => getClientNavPath(linkProps, loc));
+  const clientNavPath = untrack(() => getClientNavPath({...linkProps, reload}, loc));
   const prefetchDataset = untrack(() => getPrefetchDataset(props, clientNavPath, loc));
   linkProps['preventdefault:click'] = !!clientNavPath;
   linkProps.href = clientNavPath || originalHref;

--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -7,7 +7,6 @@ import { useLocation, useNavigate } from './use-functions';
  * @public
  */
 export const Link = component$<LinkProps>((props) => {
-  console.log('Link', props);
   const nav = useNavigate();
   const loc = useLocation();
   const originalHref = props.href;

--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -11,7 +11,7 @@ export const Link = component$<LinkProps>((props) => {
   const loc = useLocation();
   const originalHref = props.href;
   const { onClick$, reload, replaceState, scroll, ...linkProps } = (() => props)();
-  const clientNavPath = untrack(() => getClientNavPath({...linkProps, reload}, loc));
+  const clientNavPath = untrack(() => getClientNavPath({ ...linkProps, reload }, loc));
   const prefetchDataset = untrack(() => getPrefetchDataset(props, clientNavPath, loc));
   linkProps['preventdefault:click'] = !!clientNavPath;
   linkProps.href = clientNavPath || originalHref;

--- a/packages/qwik-city/runtime/src/utils.ts
+++ b/packages/qwik-city/runtime/src/utils.ts
@@ -1,6 +1,7 @@
-import { QACTION_KEY } from './constants';
-import type { LinkProps } from './link-component';
 import type { RouteActionValue, SimpleURL } from './types';
+
+import type { LinkProps } from './link-component';
+import { QACTION_KEY } from './constants';
 
 /**
  * Gets an absolute url path string (url.pathname + url.search + url.hash)
@@ -53,7 +54,7 @@ export const getClientDataPath = (
 
 export const getClientNavPath = (props: Record<string, any>, baseUrl: { url: URL }) => {
   const href = props.href;
-  if (typeof href === 'string' && typeof props.target !== 'string') {
+  if (typeof href === 'string' && typeof props.target !== 'string' && !props.reload) {
     try {
       const linkUrl = toUrl(href.trim(), baseUrl.url);
       const currentUrl = toUrl('', baseUrl.url)!;

--- a/starters/apps/qwikcity-test/src/routes/issue4792/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue4792/index.tsx
@@ -1,0 +1,14 @@
+import { Link } from "@builder.io/qwik-city";
+import { component$ } from "@builder.io/qwik";
+
+export default component$((props) => {
+  return (
+    <div>
+      <h1>Issue 4792</h1>
+      <p>link with attr `reload` was not refreshing the page</p>
+      <Link id="reload" reload={true} href="docs">
+        reload the page
+      </Link>
+    </div>
+  );
+});

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -1,4 +1,3 @@
-import { expect, test } from "@playwright/test";
 import {
   assertPage,
   getScrollHeight,
@@ -9,6 +8,7 @@ import {
   scrollDetector,
   scrollTo,
 } from "./util.js";
+import { expect, test } from "@playwright/test";
 
 test.describe("actions", () => {
   test.describe("mpa", () => {
@@ -332,6 +332,13 @@ test.describe("actions", () => {
       const res = await page.goto("/qwikcity-test/issue4531/");
       await expect(page.locator("#route")).toHaveText("should render");
       expect(await res?.headerValue("X-Qwikcity-Test")).toEqual("issue4531");
+    });
+
+    test("issue4792", async ({ page }) => {
+      const site = "/qwikcity-test/issue4792/";
+      await page.goto(site);
+      const href = page.locator("#reload");
+      await expect(href).toHaveAttribute("href", site);
     });
 
     test("media in home page", async ({ page }) => {


### PR DESCRIPTION
# Overview
closes #4792

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Do to the destructuring, the `reload` prop was no longer forwarded to the `getClientNavPath` fn

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
