### PR TITLE
docs: fix "Endpoints" link on Qwik City -> Routing page

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
@@ -10,6 +10,7 @@ contributors:
   - wtlin1228
   - AnthonyPAlicea
   - hamatoyogi
+  - jakovljevic-mladen
 ---
 
 # Routing
@@ -18,8 +19,8 @@ Routing in Qwik City is file-system based like [Next.js](https://nextjs.org/docs
 
 - **📂 Directories:** Define the URL segments to match by the router.
 - **📄 `index.tsx/mdx` files:** Define a [page](/docs/pages/).
-- **📄 `index.ts` file:** Define an [endpoint](/docs/endpoint/).
-- **🖼️ `layout.tsx` files:** Define nested [layout](/docs/layout/) and/or a [middleware](/docs/middleware).
+- **📄 `index.ts` file:** Define an [endpoint](/docs/endpoints/).
+- **🖼️ `layout.tsx` files:** Define nested [layout](/docs/layout/) and/or a [middleware](/docs/middleware/).
 
 <video autoplay>
  <source src="https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fabf8f471ba884b938d0863d85ed4c50f%2Fcompressed?apiKey=YJIGb4i01jvw0SRdL5Bt&token=abf8f471ba884b938d0863d85ed4c50f&alt=media&optimized=true"/>


### PR DESCRIPTION
# Overview
Fix a link to "endpoint" link on [Routing](https://qwik.builder.io/docs/routing/) page. [`/endpoint`](https://qwik.builder.io/docs/endpoint/) does not exist, while [`/endpoints`](https://qwik.builder.io/docs/endpoints/) do.

# What is it?

- [x] Docs / tests / types / typos

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
