### PR TITLE
cli(library): fix release script

### DIFF
--- a/starters/apps/library/package.json
+++ b/starters/apps/library/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint \"src/**/*.ts*\"",
     "start": "vite --open --mode ssr",
     "qwik": "qwik",
-    "release": "np"
+    "release": "np --no-tests"
   },
   "devDependencies": {
     "@builder.io/qwik": "latest",

--- a/starters/apps/library/package.json
+++ b/starters/apps/library/package.json
@@ -27,9 +27,10 @@
     "fmt": "prettier --write .",
     "fmt.check": "prettier --check .",
     "lint": "eslint \"src/**/*.ts*\"",
+    "test": "echo \"No test specified\" && exit 0",
     "start": "vite --open --mode ssr",
     "qwik": "qwik",
-    "release": "np --no-tests"
+    "release": "np"
   },
   "devDependencies": {
     "@builder.io/qwik": "latest",


### PR DESCRIPTION
# What is it?

- [x] Bug

# Description

The `release` script in library starter is failing. 
To solve it I added the `--no-tests` to skip the test step.
By the way there is no testing library configured in the starter

# Steps to reproduce the issue

- Create a library project with Qwik CLI: `npm create qwik` -> Library
- Run the `release` script
- "Running test using npm" step fails

# Checklist:

- [x] I have performed a self-review of my own code
