### PR TITLE
test(qwik-city): add route-matcher case with two rest params

### DIFF
--- a/packages/qwik-city/runtime/src/route-matcher.unit.ts
+++ b/packages/qwik-city/runtime/src/route-matcher.unit.ts
@@ -163,3 +163,18 @@ regression5080('/[...rest]/suffix', () => {
   equal(matchRoute('/[...rest]/suffix', '/a/b/c/suffix/'), { rest: 'a/b/c' });
 });
 regression5080.run();
+
+const regression5126 = suite('routeMatcher/#5126');
+regression5080('/[...dynamicOne]/static-segment/[...dynamicTwo]/', () => {
+  equal(
+    matchRoute(
+      '/[...dynamicOne]/static-segment/[...dynamicTwo]/',
+      '/abc/xyz/static-segment/more-dynamic-123/'
+    ),
+    {
+      dynamicOne: 'abc/xyz',
+      dynamicTwo: 'more-dynamic-123',
+    }
+  );
+});
+regression5126.run();


### PR DESCRIPTION
F

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
