### PR TITLE
fix(qwik-auth): remove qaction param from defaultCallbackUrl

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -34,7 +34,7 @@ export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikA
           '\x1b[33mWARNING: callbackUrl is deprecated - use options.callbackUrl instead\x1b[0m'
         );
       }
-      const { callbackUrl = deprecated ?? getCurrentPageForAction(req), ...rest } = options ?? {};
+      const { callbackUrl = deprecated ?? defaultCallbackURL(req), ...rest } = options ?? {};
 
       const isCredentials = providerId === 'credentials';
 
@@ -73,7 +73,7 @@ export function serverAuthQrl(authOptions: QRL<(ev: RequestEventCommon) => QwikA
 
   const useAuthSignout = globalAction$(
     async ({ callbackUrl }, req) => {
-      callbackUrl ??= getCurrentPageForAction(req);
+      callbackUrl ??= defaultCallbackURL(req);
       const auth = await authOptions(req);
       const body = new URLSearchParams({ callbackUrl });
       await authAction(body, req, `/api/auth/signout`, auth);
@@ -166,7 +166,7 @@ export const ensureAuthMiddleware = (req: RequestEvent) => {
   }
 };
 
-const getCurrentPageForAction = (req: RequestEventCommon) => {
+const defaultCallbackURL = (req: RequestEventCommon) => {
   req.url.searchParams.delete('qaction');
   return req.url.href;
 };

--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -166,7 +166,10 @@ export const ensureAuthMiddleware = (req: RequestEvent) => {
   }
 };
 
-const getCurrentPageForAction = (req: RequestEventCommon) => req.url.href.split('q-')[0];
+const getCurrentPageForAction = (req: RequestEventCommon) => {
+  req.url.searchParams.delete('qaction');
+  return req.url.href;
+};
 
 async function getSessionData(req: Request, options: AuthConfig): GetSessionResult {
   options.secret ??= process.env.AUTH_SECRET;


### PR DESCRIPTION
# Overview

When using qwik-auth with the sign in/out routeActions the following message is printed on the server
```
Seems like you are submitting a Qwik Action via GET request. Qwik Actions should be submitted via POST request.
Make sure your <form> has method="POST" attribute, like this: <form method="POST">
```

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

This is caused by the callback url containing a `qaction` query parameter which was erroneously included when determining the default callbackUrl if one wasn't specified.  This solution removes just this single query param, while leaving any others should they be present.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
