### PR TITLE
Refactor qwik cli help option

### DIFF
--- a/packages/qwik/src/cli/add/run-add-command.ts
+++ b/packages/qwik/src/cli/add/run-add-command.ts
@@ -5,11 +5,10 @@ import { printAddHelp } from './print-add-help';
 
 export async function runAddCommand(app: AppCommand) {
   try {
-    const id = app.args[1];
-    if (id === 'help') {
+    if (app.args.length > 1 && ['-h', '--help'].includes(app.args[1])) {
       await printAddHelp(app);
     } else {
-      await runAddInteractive(app, id);
+      await runAddInteractive(app, app.args[1]);
     }
   } catch (e) {
     console.error(`❌ ${red(String(e))}\n`);

--- a/packages/qwik/src/cli/add/run-add-command.ts
+++ b/packages/qwik/src/cli/add/run-add-command.ts
@@ -2,10 +2,11 @@ import type { AppCommand } from '../utils/app-command';
 import { red } from 'kleur/colors';
 import { runAddInteractive } from './run-add-interactive';
 import { printAddHelp } from './print-add-help';
+import { isAskingForHelp } from '../utils/utils';
 
 export async function runAddCommand(app: AppCommand) {
   try {
-    if (app.args.length > 1 && ['-h', '--help'].includes(app.args[1])) {
+    if (isAskingForHelp(app.args)) {
       await printAddHelp(app);
     } else {
       await runAddInteractive(app, app.args[1]);

--- a/packages/qwik/src/cli/new/run-new-command.ts
+++ b/packages/qwik/src/cli/new/run-new-command.ts
@@ -15,7 +15,7 @@ const NAME_KEY = '[name]';
 export async function runNewCommand(app: AppCommand) {
   try {
     // render help
-    if (app.args.length > 1 && app.args[1] === 'help') {
+    if (app.args.length > 1 && ['-h', '--help'].includes(app.args[1])) {
       intro(`🔭  ${bgMagenta(' Qwik Help ')}`);
       await printNewHelp();
       bye();

--- a/packages/qwik/src/cli/new/run-new-command.ts
+++ b/packages/qwik/src/cli/new/run-new-command.ts
@@ -2,7 +2,7 @@ import { green, bgMagenta, dim } from 'kleur/colors';
 import fs from 'node:fs';
 import { join } from 'path';
 import { isCancel, select, text, log, intro } from '@clack/prompts';
-import { bye } from '../utils/utils';
+import { bye, isAskingForHelp } from '../utils/utils';
 import type { Template } from '../types';
 import type { AppCommand } from '../utils/app-command';
 import { loadTemplates } from '../utils/templates';
@@ -15,7 +15,7 @@ const NAME_KEY = '[name]';
 export async function runNewCommand(app: AppCommand) {
   try {
     // render help
-    if (app.args.length > 1 && ['-h', '--help'].includes(app.args[1])) {
+    if (isAskingForHelp(app.args)) {
       intro(`🔭  ${bgMagenta(' Qwik Help ')}`);
       await printNewHelp();
       bye();

--- a/packages/qwik/src/cli/utils/utils.ts
+++ b/packages/qwik/src/cli/utils/utils.ts
@@ -64,6 +64,10 @@ export function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export function isAskingForHelp(args: string[]) {
+  return args.length > 1 && (args.includes('-h') || args.includes('--help'));
+}
+
 export function cleanPackageJson(srcPkg: IntegrationPackageJson) {
   srcPkg = { ...srcPkg };
 


### PR DESCRIPTION
"-h --help" is a standard CLI argument to have access to the command guide. It's better DX and also does not prevent users from making component named help.

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Current `qwik` CLI, use `help` as an argument to show the command guide. As `-h` or `--help` is a standard for it, this PR will refactor checking for the help argument for a better DX.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
