### PR TITLE
fix: action type

### DIFF
--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -320,7 +320,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type LoaderSignal<T> = T extends () => ValueOrPromise<infer B> ? ReadonlySignal<ValueOrPromise<B>> : ReadonlySignal<T>;\n```",
+      "content": "```typescript\nexport type LoaderSignal<TYPE> = TYPE extends () => ValueOrPromise<infer VALIDATOR> ? ReadonlySignal<ValueOrPromise<VALIDATOR>> : ReadonlySignal<TYPE>;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts",
       "mdFile": "qwik-city.loadersignal.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -31,34 +31,6 @@
       "mdFile": "qwik-city.actionconstructor.md"
     },
     {
-      "name": "ActionOptions",
-      "id": "actionoptions",
-      "hierarchy": [
-        {
-          "name": "ActionOptions",
-          "id": "actionoptions"
-        }
-      ],
-      "kind": "Interface",
-      "content": "```typescript\nexport interface ActionOptions \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [id?](#) | <code>readonly</code> | string | _(Optional)_ |\n|  [validation?](#) | <code>readonly</code> | DataValidator\\[\\] | _(Optional)_ |",
-      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts",
-      "mdFile": "qwik-city.actionoptions.md"
-    },
-    {
-      "name": "ActionOptionsWithValidation",
-      "id": "actionoptionswithvalidation",
-      "hierarchy": [
-        {
-          "name": "ActionOptionsWithValidation",
-          "id": "actionoptionswithvalidation"
-        }
-      ],
-      "kind": "Interface",
-      "content": "```typescript\nexport interface ActionOptionsWithValidation<B extends TypedDataValidator = TypedDataValidator> \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [id?](#) | <code>readonly</code> | string | _(Optional)_ |\n|  [validation](#) | <code>readonly</code> | \\[val: B, ...a: DataValidator\\[\\]\\] |  |",
-      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts",
-      "mdFile": "qwik-city.actionoptionswithvalidation.md"
-    },
-    {
       "name": "ActionStore",
       "id": "actionstore",
       "hierarchy": [

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -324,9 +324,11 @@ export interface Loader<RETURN>
 ## LoaderSignal
 
 ```typescript
-export type LoaderSignal<T> = T extends () => ValueOrPromise<infer B>
-  ? ReadonlySignal<ValueOrPromise<B>>
-  : ReadonlySignal<T>;
+export type LoaderSignal<TYPE> = TYPE extends () => ValueOrPromise<
+  infer VALIDATOR
+>
+  ? ReadonlySignal<ValueOrPromise<VALIDATOR>>
+  : ReadonlySignal<TYPE>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts)

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -20,32 +20,6 @@ export interface ActionConstructor
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts)
 
-## ActionOptions
-
-```typescript
-export interface ActionOptions
-```
-
-| Property         | Modifiers             | Type            | Description  |
-| ---------------- | --------------------- | --------------- | ------------ |
-| [id?](#)         | <code>readonly</code> | string          | _(Optional)_ |
-| [validation?](#) | <code>readonly</code> | DataValidator[] | _(Optional)_ |
-
-[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts)
-
-## ActionOptionsWithValidation
-
-```typescript
-export interface ActionOptionsWithValidation<B extends TypedDataValidator = TypedDataValidator>
-```
-
-| Property        | Modifiers             | Type                            | Description  |
-| --------------- | --------------------- | ------------------------------- | ------------ |
-| [id?](#)        | <code>readonly</code> | string                          | _(Optional)_ |
-| [validation](#) | <code>readonly</code> | [val: B, ...a: DataValidator[]] |              |
-
-[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts)
-
 ## ActionStore
 
 ```typescript

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -34,36 +34,36 @@ export interface Action<RETURN, INPUT = Record<string, any>, OPTIONAL extends bo
 // @public (undocumented)
 export interface ActionConstructor {
     // Warning: (ae-forgotten-export) The symbol "TypedDataValidator" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "DataValidator" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "GetValidatorType" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "StrictUnion" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    <O extends Record<string, any> | void | null, B extends TypedDataValidator>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: B | ActionOptionsWithValidation<B>): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>, GetValidatorType<B>, false>;
-    // Warning: (ae-forgotten-export) The symbol "DataValidator" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "FailOfRest" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    <O extends Record<string, any> | void | null, B extends TypedDataValidator, REST extends DataValidator[]>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: B, ...rest: REST): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>, GetValidatorType<B>, false>;
+    <O extends Record<string, any> | void | null, B extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: {
+        readonly id?: string;
+        readonly validation: [B, ...REST];
+    }): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>, GetValidatorType<B>, false>;
     // (undocumented)
-    <O>(actionQrl: (form: JSONObject, event: RequestEventAction, options: ActionOptions) => ValueOrPromise<O>, options?: ActionOptions): Action<StrictUnion<O>>;
+    <O extends Record<string, any> | void | null, B extends TypedDataValidator>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: {
+        readonly id?: string;
+        readonly validation: [B];
+    }): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>, GetValidatorType<B>, false>;
     // (undocumented)
-    <O extends Record<string, any> | void | null, REST extends DataValidator[]>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>, ...rest: REST): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
-}
-
-// @public (undocumented)
-export interface ActionOptions {
+    <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<O>, options: {
+        readonly id?: string;
+        readonly validation: REST;
+    }): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
     // (undocumented)
