### PR TITLE
chore: supabase-auth-helpers-qwik: update devDependencies

### DIFF
--- a/packages/supabase-auth-helpers-qwik/package.json
+++ b/packages/supabase-auth-helpers-qwik/package.json
@@ -8,9 +8,9 @@
     "@supabase/auth-helpers-shared": "^0.3.4"
   },
   "devDependencies": {
-    "@builder.io/qwik": "1.2.6",
-    "@builder.io/qwik-city": "1.2.6",
-    "@supabase/supabase-js": "^2.24.0"
+    "@builder.io/qwik": "1.2.10",
+    "@builder.io/qwik-city": "1.2.10",
+    "@supabase/supabase-js": "^2.33.1"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,13 +221,13 @@ importers:
         version: 0.8.0
       '@builder.io/qwik':
         specifier: github:BuilderIo/qwik-build#main
-        version: github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634(undici@5.22.1)
+        version: github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd(undici@5.22.1)
       '@builder.io/qwik-city':
         specifier: github:BuilderIo/qwik-city-build#main
-        version: github.com/BuilderIo/qwik-city-build/769c144a4c895f103c73b79c9004513215dceb20(rollup@3.26.3)
+        version: github.com/BuilderIo/qwik-city-build/2783c1e5201e3c64538dfa9737b5c11742673994(rollup@3.26.3)
       '@builder.io/qwik-labs':
         specifier: github:BuilderIo/qwik-labs-build#main
-        version: github.com/BuilderIo/qwik-labs-build/f8082d6cd2e0fd49adc72e2893eb25a2b5ae8589
+        version: github.com/BuilderIo/qwik-labs-build/762e4845ecd74b4677e629f93501585d3e631970
       '@builder.io/qwik-react':
         specifier: 0.5.0
         version: 0.5.0(@builder.io/qwik@1.2.9)(@types/react-dom@18.2.7)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)
@@ -245,7 +245,7 @@ importers:
         version: 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.17)(react@18.2.0)
       '@modular-forms/qwik':
         specifier: ^0.12.0
-        version: 0.12.0(@builder.io/qwik-city@1.2.9-dev20230825221223)(@builder.io/qwik@1.2.9)
+        version: 0.12.0(@builder.io/qwik-city@1.2.9-dev20230826195459)(@builder.io/qwik@1.2.9)
       '@mui/material':
         specifier: ^5.13.0
         version: 5.13.0(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)
@@ -369,13 +369,13 @@ importers:
         version: 0.7.1
       '@builder.io/qwik-auth':
         specifier: 0.1.0
-        version: 0.1.0(@auth/core@0.7.1)(@builder.io/qwik-city@1.2.9-dev20230825221223)(@builder.io/qwik@1.2.9)
+        version: 0.1.0(@auth/core@0.7.1)(@builder.io/qwik-city@1.2.9-dev20230826195459)(@builder.io/qwik@1.2.9)
       '@libsql/client':
         specifier: ^0.3.1
         version: 0.3.1
       '@modular-forms/qwik':
         specifier: ^0.12.0
-        version: 0.12.0(@builder.io/qwik-city@1.2.9-dev20230825221223)(@builder.io/qwik@1.2.9)
+        version: 0.12.0(@builder.io/qwik-city@1.2.9-dev20230826195459)(@builder.io/qwik@1.2.9)
       '@typescript/analyze-trace':
         specifier: ^0.10.0
         version: 0.10.0
@@ -397,10 +397,10 @@ importers:
     devDependencies:
       '@builder.io/qwik':
         specifier: github:BuilderIo/qwik-build#main
-        version: github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634(undici@5.22.1)
+        version: github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd(undici@5.22.1)
       '@builder.io/qwik-city':
         specifier: github:BuilderIo/qwik-city-build#main
-        version: github.com/BuilderIo/qwik-city-build/769c144a4c895f103c73b79c9004513215dceb20(rollup@3.26.3)
+        version: github.com/BuilderIo/qwik-city-build/2783c1e5201e3c64538dfa9737b5c11742673994(rollup@3.26.3)
       '@builder.io/qwik-labs':
         specifier: workspace:*
         version: link:../qwik-labs
@@ -680,17 +680,17 @@ importers:
     dependencies:
       '@supabase/auth-helpers-shared':
         specifier: ^0.3.4
-        version: 0.3.4(@supabase/supabase-js@2.24.0)
+        version: 0.3.4(@supabase/supabase-js@2.33.1)
     devDependencies:
       '@builder.io/qwik':
-        specifier: 1.2.6
-        version: 1.2.6(undici@5.22.1)
+        specifier: 1.2.10
+        version: 1.2.10(undici@5.22.1)
       '@builder.io/qwik-city':
