### PR TITLE
fix(starter): missing key attrib on `routerHead` component on `1.2.9`

### DIFF
--- a/starters/apps/basic/src/components/router-head/router-head.tsx
+++ b/starters/apps/basic/src/components/router-head/router-head.tsx
@@ -1,5 +1,6 @@
-import { component$ } from "@builder.io/qwik";
 import { useDocumentHead, useLocation } from "@builder.io/qwik-city";
+
+import { component$ } from "@builder.io/qwik";
 
 /**
  * The RouterHead component is placed inside of the document `<head>` element.
@@ -29,7 +30,7 @@ export const RouterHead = component$(() => {
       ))}
 
       {head.scripts.map((s) => (
-        <script {...s.props} dangerouslySetInnerHTML={s.script} />
+        <script key={s.key} {...s.props} dangerouslySetInnerHTML={s.script} />
       ))}
     </>
   );


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

![Bildschirmfoto 2023-08-25 um 21 59 25](https://github.com/BuilderIO/qwik/assets/3241476/a6b5f8ee-9d31-4619-9c5b-9c3d08a0174d)
Fixes an issue on the `basic` starter where you see a warning right after starting the dev server.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
