### PR TITLE
Enhance Media Controller Cookbook Recipe and fix fluid layout for smaller screens

### DIFF
--- a/packages/docs/src/routes/demo/cookbook/mediaController/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/mediaController/index.tsx
@@ -18,6 +18,7 @@ export default component$(() => {
   const videoElementSignal = useSignal<HTMLAudioElement | undefined>();
   const videoPlayButtonSignal = useSignal<HTMLButtonElement | undefined>();
   const videoIsPlayingSignal = useSignal(false);
+  const playsInlineSignal = useSignal(true);
   const location = useLocation();
 
   const videoPoster =
@@ -34,7 +35,8 @@ export default component$(() => {
           color: #1dacf2
         }
         .content {
-          width: 50%;
+          width: 60%;
+          min-width: 250px;
         }   
         button {
           padding: 20px;
@@ -43,6 +45,16 @@ export default component$(() => {
           width: 100%;
           background: #1dacf2;
           color: white;
+        }
+        .checkbox-container {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .checkbox {
+          width: 20px;
+          height: 20px;
+          margin-right: 8px;
         }
         .video-container {
           position: relative;
@@ -64,7 +76,6 @@ export default component$(() => {
   useVisibleTask$(({ track }) => {
     track(() => audioPlayButtonSignal.value);
     track(() => audioElementSignal.value);
-    if (!audioElementSignal.value) return;
 
     const play = () =>
       audioIsPlayingSignal.value
@@ -81,11 +92,10 @@ export default component$(() => {
   useVisibleTask$(({ track }) => {
     track(() => videoPlayButtonSignal.value);
     track(() => videoElementSignal.value);
-    if (!videoElementSignal.value || !videoPlayButtonSignal.value) return;
 
     const play = () =>
       videoIsPlayingSignal.value
-        ? videoElementSignal.value!.pause()
+        ? videoElementSignal.value?.pause()
         : videoElementSignal.value?.play();
 
     videoPlayButtonSignal.value?.addEventListener('click', play);
@@ -106,13 +116,12 @@ export default component$(() => {
             ref={videoElementSignal}
             src={VIDEO_SRC}
             poster={videoPoster}
-            playsInline
+            playsInline={playsInlineSignal.value}
             onPlay$={() => (videoIsPlayingSignal.value = true)}
             onPause$={() => (videoIsPlayingSignal.value = false)}
             onEnded$={() => (videoIsPlayingSignal.value = false)}
           />
         </div>
-
         <audio
           ref={audioElementSignal}
           src={AUDIO_SRC}
@@ -120,6 +129,21 @@ export default component$(() => {
           onPause$={() => (audioIsPlayingSignal.value = false)}
           onEnded$={() => (audioIsPlayingSignal.value = false)}
         />
+        <br />
+        <div class="checkbox-container">
+          <input
+            type="checkbox"
+            id="playsInlineCheckbox"
+            class="checkbox"
+            checked={playsInlineSignal.value}
+            onchange$={() => {
+              videoElementSignal.value?.pause();
+              playsInlineSignal.value = !playsInlineSignal.value;
+            }}
+          />
+          <label for="playsInlineCheckbox">playsInline (iOS)</label>
+        </div>
+
         <br />
         <button ref={videoPlayButtonSignal}>
           {videoIsPlayingSignal.value ? 'Pause' : 'Play'} Video

--- a/packages/docs/src/routes/docs/cookbook/mediaController/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/mediaController/index.mdx
@@ -8,31 +8,42 @@ import CodeSandbox, {CodeFile} from '../../../../components/code-sandbox/index.t
 
 # Media Controller
 
-Navigating the intricacies of cross-browser and cross-device code development presents its unique set of challenges. A prominent example is the management of media playback, especially on Apple iOS devices.
+Developing for a diverse range of browsers and devices often introduces unique challenges. One of the most notable challenges is ensuring consistent media playback, particularly on Apple's iOS devices.
 
-### Understanding iOS's Auto-play Restrictions
+## iOS Media Playback Restrictions Explained
 
-Apple's iOS platform enforces specific guidelines concerning the playback of audio and video content. These restrictions are rooted in:
+Apple's iOS has established specific rules for audio and video playback to enhance user experience and manage data consumption:
 
-1. **User Experience**: To prevent any unexpected disruptions, especially in serene environments, iOS doesn't allow media to auto-play. This ensures that users are not taken by surprise with sudden audio.
-2. **Data Management**: Streaming media can be data-intensive. To prevent inadvertent high data consumption, iOS mandates that users must initiate media playback, a crucial feature for those on capped or metered data plans.
+1. **User Experience**: iOS prohibits media from auto-playing to prevent unexpected disturbances. This design choice ensures users aren't unexpectedly disrupted by sudden audio, especially in quiet settings.
+2. **Data Efficiency**: Given that streaming media can be data-intensive, iOS requires users to manually initiate media playback. This design is especially beneficial for users on limited or metered data plans.
 
-### The iOS Playback Challenge
+## Deciphering the iOS Playback Challenge
 
-The crux of the challenge with iOS lies in its requirement for media playback. Any play action, such as starting a video, must be a direct result of a user-initiated event, like a tap. However, when using asynchronous event handlers, such as `onClick$` (QRL), there's a separation between the user's action and the subsequent playback command. This asynchronous behavior often leads to iOS denying playback on the initial tap, necessitating a second tap, which is not an intuitive user experience.
+At the heart of the iOS challenge is the system's insistence on user-initiated media playback. For instance, starting a video must result directly from a user action, like a tap. However, asynchronous event handlers, such as `onClick$` (QRL), can create a disconnect between the user's action and the playback command. This often results in iOS blocking playback on the first tap, requiring a second, non-intuitive tap.
 
-## A Universal Solution
+## The `playsinline` Attribute
 
-For a seamless and consistent media playback experience across diverse browsers and devices, it's imperative to employ a more universal strategy. This guide offers a method that addresses this need. To activate playback when a user interacts with a button, the `.play()` function must be executed in a synchronous manner. This synchronization is achieved by directly attaching the `click` handler within the `useVisibleTask$` function. Presented below is a prototype of an audio and video controller designed to offer a consistent user experience across a range of platforms:
+On iOS devices, especially iPhones, videos automatically play in fullscreen mode unless the `playsinline` attribute is present on the `<video>` tag. This attribute ensures that videos play within their designated container, providing a consistent experience across different devices and platforms. While primarily intended for iOS, including `playsinline` is harmless on other platforms and ensures broader compatibility.
 
-<CodeSandbox url="/demo/cookbook/mediaController/"  style={{ height: '600px' }}>
+## Crafting a Universal Playback Solution
+
+To achieve consistent media playback across various browsers and devices, a holistic approach is essential. This guide presents a solution that addresses the nuances of different platforms. To ensure immediate playback upon user interaction, the `.play()` method should be invoked synchronously. This can be accomplished by directly attaching the `click` handler within the `useVisibleTask$` function.
+
+Below, you'll find a prototype of an audio and video controller, tailored to provide a consistent user experience across multiple platforms.
+
+<CodeSandbox url="/demo/cookbook/mediaController/"  style={{ height: '700px' }}>
 </CodeSandbox>
 
 Media controller code compatible with iOS devices looks like this:
 
 <CodeFile src="/src/routes/demo/cookbook/mediaController/index.tsx">
 ```tsx
-import { component$, useSignal, useStylesScoped$, useVisibleTask$ } from '@builder.io/qwik';
+import {
+  component$,
+  useSignal,
+  useStylesScoped$,
+  useVisibleTask$,
+} from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
 
 const AUDIO_SRC =
@@ -47,6 +58,7 @@ export default component$(() => {
   const videoElementSignal = useSignal<HTMLAudioElement | undefined>();
   const videoPlayButtonSignal = useSignal<HTMLButtonElement | undefined>();
   const videoIsPlayingSignal = useSignal(false);
+  const playsInlineSignal = useSignal(true);
   const location = useLocation();
 
   const videoPoster =
@@ -63,7 +75,8 @@ export default component$(() => {
           color: #1dacf2
         }
         .content {
-          width: 50%;
+          width: 60%;
+          min-width: 250px;
         }   
         button {
           padding: 20px;
@@ -72,6 +85,16 @@ export default component$(() => {
           width: 100%;
           background: #1dacf2;
           color: white;
+        }
+        .checkbox-container {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .checkbox {
+          width: 20px;
+          height: 20px;
+          margin-right: 8px;
         }
         .video-container {
           position: relative;
@@ -93,7 +116,6 @@ export default component$(() => {
   useVisibleTask$(({ track }) => {
     track(() => audioPlayButtonSignal.value);
     track(() => audioElementSignal.value);
-    if (!audioElementSignal.value) return;
 
     const play = () =>
       audioIsPlayingSignal.value
@@ -110,11 +132,10 @@ export default component$(() => {
   useVisibleTask$(({ track }) => {
     track(() => videoPlayButtonSignal.value);
     track(() => videoElementSignal.value);
-    if (!videoElementSignal.value || !videoPlayButtonSignal.value) return;
 
     const play = () =>
       videoIsPlayingSignal.value
-        ? videoElementSignal.value!.pause()
+        ? videoElementSignal.value?.pause()
         : videoElementSignal.value?.play();
 
     videoPlayButtonSignal.value?.addEventListener('click', play);
@@ -135,13 +156,12 @@ export default component$(() => {
             ref={videoElementSignal}
             src={VIDEO_SRC}
             poster={videoPoster}
-            playsInline
+            playsInline={playsInlineSignal.value}
             onPlay$={() => (videoIsPlayingSignal.value = true)}
             onPause$={() => (videoIsPlayingSignal.value = false)}
             onEnded$={() => (videoIsPlayingSignal.value = false)}
           />
         </div>
-
         <audio
           ref={audioElementSignal}
           src={AUDIO_SRC}
@@ -149,6 +169,21 @@ export default component$(() => {
           onPause$={() => (audioIsPlayingSignal.value = false)}
           onEnded$={() => (audioIsPlayingSignal.value = false)}
         />
+        <br />
+        <div class="checkbox-container">
+          <input
+            type="checkbox"
+            id="playsInlineCheckbox"
+            class="checkbox"
+            checked={playsInlineSignal.value}
+            onchange$={() => {
+              videoElementSignal.value?.pause();
+              playsInlineSignal.value = !playsInlineSignal.value;
+            }}
+          />
+          <label for="playsInlineCheckbox">playsInline (iOS)</label>
+        </div>
+
         <br />
         <button ref={videoPlayButtonSignal}>
           {videoIsPlayingSignal.value ? 'Pause' : 'Play'} Video


### PR DESCRIPTION
* Rewrote the cookbook text to be more easily consumable 
* Add explanation behavior of `playsInline` with iOS devices
* Update CodeSandbox to support `playsInline`
* Fix fluid layout for iPhone and smaller portrait devices

_NOTE: Now that the qwik-koi video is pulled from CDN with HLS / DASH, the source CND content should be updated to 1080p for higher quality streamed video image._