### PR TITLE
chore(eslint-plugin-qwik): change eslint to ^8.45

### DIFF
--- a/packages/eslint-plugin-qwik/package.json
+++ b/packages/eslint-plugin-qwik/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "eslint": "8.45.0"
+    "eslint": "^8.45.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Overview

Allow higher than 8.45 eslint to be used as a peer dependency, solving #5109

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

- When using the plugin in a project, one might want the latest eslint to be used
- When using the plugin as part of a package, one might want to allow more than one version of eslint

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix/functionality
