### PR TITLE
feat(optimizer): add qwikVite configuration option optimizerOptions.inlineStylesUpToBytes

### DIFF
--- a/packages/docs/src/routes/api/qwik-optimizer/api.json
+++ b/packages/docs/src/routes/api/qwik-optimizer/api.json
@@ -285,7 +285,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface OptimizerOptions \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [binding?](#) |  | any | _(Optional)_ |\n|  [sys?](#) |  | [OptimizerSystem](#optimizersystem) | _(Optional)_ |",
+      "content": "```typescript\nexport interface OptimizerOptions \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [binding?](#) |  | any | _(Optional)_ |\n|  [inlineStylesUpToBytes?](#) |  | number | _(Optional)_ |\n|  [sys?](#) |  | [OptimizerSystem](#optimizersystem) | _(Optional)_ |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/optimizer/src/types.ts",
       "mdFile": "qwik.optimizeroptions.md"
     },

--- a/packages/docs/src/routes/api/qwik-optimizer/index.md
+++ b/packages/docs/src/routes/api/qwik-optimizer/index.md
@@ -267,10 +267,11 @@ export interface Optimizer
 export interface OptimizerOptions
 ```
 
-| Property      | Modifiers | Type                                | Description  |
-| ------------- | --------- | ----------------------------------- | ------------ |
-| [binding?](#) |           | any                                 | _(Optional)_ |
-| [sys?](#)     |           | [OptimizerSystem](#optimizersystem) | _(Optional)_ |
+| Property                    | Modifiers | Type                                | Description  |
+| --------------------------- | --------- | ----------------------------------- | ------------ |
+| [binding?](#)               |           | any                                 | _(Optional)_ |
+| [inlineStylesUpToBytes?](#) |           | number                              | _(Optional)_ |
+| [sys?](#)                   |           | [OptimizerSystem](#optimizersystem) | _(Optional)_ |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/optimizer/src/types.ts)
 

--- a/packages/qwik/src/optimizer/src/api.md
+++ b/packages/qwik/src/optimizer/src/api.md
@@ -112,6 +112,8 @@ export interface OptimizerOptions {
     // (undocumented)
     binding?: any;
     // (undocumented)
+    inlineStylesUpToBytes?: number;
+    // (undocumented)
     sys?: OptimizerSystem;
 }
 

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -267,7 +267,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     }
     opts.csr = !!updatedOpts.csr;
 
-    opts.inlineStylesUpToBytes = optimizerOptions.inlineStylesUpToBytes ?? 0;
+    opts.inlineStylesUpToBytes = optimizerOptions.inlineStylesUpToBytes ?? 20000;
     if (typeof opts.inlineStylesUpToBytes !== 'number' || opts.inlineStylesUpToBytes < 0) {
       opts.inlineStylesUpToBytes = 0;
     }
@@ -902,6 +902,11 @@ export interface QwikPluginOptions {
     | ((transformedModules: TransformModule[]) => Promise<void> | void)
     | null;
   devTools?: QwikPluginDevTools;
+  /**
+   * Inline styles up to a certain size (in bytes) instead of using a separate file.
+   *
+   * Default: 20kb (20,000bytes)
+   */
   inlineStylesUpToBytes?: number;
 }
 

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -95,6 +95,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     devTools: {
       clickToSource: ['Alt'],
     },
+    inlineStylesUpToBytes: null as any,
   };
 
   const init = async () => {
@@ -265,6 +266,11 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       }
     }
     opts.csr = !!updatedOpts.csr;
+
+    opts.inlineStylesUpToBytes = optimizerOptions.inlineStylesUpToBytes ?? 0;
+    if (typeof opts.inlineStylesUpToBytes !== 'number' || opts.inlineStylesUpToBytes < 0) {
+      opts.inlineStylesUpToBytes = 0;
+    }
 
     return { ...opts };
   };
@@ -896,6 +902,7 @@ export interface QwikPluginOptions {
     | ((transformedModules: TransformModule[]) => Promise<void> | void)
     | null;
   devTools?: QwikPluginDevTools;
+  inlineStylesUpToBytes?: number;
 }
 
 export interface NormalizedQwikPluginOptions extends Required<QwikPluginOptions> {

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -57,6 +57,7 @@ export function qwikRollup(qwikRollupOpts: QwikRollupPluginOptions = {}): any {
         manifestOutput: qwikRollupOpts.manifestOutput,
         manifestInput: qwikRollupOpts.manifestInput,
         transformedModuleOutput: qwikRollupOpts.transformedModuleOutput,
+        inlineStylesUpToBytes: qwikRollupOpts.optimizerOptions?.inlineStylesUpToBytes,
       };
 
       const opts = qwikPlugin.normalizeOptions(pluginOpts);

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -460,7 +460,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
             } else {
               const baseFilename = basePathname + fileName;
               if (STYLING.some((ext) => fileName.endsWith(ext))) {
-                if (typeof b.source === 'string' && b.source.length < 20000) {
+                if (typeof b.source === 'string' && b.source.length < opts.inlineStylesUpToBytes) {
                   injections.push({
                     tag: 'style',
                     location: 'head',

--- a/packages/qwik/src/optimizer/src/types.ts
+++ b/packages/qwik/src/optimizer/src/types.ts
@@ -34,6 +34,7 @@ export interface Optimizer {
 export interface OptimizerOptions {
   sys?: OptimizerSystem;
   binding?: any;
+  inlineStylesUpToBytes?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #5069

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

The Optimizer inlines styles up to 2e4 bytes. This PR makes that value configurable using:
```
qwikVite({
  optimizerOptions: {
    inlineStylesUpToBytes: 400,
  },
}),
```

Feedback needed:
1. is `inlineStylesUpToBytes` a good enough name?
2. is placing it inside `optimizerOptions` the correct scope?

# Use cases and why

- 1. Inlining 20k bytes of css might be invalid for certain use cases.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
