### PR TITLE
fix(qwik-city): Correctly SSG routes even with `trailingSlash: false`

### DIFF
--- a/packages/qwik-city/adapters/shared/vite/post-build.ts
+++ b/packages/qwik-city/adapters/shared/vite/post-build.ts
@@ -11,10 +11,11 @@ export async function postBuild(
 ) {
   const ignorePathnames = new Set([basePathname + 'build/', basePathname + 'assets/']);
 
-  const staticPaths = new Set(userStaticPaths);
+  const staticPaths = new Set(userStaticPaths.map(normalizeTrailingSlash));
   const notFounds: string[][] = [];
 
   const loadItem = async (fsDir: string, fsName: string, pathname: string) => {
+    pathname = normalizeTrailingSlash(pathname);
     if (ignorePathnames.has(pathname)) {
       return;
     }
@@ -60,6 +61,13 @@ export async function postBuild(
     notFoundPathsCode,
     staticPathsCode,
   };
+}
+
+function normalizeTrailingSlash(pathname: string) {
+  if (!pathname.endsWith('/')) {
+    return pathname + '/';
+  }
+  return pathname;
 }
 
 function createNotFoundPathsModule(basePathname: string, notFounds: string[][], format: string) {


### PR DESCRIPTION
Fix #4856

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