-    readonly id?: string;
+    <O extends Record<string, any> | void | null, B extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: B, ...rest: REST): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>, GetValidatorType<B>, false>;
     // (undocumented)
-    readonly validation?: DataValidator[];
-}
-
-// @public (undocumented)
-export interface ActionOptionsWithValidation<B extends TypedDataValidator = TypedDataValidator> {
+    <O extends Record<string, any> | void | null, B extends TypedDataValidator>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: B): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>, GetValidatorType<B>, false>;
     // (undocumented)
-    readonly id?: string;
+    <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>, ...rest: REST): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
     // (undocumented)
-    readonly validation: [val: B, ...a: DataValidator[]];
+    <O>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>, options?: {
+        readonly id?: string;
+    }): Action<StrictUnion<O>>;
 }
 
 // @public (undocumented)

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -40,30 +40,30 @@ export interface ActionConstructor {
     // Warning: (ae-forgotten-export) The symbol "FailOfRest" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    <O extends Record<string, any> | void | null, B extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: {
+    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {
         readonly id?: string;
-        readonly validation: [B, ...REST];
-    }): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>, GetValidatorType<B>, false>;
+        readonly validation: [VALIDATOR, ...REST];
+    }): Action<StrictUnion<OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>> | FailOfRest<REST>>, GetValidatorType<VALIDATOR>, false>;
     // (undocumented)
-    <O extends Record<string, any> | void | null, B extends TypedDataValidator>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: {
+    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {
         readonly id?: string;
-        readonly validation: [B];
-    }): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>, GetValidatorType<B>, false>;
+        readonly validation: [VALIDATOR];
+    }): Action<StrictUnion<OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>>>, GetValidatorType<VALIDATOR>, false>;
     // (undocumented)
-    <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<O>, options: {
+    <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {
         readonly id?: string;
         readonly validation: REST;
-    }): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+    }): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
     // (undocumented)
-    <O extends Record<string, any> | void | null, B extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: B, ...rest: REST): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>, GetValidatorType<B>, false>;
+    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR, ...rest: REST): Action<StrictUnion<OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>> | FailOfRest<REST>>, GetValidatorType<VALIDATOR>, false>;
     // (undocumented)
-    <O extends Record<string, any> | void | null, B extends TypedDataValidator>(actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>, options: B): Action<StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>, GetValidatorType<B>, false>;
+    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR): Action<StrictUnion<OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>>>, GetValidatorType<VALIDATOR>, false>;
     // (undocumented)
-    <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>, ...rest: REST): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+    <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, ...rest: REST): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
     // (undocumented)
