### PR TITLE
fix: only show qwik eslint errors in dev mode

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/eslint-plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/eslint-plugin.ts
@@ -51,6 +51,9 @@ export async function createLinter(
 
         report.forEach((file) => {
           for (const message of file.messages) {
+            if (message.ruleId != null && !message.ruleId.startsWith('qwik/')) {
+              continue;
+            }
             const err = createRollupError(file.filePath, message);
             ctx.warn(err);
           }


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

See https://github.com/BuilderIO/qwik/issues/4981 for more details.

The dev-mode linter is reporting warnings for missing rules due to ESLint ignore comment directives.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

The implemented solution is to only report ESLint rules with rule id beginning with `qwik/` aka just the `eslint-qwik-plugin` rules.

From my understanding of the original issue https://github.com/BuilderIO/qwik/issues/4858, the goal of PR https://github.com/BuilderIO/qwik/pull/4873 is to show the `qwik/valid-lexical-scope` errors more visibly during dev mode to assist in debugging and prevent confusion. Given this, I think it makes sense to only run and show the `qwik` rules. (Technically the code right now only runs the `qwik` rules as those are the only ones defined in the `createLinter` function. It just is noisy with the warnings about missing rules.)

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

See https://github.com/BuilderIO/qwik/issues/4981

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
