### PR TITLE
starters: Ensure that VSCode emmet uses JSX syntax for self-closing tags

### DIFF
--- a/starters/apps/base/.vscode/settings.json
+++ b/starters/apps/base/.vscode/settings.json
@@ -7,5 +7,5 @@
     // to ensure closing tags are used (e.g. <img/> not just <img> like in HTML)
     // https://github.com/microsoft/vscode/commit/083bf9020407ea5a91199eb1f0b373859df8d600#diff-88456bc9b7caa2f8126aea0107b4671db0f094961aaf39a7c689f890e23aaaba
     "output.selfClosingStyle": "xhtml"
-  },
+  }
 }

--- a/starters/apps/base/.vscode/settings.json
+++ b/starters/apps/base/.vscode/settings.json
@@ -2,5 +2,10 @@
   "material-icon-theme.activeIconPack": "qwik",
   "emmet.includeLanguages": {
     "typescriptreact": "html"
-  }
+  },
+  "emmet.preferences": {
+    // to ensure closing tags are used (e.g. <img/> not just <img> like in HTML)
+    // https://github.com/microsoft/vscode/commit/083bf9020407ea5a91199eb1f0b373859df8d600#diff-88456bc9b7caa2f8126aea0107b4671db0f094961aaf39a7c689f890e23aaaba
+    "output.selfClosingStyle": "xhtml"
+  },
 }


### PR DESCRIPTION
# Overview

Fix emmet behavior for base

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description


```tsx
// Before
br => <br>
// After
br => <br/>
```

Also applies to `input`, `img`, etc.


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
