### PR TITLE
fix: Yarn 3/4 PnP compatibility

### DIFF
--- a/packages/qwik-city/package.json
+++ b/packages/qwik-city/package.json
@@ -8,7 +8,9 @@
     "@types/mdx": "^2.0.8",
     "source-map": "0.7.4",
     "svgo": "^3.0.2",
+    "undici": "^5.26.0",
     "vfile": "^6.0.1",
+    "vite": "^4.4.11",
     "vite-imagetools": "^5.0.9",
     "zod": "^3.22.4"
   },
@@ -39,7 +41,6 @@
     "unified": "10.1.2",
     "unist-util-visit": "5.0.0",
     "uvu": "0.5.6",
-    "vite": "^4.4.11",
     "yaml": "^2.3.2"
   },
   "engines": {

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -22,7 +22,8 @@
     }
   ],
   "dependencies": {
-    "csstype": "^3.1.2"
+    "csstype": "^3.1.2",
+    "vite": "^4.4.11"
   },
   "devDependencies": {
     "@builder.io/qwik-dom": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,9 @@ importers:
       csstype:
         specifier: ^3.1.2
         version: 3.1.2
+      vite:
+        specifier: ^4.4.11
+        version: 4.4.11(@types/node@20.8.4)(terser@5.21.0)
     devDependencies:
       '@builder.io/qwik-dom':
         specifier: workspace:*
@@ -510,9 +513,15 @@ importers:
       svgo:
         specifier: ^3.0.2
         version: 3.0.2
+      undici:
+        specifier: ^5.26.0
+        version: 5.26.0
       vfile:
         specifier: 6.0.1
         version: 6.0.1
+      vite:
+        specifier: ^4.4.11
+        version: 4.4.11(@types/node@20.8.4)(terser@5.21.0)
       vite-imagetools:
         specifier: ^5.0.9
         version: 5.0.9(rollup@3.26.3)
@@ -598,9 +607,6 @@ importers:
       uvu:
         specifier: 0.5.6
         version: 0.5.6
-      vite:
-        specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.8.4)(terser@5.21.0)
       yaml:
         specifier: ^2.3.2
         version: 2.3.2
@@ -2569,12 +2575,10 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.18
-    dev: true
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/resolve-uri@3.1.1:
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
@@ -2585,29 +2589,24 @@ packages:
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/source-map@0.3.5:
     resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
-    dev: true
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: true
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -7797,7 +7796,6 @@ packages:
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -13722,7 +13720,6 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /nanomatch@1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -15062,7 +15059,6 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /preact-render-to-string@5.2.3(preact@10.11.3):
     resolution: {integrity: sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==}
@@ -16111,7 +16107,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /run-applescript@5.0.0:
     resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
@@ -17157,7 +17152,6 @@ packages:
       acorn: 8.10.0
       commander: 2.20.3
       source-map-support: 0.5.21
-    dev: true
 
   /text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
@@ -18176,7 +18170,6 @@ packages:
       terser: 5.21.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /vite@4.4.2(@types/node@20.8.4)(terser@5.21.0):
     resolution: {integrity: sha512-zUcsJN+UvdSyHhYa277UHhiJ3iq4hUBwHavOpsNUGsTgjBeoBlK8eDt+iT09pBq0h9/knhG/SPrZiM7cGmg7NA==}

--- a/scripts/validate-build.ts
+++ b/scripts/validate-build.ts
@@ -23,7 +23,7 @@ export async function validateBuild(config: BuildConfig) {
   const pkgFiles = [...pkg.files!, 'LICENSE', 'README.md', 'package.json'];
   const expectedFiles = pkgFiles.map((f) => join(config.distQwikPkgDir, f));
 
-  const dependencies = ['csstype'];
+  const dependencies = ['csstype', 'vite'];
   const pkgDependencies = Object.keys(pkg.dependencies!);
   if (pkgDependencies.length !== dependencies.length) {
     errors.push(


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement

# Description
As documented in #5038, we cannot start a Qwik app in a Yarn 3 or 4 workspace with PnP because some dependencies are not properly declared in both `qwik` and `qwik-city`.

The changes in this PR are simply to make the dependencies explicit or to make them as an acutal dependency instead of just a dev-dependency.

Close #5038.

<details>
<summary>For reference: here are the places I found in the code requiring each dependency.</summary>

* Qwik
  * Vite
    * `packages/qwik/src/optimizer/src/plugins/eslint-plugin.ts`
    * `packages/qwik/src/optimizer/src/plugins/vite-server.ts`
    * `packages/qwik/src/optimizer/src/plugins/vite-utils.ts`
    * `packages/qwik/src/optimizer/src/plugins/image-size-server.ts`
    * `packages/qwik/src/optimizer/src/plugins/rollup.ts`
    * `packages/qwik/src/optimizer/src/plugins/rollup.unit.ts`
    * `packages/qwik/src/optimizer/src/plugins/plugin.ts`
    * `packages/qwik/src/optimizer/src/plugins/vite.ts`
    * `packages/qwik/src/optimizer/src/plugins/vite.unit.ts`
* Qwik City
  * Vite
    * `packages/qwik-city/buildtime/vite/image-jsx.ts`
    * `packages/qwik-city/adapters/cloud-run/vite/index.ts`
    * `packages/qwik-city/buildtime/vite/config.ts`
    * `packages/qwik-city/buildtime/vite/plugin.ts`
    * `packages/qwik-city/buildtime/vite/dev-server.ts`
    * `packages/qwik-city/adapters/shared/vite/index.ts`
    * `packages/qwik-city/static/main-thread.ts`
    * `packages/qwik-city/runtime/vite.config.ts`
  * Undici
    * `packages/qwik-city/middleware/node/node-fetch.ts`
    * `packages/qwik-city/runtime/src/service-worker/utils.unit.ts`
</details>

# Use cases and why

Yarn enforces a more strict approach than other package managers (you can read more about it [here](https://yarnpkg.com/features/pnp#ghost-dependencies-protection)) regarding how dependencies are declared. In order to improve maintainability and prevent future issues, it forces all required dependency to be explicitly declared.

Even though Qwik is managed with `pnpm` and it wasn't reported as an issue until now, being aware of this and declaring dependencies explicitly should improve both the code maintainability and the adoption of Qwik (for those using Yarn 3 or 4 with PnP not in loose mode).

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