-        specifier: 1.2.6
-        version: 1.2.6(rollup@3.26.3)
+        specifier: 1.2.10
+        version: 1.2.10(rollup@3.26.3)
       '@supabase/supabase-js':
-        specifier: ^2.24.0
-        version: 2.24.0
+        specifier: ^2.33.1
+        version: 2.33.1
 
 packages:
 
@@ -1297,7 +1297,7 @@ packages:
     hasBin: true
     dev: true
 
-  /@builder.io/qwik-auth@0.1.0(@auth/core@0.7.1)(@builder.io/qwik-city@1.2.9-dev20230825221223)(@builder.io/qwik@1.2.9):
+  /@builder.io/qwik-auth@0.1.0(@auth/core@0.7.1)(@builder.io/qwik-city@1.2.9-dev20230826195459)(@builder.io/qwik@1.2.9):
     resolution: {integrity: sha512-uwwVbam6yQs9evtmof/+SpRT7DzoxD+2DSwsndGcm9JBU4Sh1xMyzll6F9QbivKVboglx+4X05OzJG7QTttWMQ==}
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
     peerDependencies:
@@ -1306,12 +1306,12 @@ packages:
       '@builder.io/qwik-city': '>=0.6.0'
     dependencies:
       '@auth/core': 0.7.1
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634(undici@5.22.1)
-      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/769c144a4c895f103c73b79c9004513215dceb20(rollup@3.26.3)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd(undici@5.22.1)
+      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/2783c1e5201e3c64538dfa9737b5c11742673994(rollup@3.26.3)
     dev: false
 
-  /@builder.io/qwik-city@1.2.6(rollup@3.26.3):
-    resolution: {integrity: sha512-/uo58NysxpdsiEwuuKo8HDM9UYYAofrniupor2v5vci3Dr6PTXcvKAFJ1Z+SdJGv2uxr5hvKsbVohnVYa9jxYg==}
+  /@builder.io/qwik-city@1.2.10(rollup@3.26.3):
+    resolution: {integrity: sha512-IKo6NjT7dYtDYY1Y0hP56/jlbjcnK89NA0sHEBmNZJZJy+YnzvWLPWf9Ft9q30hIwK3azyW+XtJZpwIJIPEAFw==}
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
     dependencies:
       '@mdx-js/mdx': 2.3.0
@@ -1336,11 +1336,22 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
     dependencies:
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634(undici@5.22.1)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd(undici@5.22.1)
       '@types/react': 18.2.17
       '@types/react-dom': 18.2.7
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
+  /@builder.io/qwik@1.2.10(undici@5.22.1):
+    resolution: {integrity: sha512-UJDqEx3p32cmafT9zPk9G623wy0HeMp+T6IE12HKOZtC28T4VC4lwbzkxowPIPd+GuwTSXfWSQzwwgbnOBiPgg==}
+    engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
+    hasBin: true
+    peerDependencies:
+      undici: ^5.14.0
+    dependencies:
+      csstype: 3.1.2
+      undici: 5.22.1
     dev: true
 
   /@builder.io/qwik@1.2.6(undici@5.22.1):
@@ -1359,7 +1370,7 @@ packages:
     peerDependencies:
       '@builder.io/qwik': '>=1.0.0'
     dependencies:
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634(undici@5.22.1)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd(undici@5.22.1)
     dev: true
 
   /@builder.io/vite-plugin-macro@0.0.7(@types/node@20.4.5)(rollup@3.26.3)(terser@5.19.2):
@@ -1457,6 +1468,7 @@ packages:
   /@commitlint/config-validator@17.6.7:
     resolution: {integrity: sha512-vJSncmnzwMvpr3lIcm0I8YVVDJTzyjy7NZAeXbTXy+MPUdAr9pKyyg7Tx/ebOQ9kqzE6O9WT6jg2164br5UdsQ==}
     engines: {node: '>=v14'}
+    requiresBuild: true
     dependencies:
       '@commitlint/types': 17.4.4
       ajv: 8.12.0
