### PR TITLE
docs: update the implicit reactivity tutorial

### DIFF
--- a/packages/docs/src/routes/tutorial/reactivity/template/index.mdx
+++ b/packages/docs/src/routes/tutorial/reactivity/template/index.mdx
@@ -1,18 +1,19 @@
 ---
-title: Implicit Template Updates | Tutorial
+title: Implicit Store Reactivity | Tutorial
 contributors:
   - adamdbradley
   - manucorporat
+  - wtlin1228
 ---
 
-This example demonstrates how mutating stores automatically update the templates.
+This example demonstrates how mutating stores automatically update its subscribers.
 
-During SSR rendering the server needs to render all of the components in the application. As it is rendering the components the bindings in those components perform reads on store properties. For example, when `<DisplayA>` reads the `countA` property from the store, Qwik records that as a subscription. Qwik now knows that if `countA` changes then `<DisplayA>` needs to be re-rendered. Rendering templates will automatically set up subscriptions on the store. Each time the template re-renders the old subscriptions are thrown away and new subscriptions are created. This means that the template can change the set of things it is listening to during its lifecycle.
+During SSR rendering the server needs to render all of the components in the application. As it is rendering the components the bindings in those components perform reads on store properties. For example, when the text node in the `<DisplayA>` reads the `countA` property from the store, Qwik records that as a subscription. Qwik now knows that if `countA` changes then the text node in the `<DisplayA>` needs to be re-render. Executing the signal operations will automatically set up subscriptions on the store. Each time the signal operations executed the old subscriptions are thrown away and new subscriptions are created. This means that the text node can change the set of things it is listening to during its lifecycle.
 
 Currently, the buttons don't do anything. Implement the buttons to increment the respective store properties.
 
-Once you make the buttons work, notice that even though all state is stored in a single store, the updates are very focused. `a++` button will only cause the re-rendering of `<DisplayA>` and `b++` button will only cause re-rendering of `<DisplayB>`. The fine-grained re-rendering is an important property of Qwik. It is what allows Qwik applications to stay lean and not download too much code unnecessarily.
+Once you make the buttons work, notice that even though all state is stored in a single store, the updates are very focused. `a++` button will only cause the re-rendering of the text node inside `<DisplayA>` and `b++` button will only cause re-rendering of the text node inside `<DisplayB>`. The fine-grained re-rendering is an important property of Qwik. It is what allows Qwik applications to stay lean and not download too much code unnecessarily.
 
-Template subscriptions are automatically created and released when the component is removed. There is no need to keep track of them or release them manually.
+Subscriptions are automatically created and released when the component is removed. There is no need to keep track of them or release them manually.
 
-Qwik is a reactive system. All reactive systems require a single full execution of the application to create subscriptions. Qwik applications also require full execution to set up all subscriptions. However, Qwik applications perform the full execution on the server and transfer the subscription information to the client. In this way, the client knows which component needs to be re-rendered when without being forced to do one full rendering of the whole application. Doing so would force all components to be eagerly downloaded, and Qwik wants to avoid that.
+Qwik is a reactive system. All reactive systems require a single full execution of the application to create subscriptions. Qwik applications also require full execution to set up all subscriptions. However, Qwik applications perform the full execution on the server and transfer the subscription information to the client. In this way, the client knows which component or part of component needs to be re-rendered when without being forced to do one full rendering of the whole application. Doing so would force all components to be eagerly downloaded, and Qwik wants to avoid that.

--- a/packages/docs/src/routes/tutorial/reactivity/template/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/reactivity/template/problem/app.tsx
@@ -22,12 +22,12 @@ export default component$(() => {
   );
 });
 
-export const DisplayA = component$((props: { store: AppStore }) => {
+export const DisplayA = component$<{ store: AppStore }>((props) => {
   console.log('Render: <DisplayA>');
   return <>{props.store.countA}</>;
 });
 
-export const DisplayB = component$((props: { store: AppStore }) => {
+export const DisplayB = component$<{ store: AppStore }>((props) => {
   console.log('Render: <DisplayB>');
   return <>{props.store.countB}</>;
 });

--- a/packages/docs/src/routes/tutorial/reactivity/template/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/reactivity/template/solution/app.tsx
@@ -22,12 +22,12 @@ export default component$(() => {
   );
 });
 
-export const DisplayA = component$((props: { store: AppStore }) => {
+export const DisplayA = component$<{ store: AppStore }>((props) => {
   console.log('Render: <DisplayA>');
   return <>{props.store.countA}</>;
 });
 
-export const DisplayB = component$((props: { store: AppStore }) => {
+export const DisplayB = component$<{ store: AppStore }>((props) => {
   console.log('Render: <DisplayB>');
   return <>{props.store.countB}</>;
 });


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

Should complete the first task from https://github.com/BuilderIO/qwik/issues/2591

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

- Avoid people from thinking that `<DisplayA>` and `<DisplayB>` will be re-rendered.
- Fix prop types.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
