### PR TITLE
docs: update reactivity's counter example

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/concepts/reactivity/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/concepts/reactivity/index.mdx
@@ -12,6 +12,7 @@ contributors:
   - the-r3aper7
   - AnthonyPAlicea
   - mhevery
+  - wtlin1228
 ---
 
 # Reactivity
@@ -54,12 +55,12 @@ export const Counter = component$(() => {
 ```
 
 1. The server performs an initial render of the component. The server rendering includes creating the proxy represented by `store`.
-2. The initial render invokes the OnRender method, which has a reference to the `store` proxy. The rendering puts the proxy to "learn" mode. During the build-up of JSX, the proxy observes a read of the `count` property. Because the proxy is in "learn" mode, it records that the `Counter` has a subscription on the `store.count`.
-3. The server serializes the state of the application into HTML. This includes the `store` as well as subscription information which says that `Counter` is subscribed to `store.count`.
-4. In the browser, the user clicks the button. Because the click event handler closed over `store`, Qwik restores the store proxy. The proxy contains the application state (the count) and the subscription, which associates the `Counter` with `state.count`.
-5. The event handler increments the `store.count`. Because the `store` is a proxy, it notices the write and uses the subscription information to invalidate the `Counter`.
-6. After `requestAnimationFrame`, the `Counter` downloads the rendering function and re-runs the OnRender method.
-7. During the OnRender, the subscription list is cleared, and a new subscription list is built up by observing what reads the JSX building performs.
+2. The initial render invokes the OnRender method, which has a reference to the `store` proxy. The rendering puts the proxy to "learn" mode. During the build-up of JSX, the proxy observes a read of the `count` property. Because the proxy is in "learn" mode, it records that the text node inside `Counter` has a subscription on the `store.count`.
+3. The server serializes the state of the application into HTML. This includes the `store` as well as subscription information which says that the text node inside `Counter` is subscribed to `store.count`.
+4. In the browser, the user clicks the button. Because the click event handler closed over `store`, Qwik restores the store proxy. The proxy contains the application state (the count) and the subscription, which associates the text node inside `Counter` with `state.count`.
+5. The event handler increments the `store.count`. Because the `store` is a proxy, it notices the write and uses the subscription information to create a signal operation in order to update the text node inside `Counter`.
+6. After `requestAnimationFrame`, the signal operation is executed.
+7. During the execution of this signal operation, the subscription of this operation is cleared, and a new subscription is built up by reading the signal's value. And the text node inside `Counter` is updated to that new value.
 
 ## Unsubscribe example
 

--- a/packages/docs/src/routes/docs/(qwik)/concepts/reactivity/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/concepts/reactivity/index.mdx
@@ -55,12 +55,11 @@ export const Counter = component$(() => {
 ```
 
 1. The server performs an initial render of the component. The server rendering includes creating the proxy represented by `store`.
-2. The initial render invokes the OnRender method, which has a reference to the `store` proxy. The rendering puts the proxy to "learn" mode. During the build-up of JSX, the proxy observes a read of the `count` property. Because the proxy is in "learn" mode, it records that the text node inside `Counter` has a subscription on the `store.count`.
+2. The initial render invokes the OnRender method, which has a reference to the `store` proxy. The rendering puts the proxy in "learn" mode. During the build-up of JSX, the proxy observes a read of the `count` property. Because the proxy is in "learn" mode, it records that the text node inside `Counter` has a subscription on the `store.count`.
 3. The server serializes the state of the application into HTML. This includes the `store` as well as subscription information which says that the text node inside `Counter` is subscribed to `store.count`.
 4. In the browser, the user clicks the button. Because the click event handler closed over `store`, Qwik restores the store proxy. The proxy contains the application state (the count) and the subscription, which associates the text node inside `Counter` with `state.count`.
-5. The event handler increments the `store.count`. Because the `store` is a proxy, it notices the write and uses the subscription information to create a signal operation in order to update the text node inside `Counter`.
-6. After `requestAnimationFrame`, the signal operation is executed.
-7. During the execution of this signal operation, the subscription of this operation is cleared, and a new subscription is built up by reading the signal's value. And the text node inside `Counter` is updated to that new value.
+5. The event handler increments the `store.count`. Because the `store` is a proxy, it notices the write and uses the subscription information to create a signal operation to update the text node inside `Counter`.
+6. After `requestAnimationFrame`, the signal value is reflected in the DOM by updating the text node's value to that of the signal.
 
 ## Unsubscribe example
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

Should complete the first task from https://github.com/BuilderIO/qwik/issues/2591

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

`Counter` will not download the rendering function and re-runs the OnRender method.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
