### PR TITLE
feat: Add route rewriting

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
@@ -329,6 +329,56 @@ Each request handler, such as `onRequest`, `onGet`, `onPost`, etc., are passed i
 - `text`: Convenience method to send an text body response. The response will be automatically set the `Content-Type` header to`text/plain; charset=utf-8`. An `text()` response can only be called once.
 - `url`: HTTP request [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL).
 
+## Rewrite routes
+
+You can rewrite your urls in order to reuse one single page component with its own middlewares and layouts for multiple pages.
+This could be useful for SEO purposes or to translate your pages in different languages.
+
+For each folder under the routes one if there are occurrences of the `paths.from`
+in the pathname the route node will be copied replacing all the occurrences of `paths.from` with the related `paths.to`.
+All path parameters will preserve the same name.
+
+You can set the rewrite rules as follows in your `vite.config.ts`:
+
+```tsx
+import { defineConfig } from 'vite';
+import { qwikCity } from '@builder.io/qwik-city/vite';
+
+export default defineConfig(async () => {
+  return {
+    plugins: [
+      qwikCity({
+        rewriteRoutes: [
+            {
+              paths: [
+                {
+                  from: 'docs',
+                  to: 'documentation',
+                },
+              ],
+            },
+            {
+              prefix: 'it',
+              paths: [
+                {
+                  from: 'docs',
+                  to: 'documentazione',
+                }, {
+                  from: 'getting-started',
+                  to: 'per-iniziare',
+                }, {
+                  from: 'products',
+                  to: 'prodotti',
+                },
+              ],
+            },
+          ],
+      }),
+    ],
+  };
+});
+```
+
 ## Advanced routing
 
 Qwik City also supports:

