### PR TITLE
cli: Add new Markdown route command

### DIFF
--- a/packages/qwik/src/cli/new/run-new-command.ts
+++ b/packages/qwik/src/cli/new/run-new-command.ts
@@ -82,9 +82,7 @@ export async function runNewCommand(app: AppCommand) {
       template = templates[0][typeArg][0];
     }
 
-    if (typeArg === 'route') {
-      outDir = join(app.rootDir, 'src', `routes`, nameArg);
-    } else if (typeArg === 'markdown') {
+    if (typeArg === 'route' || typeArg === 'markdown') {
       outDir = join(app.rootDir, 'src', `routes`, nameArg);
     } else {
       outDir = join(app.rootDir, 'src', `components`, nameArg);

--- a/packages/qwik/src/cli/new/run-new-command.ts
+++ b/packages/qwik/src/cli/new/run-new-command.ts
@@ -12,6 +12,7 @@ import { POSSIBLE_TYPES } from './utils';
 const SLUG_KEY = '[slug]';
 const NAME_KEY = '[name]';
 const MARKDOWN_SUFFIX = '.md';
+const MDX_SUFFIX = '.mdx';
 
 export async function runNewCommand(app: AppCommand) {
   try {
@@ -27,13 +28,16 @@ export async function runNewCommand(app: AppCommand) {
     const args = app.args.filter((a) => !a.startsWith('--'));
 
     const mainInput = args.slice(1).join(' ');
-    let typeArg: 'route' | 'component' | 'markdown' | undefined = undefined;
+    let typeArg: 'route' | 'component' | 'markdown' | 'mdx' | undefined = undefined;
     let nameArg: string | undefined;
     let outDir: string | undefined;
     if (mainInput && mainInput.startsWith('/')) {
       if (mainInput.endsWith(MARKDOWN_SUFFIX)) {
         typeArg = 'markdown';
         nameArg = mainInput.replace(MARKDOWN_SUFFIX, '');
+      } else if (mainInput.endsWith(MDX_SUFFIX)) {
+        typeArg = 'mdx';
+        nameArg = mainInput.replace(MDX_SUFFIX, '');
       } else {
         typeArg = 'route';
         nameArg = mainInput;
@@ -83,7 +87,7 @@ export async function runNewCommand(app: AppCommand) {
       template = templates[0][typeArg][0];
     }
 
-    if (typeArg === 'route' || typeArg === 'markdown') {
+    if (typeArg === 'route' || typeArg === 'markdown' || typeArg === 'mdx') {
       outDir = join(app.rootDir, 'src', `routes`, nameArg);
     } else {
       outDir = join(app.rootDir, 'src', `components`, nameArg);
@@ -111,6 +115,7 @@ async function selectType() {
       { value: 'component', label: 'Component' },
       { value: 'route', label: 'Route' },
       { value: 'markdown', label: 'Route (Markdown)' },
+      { value: 'mdx', label: 'Route (MDX)' },
     ],
   });
 
@@ -121,10 +126,11 @@ async function selectType() {
   return typeAnswer as (typeof POSSIBLE_TYPES)[number];
 }
 
-async function selectName(type: 'route' | 'component' | 'markdown') {
+async function selectName(type: 'route' | 'component' | 'markdown' | 'mdx') {
   const messages = {
     route: 'New route path',
     markdown: 'New Markdown route path',
+    mdx: 'New MDX route path',
     component: 'Name your component',
   };
   const message = messages[type];
@@ -132,6 +138,7 @@ async function selectName(type: 'route' | 'component' | 'markdown') {
   const placeholders = {
     route: '/product/[id]',
     markdown: '/some/page' + MARKDOWN_SUFFIX,
+    mdx: '/some/page' + MDX_SUFFIX,
     component: 'my-component',
   };
   const placeholder = placeholders[type];
@@ -152,12 +159,17 @@ async function selectName(type: 'route' | 'component' | 'markdown') {
   if (typeof nameAnswer !== 'string') {
     bye();
   }
+
   if (type === 'route' && !(nameAnswer as string).startsWith('/')) {
     return `/${nameAnswer as string}`;
   }
   if (type === 'markdown' && !(nameAnswer as string).startsWith('/')) {
     return `/${nameAnswer.replace(MARKDOWN_SUFFIX, '') as string}`;
   }
+  if (type === 'mdx' && !(nameAnswer as string).startsWith('/')) {
+    return `/${nameAnswer.replace(MDX_SUFFIX, '') as string}`;
+  }
+
   return nameAnswer.replace(MARKDOWN_SUFFIX, '') as string;
 }
 

--- a/packages/qwik/src/cli/new/run-new-command.ts
+++ b/packages/qwik/src/cli/new/run-new-command.ts
@@ -123,9 +123,20 @@ async function selectType() {
 }
 
 async function selectName(type: 'route' | 'component' | 'markdown') {
-  const message =
-    type === 'route' || type === 'markdown' ? 'New route path' : 'Name your component';
-  const placeholder = type === 'route' || type === 'markdown' ? '/product/[id]' : 'my-component';
+  const messages = {
+    route: 'New route path',
+    markdown: 'New Markdown route path',
+    component: 'Name your component',
+  };
+  const message = messages[type];
+
+  const placeholders = {
+    route: '/product/[id]',
+    markdown: '/some/page:md',
+    component: 'my-component',
+  };
+  const placeholder = placeholders[type];
+
   const nameAnswer = await text({
     message,
     placeholder,
@@ -145,7 +156,10 @@ async function selectName(type: 'route' | 'component' | 'markdown') {
   if (type === 'route' && !(nameAnswer as string).startsWith('/')) {
     return `/${nameAnswer as string}`;
   }
-  return nameAnswer as string;
+  if (type === 'markdown' && !(nameAnswer as string).startsWith('/')) {
+    return `/${nameAnswer.replace(':md', '') as string}`;
+  }
+  return nameAnswer.replace(':md', '') as string;
 }
 
 async function selectTemplate(typeArg: (typeof POSSIBLE_TYPES)[number]) {

--- a/packages/qwik/src/cli/new/run-new-command.ts
+++ b/packages/qwik/src/cli/new/run-new-command.ts
@@ -11,6 +11,7 @@ import { POSSIBLE_TYPES } from './utils';
 
 const SLUG_KEY = '[slug]';
 const NAME_KEY = '[name]';
+const MARKDOWN_SUFFIX = '.md';
 
 export async function runNewCommand(app: AppCommand) {
   try {
@@ -30,9 +31,9 @@ export async function runNewCommand(app: AppCommand) {
     let nameArg: string | undefined;
     let outDir: string | undefined;
     if (mainInput && mainInput.startsWith('/')) {
-      if (mainInput.endsWith(':md')) {
+      if (mainInput.endsWith(MARKDOWN_SUFFIX)) {
         typeArg = 'markdown';
-        nameArg = mainInput.replace(':md', '');
+        nameArg = mainInput.replace(MARKDOWN_SUFFIX, '');
       } else {
         typeArg = 'route';
         nameArg = mainInput;
@@ -130,7 +131,7 @@ async function selectName(type: 'route' | 'component' | 'markdown') {
 
   const placeholders = {
     route: '/product/[id]',
-    markdown: '/some/page:md',
+    markdown: '/some/page' + MARKDOWN_SUFFIX,
     component: 'my-component',
   };
   const placeholder = placeholders[type];
@@ -155,9 +156,9 @@ async function selectName(type: 'route' | 'component' | 'markdown') {
     return `/${nameAnswer as string}`;
   }
   if (type === 'markdown' && !(nameAnswer as string).startsWith('/')) {
-    return `/${nameAnswer.replace(':md', '') as string}`;
+    return `/${nameAnswer.replace(MARKDOWN_SUFFIX, '') as string}`;
   }
-  return nameAnswer.replace(':md', '') as string;
+  return nameAnswer.replace(MARKDOWN_SUFFIX, '') as string;
 }
 
 async function selectTemplate(typeArg: (typeof POSSIBLE_TYPES)[number]) {

--- a/packages/qwik/src/cli/new/utils.ts
+++ b/packages/qwik/src/cli/new/utils.ts
@@ -1,1 +1,1 @@
-export const POSSIBLE_TYPES = ['component', 'route'] as const;
+export const POSSIBLE_TYPES = ['component', 'route', 'markdown'] as const;

--- a/packages/qwik/src/cli/new/utils.ts
+++ b/packages/qwik/src/cli/new/utils.ts
@@ -1,1 +1,1 @@
-export const POSSIBLE_TYPES = ['component', 'route', 'markdown'] as const;
+export const POSSIBLE_TYPES = ['component', 'route', 'markdown', 'mdx'] as const;

--- a/packages/qwik/src/cli/types.ts
+++ b/packages/qwik/src/cli/types.ts
@@ -109,4 +109,5 @@ export interface TemplateSet {
   component: Template[];
   route: Template[];
   markdown: Template[];
+  mdx: Template[];
 }

--- a/packages/qwik/src/cli/types.ts
+++ b/packages/qwik/src/cli/types.ts
@@ -108,4 +108,5 @@ export interface TemplateSet {
   id: string;
   component: Template[];
   route: Template[];
+  markdown: Template[];
 }

--- a/packages/qwik/src/cli/utils/templates.ts
+++ b/packages/qwik/src/cli/utils/templates.ts
@@ -41,13 +41,16 @@ export async function loadTemplates() {
 export async function readTemplates(rootDir: string) {
   const componentDir = join(rootDir, 'component');
   const routeDir = join(rootDir, 'route');
+  const markdownDir = join(rootDir, 'markdown');
 
   const component = await getFilesDeep(componentDir);
   const route = await getFilesDeep(routeDir);
+  const markdown = await getFilesDeep(markdownDir);
 
   return {
     component: component.map((c) => parseTemplatePath(c, 'component')),
     route: route.map((r) => parseTemplatePath(r, 'route')),
+    markdown: markdown.map((m) => parseTemplatePath(m, 'markdown')),
   };
 }
 

--- a/packages/qwik/src/cli/utils/templates.ts
+++ b/packages/qwik/src/cli/utils/templates.ts
@@ -42,15 +42,18 @@ export async function readTemplates(rootDir: string) {
   const componentDir = join(rootDir, 'component');
   const routeDir = join(rootDir, 'route');
   const markdownDir = join(rootDir, 'markdown');
+  const mdxDir = join(rootDir, 'mdx');
 
   const component = await getFilesDeep(componentDir);
   const route = await getFilesDeep(routeDir);
   const markdown = await getFilesDeep(markdownDir);
+  const mdx = await getFilesDeep(mdxDir);
 
   return {
     component: component.map((c) => parseTemplatePath(c, 'component')),
     route: route.map((r) => parseTemplatePath(r, 'route')),
     markdown: markdown.map((m) => parseTemplatePath(m, 'markdown')),
+    mdx: mdx.map((m) => parseTemplatePath(m, 'mdx')),
   };
 }
 

--- a/starters/templates/qwik/markdown/index.md.template
+++ b/starters/templates/qwik/markdown/index.md.template
@@ -1,0 +1,5 @@
+---
+title: New Route
+---
+
+New route works.

--- a/starters/templates/qwik/mdx/index.mdx.template
+++ b/starters/templates/qwik/mdx/index.mdx.template
@@ -1,0 +1,5 @@
+---
+title: New Route
+---
+
+New route works.


### PR DESCRIPTION
# Overview

This PR adds a way to quickly create Markdown-based routes using a syntax very close to the existing new route command.

Fixes #4931 


```sh
# Usage

npm run qwik new /about.{md,mdx}

# Outputs src/routes/about/index.{md,mdx}
```

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

If you have a lot of Markdown routes (say a blog), adding them individually can be cumbersome. This PR just mimics the implementation of `route` and `component`. The sole difference being you can affix `:md` to a route path to get a Markdown file instead of a TSX file.

# Use cases and why

- blog posts
- documentation pages

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality (I didn't find tests for the existing CLI stuff.)