-    <O>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>, options?: {
+    <OBJ>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, options?: {
         readonly id?: string;
-    }): Action<StrictUnion<O>>;
+    }): Action<StrictUnion<OBJ>>;
 }
 
 // @public (undocumented)
@@ -273,7 +273,7 @@ export interface Loader<RETURN> {
 }
 
 // @public (undocumented)
-export type LoaderSignal<T> = T extends () => ValueOrPromise<infer B> ? ReadonlySignal<ValueOrPromise<B>> : ReadonlySignal<T>;
+export type LoaderSignal<TYPE> = TYPE extends () => ValueOrPromise<infer VALIDATOR> ? ReadonlySignal<ValueOrPromise<VALIDATOR>> : ReadonlySignal<TYPE>;
 
 // Warning: (ae-forgotten-export) The symbol "MenuModuleLoader" needs to be exported by the entry point index.d.ts
 //

--- a/packages/qwik-city/runtime/src/index.ts
+++ b/packages/qwik-city/runtime/src/index.ts
@@ -31,8 +31,6 @@ export type {
   ActionStore,
   LoaderSignal,
   ActionConstructor,
-  ActionOptions,
-  ActionOptionsWithValidation,
   FailReturn,
   ZodConstructor,
   StaticGenerate,

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -396,11 +396,8 @@ export type JSONValue = string | number | boolean | { [x: string]: JSONValue } |
  */
 export type JSONObject = { [x: string]: JSONValue };
 
-export type GetValidatorType<B extends TypedDataValidator> = B extends TypedDataValidator<
-  infer TYPE
->
-  ? zod.infer<TYPE>
-  : never;
+export type GetValidatorType<VALIDATOR extends TypedDataValidator> =
+  VALIDATOR extends TypedDataValidator<infer TYPE> ? zod.infer<TYPE> : never;
 
 /**
  * @public
@@ -422,81 +419,97 @@ export type FailOfRest<REST extends readonly DataValidator[]> = REST extends rea
 export interface ActionConstructor {
   // Use options object, use typed data validator, use data validator
   <
-    O extends Record<string, any> | void | null,
-    B extends TypedDataValidator,
+    OBJ extends Record<string, any> | void | null,
+    VALIDATOR extends TypedDataValidator,
     REST extends [DataValidator, ...DataValidator[]],
   >(
-    actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
+    actionQrl: (
+      data: GetValidatorType<VALIDATOR>,
+      event: RequestEventAction
+    ) => ValueOrPromise<OBJ>,
     options: {
       readonly id?: string;
-      readonly validation: [B, ...REST];
+      readonly validation: [VALIDATOR, ...REST];
     }
   ): Action<
-    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>,
-    GetValidatorType<B>,
+    StrictUnion<
+      OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>> | FailOfRest<REST>
+    >,
+    GetValidatorType<VALIDATOR>,
     false
   >;
 
   // Use options object, use typed data validator
-  <O extends Record<string, any> | void | null, B extends TypedDataValidator>(
-    actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
+  <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(
+    actionQrl: (
+      data: GetValidatorType<VALIDATOR>,
+      event: RequestEventAction
+    ) => ValueOrPromise<OBJ>,
     options: {
       readonly id?: string;
-      readonly validation: [B];
+      readonly validation: [VALIDATOR];
     }
   ): Action<
-    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
-    GetValidatorType<B>,
+    StrictUnion<OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>>>,
+    GetValidatorType<VALIDATOR>,
     false
   >;
 
   // Use options object, use data validator
-  <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
-    actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<O>,
+  <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
+    actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>,
     options: {
       readonly id?: string;
       readonly validation: REST;
     }
-  ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
 
   // Use typed data validator, use data validator
   <
-    O extends Record<string, any> | void | null,
-    B extends TypedDataValidator,
+    OBJ extends Record<string, any> | void | null,
+    VALIDATOR extends TypedDataValidator,
     REST extends [DataValidator, ...DataValidator[]],
   >(
-    actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
-    options: B,
+    actionQrl: (
+      data: GetValidatorType<VALIDATOR>,
+      event: RequestEventAction
+    ) => ValueOrPromise<OBJ>,
+    options: VALIDATOR,
     ...rest: REST
   ): Action<
-    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>,
-    GetValidatorType<B>,
+    StrictUnion<
+      OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>> | FailOfRest<REST>
+    >,
+    GetValidatorType<VALIDATOR>,
     false
   >;
 
   // Use typed data validator
-  <O extends Record<string, any> | void | null, B extends TypedDataValidator>(
-    actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
-    options: B
+  <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(
+    actionQrl: (
+      data: GetValidatorType<VALIDATOR>,
+      event: RequestEventAction
+    ) => ValueOrPromise<OBJ>,
+    options: VALIDATOR
   ): Action<
-    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
-    GetValidatorType<B>,
+    StrictUnion<OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>>>,
+    GetValidatorType<VALIDATOR>,
     false
   >;
 
   // Use data validator
-  <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
-    actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>,
+  <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
+    actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>,
     ...rest: REST
-  ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
 
   // No validators
-  <O>(
-    actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>,
+  <OBJ>(
+    actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>,
     options?: {
       readonly id?: string;
     }
-  ): Action<StrictUnion<O>>;
+  ): Action<StrictUnion<OBJ>>;
 }
 
 /**
@@ -505,81 +518,93 @@ export interface ActionConstructor {
 export interface ActionConstructorQRL {
   // Use options object, use typed data validator, use data validator
   <
-    O extends Record<string, any> | void | null,
-    B extends TypedDataValidator,
+    OBJ extends Record<string, any> | void | null,
+    VALIDATOR extends TypedDataValidator,
     REST extends [DataValidator, ...DataValidator[]],
   >(
-    actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
+    actionQrl: QRL<
+      (data: GetValidatorType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>
+    >,
     options: {
       readonly id?: string;
-      readonly validation: [B, ...REST];
+      readonly validation: [VALIDATOR, ...REST];
     }
   ): Action<
-    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>,
-    GetValidatorType<B>,
+    StrictUnion<
+      OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>> | FailOfRest<REST>
+    >,
+    GetValidatorType<VALIDATOR>,
     false
   >;
 
   // Use options object, use typed data validator
-  <O extends Record<string, any> | void | null, B extends TypedDataValidator>(
-    actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
+  <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(
+    actionQrl: QRL<
+      (data: GetValidatorType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>
+    >,
     options: {
       readonly id?: string;
-      readonly validation: [B];
+      readonly validation: [VALIDATOR];
     }
   ): Action<
-    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
-    GetValidatorType<B>,
+    StrictUnion<OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>>>,
+    GetValidatorType<VALIDATOR>,
     false
   >;
 
   // Use options object, use data validator
-  <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
-    actionQrl: QRL<(data: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>,
+  <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
+    actionQrl: QRL<(data: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>>,
     options: {
       readonly id?: string;
       readonly validation: REST;
     }
-  ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
 
   // Use typed data validator, use data validator
   <
-    O extends Record<string, any> | void | null,
-    B extends TypedDataValidator,
+    OBJ extends Record<string, any> | void | null,
+    VALIDATOR extends TypedDataValidator,
     REST extends [DataValidator, ...DataValidator[]],
   >(
-    actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
-    options: B,
+    actionQrl: QRL<
+      (data: GetValidatorType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>
+    >,
+    options: VALIDATOR,
     ...rest: REST
   ): Action<
-    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>,
-    GetValidatorType<B>,
+    StrictUnion<
+      OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>> | FailOfRest<REST>
+    >,
+    GetValidatorType<VALIDATOR>,
     false
   >;
 
   // Use typed data validator
-  <O extends Record<string, any> | void | null, B extends TypedDataValidator>(
-    actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
-    options: B
+  <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(
+    actionQrl: QRL<
+      (data: GetValidatorType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>
+    >,
+    options: VALIDATOR
   ): Action<
-    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
-    GetValidatorType<B>,
+    StrictUnion<OBJ | FailReturn<zod.typeToFlattenedError<GetValidatorType<VALIDATOR>>>>,
+    GetValidatorType<VALIDATOR>,
     false
   >;
 
   // Use data validator
-  <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
-    actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>,
+  <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
+    actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>>,
     ...rest: REST
-  ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
 
   // No validators
-  <O>(
-    actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>,
+  <OBJ>(
+    actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>>,
     options?: {
       readonly id?: string;
     }
-  ): Action<StrictUnion<O>>;
+  ): Action<StrictUnion<OBJ>>;
 }
 
 /**
@@ -594,16 +619,16 @@ export interface LoaderOptions {
  */
 export interface LoaderConstructor {
   // Without validation
-  <O>(
-    loaderFn: (event: RequestEventLoader) => ValueOrPromise<O>,
+  <OBJ>(
+    loaderFn: (event: RequestEventLoader) => ValueOrPromise<OBJ>,
     options?: LoaderOptions
-  ): Loader<O>;
+  ): Loader<OBJ>;
 
   // With validation
-  <O extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
-    loaderFn: (event: RequestEventLoader) => ValueOrPromise<O>,
+  <OBJ extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
+    loaderFn: (event: RequestEventLoader) => ValueOrPromise<OBJ>,
     ...rest: REST
-  ): Loader<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+  ): Loader<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
 }
 
 /**
@@ -611,16 +636,16 @@ export interface LoaderConstructor {
  */
 export interface LoaderConstructorQRL {
   // Without validation
-  <O>(
-    loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<O>>,
+  <OBJ>(
+    loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<OBJ>>,
     options?: LoaderOptions
-  ): Loader<O>;
+  ): Loader<OBJ>;
 
   // With validation
-  <O extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
-    loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<O>>,
+  <OBJ extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
+    loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<OBJ>>,
     ...rest: REST
-  ): Loader<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+  ): Loader<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
 }
 
 export type LoaderStateHolder = Record<string, Signal<any>>;
