### PR TITLE
fix(qwik): use `appendChild` (instead of `append`) which is supported in domino

### DIFF
--- a/packages/qwik/src/core/render/dom/virtual-element.ts
+++ b/packages/qwik/src/core/render/dom/virtual-element.ts
@@ -166,11 +166,12 @@ export class VirtualElementImpl implements VirtualElement {
   remove() {
     const parent = this.parentElement;
     if (parent) {
-      // const ch = this.childNodes;
       const ch = this.childNodes;
       assertEqual(this.$template$.childElementCount, 0, 'children should be empty');
       parent.removeChild(this.open);
-      this.$template$.append(...ch);
+      for (let i = 0; i < ch.length; i++) {
+        this.$template$.appendChild(ch[i]);
+      }
       parent.removeChild(this.close);
     }
   }


### PR DESCRIPTION
`append` method is not supported in domino. This results in an error when testing on nodeJS, which does not have real DOM and instead ensures on domino mock.

Fix #4914

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
