### PR TITLE
fix(core): Report errors to browser global error handler

### DIFF
--- a/packages/qwik/src/core/error/assert.ts
+++ b/packages/qwik/src/core/error/assert.ts
@@ -1,6 +1,6 @@
 import type { QwikElement, VirtualElement } from '../render/dom/virtual-element';
 import { isElement, isQwikElement } from '../util/element';
-import { logErrorAndStop } from '../util/log';
+import { throwErrorAndStop } from '../util/log';
 import { qDev } from '../util/qdev';
 
 const ASSERT_DISCLAIMER = 'Internal assert, this is likely caused by a bug in Qwik: ';
@@ -14,7 +14,7 @@ export function assertDefined<T>(
     if (value != null) {
       return;
     }
-    throw logErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
+    throwErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
   }
 }
 
@@ -28,14 +28,14 @@ export function assertEqual(
     if (value1 === value2) {
       return;
     }
-    throw logErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
+    throwErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
   }
 }
 
 export function assertFail(text: string, ...parts: any[]): never;
 export function assertFail(text: string, ...parts: any[]) {
   if (qDev) {
-    throw logErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
+    throwErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
   }
 }
 
@@ -44,7 +44,7 @@ export function assertTrue(value1: any, text: string, ...parts: any[]): asserts 
     if (value1 === true) {
       return;
     }
-    throw logErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
+    throwErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
   }
 }
 
@@ -53,7 +53,7 @@ export function assertNumber(value1: any, text: string, ...parts: any[]): assert
     if (typeof value1 === 'number') {
       return;
     }
-    throw logErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
+    throwErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
   }
 }
 
@@ -62,7 +62,7 @@ export function assertString(value1: any, text: string, ...parts: any[]): assert
     if (typeof value1 === 'string') {
       return;
     }
-    throw logErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
+    throwErrorAndStop(ASSERT_DISCLAIMER + text, ...parts);
   }
 }
 
@@ -70,7 +70,7 @@ export function assertQwikElement(el: any): asserts el is QwikElement {
   if (qDev) {
     if (!isQwikElement(el)) {
       console.error('Not a Qwik Element, got', el);
-      throw logErrorAndStop(ASSERT_DISCLAIMER + 'Not a Qwik Element');
+      throwErrorAndStop(ASSERT_DISCLAIMER + 'Not a Qwik Element');
     }
   }
 }
@@ -79,7 +79,7 @@ export function assertElement(el: Node | VirtualElement): asserts el is Element 
   if (qDev) {
     if (!isElement(el)) {
       console.error('Not a Element, got', el);
-      throw logErrorAndStop(ASSERT_DISCLAIMER + 'Not an Element');
+      throwErrorAndStop(ASSERT_DISCLAIMER + 'Not an Element');
     }
   }
 }

--- a/packages/qwik/src/core/state/common.ts
+++ b/packages/qwik/src/core/state/common.ts
@@ -13,7 +13,7 @@ import {
 } from '../use/use-task';
 import type { QwikElement } from '../render/dom/virtual-element';
 import { notifyChange } from '../render/dom/notify-render';
-import { createError, logError } from '../util/log';
+import { logError, throwErrorAndStop } from '../util/log';
 import { tryGetContext } from './context';
 import { QObjectFlagsSymbol, QObjectManagerSymbol, QOjectTargetSymbol } from './constants';
 import type { Signal } from './signal';
@@ -101,7 +101,7 @@ const _verifySerializable = <T>(value: T, seen: Set<any>, ctx: string, preMessag
       )});\n\nPlease check out https://qwik.builder.io/docs/advanced/qrl/ for more information.`;
     }
     console.error('Trying to serialize', value);
-    throw createError(message);
+    throwErrorAndStop(message);
   }
   return value;
 };


### PR DESCRIPTION
This allows tools such as Qwik Insights, Sentry or New Relic to capture errors and report them to server.

Fix #2618
https://github.com/getsentry/sentry-javascript/discussions/8867#discussioncomment-6826930

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
