### PR TITLE
fix(qwikcity): respect X-Forwarded-Host header

### DIFF
--- a/packages/qwik-city/middleware/request-handler/response-page.ts
+++ b/packages/qwik-city/middleware/request-handler/response-page.ts
@@ -18,9 +18,20 @@ export function getQwikCityServerData(requestEv: RequestEvent) {
   const formData = requestEv.sharedMap.get(RequestEvSharedActionFormData);
   const routeName = requestEv.sharedMap.get(RequestRouteName) as string;
   const nonce = requestEv.sharedMap.get(RequestEvSharedNonce);
+  const headers = requestEv.request.headers;
+  const reconstructedUrl = new URL(url.pathname + url.search, url);
+  const host = headers.get('X-Forwarded-Host')!;
+  const protocol = headers.get('X-Forwarded-Proto')!;
+  if (host) {
+    reconstructedUrl.port = '';
+    reconstructedUrl.host = host;
+  }
+  if (protocol) {
+    reconstructedUrl.protocol = protocol;
+  }
 
   return {
-    url: new URL(url.pathname + url.search, url).href,
+    url: reconstructedUrl.href,
     requestHeaders,
     locale: locale(),
     nonce,

--- a/starters/apps/qwikcity-test/src/routes/(common)/location/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/location/index.tsx
@@ -1,0 +1,16 @@
+import { component$ } from "@builder.io/qwik";
+import { useLocation } from "@builder.io/qwik-city";
+
+export default component$(() => {
+  const location = useLocation();
+  return (
+    <div>
+      <h1>useLocation()</h1>
+      <ul>
+        <li>
+          URL: <span class="url">{location.url.href}</span>
+        </li>
+      </ul>
+    </div>
+  );
+});

--- a/starters/e2e/qwikcity/location.spec.ts
+++ b/starters/e2e/qwikcity/location.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Qwik City API: useLocation", () => {
+  test("should take x-forwarded headers into account", async ({ page }) => {
+    page.setExtraHTTPHeaders({
+      "X-Forwarded-Host": "override-server",
+      "X-Forwarded-Proto": "http",
+    });
+    const rsp = (await page.goto("/qwikcity-test/location/"))!;
+    expect(rsp.status()).toBe(200);
+    const span = page.locator(".url");
+    expect(await span.textContent()).toBe(
+      "http://override-server/qwikcity-test/location/",
+    );
+  });
+
+  test("should take x-forwarded headers into account with port", async ({
+    page,
+  }) => {
+    page.setExtraHTTPHeaders({
+      "X-Forwarded-Host": "override-server:9999",
+      "X-Forwarded-Proto": "https",
+    });
+    const rsp = (await page.goto("/qwikcity-test/location/"))!;
+    expect(rsp.status()).toBe(200);
+    const span = page.locator(".url");
+    expect(await span.textContent()).toBe(
+      "https://override-server:9999/qwikcity-test/location/",
+    );
+  });
+});


### PR DESCRIPTION
Fix #4965

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