@@ -1466,6 +1478,7 @@ packages:
   /@commitlint/execute-rule@17.4.0:
     resolution: {integrity: sha512-LIgYXuCSO5Gvtc0t9bebAMSwd68ewzmqLypqI2Kke1rqOqqDbMpYcYfoPfFlv9eyLIh4jocHWwCK5FS7z9icUA==}
     engines: {node: '>=v14'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1497,6 +1510,7 @@ packages:
   /@commitlint/resolve-extends@17.6.7:
     resolution: {integrity: sha512-PfeoAwLHtbOaC9bGn/FADN156CqkFz6ZKiVDMjuC2N5N0740Ke56rKU7Wxdwya8R8xzLK9vZzHgNbuGhaOVKIg==}
     engines: {node: '>=v14'}
+    requiresBuild: true
     dependencies:
       '@commitlint/config-validator': 17.6.7
       '@commitlint/types': 17.4.4
@@ -1510,6 +1524,7 @@ packages:
   /@commitlint/types@17.4.4:
     resolution: {integrity: sha512-amRN8tRLYOsxRr6mTnGGGvB5EmW/4DDjLMgiwK3CCVEmN6Sr/6xePGEpWaspKkckILuUORCwe6VfDBw6uj4axQ==}
     engines: {node: '>=v14'}
+    requiresBuild: true
     dependencies:
       chalk: 4.1.2
     dev: true
@@ -2701,14 +2716,14 @@ packages:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
-  /@modular-forms/qwik@0.12.0(@builder.io/qwik-city@1.2.9-dev20230825221223)(@builder.io/qwik@1.2.9):
+  /@modular-forms/qwik@0.12.0(@builder.io/qwik-city@1.2.9-dev20230826195459)(@builder.io/qwik@1.2.9):
     resolution: {integrity: sha512-IJi5Uvm1Z1tJZLOpYM8jWza40Viac6tblnMre0pdrslVv7tW3MnXFgQgO539YksooOsn1Jn1KjVUVmhiMuXXuA==}
     peerDependencies:
       '@builder.io/qwik': ^1.0.0
       '@builder.io/qwik-city': ^1.0.0
     dependencies:
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634(undici@5.22.1)
-      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/769c144a4c895f103c73b79c9004513215dceb20(rollup@3.26.3)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd(undici@5.22.1)
+      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/2783c1e5201e3c64538dfa9737b5c11742673994(rollup@3.26.3)
 
   /@mui/base@5.0.0-beta.0(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ap+juKvt8R8n3cBqd/pGtZydQ4v2I/hgJKnvJRGjpSh3RvsvnDHO4rXov8MHQlH6VqpOekwgilFLGxMZjNTucA==}
@@ -4658,12 +4673,12 @@ packages:
       winston: 3.8.2
     dev: true
 
-  /@supabase/auth-helpers-shared@0.3.4(@supabase/supabase-js@2.24.0):
+  /@supabase/auth-helpers-shared@0.3.4(@supabase/supabase-js@2.33.1):
     resolution: {integrity: sha512-8I3D0SPHHexkFTSfPg0nZgJSVazWoB3tZDpT6IjRv6w89vDMUzO99Lit4H9anVLF4teW8c/nJJxawDNbDlgbgg==}
     peerDependencies:
       '@supabase/supabase-js': ^2.0.4
     dependencies:
-      '@supabase/supabase-js': 2.24.0
+      '@supabase/supabase-js': 2.33.1
       jose: 4.14.4
     dev: false
 
@@ -4681,29 +4696,12 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@supabase/postgrest-js@1.7.2:
-    resolution: {integrity: sha512-GK80JpRq8l6Qll85erICypAfQCied8tdlXfsDN14W844HqXCSOisk8AaE01DAwGJanieaoN5fuqhzA2yKxDvEQ==}
-    dependencies:
-      cross-fetch: 3.1.8
-    transitivePeerDependencies:
-      - encoding
-
   /@supabase/postgrest-js@1.8.2:
     resolution: {integrity: sha512-HrtqAOnagC9UAURDpzyDvN6Yzn014pZ49nIl19/tXdnxRLH3fjAQoFMW57cqJ2Hw+V2suh93X0LrbVuzUQC9Aw==}
     dependencies:
       cross-fetch: 3.1.8
     transitivePeerDependencies:
       - encoding
-    dev: true
-
-  /@supabase/realtime-js@2.7.3:
-    resolution: {integrity: sha512-c7TzL81sx2kqyxsxcDduJcHL9KJdCOoKimGP6lQSqiZKX42ATlBZpWbyy9KFGFBjAP4nyopMf5JhPi2ZH9jyNw==}
-    dependencies:
-      '@types/phoenix': 1.6.0
-      '@types/websocket': 1.0.5
-      websocket: 1.0.34
-    transitivePeerDependencies:
-      - supports-color
 
   /@supabase/realtime-js@2.7.4:
     resolution: {integrity: sha512-FzSzs1k9ruh/uds5AJ95Nc3beiMCCIhougExJ3O98CX1LMLAKUKFy5FivKLvcNhXnNfUEL0XUfGMb4UH2J7alg==}
@@ -4713,7 +4711,6 @@ packages:
       websocket: 1.0.34
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@supabase/storage-js@2.5.1:
     resolution: {integrity: sha512-nkR0fQA9ScAtIKA3vNoPEqbZv1k5B5HVRYEvRWdlP6mUpFphM9TwPL2jZ/ztNGMTG5xT6SrHr+H7Ykz8qzbhjw==}
@@ -4721,19 +4718,6 @@ packages:
       cross-fetch: 3.1.8
     transitivePeerDependencies:
       - encoding
-
-  /@supabase/supabase-js@2.24.0:
-    resolution: {integrity: sha512-zrAm+hp6DBICqZ7xVPk+KofmlfjJWQzXuf2sHAyPz8XVjpha84z2OVWcow2aI10YkMOrPwhRtBBQYJOnh/fx2w==}
-    dependencies:
-      '@supabase/functions-js': 2.1.2
-      '@supabase/gotrue-js': 2.46.1
-      '@supabase/postgrest-js': 1.7.2
-      '@supabase/realtime-js': 2.7.3
-      '@supabase/storage-js': 2.5.1
-      cross-fetch: 3.1.8
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   /@supabase/supabase-js@2.33.1:
     resolution: {integrity: sha512-jA00rquPTppPOHpBB6KABW98lfg0gYXcuGqP3TB1iiduznRVsi3GGk2qBKXPDLMYSe0kRlQp5xCwWWthaJr8eA==}
@@ -4747,7 +4731,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: true
 
   /@swc/helpers@0.5.1:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
@@ -5543,7 +5526,7 @@ packages:
     peerDependencies:
       '@builder.io/qwik': '*'
     dependencies:
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634(undici@5.22.1)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd(undici@5.22.1)
     dev: true
 
   /@vercel/nft@0.22.6(supports-color@9.4.0):
@@ -7964,6 +7947,7 @@ packages:
   /cosmiconfig-typescript-loader@4.4.0(@types/node@20.4.5)(cosmiconfig@8.2.0)(ts-node@10.9.1)(typescript@5.1.6):
     resolution: {integrity: sha512-BabizFdC3wBHhbI4kJh0VkQP9GkBfoHPydD0COMce1nJ1kJAB3F2TmJ/I7diULBKtmEWSwEbuN/KDtgnmUUVmw==}
     engines: {node: '>=v14.21.3'}
+    requiresBuild: true
     peerDependencies:
       '@types/node': '*'
       cosmiconfig: '>=7'
@@ -10515,6 +10499,7 @@ packages:
   /global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       ini: 1.3.8
     dev: true
@@ -12321,6 +12306,7 @@ packages:
 
   /lodash.mergewith@4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -13792,6 +13778,7 @@ packages:
 
   /nan@2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -16080,6 +16067,7 @@ packages:
   /resolve-global@1.0.0:
     resolution: {integrity: sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       global-dirs: 0.1.1
     dev: true
@@ -18990,9 +18978,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634(undici@5.22.1):
-    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-build/tar.gz/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634}
-    id: github.com/BuilderIo/qwik-build/3b0f4ac5af800c0c228a3a52fc1f5cb4daca2634
+  github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd(undici@5.22.1):
+    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-build/tar.gz/e1b47967fa609d96d51dcb00622e50bd680cd6fd}
+    id: github.com/BuilderIo/qwik-build/e1b47967fa609d96d51dcb00622e50bd680cd6fd
     name: '@builder.io/qwik'
     version: 1.2.9
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
@@ -19003,11 +18991,11 @@ packages:
       csstype: 3.1.2
       undici: 5.22.1
 
