### PR TITLE
fix(docs): add overview link

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/index.mdx
@@ -2,11 +2,12 @@
 title: Cookbook | Overview
 contributors:
   - mhevery
+  - fabiobiondi
 ---
 
 # Cookbook
 
 A cookbook contains a collection of useful patterns for solving common problems in front-end development.
 
-For example:
-- How do I build a modal dialog popup in Qwik?
+Examples:
+- [modal dialog popup](./modal)

--- a/packages/docs/src/routes/docs/cookbook/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/index.mdx
@@ -10,4 +10,4 @@ contributors:
 A cookbook contains a collection of useful patterns for solving common problems in front-end development.
 
 Examples:
-- [modal dialog popup](./modal)
+- [Modal Dialog Pop-Up](./modal)


### PR DESCRIPTION
The Cookbook page is amazing.
I added a link to the "Modal" page from the "Overview" to improve the user navigation