### PR TITLE
fix: add  options to qwik vite plugin

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/advanced/vite/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/vite/index.mdx
@@ -73,6 +73,16 @@ entryStrategy?: EntryStrategy;
 srcDir?: string;
 ```
 
+#### `tsconfigFileNames`
+
+```js
+/**
+ * List of tsconfig.json files to use for ESLint warnings during development.
+ * Default `['tsconfig.json']`
+ */
+tsconfigFileNames?: string[];
+```
+
 #### `vendorRoots`
 
 ```js

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -184,6 +184,10 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       opts.srcDir = srcDir;
     }
 
+    if (Array.isArray(updatedOpts.tsconfigFileNames) && updatedOpts.tsconfigFileNames.length > 0) {
+      opts.tsconfigFileNames = updatedOpts.tsconfigFileNames;
+    }
+
     if (Array.isArray(opts.srcInputs)) {
       opts.srcInputs.forEach((i) => {
         i.path = normalizePath(path.resolve(opts.rootDir, i.path));

--- a/packages/qwik/src/optimizer/src/plugins/plugin.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.unit.ts
@@ -16,6 +16,7 @@ test('defaults', async () => {
   equal(opts.entryStrategy, { type: 'hook' });
   equal(opts.debug, false);
   equal(opts.rootDir, normalizePath(cwd));
+  equal(opts.tsconfigFileNames, ['./tsconfig.json']);
   equal(opts.input, [normalizePath(resolve(cwd, 'src', 'root.tsx'))]);
   equal(opts.outDir, normalizePath(resolve(cwd, 'dist')));
   equal(opts.manifestInput, null);
@@ -33,6 +34,7 @@ test('defaults (buildMode: production)', async () => {
   equal(opts.resolveQwikBuild, true);
   equal(opts.debug, false);
   equal(opts.rootDir, normalizePath(cwd));
+  equal(opts.tsconfigFileNames, ['./tsconfig.json']);
   equal(opts.input, [normalizePath(resolve(cwd, 'src', 'root.tsx'))]);
   equal(opts.outDir, normalizePath(resolve(cwd, 'dist')));
   equal(opts.manifestInput, null);
@@ -51,6 +53,7 @@ test('defaults (target: ssr)', async () => {
   equal(opts.resolveQwikBuild, true);
   equal(opts.debug, false);
   equal(opts.rootDir, normalizePath(cwd));
+  equal(opts.tsconfigFileNames, ['./tsconfig.json']);
   equal(opts.input, [normalizePath(resolve(cwd, 'src', 'entry.ssr.tsx'))]);
   equal(opts.outDir, normalizePath(resolve(cwd, 'server')));
   equal(opts.manifestInput, null);
@@ -68,6 +71,7 @@ test('defaults (buildMode: production, target: ssr)', async () => {
   equal(opts.resolveQwikBuild, true);
   equal(opts.debug, false);
   equal(opts.rootDir, normalizePath(cwd));
+  equal(opts.tsconfigFileNames, ['./tsconfig.json']);
   equal(opts.input, [normalizePath(resolve(cwd, 'src', 'entry.ssr.tsx'))]);
   equal(opts.outDir, normalizePath(resolve(cwd, 'server')));
   equal(opts.manifestInput, null);
@@ -126,6 +130,22 @@ test('rootDir, rel path', async () => {
   const customRoot = 'rel-path';
   const opts = plugin.normalizeOptions({ rootDir: customRoot });
   equal(opts.rootDir, normalizePath(resolve(cwd, customRoot)));
+});
+
+test('tsconfigFileNames', async () => {
+  const plugin = await mockPlugin();
+  const opts = plugin.normalizeOptions({
+    tsconfigFileNames: ['./tsconfig.json', './tsconfig.app.json'],
+  });
+  equal(opts.tsconfigFileNames, ['./tsconfig.json', './tsconfig.app.json']);
+});
+
+test('tsconfigFileNames, empty array fallback to default', async () => {
+  const plugin = await mockPlugin();
+  const opts = plugin.normalizeOptions({
+    tsconfigFileNames: [],
+  });
+  equal(opts.tsconfigFileNames, ['./tsconfig.json']);
 });
 
 test('input string', async () => {

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -127,6 +127,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         entryStrategy: qwikViteOpts.entryStrategy,
         srcDir: qwikViteOpts.srcDir,
         rootDir: viteConfig.root,
+        tsconfigFileNames: qwikViteOpts.tsconfigFileNames,
         resolveQwikBuild: true,
         transformedModuleOutput: qwikViteOpts.transformedModuleOutput,
         vendorRoots: [...(qwikViteOpts.vendorRoots ?? []), ...vendorRoots.map((v) => v.path)],
@@ -731,6 +732,11 @@ interface QwikVitePluginCommonOptions {
    * Default `src`
    */
   srcDir?: string;
+  /**
+   * List of tsconfig.json files to use for ESLint warnings during development.
+   * Default `['tsconfig.json']`
+   */
+  tsconfigFileNames?: string[];
   /**
    * List of directories to recursively search for Qwik components or Vendors.
    * Default `[]`


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

This exposes the `tsconfigFileNames` option to fix https://github.com/BuilderIO/qwik/issues/4980.

The dev-mode linter does not work properly with projects that use [project references](https://www.typescriptlang.org/tsconfig#references) for workspace organization. Exposing this option allows the developer to specify the base `tsconfig.json` and the extending `tsconfig.json`s necessary for linting.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I exposed the `tsconfigFileNames` option to the Qwik Vite plugin so that it can be overriden from the currently hardcoded `['tsconfig.json']` value.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

(See https://github.com/BuilderIO/qwik/issues/4980 for more details)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
