### PR TITLE
fix: loader type

### DIFF
--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -166,7 +166,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type FailReturn<T> = T & {\n    failed: true;\n};\n```",
+      "content": "```typescript\nexport type FailReturn<T> = T & Failed;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts",
       "mdFile": "qwik-city.failreturn.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -193,9 +193,7 @@ export interface DocumentStyle
 ## FailReturn
 
 ```typescript
-export type FailReturn<T> = T & {
-  failed: true;
-};
+export type FailReturn<T> = T & Failed;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts)

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -205,10 +205,10 @@ export interface DocumentStyle {
     readonly style: string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Failed" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export type FailReturn<T> = T & {
-    failed: true;
-};
+export type FailReturn<T> = T & Failed;
 
 // @public (undocumented)
 export const Form: <O, I>({ action, spaReset, reloadDocument, onSubmit$, ...rest }: FormProps<O, I>, key: string | null) => QwikJSX.Element;

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -622,7 +622,7 @@ export interface LoaderConstructor {
   <OBJ>(
     loaderFn: (event: RequestEventLoader) => ValueOrPromise<OBJ>,
     options?: LoaderOptions
-  ): Loader<OBJ>;
+  ): Loader<[Extract<OBJ, Failed>] extends [never] ? OBJ : StrictUnion<OBJ>>;
 
   // With validation
   <OBJ extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
@@ -729,12 +729,14 @@ export interface ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> {
   >;
 }
 
+type Failed = {
+  failed: true;
+};
+
 /**
  * @public
  */
-export type FailReturn<T> = T & {
-  failed: true;
-};
+export type FailReturn<T> = T & Failed;
 
 /**
  * @public

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -639,7 +639,7 @@ export interface LoaderConstructorQRL {
   <OBJ>(
     loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<OBJ>>,
     options?: LoaderOptions
-  ): Loader<OBJ>;
+  ): Loader<[Extract<OBJ, Failed>] extends [never] ? OBJ : StrictUnion<OBJ>>;
 
   // With validation
   <OBJ extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(

--- a/starters/apps/qwikcity-test/src/routes/(common)/loaders/issue3979/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/loaders/issue3979/index.tsx
@@ -1,0 +1,109 @@
+import { component$ } from "@builder.io/qwik";
+import {
+  routeLoader$,
+  validator$,
+  type RequestEventAction,
+} from "@builder.io/qwik-city";
+
+const dataValidator = validator$((ev) => {
+  if (ev.query.get("secret") === "123") {
+    return {
+      success: true,
+    };
+  }
+  return {
+    success: false,
+    error: {
+      validationFailReason: "Secret not found",
+    },
+  };
+});
+
+const petLoaderQrl = () => {
+  return {
+    pet: "guinea pig",
+  };
+};
+
+const dynamicPetLoaderQrl = () => {
+  if (Math.random() > 0.5) {
+    return {
+      dog: "malamute",
+    };
+  }
+
+  return {
+    rat: "guinea pig",
+  };
+};
+
+const randomFailedLoaderQrl = ({ fail }: RequestEventAction) => {
+  if (Math.random() > 0.5) {
+    return fail(500, {
+      loaderFailedReason: "Reach Limit",
+    });
+  }
+
+  return {
+    pet: "guinea pig",
+  };
+};
+
+export const usePetLoader = routeLoader$(petLoaderQrl);
+export const usePetWithValidationLoader = routeLoader$(
+  petLoaderQrl,
+  dataValidator,
+);
+
+export const useDynamicPetLoader = routeLoader$(dynamicPetLoaderQrl);
+export const useDynamicPetWithValidationLoader = routeLoader$(
+  dynamicPetLoaderQrl,
+  dataValidator,
+);
+
+export const useRandomFailedLoader = routeLoader$(randomFailedLoaderQrl);
+export const useRandomFailedWithValidatorLoader = routeLoader$(
+  randomFailedLoaderQrl,
+  dataValidator,
+);
+
+export default component$(() => {
+  const pet = usePetLoader();
+  const petWithValidation = usePetWithValidationLoader();
+  const dynamicPet = useDynamicPetLoader();
+  const dynamicPetWithValidation = useDynamicPetWithValidationLoader();
+  const randomFailed = useRandomFailedLoader();
+  const randomFailedWithValidator = useRandomFailedWithValidatorLoader();
+
+  return (
+    <div>
+      <div>{pet.value.pet}</div>
+      <div>
+        {petWithValidation.value.pet}
+        {petWithValidation.value.failed}
+        {petWithValidation.value.validationFailReason}
+      </div>
+      <div>
+        {dynamicPet.value.dog}
+        {dynamicPet.value.rat}
+      </div>
+      <div>
+        {dynamicPetWithValidation.value.dog}
+        {dynamicPetWithValidation.value.rat}
+        {dynamicPetWithValidation.value.failed}
+        {dynamicPetWithValidation.value.validationFailReason}
+      </div>
+      <div>
+        {randomFailed.value.pet}
+        {randomFailed.value.failed}
+        {randomFailed.value.loaderFailedReason}
+      </div>
+      <div>
+        {randomFailedWithValidator.value.pet}
+        {randomFailedWithValidator.value.failed}
+        {randomFailedWithValidator.value.loaderFailedReason}
+        {randomFailedWithValidator.value.validationFailReason}
+      </div>
+    </div>
+  );
+});


### PR DESCRIPTION
# Overview

Fix loader type for the case: `loaderQrl` returns `fail(...)` without any validator.

Related issue: https://github.com/BuilderIO/qwik/issues/3979

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

I only do `StrictUnion` when the `loaderQrl` returns `fail(...)` to keep the most simple case's type the same.

```ts
// Loader<number>
export const useLoader1 = routeLoader$(() => 123); 

// Loader<{
//     foo: number;
// }>
export const useLoader2 = routeLoader$(() => ({ foo: 123 })); 
```

And for those returning `fail(...)`:

```ts
// Loader<{
//     loaderFailedReason?: string | undefined;
//     failed?: true | undefined;
//     pet?: undefined;
// } | {
//     pet?: string | undefined;
//     failed?: undefined;
//     loaderFailedReason?: undefined;
// }>
export const useRandomFailedLoader = routeLoader$(({ fail }) => {
  if (Math.random() > 0.5) {
    return fail(500, {
      loaderFailedReason: "Reach Limit",
    });
  }

  return {
    pet: "guinea pig",
  };
});
```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
