### PR TITLE
docs(qwikcity): html attributes docs page

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,8 @@
     "rust-lang.rust-analyzer",
     "ms-azuretools.vscode-docker",
     "manucorporat.vermoji",
-    "vadimcn.vscode-lldb"
+    "vadimcn.vscode-lldb",
+    "streetsidesoftware.code-spell-checker"
   ],
   "unwantedRecommendations": []
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ If you're not able to use the dev container, follow these instructions:
 
 1. Make sure [Rust](https://www.rust-lang.org/tools/install) is installed.
 2. Install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) with `cargo install wasm-pack` .
-3. Node version >= `16.8.0`.
+3. Node version >= `18`.
 4. Make sure you have [pnpm](https://pnpm.io/installation) installed.
 5. run `pnpm install`
 

--- a/packages/docs/src/routes/docs/(qwik)/advanced/containers/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/containers/index.mdx
@@ -22,7 +22,7 @@ Every Qwik application is contained inside a element, usually the `<html>` eleme
 
 ## Container Attributes
 
-Since containers are implicitally rendered by the Qwik runtime, it's not possible to define custom HTML attributes using JSX, however, the SSR render APIs, like `renderToString` and `renderToStream`, provide the `containerAttributes` option to define custom attributes:
+Since containers are implicitly rendered by the Qwik runtime, it's not possible to define custom HTML attributes using JSX, however, the SSR render APIs, like `renderToString` and `renderToStream`, provide the `containerAttributes` option to define custom attributes:
 
 ```tsx
 renderToStream(<Root />, {

--- a/packages/docs/src/routes/docs/(qwikcity)/html-attributes/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/html-attributes/index.mdx
@@ -1,0 +1,45 @@
+---
+title: HTML attributes | QwikCity
+contributors:
+  - bab2683
+---
+
+# HTML attributes
+
+Sometimes we need to add attributes to set some functionalities in the website, be it to control the theme of the application, decide the direction of text (`dir` attribute), or set up the language of (`lang` attribute). More often than not, it is practical to add these attributes to the `html` tag as it's usually the [container](../../(qwik)/advanced/containers/index.mdx) of the application.
+
+To do this with Qwik city, go to `src/entry.ssr.tsx` and add them to `containerAttributes` like so:
+
+```tsx
+export default function (opts: RenderToStreamOptions) {
+  return renderToStream(<Root />, {
+    manifest,
+    ...opts,
+    // Use container attributes to set attributes on the html tag.
+    containerAttributes: {
+      lang: "en-us",
+      ...opts.containerAttributes,
+    },
+  });
+}
+```
+
+In addition to that, from the `opts.serverData` object (and nested objects) you can get information about the request, like `request headers`, `url`, `route params`, etc. 
+By leveraging this information, now we can do the following:
+
+```tsx
+export default function (opts: RenderToStreamOptions) {
+  // With this route structure src/routes/[locale]/post/[id]/index.tsx
+  const isRTL = opts.serverData?.qwikcity.params.locale === 'ar';
+
+  return renderToStream(<Root />, {
+    manifest,
+    ...opts,
+    containerAttributes: {
+      dir: isRTL ? 'rtl' : 'ltr'
+      ...opts.containerAttributes,
+    },
+  });
+}
+```
+

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -30,6 +30,7 @@
 - [Middleware](/docs/(qwikcity)/middleware/index.mdx)
 - [server$](/docs/(qwikcity)/server$/index.mdx)
 - [Caching](/docs/(qwikcity)/caching/index.mdx)
+- [HTML attributes](/docs/(qwikcity)/html-attributes/index.mdx)
 - [Env variables](/docs/(qwikcity)/env-variables/index.mdx)
 - [API reference](/docs/(qwikcity)/api/index.mdx)
 


### PR DESCRIPTION
added docs page to easily find how to add html attributes in a qwikcity app

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

Added docs page to easily find how to add HTML attributes in Qwik City as currently is not as straightforward as it may seem. Added also a `vscode` extension to the recommendations to spot common typos.
While trying to setup the environment, `pnpm` required a node version of at least 18 so I updated that bit as well

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
