### PR TITLE
fix(qwik-city): improve StrictUnion type to avoid unnecessary partials

### DIFF
--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -377,14 +377,10 @@ export type Editable<T> = {
 
 type UnionKeys<T> = T extends T ? keyof T : never;
 type StrictUnionHelper<T, TAll> = T extends any
-  ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
+  ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, undefined>>
   : never;
 
-type StrictUnion<T> = Prettify<StrictUnionHelper<T, T>>;
-
-type Prettify<T> = {} & {
-  [K in keyof T]?: T[K];
-};
+type StrictUnion<T> = StrictUnionHelper<T, T>;
 
 /**
  * @public

--- a/starters/apps/qwikcity-test/src/routes/(common)/actions/issue5065/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/(common)/actions/issue5065/index.tsx
@@ -1,0 +1,35 @@
+import { component$ } from "@builder.io/qwik";
+import { routeAction$, zod$, z } from "@builder.io/qwik-city";
+
+// This is a TypeScript type validation test only.
+
+interface MyObject {
+  value: number;
+  optional?: string;
+}
+
+export const useSimpleObjectAction = routeAction$(
+  async () => ({ value: 42 }) as MyObject,
+);
+
+export const useZodObjectAction = routeAction$(
+  async () => ({ value: 42 }) as MyObject,
+  zod$({ name: z.string() }),
+);
+
+export default component$(() => {
+  const fooAction = useSimpleObjectAction();
+  const fooValue = fooAction.value!;
+  fooValue satisfies MyObject;
+
+  const zodAction = useZodObjectAction();
+  const zodValue = zodAction.value!;
+  if (zodValue.failed) {
+    zodValue satisfies { failed: true } & z.typeToFlattenedError<{
+      name: string;
+    }>;
+  } else {
+    zodValue satisfies MyObject;
+  }
+  return <>TEST</>;
+});


### PR DESCRIPTION
# Overview

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

This takes an alternative approach to #5079 by removing the `Prettify` type which had the effect of causing a partial on all sides of the `StrictUnion`. The all-undefined behavior on the inapplicable sides is instead accomplished by updating the `Partial` in `StrictUnionHelper`.

I added a test file for purpose of testing typings, similarly to #5079. I ran `pnpm build` locally and it didn't seem to cause any errors. Meanwhile, I tried applying a similar patch to `index.d.ts` in the project where I originally ran into #5065 and it seems to resolve it for me there.

Fixes #5065.

# Use cases and why

We shouldn't need to redundantly check/assert that multiple different properties on a successful result from a route action are defined, if the result type always defines its properties.

More details/examples are in #5065.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- (N/A) I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
