### PR TITLE
insights(feat): qwikInsights Vite Plugin + save symbol details

### DIFF
--- a/packages/docs/src/routes/docs/labs/insights/index.mdx
+++ b/packages/docs/src/routes/docs/labs/insights/index.mdx
@@ -15,7 +15,7 @@ Insights allow your application to collect real user usage information to optimi
 The optimization consists of these parts:
 - A `<Insights>` component which collects real user usage data.
 - A registered application inside the builder.io database.
-- A qwikVite configuration to load real user usage data during the build process.
+- A `qwikInsights` Vite Plugin to load and save real user usage data during the build process.
 
 > NOTE:
 > To try this new feature please drop a message inside the [Qwik Discord server](https://qwik.builder.io/chat)
@@ -69,17 +69,14 @@ file: `vite.config.js`
 ```typescript
 //..
 import { defineConfig, loadEnv } from 'vite';
-import { insightsEntryStrategy } from '@builder.io/qwik-labs/vite';
-
+import { qwikInsights } from '@builder.io/qwik-labs/vite';
 
 export default defineConfig(async () => {
   return {
     plugins: [
-      qwikVite({
-        entryStrategy: await insightsEntryStrategy({
-          publicApiKey: loadEnv('', '.', '').PUBLIC_QWIK_INSIGHTS_KEY,
-        }),
-      }), 
+      qwikInsights({
+        publicApiKey: loadEnv('', '.', '').PUBLIC_QWIK_INSIGHTS_KEY,
+      }),
       //...
     ],
     // ...

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -7,7 +7,6 @@ import { examplesData, playgroundData, tutorialData } from './vite.repl-apps';
 import { sourceResolver } from './vite.source-resolver';
 import { qwikReact } from '@builder.io/qwik-react/vite';
 import Inspect from 'vite-plugin-inspect';
-// import { insightsEntryStrategy } from '@builder.io/qwik-labs';
 
 export const PUBLIC_QWIK_INSIGHT_KEY = loadEnv('', '.', 'PUBLIC').PUBLIC_QWIK_INSIGHTS_KEY;
 
@@ -97,9 +96,6 @@ export default defineConfig(async () => {
         },
       }),
       qwikVite({
-        // entryStrategy: await insightsEntryStrategy({
-        //   publicApiKey: PUBLIC_QWIK_INSIGHT_KEY,
-        // }),
         entryStrategy: {
           type: 'smart',
           manual: {

--- a/packages/insights/drizzle/0012_omniscient_leader.sql
+++ b/packages/insights/drizzle/0012_omniscient_leader.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `symbolDetailTmp` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`hash` text NOT NULL,
+	`public_api_key` text,
+	`manifest_hash` text,
+	`full_name` text NOT NULL,
+	`origin` text NOT NULL,
+	`lo` integer NOT NULL,
+	`hi` integer NOT NULL,
+	FOREIGN KEY (`public_api_key`) REFERENCES `applications`(`public_api_key`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`public_api_key`,`manifest_hash`) REFERENCES `manifests`(`public_api_key`,`hash`) ON UPDATE no action ON DELETE no action
+);--> statement-breakpoint
+INSERT INTO `symbolDetailTmp` SELECT * FROM `symbolDetail`;--> statement-breakpoint
+DROP TABLE `symbolDetail`;--> statement-breakpoint
+ALTER TABLE `symbolDetailTmp` RENAME TO `symbolDetail`;

--- a/packages/insights/drizzle/meta/0012_snapshot.json
+++ b/packages/insights/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1629 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "b433e33c-f6e2-4ade-b42c-b899ce0ab208",
+  "prevId": "d449626c-ce26-4a45-97e3-d9cefd38f5e8",
+  "tables": {
+    "applications": {
+      "name": "applications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_api_key": {
+          "name": "public_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "publicApiKeyIndex": {
+          "name": "publicApiKeyIndex",
+          "columns": [
+            "public_api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "edges": {
+      "name": "edges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_api_key": {
+          "name": "public_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from": {
+          "name": "from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to": {
+          "name": "to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interaction": {
+          "name": "interaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_00": {
+          "name": "delay_count_00",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_01": {
+          "name": "delay_count_01",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_02": {
+          "name": "delay_count_02",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_03": {
+          "name": "delay_count_03",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_04": {
+          "name": "delay_count_04",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_05": {
+          "name": "delay_count_05",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_06": {
+          "name": "delay_count_06",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_07": {
+          "name": "delay_count_07",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_08": {
+          "name": "delay_count_08",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_09": {
+          "name": "delay_count_09",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_10": {
+          "name": "delay_count_10",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_11": {
+          "name": "delay_count_11",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_12": {
+          "name": "delay_count_12",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_13": {
+          "name": "delay_count_13",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_14": {
+          "name": "delay_count_14",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_15": {
+          "name": "delay_count_15",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_16": {
+          "name": "delay_count_16",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_17": {
+          "name": "delay_count_17",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_18": {
+          "name": "delay_count_18",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_19": {
+          "name": "delay_count_19",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_20": {
+          "name": "delay_count_20",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_21": {
+          "name": "delay_count_21",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_22": {
+          "name": "delay_count_22",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_23": {
+          "name": "delay_count_23",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_24": {
+          "name": "delay_count_24",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_25": {
+          "name": "delay_count_25",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_26": {
+          "name": "delay_count_26",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_27": {
+          "name": "delay_count_27",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_28": {
+          "name": "delay_count_28",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_29": {
+          "name": "delay_count_29",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_30": {
+          "name": "delay_count_30",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_31": {
+          "name": "delay_count_31",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_32": {
+          "name": "delay_count_32",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_33": {
+          "name": "delay_count_33",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_34": {
+          "name": "delay_count_34",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_35": {
+          "name": "delay_count_35",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_36": {
+          "name": "delay_count_36",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_37": {
+          "name": "delay_count_37",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_38": {
+          "name": "delay_count_38",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_39": {
+          "name": "delay_count_39",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_40": {
+          "name": "delay_count_40",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_41": {
+          "name": "delay_count_41",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_42": {
+          "name": "delay_count_42",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_43": {
+          "name": "delay_count_43",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_44": {
+          "name": "delay_count_44",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_45": {
+          "name": "delay_count_45",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_46": {
+          "name": "delay_count_46",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_47": {
+          "name": "delay_count_47",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_48": {
+          "name": "delay_count_48",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_count_49": {
+          "name": "delay_count_49",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_00": {
+          "name": "latency_count_00",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_01": {
+          "name": "latency_count_01",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_02": {
+          "name": "latency_count_02",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_03": {
+          "name": "latency_count_03",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_04": {
+          "name": "latency_count_04",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_05": {
+          "name": "latency_count_05",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_06": {
+          "name": "latency_count_06",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_07": {
+          "name": "latency_count_07",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_08": {
+          "name": "latency_count_08",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_09": {
+          "name": "latency_count_09",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_10": {
+          "name": "latency_count_10",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_11": {
+          "name": "latency_count_11",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_12": {
+          "name": "latency_count_12",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_13": {
+          "name": "latency_count_13",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_14": {
+          "name": "latency_count_14",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_15": {
+          "name": "latency_count_15",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_16": {
+          "name": "latency_count_16",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_17": {
+          "name": "latency_count_17",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_18": {
+          "name": "latency_count_18",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_19": {
+          "name": "latency_count_19",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_20": {
+          "name": "latency_count_20",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_21": {
+          "name": "latency_count_21",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_22": {
+          "name": "latency_count_22",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_23": {
+          "name": "latency_count_23",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_24": {
+          "name": "latency_count_24",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_25": {
+          "name": "latency_count_25",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_26": {
+          "name": "latency_count_26",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_27": {
+          "name": "latency_count_27",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_28": {
+          "name": "latency_count_28",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_29": {
+          "name": "latency_count_29",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_30": {
+          "name": "latency_count_30",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_31": {
+          "name": "latency_count_31",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_32": {
+          "name": "latency_count_32",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_33": {
+          "name": "latency_count_33",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_34": {
+          "name": "latency_count_34",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_35": {
+          "name": "latency_count_35",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_36": {
+          "name": "latency_count_36",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_37": {
+          "name": "latency_count_37",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_38": {
+          "name": "latency_count_38",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_39": {
+          "name": "latency_count_39",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_40": {
+          "name": "latency_count_40",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_41": {
+          "name": "latency_count_41",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_42": {
+          "name": "latency_count_42",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_43": {
+          "name": "latency_count_43",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_44": {
+          "name": "latency_count_44",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_45": {
+          "name": "latency_count_45",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_46": {
+          "name": "latency_count_46",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_47": {
+          "name": "latency_count_47",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_48": {
+          "name": "latency_count_48",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_count_49": {
+          "name": "latency_count_49",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edgeIndex_PublicApiKey": {
+          "name": "edgeIndex_PublicApiKey",
+          "columns": [
+            "public_api_key"
+          ],
+          "isUnique": false
+        },
+        "edgeIndex_PublicApiKey_manifestHash": {
+          "name": "edgeIndex_PublicApiKey_manifestHash",
+          "columns": [
+            "public_api_key",
+            "manifest_hash"
+          ],
+          "isUnique": false
+        },
+        "edgeIndex": {
+          "name": "edgeIndex",
+          "columns": [
+            "public_api_key",
+            "manifest_hash",
+            "from",
+            "to"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "edges_public_api_key_applications_public_api_key_fk": {
+          "name": "edges_public_api_key_applications_public_api_key_fk",
+          "tableFrom": "edges",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "public_api_key"
+          ],
+          "columnsTo": [
+            "public_api_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "errors": {
+      "name": "errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_api_key": {
+          "name": "public_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "errors_public_api_key_applications_public_api_key_fk": {
+          "name": "errors_public_api_key_applications_public_api_key_fk",
+          "tableFrom": "errors",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "public_api_key"
+          ],
+          "columnsTo": [
+            "public_api_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "errors_manifest_hash_manifests_hash_fk": {
+          "name": "errors_manifest_hash_manifests_hash_fk",
+          "tableFrom": "errors",
+          "tableTo": "manifests",
+          "columnsFrom": [
+            "manifest_hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "manifests": {
+      "name": "manifests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_api_key": {
+          "name": "public_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hashIndex": {
+          "name": "hashIndex",
+          "columns": [
+            "hash",
+            "public_api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "manifests_public_api_key_applications_public_api_key_fk": {
+          "name": "manifests_public_api_key_applications_public_api_key_fk",
+          "tableFrom": "manifests",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "public_api_key"
+          ],
+          "columnsTo": [
+            "public_api_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "routes": {
+      "name": "routes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_api_key": {
+          "name": "public_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_00": {
+          "name": "timeline_00",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_01": {
+          "name": "timeline_01",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_02": {
+          "name": "timeline_02",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_03": {
+          "name": "timeline_03",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_04": {
+          "name": "timeline_04",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_05": {
+          "name": "timeline_05",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_06": {
+          "name": "timeline_06",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_07": {
+          "name": "timeline_07",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_08": {
+          "name": "timeline_08",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_09": {
+          "name": "timeline_09",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_10": {
+          "name": "timeline_10",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_11": {
+          "name": "timeline_11",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_12": {
+          "name": "timeline_12",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_13": {
+          "name": "timeline_13",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_14": {
+          "name": "timeline_14",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_15": {
+          "name": "timeline_15",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_16": {
+          "name": "timeline_16",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_17": {
+          "name": "timeline_17",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_18": {
+          "name": "timeline_18",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_19": {
+          "name": "timeline_19",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_20": {
+          "name": "timeline_20",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_21": {
+          "name": "timeline_21",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_22": {
+          "name": "timeline_22",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_23": {
+          "name": "timeline_23",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_24": {
+          "name": "timeline_24",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_25": {
+          "name": "timeline_25",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_26": {
+          "name": "timeline_26",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_27": {
+          "name": "timeline_27",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_28": {
+          "name": "timeline_28",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_29": {
+          "name": "timeline_29",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_30": {
+          "name": "timeline_30",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_31": {
+          "name": "timeline_31",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_32": {
+          "name": "timeline_32",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_33": {
+          "name": "timeline_33",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_34": {
+          "name": "timeline_34",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_35": {
+          "name": "timeline_35",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_36": {
+          "name": "timeline_36",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_37": {
+          "name": "timeline_37",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_38": {
+          "name": "timeline_38",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_39": {
+          "name": "timeline_39",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_40": {
+          "name": "timeline_40",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_41": {
+          "name": "timeline_41",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_42": {
+          "name": "timeline_42",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_43": {
+          "name": "timeline_43",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_44": {
+          "name": "timeline_44",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_45": {
+          "name": "timeline_45",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_46": {
+          "name": "timeline_46",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_47": {
+          "name": "timeline_47",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_48": {
+          "name": "timeline_48",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeline_49": {
+          "name": "timeline_49",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "routeIndex_Symbol": {
+          "name": "routeIndex_Symbol",
+          "columns": [
+            "public_api_key",
+            "manifest_hash",
+            "route",
+            "symbol"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "routes_public_api_key_applications_public_api_key_fk": {
+          "name": "routes_public_api_key_applications_public_api_key_fk",
+          "tableFrom": "routes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "public_api_key"
+          ],
+          "columnsTo": [
+            "public_api_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "symbolDetail": {
+      "name": "symbolDetail",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_api_key": {
+          "name": "public_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lo": {
+          "name": "lo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hi": {
+          "name": "hi",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "symbolDetail_public_api_key_applications_public_api_key_fk": {
+          "name": "symbolDetail_public_api_key_applications_public_api_key_fk",
+          "tableFrom": "symbolDetail",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "public_api_key"
+          ],
+          "columnsTo": [
+            "public_api_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "symbolDetail_public_api_key_manifest_hash_manifests_public_api_key_hash_fk": {
+          "name": "symbolDetail_public_api_key_manifest_hash_manifests_public_api_key_hash_fk",
+          "tableFrom": "symbolDetail",
+          "tableTo": "manifests",
+          "columnsFrom": [
+            "public_api_key",
+            "manifest_hash"
+          ],
+          "columnsTo": [
+            "public_api_key",
+            "hash"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "symbols": {
+      "name": "symbols",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_api_key": {
+          "name": "public_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interaction": {
+          "name": "interaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prev_symbol": {
+          "name": "prev_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_delta_ms": {
+          "name": "time_delta_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "load_delay_ms": {
+          "name": "load_delay_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "symbols_public_api_key_applications_public_api_key_fk": {
+          "name": "symbols_public_api_key_applications_public_api_key_fk",
+          "tableFrom": "symbols",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "public_api_key"
+          ],
+          "columnsTo": [
+            "public_api_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/packages/insights/drizzle/meta/_journal.json
+++ b/packages/insights/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1692475220822,
       "tag": "0011_thin_captain_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1692906645372,
+      "tag": "0012_omniscient_leader",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/insights/src/db/schema.ts
+++ b/packages/insights/src/db/schema.ts
@@ -1,4 +1,11 @@
-import { integer, sqliteTable, text, uniqueIndex, index } from 'drizzle-orm/sqlite-core';
+import {
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+  index,
+  foreignKey,
+} from 'drizzle-orm/sqlite-core';
 
 export type DatabaseSchema = {
   applicationTable: typeof applicationTable;
@@ -59,16 +66,31 @@ export const manifestTable = sqliteTable(
   })
 );
 
-export const symbolDetailTable = sqliteTable('symbolDetail', {
-  id: integer('id').primaryKey(),
-  hash: text('hash').notNull(),
-  publicApiKey: text('public_api_key').references(() => applicationTable.publicApiKey),
-  manifestHash: text('manifest_hash').references(() => manifestTable.hash),
-  fullName: text('full_name').notNull(),
-  origin: text('origin').notNull(),
-  lo: integer('lo').notNull(),
-  hi: integer('hi').notNull(),
-});
+export const symbolDetailTable = sqliteTable(
+  'symbolDetail',
+  {
+    id: integer('id').primaryKey(),
+    hash: text('hash').notNull(),
+    publicApiKey: text('public_api_key'),
+    manifestHash: text('manifest_hash'),
+    fullName: text('full_name').notNull(),
+    origin: text('origin').notNull(),
+    lo: integer('lo').notNull(),
+    hi: integer('hi').notNull(),
+  },
+  (symbolDetailTable) => {
+    return {
+      publicApiKeyReference: foreignKey(() => ({
+        columns: [symbolDetailTable.publicApiKey],
+        foreignColumns: [applicationTable.publicApiKey],
+      })),
+      manifestHashReference: foreignKey(() => ({
+        columns: [symbolDetailTable.publicApiKey, symbolDetailTable.manifestHash],
+        foreignColumns: [manifestTable.publicApiKey, manifestTable.hash],
+      })),
+    };
+  }
+);
 
 export const edgeTable = sqliteTable(
   'edges',

--- a/packages/insights/src/routes/api/v1/[publicApiKey]/post/manifest/index.tsx
+++ b/packages/insights/src/routes/api/v1/[publicApiKey]/post/manifest/index.tsx
@@ -1,5 +1,5 @@
 import { type RequestHandler } from '@builder.io/qwik-city';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { getDB, symbolDetailTable } from '~/db';
 import { dbGetManifestInfo } from '~/db/sql-manifest';
 import { QManifest } from '~/types/q-manifest';
@@ -16,7 +16,12 @@ export const onPost: RequestHandler = async ({ exit, json, request, params }) =>
     const existing = await db
       .select()
       .from(symbolDetailTable)
-      .where(eq(symbolDetailTable.publicApiKey, publicApiKey))
+      .where(
+        and(
+          eq(symbolDetailTable.publicApiKey, publicApiKey),
+          eq(symbolDetailTable.manifestHash, manifestHash)
+        )
+      )
       .all();
     const existingMap = new Map<string, (typeof existing)[0]>();
     existing.forEach((row) => existingMap.set(row.hash, row));

--- a/packages/insights/vite.config.ts
+++ b/packages/insights/vite.config.ts
@@ -2,9 +2,8 @@ import { defineConfig, loadEnv } from 'vite';
 import { qwikVite } from '@builder.io/qwik/optimizer';
 import { qwikCity } from '@builder.io/qwik-city/vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { qwikTypes } from '@builder.io/qwik-labs/vite';
+import { qwikInsights, qwikTypes } from '@builder.io/qwik-labs/vite';
 import { macroPlugin } from '@builder.io/vite-plugin-macro';
-import { insightsEntryStrategy } from '@builder.io/qwik-labs/vite';
 
 export default defineConfig(async () => {
   return {
@@ -12,12 +11,9 @@ export default defineConfig(async () => {
       macroPlugin({ preset: 'pandacss' }),
       qwikCity(),
       qwikTypes(),
-      qwikVite({
-        entryStrategy: await insightsEntryStrategy({
-          publicApiKey: loadEnv('', '.', '').PUBLIC_QWIK_INSIGHTS_KEY,
-        }),
-      }),
+      qwikVite(),
       tsconfigPaths({ projects: ['.'] }),
+      qwikInsights({ publicApiKey: loadEnv('', '.', '').PUBLIC_QWIK_INSIGHTS_KEY }),
     ],
     preview: {
       headers: {

--- a/packages/qwik-labs/src-vite/insights/index.ts
+++ b/packages/qwik-labs/src-vite/insights/index.ts
@@ -33,9 +33,9 @@ export async function qwikInsights(qwikInsightsOpts: {
       }
     },
     closeBundle: async () => {
-      if (isProd && existsSync(INSIGHTS_Q_MANIFEST_FILENAME)) {
-        const qManifest = await readFile(INSIGHTS_Q_MANIFEST_FILENAME, 'utf-8');
-        await unlink(INSIGHTS_Q_MANIFEST_FILENAME);
+      const Q_MANIFEST_FILENAME = './dist/q-manifest.json';
+      if (isProd && existsSync('./dist/q-manifest.json')) {
+        const qManifest = await readFile(Q_MANIFEST_FILENAME, 'utf-8');
 
         try {
           await fetch(`${baseUrl}/api/v1/${publicApiKey}/post/manifest`, {

--- a/packages/qwik-labs/src-vite/insights/index.ts
+++ b/packages/qwik-labs/src-vite/insights/index.ts
@@ -1,9 +1,9 @@
 import { type QwikVitePluginOptions } from '@builder.io/qwik/optimizer';
 import { existsSync } from 'fs';
-import { readFile, unlink, writeFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { PluginOption } from 'vite';
 
-const INSIGHTS_Q_MANIFEST_FILENAME = './insights-q-manifest.json';
+const INSIGHTS_Q_MANIFEST_FILENAME = './dist/insights-q-manifest.json';
 
 const logWarn = (message?: any) => {
   console.warn('\x1b[33m%s\x1b[0m', `\n\nQWIK WARN: ${message}\n`);

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -115,6 +115,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
           if (entryStrategy) {
             qwikViteOpts.entryStrategy = entryStrategy;
           }
+          await fs.promises.unlink(INSIGHTS_Q_MANIFEST_FILENAME);
         } catch (e) {
           // ok to ignore
         }

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -108,7 +108,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
       if (sys.env === 'node' && !qwikViteOpts.entryStrategy) {
         const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
         try {
-          const INSIGHTS_Q_MANIFEST_FILENAME = './insights-q-manifest.json';
+          const INSIGHTS_Q_MANIFEST_FILENAME = './dist/insights-q-manifest.json';
           const entryStrategy = JSON.parse(
             await fs.promises.readFile(INSIGHTS_Q_MANIFEST_FILENAME, 'utf-8')
           );

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -105,6 +105,20 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
 
       qwikPlugin.log(`vite config(), command: ${viteCommand}, env.mode: ${viteEnv.mode}`);
 
+      if (sys.env === 'node' && !qwikViteOpts.entryStrategy) {
+        const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
+        try {
+          const INSIGHTS_Q_MANIFEST_FILENAME = './insights-q-manifest.json';
+          const entryStrategy = JSON.parse(await fs.promises.readFile(INSIGHTS_Q_MANIFEST_FILENAME, 'utf-8'));
+          if (entryStrategy) {
+            qwikViteOpts.entryStrategy = entryStrategy;
+          }
+
+        } catch (e) {
+          // ok to ignore
+        }
+      }
+
       if (viteCommand === 'serve') {
         qwikViteOpts.entryStrategy = { type: 'hook' };
       } else {

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -109,11 +109,12 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
         try {
           const INSIGHTS_Q_MANIFEST_FILENAME = './insights-q-manifest.json';
-          const entryStrategy = JSON.parse(await fs.promises.readFile(INSIGHTS_Q_MANIFEST_FILENAME, 'utf-8'));
+          const entryStrategy = JSON.parse(
+            await fs.promises.readFile(INSIGHTS_Q_MANIFEST_FILENAME, 'utf-8')
+          );
           if (entryStrategy) {
             qwikViteOpts.entryStrategy = entryStrategy;
           }
-
         } catch (e) {
           // ok to ignore
         }


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement

# Description

This PR creates the plugin for Qwik Insights, this plugin runs only in production build.
The remote baseUrl by default is `https://qwik-insights.builder.io`

This is the new proposed process flow:
1) `qwikInsights` plugin runs before all Vite plugins and downloads the recorded real user data. 
2) `qwikVite` reads this data to optimise the bundle.
3) `qwikInsights` send the `q-manifest.json` file to the remote Insights baseUrl.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
