### PR TITLE
fix: docs/cookbook/index.mdx link to portal page

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/index.mdx
@@ -10,4 +10,4 @@ contributors:
 A cookbook contains a collection of useful patterns for solving common problems in front-end development.
 
 Examples:
-- [Modal Dialog Pop-Up](./modal)
+- [Modal Dialog Pop-Up](./portal/)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Fix docs/cookbook/index.mdx link to portal page

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