@@ -714,9 +739,9 @@ export type FailReturn<T> = T & {
 /**
  * @public
  */
-export type LoaderSignal<T> = T extends () => ValueOrPromise<infer B>
-  ? ReadonlySignal<ValueOrPromise<B>>
-  : ReadonlySignal<T>;
+export type LoaderSignal<TYPE> = TYPE extends () => ValueOrPromise<infer VALIDATOR>
+  ? ReadonlySignal<ValueOrPromise<VALIDATOR>>
+  : ReadonlySignal<TYPE>;
 
 /**
  * @public

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -429,7 +429,7 @@ export interface ActionConstructor {
     actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
     options: {
       readonly id?: string;
-      validation: [B, ...REST];
+      readonly validation: [B, ...REST];
     }
   ): Action<
     StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>,
@@ -442,7 +442,7 @@ export interface ActionConstructor {
     actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
     options: {
       readonly id?: string;
-      validation: [B];
+      readonly validation: [B];
     }
   ): Action<
     StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
@@ -455,7 +455,7 @@ export interface ActionConstructor {
     actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<O>,
     options: {
       readonly id?: string;
-      validation: REST;
+      readonly validation: REST;
     }
   ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
 
@@ -491,8 +491,11 @@ export interface ActionConstructor {
   ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
 
   // No validators
-  <O extends Record<string, any> | void | null>(
-    actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>
+  <O>(
+    actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>,
+    options?: {
+      readonly id?: string;
+    }
   ): Action<StrictUnion<O>>;
 }
 
@@ -509,7 +512,7 @@ export interface ActionConstructorQRL {
     actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
     options: {
       readonly id?: string;
-      validation: [B, ...REST];
+      readonly validation: [B, ...REST];
     }
   ): Action<
     StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>,
@@ -522,7 +525,7 @@ export interface ActionConstructorQRL {
     actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
     options: {
       readonly id?: string;
-      validation: [B];
+      readonly validation: [B];
     }
   ): Action<
     StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
@@ -535,7 +538,7 @@ export interface ActionConstructorQRL {
     actionQrl: QRL<(data: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>,
     options: {
       readonly id?: string;
-      validation: REST;
+      readonly validation: REST;
     }
   ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
 
@@ -571,8 +574,11 @@ export interface ActionConstructorQRL {
   ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
 
   // No validators
-  <O extends Record<string, any> | void | null>(
-    actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>
+  <O>(
+    actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>,
+    options?: {
+      readonly id?: string;
+    }
   ): Action<StrictUnion<O>>;
 }
 

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -405,22 +405,6 @@ export type GetValidatorType<B extends TypedDataValidator> = B extends TypedData
 /**
  * @public
  */
-export interface ActionOptions {
-  readonly id?: string;
-  readonly validation?: DataValidator[];
-}
-
-/**
- * @public
- */
-export interface ActionOptionsWithValidation<B extends TypedDataValidator = TypedDataValidator> {
-  readonly id?: string;
-  readonly validation: [val: B, ...a: DataValidator[]];
-}
-
-/**
- * @public
- */
 export interface CommonLoaderActionOptions {
   readonly id?: string;
   readonly validation?: DataValidator[];
@@ -436,21 +420,50 @@ export type FailOfRest<REST extends readonly DataValidator[]> = REST extends rea
  * @public
  */
 export interface ActionConstructor {
-  // With validation
+  // Use options object, use typed data validator, use data validator
+  <
+    O extends Record<string, any> | void | null,
+    B extends TypedDataValidator,
+    REST extends [DataValidator, ...DataValidator[]],
+  >(
+    actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
+    options: {
+      readonly id?: string;
+      validation: [B, ...REST];
+    }
+  ): Action<
+    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>,
+    GetValidatorType<B>,
+    false
+  >;
+
+  // Use options object, use typed data validator
   <O extends Record<string, any> | void | null, B extends TypedDataValidator>(
     actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
-    options: B | ActionOptionsWithValidation<B>
+    options: {
+      readonly id?: string;
+      validation: [B];
+    }
   ): Action<
     StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
     GetValidatorType<B>,
     false
   >;
 
-  // With multiple validators
+  // Use options object, use data validator
+  <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
+    actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<O>,
+    options: {
+      readonly id?: string;
+      validation: REST;
+    }
+  ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+
+  // Use typed data validator, use data validator
   <
     O extends Record<string, any> | void | null,
     B extends TypedDataValidator,
-    REST extends DataValidator[],
+    REST extends [DataValidator, ...DataValidator[]],
   >(
     actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
     options: B,
@@ -461,42 +474,76 @@ export interface ActionConstructor {
     false
   >;
 
-  // Without validation
-  <O>(
-    actionQrl: (
-      form: JSONObject,
-      event: RequestEventAction,
-      options: ActionOptions
-    ) => ValueOrPromise<O>,
-    options?: ActionOptions
-  ): Action<StrictUnion<O>>;
+  // Use typed data validator
+  <O extends Record<string, any> | void | null, B extends TypedDataValidator>(
+    actionQrl: (data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>,
+    options: B
+  ): Action<
+    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
+    GetValidatorType<B>,
+    false
+  >;
 
-  // Without validation
-  <O extends Record<string, any> | void | null, REST extends DataValidator[]>(
+  // Use data validator
+  <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
     actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>,
     ...rest: REST
   ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+
+  // No validators
+  <O extends Record<string, any> | void | null>(
+    actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>
+  ): Action<StrictUnion<O>>;
 }
 
 /**
  * @public
  */
 export interface ActionConstructorQRL {
-  // With validation
+  // Use options object, use typed data validator, use data validator
+  <
+    O extends Record<string, any> | void | null,
+    B extends TypedDataValidator,
+    REST extends [DataValidator, ...DataValidator[]],
+  >(
+    actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
+    options: {
+      readonly id?: string;
+      validation: [B, ...REST];
+    }
+  ): Action<
+    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>> | FailOfRest<REST>>,
+    GetValidatorType<B>,
+    false
+  >;
+
+  // Use options object, use typed data validator
   <O extends Record<string, any> | void | null, B extends TypedDataValidator>(
     actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
-    options: B | ActionOptionsWithValidation<B>
+    options: {
+      readonly id?: string;
+      validation: [B];
+    }
   ): Action<
     StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
     GetValidatorType<B>,
     false
   >;
 
-  // With multiple validators
+  // Use options object, use data validator
+  <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
+    actionQrl: QRL<(data: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>,
+    options: {
+      readonly id?: string;
+      validation: REST;
+    }
+  ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+
+  // Use typed data validator, use data validator
   <
     O extends Record<string, any> | void | null,
     B extends TypedDataValidator,
-    REST extends DataValidator[],
+    REST extends [DataValidator, ...DataValidator[]],
   >(
     actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
     options: B,
@@ -507,19 +554,26 @@ export interface ActionConstructorQRL {
     false
   >;
 
-  // Without validation
-  <O>(
-    actionQrl: QRL<
-      (form: JSONObject, event: RequestEventAction, options: ActionOptions) => ValueOrPromise<O>
-    >,
-    options?: ActionOptions
-  ): Action<O>;
+  // Use typed data validator
+  <O extends Record<string, any> | void | null, B extends TypedDataValidator>(
+    actionQrl: QRL<(data: GetValidatorType<B>, event: RequestEventAction) => ValueOrPromise<O>>,
+    options: B
+  ): Action<
+    StrictUnion<O | FailReturn<zod.typeToFlattenedError<GetValidatorType<B>>>>,
+    GetValidatorType<B>,
+    false
+  >;
 
-  // Without validation
-  <O extends Record<string, any> | void | null, REST extends DataValidator[]>(
+  // Use data validator
+  <O extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
     actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>,
     ...rest: REST
   ): Action<StrictUnion<O | FailReturn<FailOfRest<REST>>>>;
+
+  // No validators
+  <O extends Record<string, any> | void | null>(
+    actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<O>>
+  ): Action<StrictUnion<O>>;
 }
 
 /**

--- a/starters/apps/qwikcity-test/src/routes/(common)/actions/validated/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/actions/validated/index.tsx
@@ -6,9 +6,16 @@ import {
   z,
   zod$,
 } from "@builder.io/qwik-city";
-import type { JSONObject } from "packages/qwik-city/runtime/src/types";
+import type {
+  JSONObject,
+  RequestEventAction,
+} from "packages/qwik-city/runtime/src/types";
 
-const queryContainsSecret = validator$((ev) => {
+const typedDataValidator = zod$({
+  category: z.enum(["bird", "dog", "rat"]),
+});
+
+const dataValidator = validator$((ev) => {
   if (ev.query.get("secret") === "123") {
     return {
       success: true,
@@ -22,55 +29,51 @@ const queryContainsSecret = validator$((ev) => {
   };
 });
 
+const actionQrl = (data: JSONObject, { fail }: RequestEventAction) => {
+  if (Math.random() > 0.5) {
+    return fail(500, {
+      actionFail: "secret",
+    });
+  }
+
+  return {
+    actionSuccess: "シマエナガ",
+  };
+};
+
 export const useLoader = routeLoader$(() => {
   return {
     stuff: "hello",
   };
-}, queryContainsSecret);
+}, dataValidator);
 
-export const useAction1 = routeAction$((value) => {
-  return value satisfies JSONObject;
-}, queryContainsSecret);
-
-export const useAction2 = routeAction$(
-  (input) => {
-    return input satisfies {
-      name: string;
-    };
-  },
-  zod$({
-    name: z.string(),
-  }),
-  queryContainsSecret,
-);
-
-export const useAction3 = routeAction$((input, { fail }) => {
-  if (Math.random() > 1.0) {
-    return fail(500, {
-      error: "Random error",
-    });
-  }
-  return {
-    success: input.name as string,
-  };
+export const useAction1 = routeAction$(actionQrl, {
+  validation: [typedDataValidator, dataValidator],
 });
-
-// export const useAction3 = routeAction$((input) => {
-
-//   return input satisfies {
-//     name: string;
-//   };
-// }, {
-//   id: 'action-2',
-//   validators: [
-//     zod$({name: z.string()}),
-//     queryContainsSecret
-//   ]
-// });
+export const useAction2 = routeAction$(actionQrl, {
+  validation: [typedDataValidator],
+});
+export const useAction3 = routeAction$(actionQrl, {
+  validation: [dataValidator],
+});
+export const useAction4 = routeAction$(
+  actionQrl,
+  typedDataValidator,
+  dataValidator,
+);
+export const useAction5 = routeAction$(actionQrl, typedDataValidator);
+export const useAction6 = routeAction$(actionQrl, dataValidator);
+export const useAction7 = routeAction$(actionQrl);
 
 export default component$(() => {
   const loader = useLoader();
-  const action = useAction3();
+  const action1 = useAction1();
+  const action2 = useAction2();
+  const action3 = useAction3();
+  const action4 = useAction4();
+  const action5 = useAction5();
+  const action6 = useAction6();
+  const action7 = useAction7();
 
   return (
     <div>
@@ -87,8 +90,53 @@ export default component$(() => {
         </div>
       )}
       <div>
-        {action.value?.success}
-        {action.value?.error}
+        <h2>
+          Use options object, use typed data validator, use data validator
+        </h2>
+        {action1.value?.actionSuccess}
+        {action1.value?.actionFail}
+        {action1.value?.message}
+        {action1.value?.fieldErrors?.category}
+        {action1.value?.formErrors}
+      </div>
+      <div>
+        <h2>Use options object, use typed data validator</h2>
+        {action2.value?.actionSuccess}
+        {action2.value?.actionFail}
+        {action2.value?.fieldErrors?.category}
+        {action2.value?.formErrors}
+      </div>
+      <div>
+        <h2>Use options object, use data validator</h2>
+        {action3.value?.actionSuccess}
+        {action3.value?.actionFail}
+        {action3.value?.message}
+      </div>
+      <div>
+        <h2>Use typed data validator, use data validator</h2>
+        {action4.value?.actionSuccess}
+        {action4.value?.actionFail}
+        {action4.value?.message}
+        {action4.value?.fieldErrors?.category}
+        {action4.value?.formErrors}
+      </div>
+      <div>
+        <h2>Use typed data validator</h2>
+        {action5.value?.actionSuccess}
+        {action5.value?.actionFail}
+        {action5.value?.fieldErrors?.category}
+        {action5.value?.formErrors}
+      </div>
+      <div>
+        <h2>Use data validator</h2>
+        {action6.value?.actionSuccess}
+        {action6.value?.actionFail}
+        {action6.value?.message}
+      </div>
+      <div>
+        <h2>No validators</h2>
+        {action7.value?.actionSuccess}
+        {action7.value?.actionFail}
       </div>
     </div>
   );

--- a/starters/apps/qwikcity-test/src/routes/(common)/actions/validated/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/actions/validated/index.tsx
@@ -64,6 +64,10 @@ export const useAction4 = routeAction$(
 export const useAction5 = routeAction$(actionQrl, typedDataValidator);
 export const useAction6 = routeAction$(actionQrl, dataValidator);
 export const useAction7 = routeAction$(actionQrl);
+export const useAction8 = routeAction$(() => true);
+export const useAction9 = routeAction$(() => true, {
+  id: "route-action",
+});
 
 export default component$(() => {
   const loader = useLoader();


### PR DESCRIPTION
# Overview

Fix action type. 

Related issue: https://github.com/BuilderIO/qwik/issues/3979

I will try to fix the loader type in later PR.

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

![Untitled-2021-11-01-0150](https://github.com/BuilderIO/qwik/assets/16910748/82bebe6c-5ba2-496d-ad22-566792ad239d)

There are  7 overrides for router action:

- Use options object, use typed data validator, use data validator
- Use options object, use typed data validator
- Use options object, use data validator
- Use typed data validator, use data validator
- Use typed data validator
- Use data validator
- No validators

I rewrited the types return the correct types. And to keep it simple, I separated the cases for "with options object" and "without options object".

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