--- a/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
@@ -350,27 +350,17 @@ export default defineConfig(async () => {
       qwikCity({
         rewriteRoutes: [
             {
-              paths: [
-                {
-                  from: 'docs',
-                  to: 'documentation',
-                },
-              ],
+              paths: {
+                  'docs': 'documentation'
+              },
             },
             {
               prefix: 'it',
-              paths: [
-                {
-                  from: 'docs',
-                  to: 'documentazione',
-                }, {
-                  from: 'getting-started',
-                  to: 'per-iniziare',
-                }, {
-                  from: 'products',
-                  to: 'prodotti',
-                },
-              ],
+              paths: {
+                'docs': 'documentazione',
+                'getting-started': 'per-iniziare',
+                'products': 'prodotti',
+              },
             },
           ],
       }),

--- a/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
@@ -331,12 +331,12 @@ Each request handler, such as `onRequest`, `onGet`, `onPost`, etc., are passed i
 
 ## Rewrite routes
 
-You can rewrite your urls in order to reuse one single page component with its own middlewares and layouts for multiple pages.
+You can rewrite your pathnames in order to reuse one single page component with its own middlewares and layouts for multiple pages.
 This could be useful for SEO purposes or to translate your pages in different languages.
 
 For each folder under the routes one if there are occurrences of the `paths` keys
 in the pathname the route node will be copied replacing all the occurrences of `paths` keys with the related `paths` values.
-All path parameters will preserve the same name.
+All path parameters will preserve the same name. If there is a prefix it will be added at the beginning of the rewrited pathname.
 
 You can set the rewrite rules as follows in your `vite.config.ts`:
 

--- a/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
@@ -334,8 +334,8 @@ Each request handler, such as `onRequest`, `onGet`, `onPost`, etc., are passed i
 You can rewrite your urls in order to reuse one single page component with its own middlewares and layouts for multiple pages.
 This could be useful for SEO purposes or to translate your pages in different languages.
 
-For each folder under the routes one if there are occurrences of the `paths.from`
-in the pathname the route node will be copied replacing all the occurrences of `paths.from` with the related `paths.to`.
+For each folder under the routes one if there are occurrences of the `paths` keys
+in the pathname the route node will be copied replacing all the occurrences of `paths` keys with the related `paths` values.
 All path parameters will preserve the same name.
 
 You can set the rewrite rules as follows in your `vite.config.ts`:

--- a/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
+++ b/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
@@ -1,0 +1,169 @@
+import * as assert from 'uvu/assert';
+import { testAppSuite } from '../utils/test-suite';
+
+const test = testAppSuite('Build Pages Rewrited', {
+  rewriteRoutes: [
+    {
+      paths: [
+        {
+          from: 'docs',
+          to: 'documentazione',
+        }, {
+          from: 'getting-started',
+          to: 'per-iniziare',
+        }, {
+          from: 'about-us',
+          to: 'informazioni',
+        }, {
+          from: 'products',
+          to: 'prodotti',
+        }
+      ]
+    }, {
+      prefix: 'it',
+      paths: [
+        {
+          from: 'docs',
+          to: 'documentazione',
+        }, {
+          from: 'getting-started',
+          to: 'per-iniziare',
+        }, {
+          from: 'about-us',
+          to: 'informazioni',
+        }, {
+          from: 'products',
+          to: 'prodotti',
+        }
+      ]
+    }
+  ]
+});
+
+test('translated pathname /docs/getting-started with prefix', ({ assertRoute, opts }) => {
+  const r = assertRoute('/it/documentazione/per-iniziare/');
+  assert.equal(r.id, 'DocsGettingstartedRouteIT');
+  assert.equal(r.pathname, '/it/documentazione/per-iniziare/');
+  assert.equal(r.routeName, 'it/documentazione/per-iniziare/');
+  assert.equal(r.pattern, /^\/it\/documentazione\/per-iniziare\/?/);
+  assert.equal(r.paramNames.length, 0);
+  assert.equal(r.segments[0][0].content, 'it');
+  assert.equal(r.segments[1][0].content, 'documentazione');
+  assert.equal(r.segments[2][0].content, 'per-iniziare');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md'));
+});
+
+test('translated pathname /docs/[category]/[id] with prefix', ({ assertRoute, opts }) => {
+  const r = assertRoute('/it/documentazione/[category]/[id]/');
+  assert.equal(r.id, 'DocsCategoryIdRouteIT');
+  assert.equal(r.pathname, '/it/documentazione/[category]/[id]/');
+  assert.equal(r.routeName, 'it/documentazione/[category]/[id]/');
+  assert.equal(r.pattern,  /^\/it\/documentazione\/([^/]+?)\/([^/]+?)\/?/);
+  assert.equal(r.paramNames[0], 'category');
+  assert.equal(r.paramNames[1], 'id');
+  assert.equal(r.segments[0][0].content, 'it');
+  assert.equal(r.segments[1][0].content, 'documentazione');
+  assert.equal(r.segments[2][0].content, 'category');
+  assert.equal(r.segments[3][0].content, 'id');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx'));
+});
+
+test('translated pathname /about-us with prefix', ({ assertRoute, opts }) => {
+  const r = assertRoute('/it/informazioni/');
+  assert.equal(r.id, 'CommonAboutusRouteIT');
+  assert.equal(r.pathname, '/it/informazioni/');
+  assert.equal(r.routeName, 'it/informazioni/');
+  assert.equal(r.pattern, /^\/it\/informazioni\/?/);
+  assert.equal(r.paramNames.length, 0);
+  assert.equal(r.segments[0][0].content, 'it');
+  assert.equal(r.segments[1][0].content, 'informazioni');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx'));
+});
+
+test('translated pathname /products/[id] with prefix', ({ assertRoute, opts }) => {
+  const r = assertRoute('/it/prodotti/[id]/');
+  assert.equal(r.id, 'CommonProductsIdRouteIT');
+  assert.equal(r.pathname, '/it/prodotti/[id]/');
+  assert.equal(r.routeName, 'it/prodotti/[id]/');
+  assert.equal(r.pattern, /^\/it\/prodotti\/([^/]+?)\/?/);
+  assert.equal(r.paramNames[0], 'id');
+  assert.equal(r.segments[0][0].content, 'it');
+  assert.equal(r.segments[1][0].content, 'prodotti');
+  assert.equal(r.segments[2][0].content, 'id');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx'));
+});
+
+test('translated pathname /docs/getting-started', ({ assertRoute, opts }) => {
+  const r = assertRoute('/documentazione/per-iniziare/');
+  assert.equal(r.id, 'DocsGettingstartedRoute0');
+  assert.equal(r.pathname, '/documentazione/per-iniziare/');
+  assert.equal(r.routeName, 'documentazione/per-iniziare/');
+  assert.equal(r.pattern, /^\/documentazione\/per-iniziare\/?/);
+  assert.equal(r.paramNames.length, 0);
+  assert.equal(r.segments[0][0].content, 'documentazione');
+  assert.equal(r.segments[1][0].content, 'per-iniziare');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md'));
+});
+
+test('translated pathname /docs/[category]/[id]', ({ assertRoute, opts }) => {
+  const r = assertRoute('/documentazione/[category]/[id]/');
+  assert.equal(r.id, 'DocsCategoryIdRoute0');
+  assert.equal(r.pathname, '/documentazione/[category]/[id]/');
+  assert.equal(r.routeName, 'documentazione/[category]/[id]/');
+  assert.equal(r.pattern,  /^\/documentazione\/([^/]+?)\/([^/]+?)\/?/);
+  assert.equal(r.paramNames[0], 'category');
+  assert.equal(r.paramNames[1], 'id');
+  assert.equal(r.segments[0][0].content, 'documentazione');
+  assert.equal(r.segments[1][0].content, 'category');
+  assert.equal(r.segments[2][0].content, 'id');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx'));
+});
+
+test('translated pathname /about-us', ({ assertRoute, opts }) => {
+  const r = assertRoute('/informazioni/');
+  assert.equal(r.id, 'CommonAboutusRoute0');
+  assert.equal(r.pathname, '/informazioni/');
+  assert.equal(r.routeName, 'informazioni/');
+  assert.equal(r.pattern, /^\/informazioni\/?/);
+  assert.equal(r.paramNames.length, 0);
+  assert.equal(r.segments[0][0].content, 'informazioni');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx'));
+});
+
+test('translated pathname /products/[id]', ({ assertRoute, opts }) => {
+  const r = assertRoute('/prodotti/[id]/');
+  assert.equal(r.id, 'CommonProductsIdRoute0');
+  assert.equal(r.pathname, '/prodotti/[id]/');
+  assert.equal(r.routeName, 'prodotti/[id]/');
+  assert.equal(r.pattern, /^\/prodotti\/([^/]+?)\/?/);
+  assert.equal(r.paramNames[0], 'id');
+  assert.equal(r.segments[0][0].content, 'prodotti');
+  assert.equal(r.segments[1][0].content, 'id');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx'));
+});
+
+test.run();

--- a/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
+++ b/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
@@ -8,36 +8,43 @@ const test = testAppSuite('Build Pages Rewrited', {
         {
           from: 'docs',
           to: 'documentazione',
-        }, {
+        },
+        {
           from: 'getting-started',
           to: 'per-iniziare',
-        }, {
+        },
+        {
           from: 'about-us',
           to: 'informazioni',
-        }, {
+        },
+        {
           from: 'products',
           to: 'prodotti',
-        }
-      ]
-    }, {
+        },
+      ],
+    },
+    {
       prefix: 'it',
       paths: [
         {
           from: 'docs',
           to: 'documentazione',
-        }, {
+        },
+        {
           from: 'getting-started',
           to: 'per-iniziare',
-        }, {
+        },
+        {
           from: 'about-us',
           to: 'informazioni',
-        }, {
+        },
+        {
           from: 'products',
           to: 'prodotti',
-        }
-      ]
-    }
-  ]
+        },
+      ],
+    },
+  ],
 });
 
 test('translated pathname /docs/getting-started with prefix', ({ assertRoute, opts }) => {
@@ -52,8 +59,12 @@ test('translated pathname /docs/getting-started with prefix', ({ assertRoute, op
   assert.equal(r.segments[2][0].content, 'per-iniziare');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md')
+  );
 });
 
 test('translated pathname /docs/[category]/[id] with prefix', ({ assertRoute, opts }) => {
@@ -61,7 +72,7 @@ test('translated pathname /docs/[category]/[id] with prefix', ({ assertRoute, op
   assert.equal(r.id, 'DocsCategoryIdRouteIT');
   assert.equal(r.pathname, '/it/documentazione/[category]/[id]/');
   assert.equal(r.routeName, 'it/documentazione/[category]/[id]/');
-  assert.equal(r.pattern,  /^\/it\/documentazione\/([^/]+?)\/([^/]+?)\/?/);
+  assert.equal(r.pattern, /^\/it\/documentazione\/([^/]+?)\/([^/]+?)\/?/);
   assert.equal(r.paramNames[0], 'category');
   assert.equal(r.paramNames[1], 'id');
   assert.equal(r.segments[0][0].content, 'it');
@@ -70,8 +81,12 @@ test('translated pathname /docs/[category]/[id] with prefix', ({ assertRoute, op
   assert.equal(r.segments[3][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx')
+  );
 });
 
 test('translated pathname /about-us with prefix', ({ assertRoute, opts }) => {
@@ -85,8 +100,12 @@ test('translated pathname /about-us with prefix', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'informazioni');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx')
+  );
 });
 
 test('translated pathname /products/[id] with prefix', ({ assertRoute, opts }) => {
@@ -101,8 +120,12 @@ test('translated pathname /products/[id] with prefix', ({ assertRoute, opts }) =
   assert.equal(r.segments[2][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx')
+  );
 });
 
 test('translated pathname /docs/getting-started', ({ assertRoute, opts }) => {
@@ -116,8 +139,12 @@ test('translated pathname /docs/getting-started', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'per-iniziare');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md')
+  );
 });
 
 test('translated pathname /docs/[category]/[id]', ({ assertRoute, opts }) => {
@@ -125,7 +152,7 @@ test('translated pathname /docs/[category]/[id]', ({ assertRoute, opts }) => {
   assert.equal(r.id, 'DocsCategoryIdRoute0');
   assert.equal(r.pathname, '/documentazione/[category]/[id]/');
   assert.equal(r.routeName, 'documentazione/[category]/[id]/');
-  assert.equal(r.pattern,  /^\/documentazione\/([^/]+?)\/([^/]+?)\/?/);
+  assert.equal(r.pattern, /^\/documentazione\/([^/]+?)\/([^/]+?)\/?/);
   assert.equal(r.paramNames[0], 'category');
   assert.equal(r.paramNames[1], 'id');
   assert.equal(r.segments[0][0].content, 'documentazione');
@@ -133,8 +160,12 @@ test('translated pathname /docs/[category]/[id]', ({ assertRoute, opts }) => {
   assert.equal(r.segments[2][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx')
+  );
 });
 
 test('translated pathname /about-us', ({ assertRoute, opts }) => {
@@ -147,8 +178,12 @@ test('translated pathname /about-us', ({ assertRoute, opts }) => {
   assert.equal(r.segments[0][0].content, 'informazioni');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx')
+  );
 });
 
 test('translated pathname /products/[id]', ({ assertRoute, opts }) => {
@@ -162,8 +197,12 @@ test('translated pathname /products/[id]', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx')
+  );
 });
 
 test.run();

--- a/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
+++ b/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
@@ -4,45 +4,21 @@ import { testAppSuite } from '../utils/test-suite';
 const test = testAppSuite('Build Pages Rewrited', {
   rewriteRoutes: [
     {
-      paths: [
-        {
-          from: 'docs',
-          to: 'documentazione',
-        },
-        {
-          from: 'getting-started',
-          to: 'per-iniziare',
-        },
-        {
-          from: 'about-us',
-          to: 'informazioni',
-        },
-        {
-          from: 'products',
-          to: 'prodotti',
-        },
-      ],
+      paths: {
+        docs: 'documentazione',
+        'getting-started': 'per-iniziare',
+        'about-us': 'informazioni',
+        products: 'prodotti',
+      },
     },
     {
       prefix: 'it',
-      paths: [
-        {
-          from: 'docs',
-          to: 'documentazione',
-        },
-        {
-          from: 'getting-started',
-          to: 'per-iniziare',
-        },
-        {
-          from: 'about-us',
-          to: 'informazioni',
-        },
-        {
-          from: 'products',
-          to: 'prodotti',
-        },
-      ],
+      paths: {
+        docs: 'documentazione',
+        'getting-started': 'per-iniziare',
+        'about-us': 'informazioni',
+        products: 'prodotti',
+      },
     },
   ],
 });

--- a/packages/qwik-city/buildtime/build.ts
+++ b/packages/qwik-city/buildtime/build.ts
@@ -49,8 +49,7 @@ export async function updateBuildContext(ctx: BuildContext) {
 
 function rewriteRoutes(ctx: BuildContext, resolved: ReturnType<typeof resolveSourceFiles>) {
   if (ctx.opts.rewriteRoutes) {
-    for (let rewriteIndex = 0; rewriteIndex < ctx.opts.rewriteRoutes.length; rewriteIndex++) {
-      const rewriteOpt = ctx.opts.rewriteRoutes[rewriteIndex];
+    ctx.opts.rewriteRoutes.forEach((rewriteOpt, rewriteIndex) => {
       const rewriteFrom = Object.keys(rewriteOpt.paths || {});
       const rewriteRoutes = (resolved.routes || []).filter((route) =>
         rewriteFrom.some((from) => route.pathname.includes(from))
@@ -58,7 +57,7 @@ function rewriteRoutes(ctx: BuildContext, resolved: ReturnType<typeof resolveSou
 
       const replacePath = (part: string) => (rewriteOpt.paths || {})[part] ?? part;
 
-      for (const rewriteRoute of rewriteRoutes) {
+      rewriteRoutes.forEach((rewriteRoute) => {
         const pathnamePrefix = rewriteOpt.prefix ? '/' + rewriteOpt.prefix : '';
         const routeNamePrefix = rewriteOpt.prefix ? rewriteOpt.prefix + '/' : '';
         const idSuffix = rewriteOpt.prefix?.toUpperCase().replace(/-/g, '');
@@ -106,8 +105,8 @@ function rewriteRoutes(ctx: BuildContext, resolved: ReturnType<typeof resolveSou
           pattern: new RegExp(translatedRegExp),
           segments: translatedSegments,
         });
-      }
-    }
+      });
+    });
   }
 }
 

--- a/packages/qwik-city/buildtime/markdown/markdown-url.unit.ts
+++ b/packages/qwik-city/buildtime/markdown/markdown-url.unit.ts
@@ -80,6 +80,7 @@ const menuFilePath = join(routesDir, 'docs', 'menu.md');
       },
       mdx: {},
       platform: {},
+      rewriteRoutes: [],
     };
     equal(getMarkdownRelativeUrl(opts, menuFilePath, t.href), t.expect);
   });

--- a/packages/qwik-city/buildtime/routing/resolve-source-file.unit.ts
+++ b/packages/qwik-city/buildtime/routing/resolve-source-file.unit.ts
@@ -49,6 +49,7 @@ test('resolveLayout', () => {
       },
       mdx: {},
       platform: {},
+      rewriteRoutes: [],
     };
     const sourceFile: RouteSourceFile = {
       ...getSourceFile(c.fileName)!,

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -122,10 +122,7 @@ export interface ParsedMenuItem {
  */
 export interface RewriteRouteOption {
   prefix?: string;
-  paths: {
-    from: string;
-    to: string;
-  }[];
+  paths: Record<string, string>;
 }
 
 /**

--- a/packages/qwik-city/buildtime/types.ts
+++ b/packages/qwik-city/buildtime/types.ts
@@ -120,6 +120,17 @@ export interface ParsedMenuItem {
 /**
  * @public
  */
+export interface RewriteRouteOption {
+  prefix?: string;
+  paths: {
+    from: string;
+    to: string;
+  }[];
+}
+
+/**
+ * @public
+ */
 export interface PluginOptions {
   /**
    * Directory of the `routes`. Defaults to `src/routes`.
@@ -152,6 +163,10 @@ export interface PluginOptions {
    * The platform object which can be used to mock the Cloudflare bindings.
    */
   platform?: Record<string, unknown>;
+  /**
+   * Configuration to rewrite url paths
+   */
+  rewriteRoutes?: RewriteRouteOption[];
 }
 
 export interface MdxPlugins {

--- a/packages/qwik-city/utils/fs.unit.ts
+++ b/packages/qwik-city/utils/fs.unit.ts
@@ -265,6 +265,7 @@ test('createFileId, Menu', () => {
       },
       mdx: {},
       platform: {},
+      rewriteRoutes: [],
     };
     const pathname = getPathnameFromDirPath(opts, t.dirPath);
     equal(pathname, t.expect, t.dirPath);
@@ -365,6 +366,7 @@ test('parseRouteIndexName', () => {
       },
       mdx: {},
       platform: {},
+      rewriteRoutes: [],
     };
     const pathname = getMenuPathname(opts, t.filePath);
     equal(pathname, t.expect);

--- a/packages/qwik-city/utils/test-suite.ts
+++ b/packages/qwik-city/utils/test-suite.ts
@@ -8,6 +8,7 @@ import type {
   BuildRoute,
   MarkdownAttributes,
   NormalizedPluginOptions,
+  PluginOptions,
 } from '../buildtime/types';
 import { createBuildContext } from '../buildtime/context';
 import { tmpdir } from 'node:os';
@@ -36,7 +37,7 @@ export function suite(title?: string) {
   return s;
 }
 
-export function testAppSuite(title: string) {
+export function testAppSuite(title: string, userOpts?: PluginOptions) {
   const s = uvuSuite<TestAppBuildContext>(title);
   let buildCtx: any = null;
 
@@ -45,7 +46,7 @@ export function testAppSuite(title: string) {
       const __dirname = fileURLToPath(new URL('.', import.meta.url));
       const testAppRootDir = join(__dirname, '..', '..', '..', 'starters', 'apps', 'qwikcity-test');
       const basePath = '/';
-      const ctx = createBuildContext(testAppRootDir, basePath);
+      const ctx = createBuildContext(testAppRootDir, basePath, userOpts);
 
       assert.is(normalizePath(testAppRootDir), ctx.rootDir);
       assert.is(normalizePath(join(testAppRootDir, 'src', 'routes')), ctx.opts.routesDir);


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Now you can rewrite your urls using the same page component, layout and middlewares. 
You can use a prefix to localize your routes or you can simply rewrite urls without prefix.

# Use cases and why

- 1. **Translate localized urls with prefix**: for localization purposes you may want to translate your routes from `/products` to `/it/prodotti` or to `/fr/produits` and `/products/product-name` to `/it/prodotti/nome-prodotto` or `/fr/produits/nom-du-produit` without having multiple routes files for each locale but reusing the same page component, layouts, middlewares and so on. parameters name will not be changed so if the routePath is `/products/[slug]` you will receive `product-name`, `nome-prodotto` or `nom-du-produit` as the values for the same `slug` path parameter.
- 2. **Rewrite urls without prefix**: it's rare but you may want to have aliases for the same path as stated in the issue below. for example you may want both `/docs` and `/documents` to be rendered from the same page component.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality

# Issues

This should close the issue #4835 
