### PR TITLE
bug(vite): populate rollup cache after transform

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -630,7 +630,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       } else {
         results.set(normalizedID, newOutput);
       }
-      const deps = new Set();
+      const deps = new Set<string>();
       for (const mod of newOutput.modules) {
         if (mod.isEntry) {
           const key = normalizePath(path.join(srcDir, mod.path));
@@ -674,6 +674,14 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
             deps.add(key);
           }
         }
+      }
+
+      // Force loading generated submodules into Rollup cache so later
+      // unchanged imports are not missing in our internal transform cache
+      // This can happen in the repl when the plugin is re-initialized
+      // and possibly in other places
+      for (const id of deps.values()) {
+        await ctx.load({ id });
       }
 
       const module = newOutput.modules.find((m) => !m.isEntry)!;


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I think this might fix what was wrong with the playground.

The Qwik optimizer transform will create new QRL imports and stores them in memory until they are loaded by rollup/vite.

If a subsequent run tries to load a QRL, it won't be in the transform cache.

This change hopefully loads the code into the cache, but I wasn't able to actually test this.

I also wonder how rollup knows that a QRL  has changed when the source file has changed.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