-  github.com/BuilderIo/qwik-city-build/769c144a4c895f103c73b79c9004513215dceb20(rollup@3.26.3):
-    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-city-build/tar.gz/769c144a4c895f103c73b79c9004513215dceb20}
-    id: github.com/BuilderIo/qwik-city-build/769c144a4c895f103c73b79c9004513215dceb20
+  github.com/BuilderIo/qwik-city-build/2783c1e5201e3c64538dfa9737b5c11742673994(rollup@3.26.3):
+    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-city-build/tar.gz/2783c1e5201e3c64538dfa9737b5c11742673994}
+    id: github.com/BuilderIo/qwik-city-build/2783c1e5201e3c64538dfa9737b5c11742673994
     name: '@builder.io/qwik-city'
-    version: 1.2.9-dev20230825221223
+    version: 1.2.9-dev20230826195459
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
     dependencies:
       '@mdx-js/mdx': 2.3.0
@@ -19021,8 +19009,8 @@ packages:
       - rollup
       - supports-color
 
-  github.com/BuilderIo/qwik-labs-build/f8082d6cd2e0fd49adc72e2893eb25a2b5ae8589:
-    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-labs-build/tar.gz/f8082d6cd2e0fd49adc72e2893eb25a2b5ae8589}
+  github.com/BuilderIo/qwik-labs-build/762e4845ecd74b4677e629f93501585d3e631970:
+    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-labs-build/tar.gz/762e4845ecd74b4677e629f93501585d3e631970}
     name: '@builder.io/qwik-labs'
     version: 0.0.1
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}


### PR DESCRIPTION
# What is it?

- [X] Fix

# Description

I updated `supabase-auth-helpers-qwik` devDependencies to solve a building clash with the last `@supabase/supabase-js` release.
Close #5039

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
