### PR TITLE
fix(qwik-city): enable matching route and pathname with an optional t…

### DIFF
--- a/packages/qwik-city/runtime/src/route-matcher.ts
+++ b/packages/qwik-city/runtime/src/route-matcher.ts
@@ -10,7 +10,7 @@ import type { PathParams } from './types';
 export function matchRoute(route: string, path: string): PathParams | null {
   const params: PathParams = {};
   let routeIdx: number = startIdxSkipSlash(route);
-  const routeLength = route.length;
+  const routeLength = lengthNoTrailingSlash(route);
   let pathIdx: number = startIdxSkipSlash(path);
   const pathLength = lengthNoTrailingSlash(path);
   while (routeIdx < routeLength) {

--- a/packages/qwik-city/runtime/src/route-matcher.unit.ts
+++ b/packages/qwik-city/runtime/src/route-matcher.unit.ts
@@ -15,9 +15,21 @@ routeMatchSuite('should match /foo/', () => {
   equal(matchRoute('/foo', '/foo/extra'), null, 'should not match extra');
 });
 
+routeMatchSuite('should match /foo/ with trailing slash', () => {
+  equal(matchRoute('/foo/', '/foo/'), {});
+  equal(matchRoute('/foo/', '/foo'), {});
+  equal(matchRoute('foo/', '/foo/'), {});
+  equal(matchRoute('/foo/', '/foo/extra'), null, 'should not match extra');
+});
+
 routeMatchSuite('should match /seg/[slug]/', () => {
   equal(matchRoute('/seg/[slug]', '/seg/extract-text/'), { slug: 'extract-text' });
   equal(matchRoute('/seg/[slug]', '/seg/[slug]/extra'), null, 'should not match extra');
+});
+
+routeMatchSuite('should match /seg/[slug]/ with trailing slash', () => {
+  equal(matchRoute('/seg/[slug]/', '/seg/extract-text/'), { slug: 'extract-text' });
+  equal(matchRoute('/seg/[slug]/', '/seg/[slug]/extra'), null, 'should not match extra');
 });
 
 routeMatchSuite('should match /seg/[slug]/[param]/', () => {
@@ -28,8 +40,20 @@ routeMatchSuite('should match /seg/[slug]/[param]/', () => {
   equal(matchRoute('/seg/[slug]/[param]', '/seg/slug/param/extra'), null, 'should not match extra');
 });
 
+routeMatchSuite('should match /seg/[slug]/[param]/ with trailing slash', () => {
+  equal(matchRoute('/seg/[slug]/[param]/', '/seg/extract-text/param-text/'), {
+    slug: 'extract-text',
+    param: 'param-text',
+  });
+  equal(matchRoute('/seg/[slug]/[param]/', '/seg/slug/param/extra'), null, 'should not match extra');
+});
+
 routeMatchSuite('should match /seg/[...rest]', () => {
   equal(matchRoute('/seg/[...rest]', '/seg/a/b/c'), { rest: 'a/b/c' });
+});
+
+routeMatchSuite('should match /seg/[...rest] with trailing slash', () => {
+  equal(matchRoute('/seg/[...rest]/', '/seg/a/b/c'), { rest: 'a/b/c' });
 });
 
 routeMatchSuite('should match /stuff/[...param]', () => {
@@ -37,8 +61,17 @@ routeMatchSuite('should match /stuff/[...param]', () => {
   equal(matchRoute('/stuff/[...param]', '/stuff'), { param: '' }, '2');
 });
 
+routeMatchSuite('should match /stuff/[...param] with trailing slash', () => {
+  equal(matchRoute('/stuff/[...param]/', '/stuff/'), { param: '' }, '1');
+  equal(matchRoute('/stuff/[...param]/', '/stuff'), { param: '' }, '2');
+});
+
 routeMatchSuite('should match /seg/[paramA]/[...rest]', () => {
   equal(matchRoute('/seg/[paramA]/[...rest]', '/seg/a/b/c'), { paramA: 'a', rest: 'b/c' });
+});
+
+routeMatchSuite('should match /seg/[paramA]/[...rest] with trailing slash', () => {
+  equal(matchRoute('/seg/[paramA]/[...rest]/', '/seg/a/b/c'), { paramA: 'a', rest: 'b/c' });
 });
 
 routeMatchSuite('regressions', () => {
@@ -67,8 +100,20 @@ routeMatchSuite('/a/pre[infix]post', () => {
   });
 });
 
+routeMatchSuite('should match /a/pre[infix]post with trailing slash', () => {
+  equal(matchRoute('/a/pre[infix]post/', '/a/preINpost'), {
+    infix: 'IN',
+  });
+  equal(matchRoute('/a/pre[infix]post/', '/a/prepost'), {
+    infix: '',
+  });
+});
+
 routeMatchSuite('/[...rest] ignore trailing slash', () => {
   equal(matchRoute('/[...rest]', '/a/b/c/'), {
+    rest: 'a/b/c',
+  });
+  equal(matchRoute('/[...rest]/', '/a/b/c/'), {
     rest: 'a/b/c',
   });
 });

--- a/packages/qwik-city/runtime/src/route-matcher.unit.ts
+++ b/packages/qwik-city/runtime/src/route-matcher.unit.ts
@@ -45,7 +45,11 @@ routeMatchSuite('should match /seg/[slug]/[param]/ with trailing slash', () => {
     slug: 'extract-text',
     param: 'param-text',
   });
-  equal(matchRoute('/seg/[slug]/[param]/', '/seg/slug/param/extra'), null, 'should not match extra');
+  equal(
+    matchRoute('/seg/[slug]/[param]/', '/seg/slug/param/extra'),
+    null,
+    'should not match extra'
+  );
 });
 
 routeMatchSuite('should match /seg/[...rest]', () => {


### PR DESCRIPTION
…railing slash

match both route and pathname without the optional ending slash

fix #5003

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
