### PR TITLE
enhancement: Allow binding this to the store in useStore

### DIFF
--- a/packages/qwik/src/core/use/use-store.public.ts
+++ b/packages/qwik/src/core/use/use-store.public.ts
@@ -110,18 +110,18 @@ export const useStore = <STATE extends object>(
     const newStore = getOrCreateProxy(value, containerState, flags);
 
     const bindFunctionsRecursively = (obj: any) => {
-      for (const key in obj) {
-        if (typeof obj[key] === 'function') {
-          obj[key] = obj[key].bind(newStore);
-        } else if (typeof obj[key] === 'object' && obj[key] !== null) {
-          bindFunctionsRecursively(obj[key]);
+      for (const [key, value] of Object.entries(obj)) {
+        if (typeof value === 'function') {
+          obj[key] = value.bind(newStore);
+        } else if (typeof value === 'object' && value !== null) {
+          bindFunctionsRecursively(value);
         }
       }
     };
 
     bindFunctionsRecursively(newStore);
     set(newStore);
-    
+
     if (opts?.bind !== false) {
       return newStore as STATE;
     }

--- a/packages/qwik/src/core/use/use-store.public.ts
+++ b/packages/qwik/src/core/use/use-store.public.ts
@@ -108,8 +108,20 @@ export const useStore = <STATE extends object>(
     const recursive = opts?.deep ?? true;
     const flags = recursive ? QObjectRecursive : 0;
     const newStore = getOrCreateProxy(value, containerState, flags);
-    set(newStore);
 
+    const bindFunctionsRecursively = (obj: any) => {
+      for (const key in obj) {
+        if (typeof obj[key] === 'function') {
+          obj[key] = obj[key].bind(newStore);
+        } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+          bindFunctionsRecursively(obj[key]);
+        }
+      }
+    };
+
+    bindFunctionsRecursively(newStore);
+    set(newStore);
+    
     if (opts?.bind !== false) {
       return newStore as STATE;
     }

--- a/packages/qwik/src/core/use/use-store.public.ts
+++ b/packages/qwik/src/core/use/use-store.public.ts
@@ -19,6 +19,13 @@ export interface UseStoreOptions {
    * Default is `true`.
    */
   reactive?: boolean;
+
+  /**
+   * If `true` then bind method is called on the `newStore` object to ensure
+   * that the `this` context is bound to the store object.
+   * Default is `true`.
+   */
+  bind?: boolean;
 }
 
 // <docs markdown="../readme.md#useStore">
@@ -102,6 +109,11 @@ export const useStore = <STATE extends object>(
     const flags = recursive ? QObjectRecursive : 0;
     const newStore = getOrCreateProxy(value, containerState, flags);
     set(newStore);
+
+    if (opts?.bind !== false) {
+      return newStore as STATE;
+    }
+
     return newStore;
   }
 };


### PR DESCRIPTION
# What is it?
Allow binding this to the store in useStore
https://github.com/BuilderIO/qwik/issues/5087

- [x ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

In this modified code, I've added a bind option to the opts parameter, and by default, it's set to true. When the bind option is true, the bind method is called on the newStore object to ensure that the this context is bound to the store object.

You can now use the bind option to control whether the this context should be bound when using the useStore function, and it can be used in combination with the deep and reactive options as needed.

# Checklist:

- [x ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
