### PR TITLE
Towards personalized SSG

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
@@ -16,9 +16,9 @@ Additionally, due to Qwik's underlying architecture, page performance also benef
 
 Qwik City is capable of taking a Qwik application, no matter if it's a "webapp" or "website", and generate static HTML. Once it's generated as HTML, Qwik is fundamentally able to skip rebuilding the app by using [resumability](../../../(qwik)/concepts/resumable/index.mdx), since the app was already generated as HTML. Both Static Site Generation (SSG) and Server-Side Rendering (SSR) use the same process to generate the HTML. The main difference between the SSG and SSR however, is "when" the HTML is generated.
 
-In a traditional setup, SSG pre-renders each webpage at build-time, while SSR render's each webpage on-demand for each HTTP request. SSG only needs to generate the HTML one time per build, which is great for webpages where each visitor should see the same content. In contrast, SSR is great when the webpage may be different for each visitor, and would need to render custom HTML for each individual HTTP request.
+In a traditional setup, SSG pre-renders each webpage at build-time, while SSR render's each webpage on-demand for each HTTP request. SSG only needs to generate the HTML one time per build, which is great for webpages where multiple visitors should see the same content. In contrast, SSR is great when the webpage may be different for each visitor, and would need to render custom HTML for each individual HTTP request.
 
-For example, SSG is ideal for a blog or docs site, where all the content should be the same for each visitor. While SSR may work fine for a blog, it may be an unnecessary strain for your HTTP servers to render the blog content for every visitor, even though they'd all end up seeing the same HTML.
+For example, SSG is ideal for a blog or docs site, where all the content should be the same for multiple visitors. While SSR may work fine for a blog, it may be an unnecessary strain for your HTTP servers to render the blog content for every visitor, even though they'd all end up seeing the same HTML.
 
 However, an account dashboard would commonly have different content for each signed-in user. In this setup, each user should get their own rendered HTML with their account information, rather than everyone seeing the exact same content. This is where SSR would be preferred.
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

Hi folks,

I am just discovering Qwik, coming from Next.js with a solid experience regarding static rendering.

My pet peeve is the belief that static rendering is best for content that is the same for all visitors. I think this doesn't give static rendering justice, because SSG is also perfectly viable for content that is the same for *groups* of visitors. 

**So, my proposal:**
- first I've changed the doc in this PR to be clearer about the fact that SSG is not limited to content that is the same for all visitors. More on that below.
- then, I think it would be interesting to open up the discussion and document more advanced patterns, like redirecting to static content depending on the request. Perhaps this has been discussed already, or considered very easy, then it would be interesting to include the relevant links directly in the documentation.

This is in my opinion a relatively important matter when trying to compare Qwik with say Next.js on use cases where Next.js shines, namely content app (e-commerce websites, media websites, basically any app where you have a strong marketing service behind with contradictory requirements between rich content, personalization and performances).

I'd be eager to get Qwik developers stance on this idea!

# Use cases and why

The difference between "same for everybody" and "same for groups of people" seems subtle, but actually opens up so many use cases for static rendering:
- A/B tests: some users see version A, some version B. But A and B are known in advance: let's statically render that!
- i18n: some users see language FR, some se language EN, DE...
- marketing segmentation: "top-notch VIP", "people who won't buy without a coupon", "new customers"
- dark/light theme
- multi-tenancy: the company logo in the layout changes depending on the organization you belong to.

And more broadly whatever personalization pattern you may encounter in the wild.

For previous art, I've opened similar issues with explanations:
- for Persus, a Next.js inspired Rust framework: https://github.com/framesurge/perseus/issues/295
- for Next.js: https://github.com/vercel/next.js/pull/36018

And I've written articles on the topic:
- "A New Pattern For The Jamstack: Segmented Rendering" for Smashing Magazine https://www.smashingmagazine.com/2022/07/new-pattern-jamstack-segmented-rendering/
- Same idea presented at React Advanced London: https://portal.gitnation.org/contents/treat-your-users-right-with-segmented-rendering
- The math behind SSR/SSG (a bit old and hard to read but lay down some ideas): https://tinyurl.com/ssr-theory

That's for the rough idea. If you think a bit about this idea a bit more, you should quickly understand that the key to this personnalisation is to redirect the user towards the right version of the page. 

In Next.js, this can be done natively using middlewares. I deplore the fact that Next.js only allows static rendering based on a route parameter, and not say cookies, headers, or URL search params. Hopefully this limitation can be bypassed by using URL rewrites. I've written another aticle showing this pattern: "Render anything statically with Next.js and the Megaparam" https://blog.vulcanjs.org/render-anything-statically-with-next-js-and-the-megaparam-4039e66ffde"

I think Qwik has a similar approach so could benefit from this pattern too but not sure about the specific implementation.

Lastly, you might think: "ok but this is actually SSR coupled with HTTP caching, not SSG". Yes but no, doing static personalization at "framework level" is more flexible. HTTP cache is not evenly supported, namely it's hard to cache variations depending on a subtile change like the precise value of one cookie (Vary header and such).

Bonus: you may encounter another kind of personalization, that is altering the page at the Edge (Eleventy-style). This is great too but often limited to slight adaptations, because you have to alter already rendered HTML so you can't rely on the rendering framework at this stage.
