### PR TITLE
fix(core.d.ts): export HTMLAttributes and DevJSX to fix TS4023 issue …

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -3,6 +3,40 @@
   "package": "@builder.io/qwik",
   "members": [
     {
+      "name": "\"bind:checked\"",
+      "id": "inputhtmlattributes-_bind_checked_",
+      "hierarchy": [
+        {
+          "name": "InputHTMLAttributes",
+          "id": "inputhtmlattributes-_bind_checked_"
+        },
+        {
+          "name": "\"bind:checked\"",
+          "id": "inputhtmlattributes-_bind_checked_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'bind:checked'?: Signal<boolean | undefined>;\n```",
+      "mdFile": "qwik.inputhtmlattributes._bind_checked_.md"
+    },
+    {
+      "name": "\"bind:value\"",
+      "id": "inputhtmlattributes-_bind_value_",
+      "hierarchy": [
+        {
+          "name": "InputHTMLAttributes",
+          "id": "inputhtmlattributes-_bind_value_"
+        },
+        {
+          "name": "\"bind:value\"",
+          "id": "inputhtmlattributes-_bind_value_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'bind:value'?: Signal<string | undefined>;\n```",
+      "mdFile": "qwik.inputhtmlattributes._bind_value_.md"
+    },
+    {
       "name": "\"q:slot\"",
       "id": "componentbaseprops-_q_slot_",
       "hierarchy": [
@@ -34,6 +68,34 @@
       "mdFile": "qwik._.md"
     },
     {
+      "name": "AnchorHTMLAttributes",
+      "id": "anchorhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "AnchorHTMLAttributes",
+          "id": "anchorhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [download?](#) |  | any | _(Optional)_ |\n|  [href?](#) |  | string \\| undefined | _(Optional)_ |\n|  [hrefLang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [ping?](#) |  | string \\| undefined | _(Optional)_ |\n|  [referrerPolicy?](#) |  | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \\| undefined | _(Optional)_ |\n|  [rel?](#) |  | string \\| undefined | _(Optional)_ |\n|  [target?](#) |  | [HTMLAttributeAnchorTarget](#htmlattributeanchortarget) \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.anchorhtmlattributes.md"
+    },
+    {
+      "name": "AreaHTMLAttributes",
+      "id": "areahtmlattributes",
+      "hierarchy": [
+        {
+          "name": "AreaHTMLAttributes",
+          "id": "areahtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface AreaHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [alt?](#) |  | string \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [coords?](#) |  | string \\| undefined | _(Optional)_ |\n|  [download?](#) |  | any | _(Optional)_ |\n|  [href?](#) |  | string \\| undefined | _(Optional)_ |\n|  [hrefLang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [referrerPolicy?](#) |  | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \\| undefined | _(Optional)_ |\n|  [rel?](#) |  | string \\| undefined | _(Optional)_ |\n|  [shape?](#) |  | string \\| undefined | _(Optional)_ |\n|  [target?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.areahtmlattributes.md"
+    },
+    {
       "name": "AriaAttributes",
       "id": "ariaattributes",
       "hierarchy": [
@@ -43,7 +105,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface AriaAttributes \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [\"aria-activedescendant\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. |\n|  [\"aria-atomic\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. |\n|  [\"aria-autocomplete\"?](#) |  | 'none' \\| 'inline' \\| 'list' \\| 'both' \\| undefined | _(Optional)_ Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made. |\n|  [\"aria-busy\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. |\n|  [\"aria-checked\"?](#) |  | boolean \\| 'false' \\| 'mixed' \\| 'true' \\| undefined | _(Optional)_ Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets. |\n|  [\"aria-colcount\"?](#) |  | number \\| undefined | _(Optional)_ Defines the total number of columns in a table, grid, or treegrid. |\n|  [\"aria-colindex\"?](#) |  | number \\| undefined | _(Optional)_ Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid. |\n|  [\"aria-colspan\"?](#) |  | number \\| undefined | _(Optional)_ Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid. |\n|  [\"aria-controls\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element (or elements) whose contents or presence are controlled by the current element. |\n|  [\"aria-current\"?](#) |  | boolean \\| 'false' \\| 'true' \\| 'page' \\| 'step' \\| 'location' \\| 'date' \\| 'time' \\| undefined | _(Optional)_ Indicates the element that represents the current item within a container or set of related elements. |\n|  [\"aria-describedby\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element (or elements) that describes the object. |\n|  [\"aria-details\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element that provides a detailed, extended description for the object. |\n|  [\"aria-disabled\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable. |\n|  [\"aria-dropeffect\"?](#) |  | 'none' \\| 'copy' \\| 'execute' \\| 'link' \\| 'move' \\| 'popup' \\| undefined | _(Optional)_ Indicates what functions can be performed when a dragged object is released on the drop target. |\n|  [\"aria-errormessage\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element that provides an error message for the object. |\n|  [\"aria-expanded\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. |\n|  [\"aria-flowto\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order. |\n|  [\"aria-grabbed\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates an element's \"grabbed\" state in a drag-and-drop operation. |\n|  [\"aria-haspopup\"?](#) |  | boolean \\| 'false' \\| 'true' \\| 'menu' \\| 'listbox' \\| 'tree' \\| 'grid' \\| 'dialog' \\| undefined | _(Optional)_ Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. |\n|  [\"aria-hidden\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates whether the element is exposed to an accessibility API. |\n|  [\"aria-invalid\"?](#) |  | boolean \\| 'false' \\| 'true' \\| 'grammar' \\| 'spelling' \\| undefined | _(Optional)_ Indicates the entered value does not conform to the format expected by the application. |\n|  [\"aria-keyshortcuts\"?](#) |  | string \\| undefined | _(Optional)_ Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. |\n|  [\"aria-label\"?](#) |  | string \\| undefined | _(Optional)_ Defines a string value that labels the current element. |\n|  [\"aria-labelledby\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element (or elements) that labels the current element. |\n|  [\"aria-level\"?](#) |  | number \\| undefined | _(Optional)_ Defines the hierarchical level of an element within a structure. |\n|  [\"aria-live\"?](#) |  | 'off' \\| 'assertive' \\| 'polite' \\| undefined | _(Optional)_ Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. |\n|  [\"aria-modal\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates whether an element is modal when displayed. |\n|  [\"aria-multiline\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates whether a text box accepts multiple lines of input or only a single line. |\n|  [\"aria-multiselectable\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates that the user may select more than one item from the current selectable descendants. |\n|  [\"aria-orientation\"?](#) |  | 'horizontal' \\| 'vertical' \\| undefined | _(Optional)_ Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. |\n|  [\"aria-owns\"?](#) |  | string \\| undefined | _(Optional)_ Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent the relationship. |\n|  [\"aria-placeholder\"?](#) |  | string \\| undefined | _(Optional)_ Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format. |\n|  [\"aria-posinset\"?](#) |  | number \\| undefined | _(Optional)_ Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. |\n|  [\"aria-pressed\"?](#) |  | boolean \\| 'false' \\| 'mixed' \\| 'true' \\| undefined | _(Optional)_ Indicates the current \"pressed\" state of toggle buttons. |\n|  [\"aria-readonly\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates that the element is not editable, but is otherwise operable. |\n|  [\"aria-relevant\"?](#) |  | 'additions' \\| 'additions removals' \\| 'additions text' \\| 'all' \\| 'removals' \\| 'removals additions' \\| 'removals text' \\| 'text' \\| 'text additions' \\| 'text removals' \\| undefined | _(Optional)_ Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. |\n|  [\"aria-required\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates that user input is required on the element before a form may be submitted. |\n|  [\"aria-roledescription\"?](#) |  | string \\| undefined | _(Optional)_ Defines a human-readable, author-localized description for the role of an element. |\n|  [\"aria-rowcount\"?](#) |  | number \\| undefined | _(Optional)_ Defines the total number of rows in a table, grid, or treegrid. |\n|  [\"aria-rowindex\"?](#) |  | number \\| undefined | _(Optional)_ Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid. |\n|  [\"aria-rowspan\"?](#) |  | number \\| undefined | _(Optional)_ Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid. |\n|  [\"aria-selected\"?](#) |  | Booleanish \\| undefined | _(Optional)_ Indicates the current \"selected\" state of various widgets. |\n|  [\"aria-setsize\"?](#) |  | number \\| undefined | _(Optional)_ Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. |\n|  [\"aria-sort\"?](#) |  | 'none' \\| 'ascending' \\| 'descending' \\| 'other' \\| undefined | _(Optional)_ Indicates if items in a table or grid are sorted in ascending or descending order. |\n|  [\"aria-valuemax\"?](#) |  | number \\| undefined | _(Optional)_ Defines the maximum allowed value for a range widget. |\n|  [\"aria-valuemin\"?](#) |  | number \\| undefined | _(Optional)_ Defines the minimum allowed value for a range widget. |\n|  [\"aria-valuenow\"?](#) |  | number \\| undefined | _(Optional)_ Defines the current value for a range widget. |\n|  [\"aria-valuetext\"?](#) |  | string \\| undefined | _(Optional)_ Defines the human readable text alternative of aria-valuenow for a range widget. |",
+      "content": "```typescript\nexport interface AriaAttributes \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [\"aria-activedescendant\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. |\n|  [\"aria-atomic\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. |\n|  [\"aria-autocomplete\"?](#) |  | 'none' \\| 'inline' \\| 'list' \\| 'both' \\| undefined | _(Optional)_ Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made. |\n|  [\"aria-busy\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. |\n|  [\"aria-checked\"?](#) |  | boolean \\| 'false' \\| 'mixed' \\| 'true' \\| undefined | _(Optional)_ Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets. |\n|  [\"aria-colcount\"?](#) |  | number \\| undefined | _(Optional)_ Defines the total number of columns in a table, grid, or treegrid. |\n|  [\"aria-colindex\"?](#) |  | number \\| undefined | _(Optional)_ Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid. |\n|  [\"aria-colspan\"?](#) |  | number \\| undefined | _(Optional)_ Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid. |\n|  [\"aria-controls\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element (or elements) whose contents or presence are controlled by the current element. |\n|  [\"aria-current\"?](#) |  | boolean \\| 'false' \\| 'true' \\| 'page' \\| 'step' \\| 'location' \\| 'date' \\| 'time' \\| undefined | _(Optional)_ Indicates the element that represents the current item within a container or set of related elements. |\n|  [\"aria-describedby\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element (or elements) that describes the object. |\n|  [\"aria-details\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element that provides a detailed, extended description for the object. |\n|  [\"aria-disabled\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable. |\n|  [\"aria-dropeffect\"?](#) |  | 'none' \\| 'copy' \\| 'execute' \\| 'link' \\| 'move' \\| 'popup' \\| undefined | _(Optional)_ Indicates what functions can be performed when a dragged object is released on the drop target. |\n|  [\"aria-errormessage\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element that provides an error message for the object. |\n|  [\"aria-expanded\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. |\n|  [\"aria-flowto\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order. |\n|  [\"aria-grabbed\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates an element's \"grabbed\" state in a drag-and-drop operation. |\n|  [\"aria-haspopup\"?](#) |  | boolean \\| 'false' \\| 'true' \\| 'menu' \\| 'listbox' \\| 'tree' \\| 'grid' \\| 'dialog' \\| undefined | _(Optional)_ Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. |\n|  [\"aria-hidden\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates whether the element is exposed to an accessibility API. |\n|  [\"aria-invalid\"?](#) |  | boolean \\| 'false' \\| 'true' \\| 'grammar' \\| 'spelling' \\| undefined | _(Optional)_ Indicates the entered value does not conform to the format expected by the application. |\n|  [\"aria-keyshortcuts\"?](#) |  | string \\| undefined | _(Optional)_ Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. |\n|  [\"aria-label\"?](#) |  | string \\| undefined | _(Optional)_ Defines a string value that labels the current element. |\n|  [\"aria-labelledby\"?](#) |  | string \\| undefined | _(Optional)_ Identifies the element (or elements) that labels the current element. |\n|  [\"aria-level\"?](#) |  | number \\| undefined | _(Optional)_ Defines the hierarchical level of an element within a structure. |\n|  [\"aria-live\"?](#) |  | 'off' \\| 'assertive' \\| 'polite' \\| undefined | _(Optional)_ Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. |\n|  [\"aria-modal\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates whether an element is modal when displayed. |\n|  [\"aria-multiline\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates whether a text box accepts multiple lines of input or only a single line. |\n|  [\"aria-multiselectable\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates that the user may select more than one item from the current selectable descendants. |\n|  [\"aria-orientation\"?](#) |  | 'horizontal' \\| 'vertical' \\| undefined | _(Optional)_ Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. |\n|  [\"aria-owns\"?](#) |  | string \\| undefined | _(Optional)_ Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent the relationship. |\n|  [\"aria-placeholder\"?](#) |  | string \\| undefined | _(Optional)_ Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format. |\n|  [\"aria-posinset\"?](#) |  | number \\| undefined | _(Optional)_ Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. |\n|  [\"aria-pressed\"?](#) |  | boolean \\| 'false' \\| 'mixed' \\| 'true' \\| undefined | _(Optional)_ Indicates the current \"pressed\" state of toggle buttons. |\n|  [\"aria-readonly\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates that the element is not editable, but is otherwise operable. |\n|  [\"aria-relevant\"?](#) |  | 'additions' \\| 'additions removals' \\| 'additions text' \\| 'all' \\| 'removals' \\| 'removals additions' \\| 'removals text' \\| 'text' \\| 'text additions' \\| 'text removals' \\| undefined | _(Optional)_ Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. |\n|  [\"aria-required\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates that user input is required on the element before a form may be submitted. |\n|  [\"aria-roledescription\"?](#) |  | string \\| undefined | _(Optional)_ Defines a human-readable, author-localized description for the role of an element. |\n|  [\"aria-rowcount\"?](#) |  | number \\| undefined | _(Optional)_ Defines the total number of rows in a table, grid, or treegrid. |\n|  [\"aria-rowindex\"?](#) |  | number \\| undefined | _(Optional)_ Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid. |\n|  [\"aria-rowspan\"?](#) |  | number \\| undefined | _(Optional)_ Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid. |\n|  [\"aria-selected\"?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ Indicates the current \"selected\" state of various widgets. |\n|  [\"aria-setsize\"?](#) |  | number \\| undefined | _(Optional)_ Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. |\n|  [\"aria-sort\"?](#) |  | 'none' \\| 'ascending' \\| 'descending' \\| 'other' \\| undefined | _(Optional)_ Indicates if items in a table or grid are sorted in ascending or descending order. |\n|  [\"aria-valuemax\"?](#) |  | number \\| undefined | _(Optional)_ Defines the maximum allowed value for a range widget. |\n|  [\"aria-valuemin\"?](#) |  | number \\| undefined | _(Optional)_ Defines the minimum allowed value for a range widget. |\n|  [\"aria-valuenow\"?](#) |  | number \\| undefined | _(Optional)_ Defines the current value for a range widget. |\n|  [\"aria-valuetext\"?](#) |  | string \\| undefined | _(Optional)_ Defines the human readable text alternative of aria-valuenow for a range widget. |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.ariaattributes.md"
     },
@@ -62,6 +124,76 @@
       "mdFile": "qwik.ariarole.md"
     },
     {
+      "name": "AudioHTMLAttributes",
+      "id": "audiohtmlattributes",
+      "hierarchy": [
+        {
+          "name": "AudioHTMLAttributes",
+          "id": "audiohtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface AudioHTMLAttributes<T extends Element> extends MediaHTMLAttributes<T> \n```\n**Extends:** [MediaHTMLAttributes](#mediahtmlattributes)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.audiohtmlattributes.md"
+    },
+    {
+      "name": "BaseHTMLAttributes",
+      "id": "basehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "BaseHTMLAttributes",
+          "id": "basehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface BaseHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [href?](#) |  | string \\| undefined | _(Optional)_ |\n|  [target?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.basehtmlattributes.md"
+    },
+    {
+      "name": "BlockquoteHTMLAttributes",
+      "id": "blockquotehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "BlockquoteHTMLAttributes",
+          "id": "blockquotehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface BlockquoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [cite?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.blockquotehtmlattributes.md"
+    },
+    {
+      "name": "Booleanish",
+      "id": "booleanish",
+      "hierarchy": [
+        {
+          "name": "Booleanish",
+          "id": "booleanish"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type Booleanish = boolean | `${boolean}`;\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.booleanish.md"
+    },
+    {
+      "name": "ButtonHTMLAttributes",
+      "id": "buttonhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ButtonHTMLAttributes",
+          "id": "buttonhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [autoFocus?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [formAction?](#) |  | string \\| undefined | _(Optional)_ |\n|  [formEncType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [formMethod?](#) |  | string \\| undefined | _(Optional)_ |\n|  [formNoValidate?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [formTarget?](#) |  | string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | 'submit' \\| 'reset' \\| 'button' \\| undefined | _(Optional)_ |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.buttonhtmlattributes.md"
+    },
+    {
       "name": "cache",
       "id": "resourcectx-cache",
       "hierarchy": [
@@ -77,6 +209,20 @@
       "kind": "MethodSignature",
       "content": "```typescript\ncache(policyOrMilliseconds: number | 'immutable'): void;\n```\n\n\n|  Parameter | Type | Description |\n|  --- | --- | --- |\n|  policyOrMilliseconds | number \\| 'immutable' |  |\n\n**Returns:**\n\nvoid",
       "mdFile": "qwik.resourcectx.cache.md"
+    },
+    {
+      "name": "CanvasHTMLAttributes",
+      "id": "canvashtmlattributes",
+      "hierarchy": [
+        {
+          "name": "CanvasHTMLAttributes",
+          "id": "canvashtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface CanvasHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [height?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.canvashtmlattributes.md"
     },
     {
       "name": "ClassList",
@@ -108,6 +254,34 @@
       "kind": "MethodSignature",
       "content": "```typescript\ncleanup(): void;\n```\n**Returns:**\n\nvoid",
       "mdFile": "qwik.renderresult.cleanup.md"
+    },
+    {
+      "name": "ColgroupHTMLAttributes",
+      "id": "colgrouphtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ColgroupHTMLAttributes",
+          "id": "colgrouphtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ColgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [span?](#) |  | number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.colgrouphtmlattributes.md"
+    },
+    {
+      "name": "ColHTMLAttributes",
+      "id": "colhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ColHTMLAttributes",
+          "id": "colhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ColHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [span?](#) |  | number \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.colhtmlattributes.md"
     },
     {
       "name": "Component",
@@ -222,6 +396,76 @@
       "mdFile": "qwik.cssproperties.md"
     },
     {
+      "name": "DataHTMLAttributes",
+      "id": "datahtmlattributes",
+      "hierarchy": [
+        {
+          "name": "DataHTMLAttributes",
+          "id": "datahtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface DataHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.datahtmlattributes.md"
+    },
+    {
+      "name": "DelHTMLAttributes",
+      "id": "delhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "DelHTMLAttributes",
+          "id": "delhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface DelHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [cite?](#) |  | string \\| undefined | _(Optional)_ |\n|  [dateTime?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.delhtmlattributes.md"
+    },
+    {
+      "name": "DetailsHTMLAttributes",
+      "id": "detailshtmlattributes",
+      "hierarchy": [
+        {
+          "name": "DetailsHTMLAttributes",
+          "id": "detailshtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface DetailsHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [open?](#) |  | boolean \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.detailshtmlattributes.md"
+    },
+    {
+      "name": "DevJSX",
+      "id": "devjsx",
+      "hierarchy": [
+        {
+          "name": "DevJSX",
+          "id": "devjsx"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface DevJSX \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [columnNumber](#) |  | number |  |\n|  [fileName](#) |  | string |  |\n|  [lineNumber](#) |  | number |  |\n|  [stack?](#) |  | string | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-node.ts",
+      "mdFile": "qwik.devjsx.md"
+    },
+    {
+      "name": "DialogHTMLAttributes",
+      "id": "dialoghtmlattributes",
+      "hierarchy": [
+        {
+          "name": "DialogHTMLAttributes",
+          "id": "dialoghtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface DialogHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [open?](#) |  | boolean \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.dialoghtmlattributes.md"
+    },
+    {
       "name": "DOMAttributes",
       "id": "domattributes",
       "hierarchy": [
@@ -292,6 +536,20 @@
       "mdFile": "qwik.h.jsx.elementchildrenattribute.md"
     },
     {
+      "name": "EmbedHTMLAttributes",
+      "id": "embedhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "EmbedHTMLAttributes",
+          "id": "embedhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface EmbedHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [height?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.embedhtmlattributes.md"
+    },
+    {
       "name": "ErrorBoundaryStore",
       "id": "errorboundarystore",
       "hierarchy": [
@@ -332,6 +590,34 @@
       "content": "```typescript\neventQrl: <T>(qrl: QRL<T>) => QRL<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts",
       "mdFile": "qwik.eventqrl.md"
+    },
+    {
+      "name": "FieldsetHTMLAttributes",
+      "id": "fieldsethtmlattributes",
+      "hierarchy": [
+        {
+          "name": "FieldsetHTMLAttributes",
+          "id": "fieldsethtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface FieldsetHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.fieldsethtmlattributes.md"
+    },
+    {
+      "name": "FormHTMLAttributes",
+      "id": "formhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "FormHTMLAttributes",
+          "id": "formhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [acceptCharset?](#) |  | string \\| undefined | _(Optional)_ |\n|  [action?](#) |  | string \\| undefined | _(Optional)_ |\n|  [autoComplete?](#) |  | 'on' \\| 'off' \\| Omit&lt;'on' \\| 'off', string&gt; \\| undefined | _(Optional)_ |\n|  [encType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [method?](#) |  | string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [noValidate?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [target?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.formhtmlattributes.md"
     },
     {
       "name": "Fragment",
@@ -472,6 +758,48 @@
       "mdFile": "qwik.h.md"
     },
     {
+      "name": "HrHTMLAttributes",
+      "id": "hrhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "HrHTMLAttributes",
+          "id": "hrhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface HrHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.hrhtmlattributes.md"
+    },
+    {
+      "name": "HTMLAttributeAnchorTarget",
+      "id": "htmlattributeanchortarget",
+      "hierarchy": [
+        {
+          "name": "HTMLAttributeAnchorTarget",
+          "id": "htmlattributeanchortarget"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {});\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.htmlattributeanchortarget.md"
+    },
+    {
+      "name": "HTMLAttributeReferrerPolicy",
+      "id": "htmlattributereferrerpolicy",
+      "hierarchy": [
+        {
+          "name": "HTMLAttributeReferrerPolicy",
+          "id": "htmlattributereferrerpolicy"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type HTMLAttributeReferrerPolicy = '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url';\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.htmlattributereferrerpolicy.md"
+    },
+    {
       "name": "HTMLAttributes",
       "id": "htmlattributes",
       "hierarchy": [
@@ -484,6 +812,20 @@
       "content": "```typescript\nexport interface HTMLAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> \n```\n**Extends:** [AriaAttributes](#ariaattributes)<!-- -->, [DOMAttributes](#domattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [about?](#) |  | string \\| undefined | _(Optional)_ |\n|  [accessKey?](#) |  | string \\| undefined | _(Optional)_ |\n|  [autoCapitalize?](#) |  | string \\| undefined | _(Optional)_ |\n|  [autoCorrect?](#) |  | string \\| undefined | _(Optional)_ |\n|  [autoSave?](#) |  | string \\| undefined | _(Optional)_ |\n|  [color?](#) |  | string \\| undefined | _(Optional)_ |\n|  [contentEditable?](#) |  | 'true' \\| 'false' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [contextMenu?](#) |  | string \\| undefined | _(Optional)_ |\n|  [datatype?](#) |  | string \\| undefined | _(Optional)_ |\n|  [dir?](#) |  | 'ltr' \\| 'rtl' \\| 'auto' \\| undefined | _(Optional)_ |\n|  [draggable?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [hidden?](#) |  | boolean \\| 'hidden' \\| 'until-found' \\| undefined | _(Optional)_ |\n|  [id?](#) |  | string \\| undefined | _(Optional)_ |\n|  [inlist?](#) |  | any | _(Optional)_ |\n|  [inputMode?](#) |  | 'none' \\| 'text' \\| 'tel' \\| 'url' \\| 'email' \\| 'numeric' \\| 'decimal' \\| 'search' \\| undefined | _(Optional)_ Hints at the type of data that might be entered by the user while editing the element or its contents |\n|  [is?](#) |  | string \\| undefined | _(Optional)_ Specify that a standard HTML element should behave like a defined custom built-in element |\n|  [itemID?](#) |  | string \\| undefined | _(Optional)_ |\n|  [itemProp?](#) |  | string \\| undefined | _(Optional)_ |\n|  [itemRef?](#) |  | string \\| undefined | _(Optional)_ |\n|  [itemScope?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [itemType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [lang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [placeholder?](#) |  | string \\| undefined | _(Optional)_ |\n|  [prefix?](#) |  | string \\| undefined | _(Optional)_ |\n|  [property?](#) |  | string \\| undefined | _(Optional)_ |\n|  [radioGroup?](#) |  | string \\| undefined | _(Optional)_ |\n|  [resource?](#) |  | string \\| undefined | _(Optional)_ |\n|  [results?](#) |  | number \\| undefined | _(Optional)_ |\n|  [role?](#) |  | [AriaRole](#ariarole) \\| undefined | _(Optional)_ |\n|  [security?](#) |  | string \\| undefined | _(Optional)_ |\n|  [slot?](#) |  | string \\| undefined | _(Optional)_ |\n|  [spellcheck?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [style?](#) |  | [CSSProperties](#cssproperties) \\| string \\| undefined | _(Optional)_ |\n|  [tabIndex?](#) |  | number \\| undefined | _(Optional)_ |\n|  [title?](#) |  | string \\| undefined | _(Optional)_ |\n|  [translate?](#) |  | 'yes' \\| 'no' \\| undefined | _(Optional)_ |\n|  [typeof?](#) |  | string \\| undefined | _(Optional)_ |\n|  [unselectable?](#) |  | 'on' \\| 'off' \\| undefined | _(Optional)_ |\n|  [vocab?](#) |  | string \\| undefined | _(Optional)_ |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.htmlattributes.md"
+    },
+    {
+      "name": "HTMLCrossOriginAttribute",
+      "id": "htmlcrossoriginattribute",
+      "hierarchy": [
+        {
+          "name": "HTMLCrossOriginAttribute",
+          "id": "htmlcrossoriginattribute"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type HTMLCrossOriginAttribute = 'anonymous' | 'use-credentials' | '' | undefined;\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.htmlcrossoriginattribute.md"
     },
     {
       "name": "HTMLFragment",
@@ -500,6 +842,76 @@
       "mdFile": "qwik.htmlfragment.md"
     },
     {
+      "name": "HtmlHTMLAttributes",
+      "id": "htmlhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "HtmlHTMLAttributes",
+          "id": "htmlhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface HtmlHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [manifest?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.htmlhtmlattributes.md"
+    },
+    {
+      "name": "HTMLInputAutocompleteAttribute",
+      "id": "htmlinputautocompleteattribute",
+      "hierarchy": [
+        {
+          "name": "HTMLInputAutocompleteAttribute",
+          "id": "htmlinputautocompleteattribute"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type HTMLInputAutocompleteAttribute = 'on' | 'off' | 'billing' | 'shipping' | 'name' | 'honorific-prefix' | 'given-name' | 'additional-name' | 'family-name' | 'honorific-suffix' | 'nickname' | 'username' | 'new-password' | 'current-password' | 'one-time-code' | 'organization-title' | 'organization' | 'street-address' | 'address-line1' | 'address-line2' | 'address-line3' | 'address-level4' | 'address-level3' | 'address-level2' | 'address-level1' | 'country' | 'country-name' | 'postal-code' | 'cc-name' | 'cc-given-name' | 'cc-additional-name' | 'cc-family-name' | 'cc-number' | 'cc-exp' | 'cc-exp-month' | 'cc-exp-year' | 'cc-csc' | 'cc-type' | 'transaction-currency' | 'transaction-amount' | 'language' | 'bday' | 'bday-day' | 'bday-month' | 'bday-year' | 'sex' | 'url' | 'photo';\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.htmlinputautocompleteattribute.md"
+    },
+    {
+      "name": "HTMLInputTypeAttribute",
+      "id": "htmlinputtypeattribute",
+      "hierarchy": [
+        {
+          "name": "HTMLInputTypeAttribute",
+          "id": "htmlinputtypeattribute"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type HTMLInputTypeAttribute = 'button' | 'checkbox' | 'color' | 'date' | 'datetime-local' | 'email' | 'file' | 'hidden' | 'image' | 'month' | 'number' | 'password' | 'radio' | 'range' | 'reset' | 'search' | 'submit' | 'tel' | 'text' | 'time' | 'url' | 'week' | (string & {});\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.htmlinputtypeattribute.md"
+    },
+    {
+      "name": "IframeHTMLAttributes",
+      "id": "iframehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "IframeHTMLAttributes",
+          "id": "iframehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface IframeHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [allow?](#) |  | string \\| undefined | _(Optional)_ |\n|  [allowFullScreen?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [allowTransparency?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [frameBorder?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [loading?](#) |  | 'eager' \\| 'lazy' \\| undefined | _(Optional)_ |\n|  [marginHeight?](#) |  | number \\| undefined | _(Optional)_ |\n|  [marginWidth?](#) |  | number \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [referrerPolicy?](#) |  | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \\| undefined | _(Optional)_ |\n|  [sandbox?](#) |  | string \\| undefined | _(Optional)_ |\n|  [scrolling?](#) |  | string \\| undefined | _(Optional)_ |\n|  [seamless?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |\n|  [srcDoc?](#) |  | string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.iframehtmlattributes.md"
+    },
+    {
+      "name": "ImgHTMLAttributes",
+      "id": "imghtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ImgHTMLAttributes",
+          "id": "imghtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ImgHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [alt?](#) |  | string \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |\n|  [decoding?](#) |  | 'async' \\| 'auto' \\| 'sync' \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Numberish](#numberish) \\| undefined | _(Optional)_ Intrinsic height of the image in pixels. |\n|  [loading?](#) |  | 'eager' \\| 'lazy' \\| undefined | _(Optional)_ |\n|  [referrerPolicy?](#) |  | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \\| undefined | _(Optional)_ |\n|  [sizes?](#) |  | string \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |\n|  [srcSet?](#) |  | string \\| undefined | _(Optional)_ |\n|  [useMap?](#) |  | string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Numberish](#numberish) \\| undefined | _(Optional)_ Intrinsic width of the image in pixels. |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.imghtmlattributes.md"
+    },
+    {
       "name": "implicit$FirstArg",
       "id": "implicit_firstarg",
       "hierarchy": [
@@ -512,6 +924,34 @@
       "content": "Create a `____$(...)` convenience method from `___(...)`<!-- -->.\n\nIt is very common for functions to take a lazy-loadable resource as a first argument. For this reason, the Qwik Optimizer automatically extracts the first argument from any function which ends in `$`<!-- -->.\n\nThis means that `foo$(arg0)` and `foo($(arg0))` are equivalent with respect to Qwik Optimizer. The former is just a shorthand for the latter.\n\nFor example, these function calls are equivalent:\n\n- `component$(() => {...})` is same as `component($(() => {...}))`\n\n```tsx\nexport function myApi(callback: QRL<() => void>): void {\n  // ...\n}\n\nexport const myApi$ = implicit$FirstArg(myApi);\n// type of myApi$: (callback: () => void): void\n\n// can be used as:\nmyApi$(() => console.log('callback'));\n\n// will be transpiled to:\n// FILE: <current file>\nmyApi(qrl('./chunk-abc.js', 'callback'));\n\n// FILE: chunk-abc.js\nexport const callback = () => console.log('callback');\n```\n\n\n```typescript\nimplicit$FirstArg: <FIRST, REST extends any[], RET>(fn: (first: QRL<FIRST>, ...rest: REST) => RET) => (first: FIRST, ...rest: REST) => RET\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/util/implicit_dollar.ts",
       "mdFile": "qwik.implicit_firstarg.md"
+    },
+    {
+      "name": "InputHTMLAttributes",
+      "id": "inputhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "InputHTMLAttributes",
+          "id": "inputhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface InputHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [\"bind:checked\"?](#inputhtmlattributes-_bind_checked_) |  | [Signal](#signal)<!-- -->&lt;boolean \\| undefined&gt; | _(Optional)_ |\n|  [\"bind:value\"?](#inputhtmlattributes-_bind_value_) |  | [Signal](#signal)<!-- -->&lt;string \\| undefined&gt; | _(Optional)_ |\n|  [accept?](#) |  | string \\| undefined | _(Optional)_ |\n|  [alt?](#) |  | string \\| undefined | _(Optional)_ |\n|  [autoComplete?](#) |  | [HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute) \\| Omit&lt;[HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute)<!-- -->, string&gt; \\| undefined | _(Optional)_ |\n|  [autoFocus?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [capture?](#) |  | boolean \\| 'user' \\| 'environment' \\| undefined | _(Optional)_ |\n|  [checked?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [enterKeyHint?](#) |  | 'enter' \\| 'done' \\| 'go' \\| 'next' \\| 'previous' \\| 'search' \\| 'send' \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [formAction?](#) |  | string \\| undefined | _(Optional)_ |\n|  [formEncType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [formMethod?](#) |  | string \\| undefined | _(Optional)_ |\n|  [formNoValidate?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [formTarget?](#) |  | string \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [list?](#) |  | string \\| undefined | _(Optional)_ |\n|  [max?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [maxLength?](#) |  | number \\| undefined | _(Optional)_ |\n|  [min?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [minLength?](#) |  | number \\| undefined | _(Optional)_ |\n|  [multiple?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [pattern?](#) |  | string \\| undefined | _(Optional)_ |\n|  [placeholder?](#) |  | string \\| undefined | _(Optional)_ |\n|  [readOnly?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [required?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [size?](#) |  | number \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |\n|  [step?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | [HTMLInputTypeAttribute](#htmlinputtypeattribute) \\| undefined | _(Optional)_ |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined \\| null \\| FormDataEntryValue | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.inputhtmlattributes.md"
+    },
+    {
+      "name": "InsHTMLAttributes",
+      "id": "inshtmlattributes",
+      "hierarchy": [
+        {
+          "name": "InsHTMLAttributes",
+          "id": "inshtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface InsHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [cite?](#) |  | string \\| undefined | _(Optional)_ |\n|  [dateTime?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.inshtmlattributes.md"
     },
     {
       "name": "IntrinsicAttributes",
@@ -554,6 +994,34 @@
       "kind": "Interface",
       "content": "```typescript\ninterface IntrinsicElements extends QwikJSX.IntrinsicElements \n```\n**Extends:** [QwikJSX.IntrinsicElements](#)",
       "mdFile": "qwik.h.jsx.intrinsicelements.md"
+    },
+    {
+      "name": "IntrinsicHTMLElements",
+      "id": "intrinsichtmlelements",
+      "hierarchy": [
+        {
+          "name": "IntrinsicHTMLElements",
+          "id": "intrinsichtmlelements"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface IntrinsicHTMLElements \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [a](#) |  | [AnchorHTMLAttributes](#anchorhtmlattributes)<!-- -->&lt;HTMLAnchorElement&gt; |  |\n|  [abbr](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [address](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [area](#) |  | [AreaHTMLAttributes](#areahtmlattributes)<!-- -->&lt;HTMLAreaElement&gt; |  |\n|  [article](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [aside](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [audio](#) |  | [AudioHTMLAttributes](#audiohtmlattributes)<!-- -->&lt;HTMLAudioElement&gt; |  |\n|  [b](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [base](#) |  | [BaseHTMLAttributes](#basehtmlattributes)<!-- -->&lt;HTMLBaseElement&gt; |  |\n|  [bdi](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [bdo](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [big](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [blockquote](#) |  | [BlockquoteHTMLAttributes](#blockquotehtmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [body](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLBodyElement&gt; |  |\n|  [br](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLBRElement&gt; |  |\n|  [button](#) |  | [ButtonHTMLAttributes](#buttonhtmlattributes)<!-- -->&lt;HTMLButtonElement&gt; |  |\n|  [canvas](#) |  | [CanvasHTMLAttributes](#canvashtmlattributes)<!-- -->&lt;HTMLCanvasElement&gt; |  |\n|  [caption](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [cite](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [code](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [col](#) |  | [ColHTMLAttributes](#colhtmlattributes)<!-- -->&lt;HTMLTableColElement&gt; |  |\n|  [colgroup](#) |  | [ColgroupHTMLAttributes](#colgrouphtmlattributes)<!-- -->&lt;HTMLTableColElement&gt; |  |\n|  [data](#) |  | [DataHTMLAttributes](#datahtmlattributes)<!-- -->&lt;HTMLDataElement&gt; |  |\n|  [datalist](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLDataListElement&gt; |  |\n|  [dd](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [del](#) |  | [DelHTMLAttributes](#delhtmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [details](#) |  | [DetailsHTMLAttributes](#detailshtmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [dfn](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [dialog](#) |  | [DialogHTMLAttributes](#dialoghtmlattributes)<!-- -->&lt;HTMLDialogElement&gt; |  |\n|  [div](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLDivElement&gt; |  |\n|  [dl](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLDListElement&gt; |  |\n|  [dt](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [em](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [embed](#) |  | [EmbedHTMLAttributes](#embedhtmlattributes)<!-- -->&lt;HTMLEmbedElement&gt; |  |\n|  [fieldset](#) |  | [FieldsetHTMLAttributes](#fieldsethtmlattributes)<!-- -->&lt;HTMLFieldSetElement&gt; |  |\n|  [figcaption](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [figure](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [footer](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [form](#) |  | [FormHTMLAttributes](#formhtmlattributes)<!-- -->&lt;HTMLFormElement&gt; |  |\n|  [h1](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLHeadingElement&gt; |  |\n|  [h2](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLHeadingElement&gt; |  |\n|  [h3](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLHeadingElement&gt; |  |\n|  [h4](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLHeadingElement&gt; |  |\n|  [h5](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLHeadingElement&gt; |  |\n|  [h6](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLHeadingElement&gt; |  |\n|  [head](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLHeadElement&gt; |  |\n|  [header](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [hgroup](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [hr](#) |  | [HrHTMLAttributes](#hrhtmlattributes)<!-- -->&lt;HTMLHRElement&gt; |  |\n|  [html](#) |  | [HtmlHTMLAttributes](#htmlhtmlattributes)<!-- -->&lt;HTMLHtmlElement&gt; |  |\n|  [i](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [iframe](#) |  | [IframeHTMLAttributes](#iframehtmlattributes)<!-- -->&lt;HTMLIFrameElement&gt; |  |\n|  [img](#) |  | [ImgHTMLAttributes](#imghtmlattributes)<!-- -->&lt;HTMLImageElement&gt; |  |\n|  [input](#) |  | [InputHTMLAttributes](#inputhtmlattributes)<!-- -->&lt;HTMLInputElement&gt; |  |\n|  [ins](#) |  | [InsHTMLAttributes](#inshtmlattributes)<!-- -->&lt;HTMLModElement&gt; |  |\n|  [kbd](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [keygen](#) |  | [KeygenHTMLAttributes](#keygenhtmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [label](#) |  | [LabelHTMLAttributes](#labelhtmlattributes)<!-- -->&lt;HTMLLabelElement&gt; |  |\n|  [legend](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLLegendElement&gt; |  |\n|  [li](#) |  | [LiHTMLAttributes](#lihtmlattributes)<!-- -->&lt;HTMLLIElement&gt; |  |\n|  [link](#) |  | [LinkHTMLAttributes](#linkhtmlattributes)<!-- -->&lt;HTMLLinkElement&gt; |  |\n|  [main](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [map](#) |  | [MapHTMLAttributes](#maphtmlattributes)<!-- -->&lt;HTMLMapElement&gt; |  |\n|  [mark](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [menu](#) |  | [MenuHTMLAttributes](#menuhtmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [menuitem](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [meta](#) |  | [MetaHTMLAttributes](#metahtmlattributes)<!-- -->&lt;HTMLMetaElement&gt; |  |\n|  [meter](#) |  | [MeterHTMLAttributes](#meterhtmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [nav](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [noindex](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [noscript](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [object](#) |  | [ObjectHTMLAttributes](#objecthtmlattributes)<!-- -->&lt;HTMLObjectElement&gt; |  |\n|  [ol](#) |  | [OlHTMLAttributes](#olhtmlattributes)<!-- -->&lt;HTMLOListElement&gt; |  |\n|  [optgroup](#) |  | [OptgroupHTMLAttributes](#optgrouphtmlattributes)<!-- -->&lt;HTMLOptGroupElement&gt; |  |\n|  [option](#) |  | [OptionHTMLAttributes](#optionhtmlattributes)<!-- -->&lt;HTMLOptionElement&gt; |  |\n|  [output](#) |  | [OutputHTMLAttributes](#outputhtmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [p](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLParagraphElement&gt; |  |\n|  [param](#) |  | [ParamHTMLAttributes](#paramhtmlattributes)<!-- -->&lt;HTMLParamElement&gt; |  |\n|  [picture](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [pre](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLPreElement&gt; |  |\n|  [progress](#) |  | [ProgressHTMLAttributes](#progresshtmlattributes)<!-- -->&lt;HTMLProgressElement&gt; |  |\n|  [q](#) |  | [QuoteHTMLAttributes](#quotehtmlattributes)<!-- -->&lt;HTMLQuoteElement&gt; |  |\n|  [rp](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [rt](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [ruby](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [s](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [samp](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [script](#) |  | [ScriptHTMLAttributes](#scripthtmlattributes)<!-- -->&lt;HTMLScriptElement&gt; |  |\n|  [section](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [select](#) |  | [SelectHTMLAttributes](#selecthtmlattributes)<!-- -->&lt;HTMLSelectElement&gt; |  |\n|  [slot](#) |  | [SlotHTMLAttributes](#slothtmlattributes)<!-- -->&lt;HTMLSlotElement&gt; |  |\n|  [small](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [source](#) |  | [SourceHTMLAttributes](#sourcehtmlattributes)<!-- -->&lt;HTMLSourceElement&gt; |  |\n|  [span](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLSpanElement&gt; |  |\n|  [strong](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [style](#) |  | [StyleHTMLAttributes](#stylehtmlattributes)<!-- -->&lt;HTMLStyleElement&gt; |  |\n|  [sub](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [summary](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [sup](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [table](#) |  | [TableHTMLAttributes](#tablehtmlattributes)<!-- -->&lt;HTMLTableElement&gt; |  |\n|  [tbody](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLTableSectionElement&gt; |  |\n|  [td](#) |  | [TdHTMLAttributes](#tdhtmlattributes)<!-- -->&lt;HTMLTableDataCellElement&gt; |  |\n|  [template](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLTemplateElement&gt; |  |\n|  [textarea](#) |  | [TextareaHTMLAttributes](#textareahtmlattributes)<!-- -->&lt;HTMLTextAreaElement&gt; |  |\n|  [tfoot](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLTableSectionElement&gt; |  |\n|  [th](#) |  | [ThHTMLAttributes](#thhtmlattributes)<!-- -->&lt;HTMLTableHeaderCellElement&gt; |  |\n|  [thead](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLTableSectionElement&gt; |  |\n|  [time](#) |  | [TimeHTMLAttributes](#timehtmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [title](#) |  | [TitleHTMLAttributes](#titlehtmlattributes)<!-- -->&lt;HTMLTitleElement&gt; |  |\n|  [tr](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLTableRowElement&gt; |  |\n|  [track](#) |  | [TrackHTMLAttributes](#trackhtmlattributes)<!-- -->&lt;HTMLTrackElement&gt; |  |\n|  [tt](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [u](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [ul](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLUListElement&gt; |  |\n|  [video](#) |  | [VideoHTMLAttributes](#videohtmlattributes)<!-- -->&lt;HTMLVideoElement&gt; |  |\n|  [wbr](#) |  | [HTMLAttributes](#htmlattributes)<!-- -->&lt;HTMLElement&gt; |  |\n|  [webview](#) |  | [WebViewHTMLAttributes](#webviewhtmlattributes)<!-- -->&lt;HTMLWebViewElement&gt; |  |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.intrinsichtmlelements.md"
+    },
+    {
+      "name": "IntrinsicSVGElements",
+      "id": "intrinsicsvgelements",
+      "hierarchy": [
+        {
+          "name": "IntrinsicSVGElements",
+          "id": "intrinsicsvgelements"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface IntrinsicSVGElements \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [animate](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGElement&gt; |  |\n|  [animateMotion](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGElement&gt; |  |\n|  [animateTransform](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGElement&gt; |  |\n|  [circle](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGCircleElement&gt; |  |\n|  [clipPath](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGClipPathElement&gt; |  |\n|  [defs](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGDefsElement&gt; |  |\n|  [desc](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGDescElement&gt; |  |\n|  [ellipse](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGEllipseElement&gt; |  |\n|  [feBlend](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEBlendElement&gt; |  |\n|  [feColorMatrix](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEColorMatrixElement&gt; |  |\n|  [feComponentTransfer](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEComponentTransferElement&gt; |  |\n|  [feComposite](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFECompositeElement&gt; |  |\n|  [feConvolveMatrix](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEConvolveMatrixElement&gt; |  |\n|  [feDiffuseLighting](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEDiffuseLightingElement&gt; |  |\n|  [feDisplacementMap](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEDisplacementMapElement&gt; |  |\n|  [feDistantLight](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEDistantLightElement&gt; |  |\n|  [feDropShadow](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEDropShadowElement&gt; |  |\n|  [feFlood](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEFloodElement&gt; |  |\n|  [feFuncA](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEFuncAElement&gt; |  |\n|  [feFuncB](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEFuncBElement&gt; |  |\n|  [feFuncG](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEFuncGElement&gt; |  |\n|  [feFuncR](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEFuncRElement&gt; |  |\n|  [feGaussianBlur](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEGaussianBlurElement&gt; |  |\n|  [feImage](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEImageElement&gt; |  |\n|  [feMerge](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEMergeElement&gt; |  |\n|  [feMergeNode](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEMergeNodeElement&gt; |  |\n|  [feMorphology](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEMorphologyElement&gt; |  |\n|  [feOffset](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEOffsetElement&gt; |  |\n|  [fePointLight](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFEPointLightElement&gt; |  |\n|  [feSpecularLighting](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFESpecularLightingElement&gt; |  |\n|  [feSpotLight](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFESpotLightElement&gt; |  |\n|  [feTile](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFETileElement&gt; |  |\n|  [feTurbulence](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFETurbulenceElement&gt; |  |\n|  [filter](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGFilterElement&gt; |  |\n|  [foreignObject](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGForeignObjectElement&gt; |  |\n|  [g](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGGElement&gt; |  |\n|  [image](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGImageElement&gt; |  |\n|  [line](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGLineElement&gt; |  |\n|  [linearGradient](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGLinearGradientElement&gt; |  |\n|  [marker](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGMarkerElement&gt; |  |\n|  [mask](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGMaskElement&gt; |  |\n|  [metadata](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGMetadataElement&gt; |  |\n|  [mpath](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGElement&gt; |  |\n|  [path](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGPathElement&gt; |  |\n|  [pattern](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGPatternElement&gt; |  |\n|  [polygon](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGPolygonElement&gt; |  |\n|  [polyline](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGPolylineElement&gt; |  |\n|  [radialGradient](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGRadialGradientElement&gt; |  |\n|  [rect](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGRectElement&gt; |  |\n|  [stop](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGStopElement&gt; |  |\n|  [svg](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGSVGElement&gt; |  |\n|  [switch](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGSwitchElement&gt; |  |\n|  [symbol](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGSymbolElement&gt; |  |\n|  [text](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGTextElement&gt; |  |\n|  [textPath](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGTextPathElement&gt; |  |\n|  [tspan](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGTSpanElement&gt; |  |\n|  [use](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGUseElement&gt; |  |\n|  [view](#) |  | [SVGProps](#svgprops)<!-- -->&lt;SVGViewElement&gt; |  |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.intrinsicsvgelements.md"
     },
     {
       "name": "jsx",
@@ -624,7 +1092,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface JSXNode<T = string | FunctionComponent> \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children](#) |  | any \\| null |  |\n|  [dev?](#) |  | DevJSX | _(Optional)_ |\n|  [flags](#) |  | number |  |\n|  [immutableProps](#) |  | Record&lt;string, any&gt; \\| null |  |\n|  [key](#) |  | string \\| null |  |\n|  [props](#) |  | T extends [FunctionComponent](#functioncomponent)<!-- -->&lt;infer B&gt; ? B : Record&lt;string, any&gt; |  |\n|  [type](#) |  | T |  |",
+      "content": "```typescript\nexport interface JSXNode<T = string | FunctionComponent> \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children](#) |  | any \\| null |  |\n|  [dev?](#) |  | [DevJSX](#devjsx) | _(Optional)_ |\n|  [flags](#) |  | number |  |\n|  [immutableProps](#) |  | Record&lt;string, any&gt; \\| null |  |\n|  [key](#) |  | string \\| null |  |\n|  [props](#) |  | T extends [FunctionComponent](#functioncomponent)<!-- -->&lt;infer B&gt; ? B : Record&lt;string, any&gt; |  |\n|  [type](#) |  | T |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-node.ts",
       "mdFile": "qwik.jsxnode.md"
     },
@@ -641,6 +1109,132 @@
       "content": "```typescript\nexport type JSXTagName = keyof HTMLElementTagNameMap | Omit<string, keyof HTMLElementTagNameMap>;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts",
       "mdFile": "qwik.jsxtagname.md"
+    },
+    {
+      "name": "KeygenHTMLAttributes",
+      "id": "keygenhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "KeygenHTMLAttributes",
+          "id": "keygenhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [autoFocus?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [challenge?](#) |  | string \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [keyParams?](#) |  | string \\| undefined | _(Optional)_ |\n|  [keyType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.keygenhtmlattributes.md"
+    },
+    {
+      "name": "LabelHTMLAttributes",
+      "id": "labelhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "LabelHTMLAttributes",
+          "id": "labelhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface LabelHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [for?](#) |  | string \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.labelhtmlattributes.md"
+    },
+    {
+      "name": "LiHTMLAttributes",
+      "id": "lihtmlattributes",
+      "hierarchy": [
+        {
+          "name": "LiHTMLAttributes",
+          "id": "lihtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface LiHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.lihtmlattributes.md"
+    },
+    {
+      "name": "LinkHTMLAttributes",
+      "id": "linkhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "LinkHTMLAttributes",
+          "id": "linkhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface LinkHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [as?](#) |  | string \\| undefined | _(Optional)_ |\n|  [charSet?](#) |  | string \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |\n|  [href?](#) |  | string \\| undefined | _(Optional)_ |\n|  [hrefLang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [imageSizes?](#) |  | string \\| undefined | _(Optional)_ |\n|  [imageSrcSet?](#) |  | string \\| undefined | _(Optional)_ |\n|  [integrity?](#) |  | string \\| undefined | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [referrerPolicy?](#) |  | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \\| undefined | _(Optional)_ |\n|  [rel?](#) |  | string \\| undefined | _(Optional)_ |\n|  [sizes?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.linkhtmlattributes.md"
+    },
+    {
+      "name": "MapHTMLAttributes",
+      "id": "maphtmlattributes",
+      "hierarchy": [
+        {
+          "name": "MapHTMLAttributes",
+          "id": "maphtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface MapHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.maphtmlattributes.md"
+    },
+    {
+      "name": "MediaHTMLAttributes",
+      "id": "mediahtmlattributes",
+      "hierarchy": [
+        {
+          "name": "MediaHTMLAttributes",
+          "id": "mediahtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [autoPlay?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [controls?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [controlsList?](#) |  | string \\| undefined | _(Optional)_ |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |\n|  [loop?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [mediaGroup?](#) |  | string \\| undefined | _(Optional)_ |\n|  [muted?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [playsInline?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [preload?](#) |  | string \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.mediahtmlattributes.md"
+    },
+    {
+      "name": "MenuHTMLAttributes",
+      "id": "menuhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "MenuHTMLAttributes",
+          "id": "menuhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface MenuHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.menuhtmlattributes.md"
+    },
+    {
+      "name": "MetaHTMLAttributes",
+      "id": "metahtmlattributes",
+      "hierarchy": [
+        {
+          "name": "MetaHTMLAttributes",
+          "id": "metahtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface MetaHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [charSet?](#) |  | string \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [content?](#) |  | string \\| undefined | _(Optional)_ |\n|  [httpEquiv?](#) |  | string \\| undefined | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.metahtmlattributes.md"
+    },
+    {
+      "name": "MeterHTMLAttributes",
+      "id": "meterhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "MeterHTMLAttributes",
+          "id": "meterhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [high?](#) |  | number \\| undefined | _(Optional)_ |\n|  [low?](#) |  | number \\| undefined | _(Optional)_ |\n|  [max?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [min?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [optimum?](#) |  | number \\| undefined | _(Optional)_ |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.meterhtmlattributes.md"
     },
     {
       "name": "NativeAnimationEvent",
@@ -839,6 +1433,48 @@
       "mdFile": "qwik.noserialize.md"
     },
     {
+      "name": "Numberish",
+      "id": "numberish",
+      "hierarchy": [
+        {
+          "name": "Numberish",
+          "id": "numberish"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type Numberish = number | `${number}`;\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.numberish.md"
+    },
+    {
+      "name": "ObjectHTMLAttributes",
+      "id": "objecthtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ObjectHTMLAttributes",
+          "id": "objecthtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [classID?](#) |  | string \\| undefined | _(Optional)_ |\n|  [data?](#) |  | string \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |\n|  [useMap?](#) |  | string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [wmode?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.objecthtmlattributes.md"
+    },
+    {
+      "name": "OlHTMLAttributes",
+      "id": "olhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "OlHTMLAttributes",
+          "id": "olhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface OlHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [reversed?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [start?](#) |  | number \\| undefined | _(Optional)_ |\n|  [type?](#) |  | '1' \\| 'a' \\| 'A' \\| 'i' \\| 'I' \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.olhtmlattributes.md"
+    },
+    {
       "name": "OnRenderFn",
       "id": "onrenderfn",
       "hierarchy": [
@@ -865,6 +1501,76 @@
       "content": "```typescript\nexport interface OnVisibleTaskOptions \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [strategy?](#) |  | [VisibleTaskStrategy](#visibletaskstrategy) | <p>_(Optional)_ The strategy to use to determine when the \"VisibleTask\" should first execute.</p><p>- <code>intersection-observer</code>: the task will first execute when the element is visible in the viewport, under the hood it uses the IntersectionObserver API. - <code>document-ready</code>: the task will first execute when the document is ready, under the hood it uses the document <code>load</code> event. - <code>document-idle</code>: the task will first execute when the document is idle, under the hood it uses the requestIdleCallback API.</p> |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "qwik.onvisibletaskoptions.md"
+    },
+    {
+      "name": "OptgroupHTMLAttributes",
+      "id": "optgrouphtmlattributes",
+      "hierarchy": [
+        {
+          "name": "OptgroupHTMLAttributes",
+          "id": "optgrouphtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface OptgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [label?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.optgrouphtmlattributes.md"
+    },
+    {
+      "name": "OptionHTMLAttributes",
+      "id": "optionhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "OptionHTMLAttributes",
+          "id": "optionhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface OptionHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | string | _(Optional)_ |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [label?](#) |  | string \\| undefined | _(Optional)_ |\n|  [selected?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.optionhtmlattributes.md"
+    },
+    {
+      "name": "OutputHTMLAttributes",
+      "id": "outputhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "OutputHTMLAttributes",
+          "id": "outputhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [for?](#) |  | string \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.outputhtmlattributes.md"
+    },
+    {
+      "name": "ParamHTMLAttributes",
+      "id": "paramhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ParamHTMLAttributes",
+          "id": "paramhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ParamHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.paramhtmlattributes.md"
+    },
+    {
+      "name": "ProgressHTMLAttributes",
+      "id": "progresshtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ProgressHTMLAttributes",
+          "id": "progresshtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ProgressHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [max?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.progresshtmlattributes.md"
     },
     {
       "name": "PropFnInterface",
@@ -963,6 +1669,20 @@
       "content": "Used by Qwik Optimizer to point to lazy-loaded resources.\n\nThis function should be used by the Qwik Optimizer only. The function should not be directly referred to in the source code of the application.\n\n\n```typescript\nqrl: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: string, lexicalScopeCapture?: any[], stackOffset?: number) => QRL<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts",
       "mdFile": "qwik.qrl.md"
+    },
+    {
+      "name": "QuoteHTMLAttributes",
+      "id": "quotehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "QuoteHTMLAttributes",
+          "id": "quotehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [cite?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.quotehtmlattributes.md"
     },
     {
       "name": "QwikAnimationEvent",
@@ -1072,7 +1792,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "The interface holds available attributes of both native DOM elements and custom Qwik elements. An example showing how to define a customizable wrapper component:\n\n```tsx\nimport { component$, Slot, type QwikIntrinsicElements } from \"@builder.io/qwik\";\n\ntype WrapperProps = {\n  attributes?: QwikIntrinsicElements[\"div\"];\n};\n\nexport default component$<WrapperProps>(({ attributes }) => {\n  return (\n    <div {...attributes} class=\"p-2\">\n      <Slot />\n    </div>\n  );\n});\n```\n\n\n```typescript\nexport interface QwikIntrinsicElements extends IntrinsicHTMLElements \n```\n**Extends:** IntrinsicHTMLElements",
+      "content": "The interface holds available attributes of both native DOM elements and custom Qwik elements. An example showing how to define a customizable wrapper component:\n\n```tsx\nimport { component$, Slot, type QwikIntrinsicElements } from \"@builder.io/qwik\";\n\ntype WrapperProps = {\n  attributes?: QwikIntrinsicElements[\"div\"];\n};\n\nexport default component$<WrapperProps>(({ attributes }) => {\n  return (\n    <div {...attributes} class=\"p-2\">\n      <Slot />\n    </div>\n  );\n});\n```\n\n\n```typescript\nexport interface QwikIntrinsicElements extends IntrinsicHTMLElements \n```\n**Extends:** [IntrinsicHTMLElements](#intrinsichtmlelements)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-elements.ts",
       "mdFile": "qwik.qwikintrinsicelements.md"
     },
@@ -1444,6 +2164,34 @@
       "mdFile": "qwik.resourcereturn.md"
     },
     {
+      "name": "ScriptHTMLAttributes",
+      "id": "scripthtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ScriptHTMLAttributes",
+          "id": "scripthtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [async?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [charSet?](#) |  | string \\| undefined | _(Optional)_ |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |\n|  [defer?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [integrity?](#) |  | string \\| undefined | _(Optional)_ |\n|  [noModule?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [nonce?](#) |  | string \\| undefined | _(Optional)_ |\n|  [referrerPolicy?](#) |  | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.scripthtmlattributes.md"
+    },
+    {
+      "name": "SelectHTMLAttributes",
+      "id": "selecthtmlattributes",
+      "hierarchy": [
+        {
+          "name": "SelectHTMLAttributes",
+          "id": "selecthtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [\"bind:value\"?](#) |  | [Signal](#signal)<!-- -->&lt;string \\| undefined&gt; | _(Optional)_ |\n|  [autoComplete?](#) |  | [HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute) \\| Omit&lt;[HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute)<!-- -->, string&gt; \\| undefined | _(Optional)_ |\n|  [autoFocus?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [multiple?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [required?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [size?](#) |  | number \\| undefined | _(Optional)_ |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.selecthtmlattributes.md"
+    },
+    {
       "name": "setPlatform",
       "id": "setplatform",
       "hierarchy": [
@@ -1472,6 +2220,20 @@
       "mdFile": "qwik.signal.md"
     },
     {
+      "name": "Size",
+      "id": "size",
+      "hierarchy": [
+        {
+          "name": "Size",
+          "id": "size"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type Size = number | string;\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.size.md"
+    },
+    {
       "name": "SkipRender",
       "id": "skiprender",
       "hierarchy": [
@@ -1498,6 +2260,20 @@
       "content": "Allows to project the children of the current component. <Slot/> can only be used within the context of a component defined with `component$`<!-- -->.\n\n\n```typescript\nSlot: FunctionComponent<{\n    name?: string;\n}>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/slot.public.ts",
       "mdFile": "qwik.slot.md"
+    },
+    {
+      "name": "SlotHTMLAttributes",
+      "id": "slothtmlattributes",
+      "hierarchy": [
+        {
+          "name": "SlotHTMLAttributes",
+          "id": "slothtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface SlotHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.slothtmlattributes.md"
     },
     {
       "name": "SnapshotListener",
@@ -1568,6 +2344,20 @@
       "content": "```typescript\nexport interface SnapshotState \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [ctx](#) |  | [SnapshotMeta](#snapshotmeta) |  |\n|  [objs](#) |  | any\\[\\] |  |\n|  [refs](#) |  | Record&lt;string, string&gt; |  |\n|  [subs](#) |  | any\\[\\] |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/container/container.ts",
       "mdFile": "qwik.snapshotstate.md"
+    },
+    {
+      "name": "SourceHTMLAttributes",
+      "id": "sourcehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "SourceHTMLAttributes",
+          "id": "sourcehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface SourceHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [height?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [sizes?](#) |  | string \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |\n|  [srcSet?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.sourcehtmlattributes.md"
     },
     {
       "name": "SSRComment",
@@ -1682,6 +2472,62 @@
       "mdFile": "qwik.streamwriter.md"
     },
     {
+      "name": "StyleHTMLAttributes",
+      "id": "stylehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "StyleHTMLAttributes",
+          "id": "stylehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | string | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [nonce?](#) |  | string \\| undefined | _(Optional)_ |\n|  [scoped?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.stylehtmlattributes.md"
+    },
+    {
+      "name": "SVGAttributes",
+      "id": "svgattributes",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> \n```\n**Extends:** [AriaAttributes](#ariaattributes)<!-- -->, [DOMAttributes](#domattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [\"accent-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"alignment-baseline\"?](#) |  | 'auto' \\| 'baseline' \\| 'before-edge' \\| 'text-before-edge' \\| 'middle' \\| 'central' \\| 'after-edge' \\| 'text-after-edge' \\| 'ideographic' \\| 'alphabetic' \\| 'hanging' \\| 'mathematical' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"arabic-form\"?](#) |  | 'initial' \\| 'medial' \\| 'terminal' \\| 'isolated' \\| undefined | _(Optional)_ |\n|  [\"baseline-shift\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"cap-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"clip-path\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"clip-rule\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-interpolation-filters\"?](#) |  | 'auto' \\| 's-rGB' \\| 'linear-rGB' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"color-interpolation\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-profile\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"dominant-baseline\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"edge-mode\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"enable-background\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"fill-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"fill-rule\"?](#) |  | 'nonzero' \\| 'evenodd' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"flood-color\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"flood-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-family\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"font-size-adjust\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-size\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-stretch\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-style\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-variant\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-weight\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-name\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-orientation-horizontal\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-orientation-vertical\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"horiz-adv-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"horiz-origin-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"image-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"letter-spacing\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"lighting-color\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"marker-end\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"marker-mid\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"marker-start\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"overline-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"overline-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"paint-order\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"pointer-events\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"rendering-intent\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"shape-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stop-color\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"stop-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"strikethrough-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"strikethrough-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stroke-dasharray\"?](#) |  | string \\| number \\| undefined | _(Optional)_ |\n|  [\"stroke-dashoffset\"?](#) |  | string \\| number \\| undefined | _(Optional)_ |\n|  [\"stroke-linecap\"?](#) |  | 'butt' \\| 'round' \\| 'square' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"stroke-linejoin\"?](#) |  | 'miter' \\| 'round' \\| 'bevel' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"stroke-miterlimit\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"stroke-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stroke-width\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"text-anchor\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"text-decoration\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"text-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"underline-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"underline-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"unicode-bidi\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"unicode-range\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"units-per-em\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-alphabetic\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-hanging\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-ideographic\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-mathematical\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vector-effect\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-adv-y\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-origin-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-origin-y\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"word-spacing\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"writing-mode\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"x-channel-selector\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"x-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [accumulate?](#) |  | 'none' \\| 'sum' \\| undefined | _(Optional)_ |\n|  [additive?](#) |  | 'replace' \\| 'sum' \\| undefined | _(Optional)_ |\n|  [allowReorder?](#) |  | 'no' \\| 'yes' \\| undefined | _(Optional)_ |\n|  [alphabetic?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [amplitude?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [ascent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [attributeName?](#) |  | string \\| undefined | _(Optional)_ |\n|  [attributeType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [autoReverse?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ |\n|  [azimuth?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [baseFrequency?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [baseProfile?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [bbox?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [begin?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [bias?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [by?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [calcMode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [class?](#) |  | [ClassList](#classlist) \\| undefined | _(Optional)_ |\n|  [className?](#) |  | string \\| undefined | _(Optional)_ |\n|  [clip?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [clipPathUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [color?](#) |  | string \\| undefined | _(Optional)_ |\n|  [contentScriptType?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [contentStyleType?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |\n|  [cursor?](#) |  | number \\| string | _(Optional)_ |\n|  [cx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [cy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [d?](#) |  | string \\| undefined | _(Optional)_ |\n|  [decelerate?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [descent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [diffuseConstant?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [direction?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [display?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [divisor?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dur?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [elevation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [end?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [exponent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [externalResourcesRequired?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fill?](#) |  | string \\| undefined | _(Optional)_ |\n|  [filter?](#) |  | string \\| undefined | _(Optional)_ |\n|  [filterRes?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [filterUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [focusable?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [format?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fr?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [from?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [g1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [g2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [glyphRef?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [gradientTransform?](#) |  | string \\| undefined | _(Optional)_ |\n|  [gradientUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [hanging?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Numberish](#numberish) \\| undefined | _(Optional)_ |\n|  [href?](#) |  | string \\| undefined | _(Optional)_ |\n|  [id?](#) |  | string \\| undefined | _(Optional)_ |\n|  [ideographic?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [in?](#) |  | string \\| undefined | _(Optional)_ |\n|  [in2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [intercept?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k3?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k4?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kernelMatrix?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kernelUnitLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kerning?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keyPoints?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keySplines?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keyTimes?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [lang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [lengthAdjust?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [limitingConeAngle?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [local?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerHeight?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerWidth?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mask?](#) |  | string \\| undefined | _(Optional)_ |\n|  [maskContentUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [maskUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mathematical?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [max?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [method?](#) |  | string \\| undefined | _(Optional)_ |\n|  [min?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [numOctaves?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [offset?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [opacity?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [operator?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [order?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [orient?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [orientation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [origin?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [overflow?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [panose1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [path?](#) |  | string \\| undefined | _(Optional)_ |\n|  [pathLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [patternContentUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [patternTransform?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [patternUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [points?](#) |  | string \\| undefined | _(Optional)_ |\n|  [pointsAtX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [pointsAtY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [pointsAtZ?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [preserveAlpha?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [preserveAspectRatio?](#) |  | string \\| undefined | _(Optional)_ |\n|  [primitiveUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [r?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [radius?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [refX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [refY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [repeatCount?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [repeatDur?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [requiredextensions?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [requiredFeatures?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [restart?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [result?](#) |  | string \\| undefined | _(Optional)_ |\n|  [role?](#) |  | string \\| undefined | _(Optional)_ |\n|  [rotate?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [rx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [ry?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [scale?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [seed?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [slope?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [spacing?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [specularConstant?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [specularExponent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [speed?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [spreadMethod?](#) |  | string \\| undefined | _(Optional)_ |\n|  [startOffset?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stdDeviation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stemh?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stemv?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stitchTiles?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [string?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stroke?](#) |  | string \\| undefined | _(Optional)_ |\n|  [style?](#) |  | [CSSProperties](#cssproperties) \\| string \\| undefined | _(Optional)_ |\n|  [surfaceScale?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [systemLanguage?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [tabindex?](#) |  | number \\| undefined | _(Optional)_ |\n|  [tableValues?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [target?](#) |  | string \\| undefined | _(Optional)_ |\n|  [targetX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [targetY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [textLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [to?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [transform?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |\n|  [u1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [u2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [unicode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [values?](#) |  | string \\| undefined | _(Optional)_ |\n|  [version?](#) |  | string \\| undefined | _(Optional)_ |\n|  [viewBox?](#) |  | string \\| undefined | _(Optional)_ |\n|  [viewTarget?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [visibility?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Numberish](#numberish) \\| undefined | _(Optional)_ |\n|  [widths?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [xlinkActuate?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkArcrole?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkHref?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkRole?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkShow?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkTitle?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xmlBase?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xmlLang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xmlns?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xmlSpace?](#) |  | string \\| undefined | _(Optional)_ |\n|  [y?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [y1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [y2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [yChannelSelector?](#) |  | string \\| undefined | _(Optional)_ |\n|  [z?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [zoomAndPan?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.svgattributes.md"
+    },
+    {
+      "name": "SVGProps",
+      "id": "svgprops",
+      "hierarchy": [
+        {
+          "name": "SVGProps",
+          "id": "svgprops"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface SVGProps<T extends Element> extends SVGAttributes<T> \n```\n**Extends:** [SVGAttributes](#svgattributes)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.svgprops.md"
+    },
+    {
+      "name": "TableHTMLAttributes",
+      "id": "tablehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "TableHTMLAttributes",
+          "id": "tablehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface TableHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [cellPadding?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [cellSpacing?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [summary?](#) |  | string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.tablehtmlattributes.md"
+    },
+    {
       "name": "TaskCtx",
       "id": "taskctx",
       "hierarchy": [
@@ -1710,6 +2556,76 @@
       "mdFile": "qwik.taskfn.md"
     },
     {
+      "name": "TdHTMLAttributes",
+      "id": "tdhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "TdHTMLAttributes",
+          "id": "tdhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [abbr?](#) |  | string \\| undefined | _(Optional)_ |\n|  [align?](#) |  | 'left' \\| 'center' \\| 'right' \\| 'justify' \\| 'char' \\| undefined | _(Optional)_ |\n|  [colSpan?](#) |  | number \\| undefined | _(Optional)_ |\n|  [headers?](#) |  | string \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [rowSpan?](#) |  | number \\| undefined | _(Optional)_ |\n|  [scope?](#) |  | string \\| undefined | _(Optional)_ |\n|  [valign?](#) |  | 'top' \\| 'middle' \\| 'bottom' \\| 'baseline' \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.tdhtmlattributes.md"
+    },
+    {
+      "name": "TextareaHTMLAttributes",
+      "id": "textareahtmlattributes",
+      "hierarchy": [
+        {
+          "name": "TextareaHTMLAttributes",
+          "id": "textareahtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface TextareaHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [\"bind:value\"?](#) |  | [Signal](#signal)<!-- -->&lt;string \\| undefined&gt; | _(Optional)_ |\n|  [autoComplete?](#) |  | [HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute) \\| Omit&lt;[HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute)<!-- -->, string&gt; \\| undefined | _(Optional)_ |\n|  [autoFocus?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [cols?](#) |  | number \\| undefined | _(Optional)_ |\n|  [dirName?](#) |  | string \\| undefined | _(Optional)_ |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [enterKeyHint?](#) |  | 'enter' \\| 'done' \\| 'go' \\| 'next' \\| 'previous' \\| 'search' \\| 'send' \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [maxLength?](#) |  | number \\| undefined | _(Optional)_ |\n|  [minLength?](#) |  | number \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [placeholder?](#) |  | string \\| undefined | _(Optional)_ |\n|  [readOnly?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [required?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [rows?](#) |  | number \\| undefined | _(Optional)_ |\n|  [value?](#) |  | string \\| ReadonlyArray&lt;string&gt; \\| number \\| undefined | _(Optional)_ |\n|  [wrap?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.textareahtmlattributes.md"
+    },
+    {
+      "name": "ThHTMLAttributes",
+      "id": "thhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "ThHTMLAttributes",
+          "id": "thhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface ThHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [abbr?](#) |  | string \\| undefined | _(Optional)_ |\n|  [align?](#) |  | 'left' \\| 'center' \\| 'right' \\| 'justify' \\| 'char' \\| undefined | _(Optional)_ |\n|  [colSpan?](#) |  | number \\| undefined | _(Optional)_ |\n|  [headers?](#) |  | string \\| undefined | _(Optional)_ |\n|  [rowSpan?](#) |  | number \\| undefined | _(Optional)_ |\n|  [scope?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.thhtmlattributes.md"
+    },
+    {
+      "name": "TimeHTMLAttributes",
+      "id": "timehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "TimeHTMLAttributes",
+          "id": "timehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface TimeHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [dateTime?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.timehtmlattributes.md"
+    },
+    {
+      "name": "TitleHTMLAttributes",
+      "id": "titlehtmlattributes",
+      "hierarchy": [
+        {
+          "name": "TitleHTMLAttributes",
+          "id": "titlehtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface TitleHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | string | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.titlehtmlattributes.md"
+    },
+    {
       "name": "Tracker",
       "id": "tracker",
       "hierarchy": [
@@ -1722,6 +2638,20 @@
       "content": "Used to signal to Qwik which state should be watched for changes.\n\nThe `Tracker` is passed into the `taskFn` of `useTask`<!-- -->. It is intended to be used to wrap state objects in a read proxy which signals to Qwik which properties should be watched for changes. A change to any of the properties causes the `taskFn` to rerun.\n\n\\#\\#\\# Example\n\nThe `obs` passed into the `taskFn` is used to mark `state.count` as a property of interest. Any changes to the `state.count` property will cause the `taskFn` to rerun.\n\n```tsx\nconst Cmp = component$(() => {\n  const store = useStore({ count: 0, doubleCount: 0 });\n  useTask$(({ track }) => {\n    const count = track(() => store.count);\n    store.doubleCount = 2 * count;\n  });\n  return (\n    <div>\n      <span>\n        {store.count} / {store.doubleCount}\n      </span>\n      <button onClick$={() => store.count++}>+</button>\n    </div>\n  );\n});\n```\n\n\n```typescript\nexport interface Tracker \n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "qwik.tracker.md"
+    },
+    {
+      "name": "TrackHTMLAttributes",
+      "id": "trackhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "TrackHTMLAttributes",
+          "id": "trackhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface TrackHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [default?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [kind?](#) |  | string \\| undefined | _(Optional)_ |\n|  [label?](#) |  | string \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |\n|  [srcLang?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.trackhtmlattributes.md"
     },
     {
       "name": "untrack",
@@ -2130,6 +3060,20 @@
       "mdFile": "qwik.version.md"
     },
     {
+      "name": "VideoHTMLAttributes",
+      "id": "videohtmlattributes",
+      "hierarchy": [
+        {
+          "name": "VideoHTMLAttributes",
+          "id": "videohtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface VideoHTMLAttributes<T extends Element> extends MediaHTMLAttributes<T> \n```\n**Extends:** [MediaHTMLAttributes](#mediahtmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [disablePictureInPicture?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [disableRemotePlayback?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Numberish](#numberish) \\| undefined | _(Optional)_ |\n|  [playsInline?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [poster?](#) |  | string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Numberish](#numberish) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.videohtmlattributes.md"
+    },
+    {
       "name": "VisibleTaskStrategy",
       "id": "visibletaskstrategy",
       "hierarchy": [
@@ -2142,6 +3086,20 @@
       "content": "```typescript\nexport type VisibleTaskStrategy = 'intersection-observer' | 'document-ready' | 'document-idle';\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "qwik.visibletaskstrategy.md"
+    },
+    {
+      "name": "WebViewHTMLAttributes",
+      "id": "webviewhtmlattributes",
+      "hierarchy": [
+        {
+          "name": "WebViewHTMLAttributes",
+          "id": "webviewhtmlattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface WebViewHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [allowFullScreen?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [allowpopups?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [autoFocus?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [autosize?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [blinkfeatures?](#) |  | string \\| undefined | _(Optional)_ |\n|  [disableblinkfeatures?](#) |  | string \\| undefined | _(Optional)_ |\n|  [disableguestresize?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [disablewebsecurity?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [guestinstance?](#) |  | string \\| undefined | _(Optional)_ |\n|  [httpreferrer?](#) |  | string \\| undefined | _(Optional)_ |\n|  [nodeintegration?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [partition?](#) |  | string \\| undefined | _(Optional)_ |\n|  [plugins?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [preload?](#) |  | string \\| undefined | _(Optional)_ |\n|  [src?](#) |  | string \\| undefined | _(Optional)_ |\n|  [useragent?](#) |  | string \\| undefined | _(Optional)_ |\n|  [webpreferences?](#) |  | string \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.webviewhtmlattributes.md"
     }
   ]
 }

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -4,6 +4,18 @@ title: \@builder.io/qwik API Reference
 
 # [API](/api) &rsaquo; @builder.io/qwik
 
+## "bind:checked"
+
+```typescript
+'bind:checked'?: Signal<boolean | undefined>;
+```
+
+## "bind:value"
+
+```typescript
+'bind:value'?: Signal<string | undefined>;
+```
+
 ## "q:slot"
 
 ```typescript
@@ -22,6 +34,52 @@ $: <T,>(expression: T) => QRL<T>;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts)
 
+## AnchorHTMLAttributes
+
+```typescript
+export interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property             | Modifiers | Type                                                                     | Description  |
+| -------------------- | --------- | ------------------------------------------------------------------------ | ------------ |
+| [download?](#)       |           | any                                                                      | _(Optional)_ |
+| [href?](#)           |           | string \| undefined                                                      | _(Optional)_ |
+| [hrefLang?](#)       |           | string \| undefined                                                      | _(Optional)_ |
+| [media?](#)          |           | string \| undefined                                                      | _(Optional)_ |
+| [ping?](#)           |           | string \| undefined                                                      | _(Optional)_ |
+| [referrerPolicy?](#) |           | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \| undefined | _(Optional)_ |
+| [rel?](#)            |           | string \| undefined                                                      | _(Optional)_ |
+| [target?](#)         |           | [HTMLAttributeAnchorTarget](#htmlattributeanchortarget) \| undefined     | _(Optional)_ |
+| [type?](#)           |           | string \| undefined                                                      | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## AreaHTMLAttributes
+
+```typescript
+export interface AreaHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property             | Modifiers | Type                                                                     | Description  |
+| -------------------- | --------- | ------------------------------------------------------------------------ | ------------ |
+| [alt?](#)            |           | string \| undefined                                                      | _(Optional)_ |
+| [children?](#)       |           | undefined                                                                | _(Optional)_ |
+| [coords?](#)         |           | string \| undefined                                                      | _(Optional)_ |
+| [download?](#)       |           | any                                                                      | _(Optional)_ |
+| [href?](#)           |           | string \| undefined                                                      | _(Optional)_ |
+| [hrefLang?](#)       |           | string \| undefined                                                      | _(Optional)_ |
+| [media?](#)          |           | string \| undefined                                                      | _(Optional)_ |
+| [referrerPolicy?](#) |           | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \| undefined | _(Optional)_ |
+| [rel?](#)            |           | string \| undefined                                                      | _(Optional)_ |
+| [shape?](#)          |           | string \| undefined                                                      | _(Optional)_ |
+| [target?](#)         |           | string \| undefined                                                      | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## AriaAttributes
 
 ```typescript
@@ -31,9 +89,9 @@ export interface AriaAttributes
 | Property                      | Modifiers | Type                                                                                                                                                                                    | Description                                                                                                                                                                                                                       |
 | ----------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ["aria-activedescendant"?](#) |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.                                                                                                     |
-| ["aria-atomic"?](#)           |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.                                            |
+| ["aria-atomic"?](#)           |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.                                            |
 | ["aria-autocomplete"?](#)     |           | 'none' \| 'inline' \| 'list' \| 'both' \| undefined                                                                                                                                     | _(Optional)_ Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.                       |
-| ["aria-busy"?](#)             |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.                                                       |
+| ["aria-busy"?](#)             |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.                                                       |
 | ["aria-checked"?](#)          |           | boolean \| 'false' \| 'mixed' \| 'true' \| undefined                                                                                                                                    | _(Optional)_ Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.                                                                                                                               |
 | ["aria-colcount"?](#)         |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines the total number of columns in a table, grid, or treegrid.                                                                                                                                                   |
 | ["aria-colindex"?](#)         |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.                                                                                         |
@@ -42,36 +100,36 @@ export interface AriaAttributes
 | ["aria-current"?](#)          |           | boolean \| 'false' \| 'true' \| 'page' \| 'step' \| 'location' \| 'date' \| 'time' \| undefined                                                                                         | _(Optional)_ Indicates the element that represents the current item within a container or set of related elements.                                                                                                                |
 | ["aria-describedby"?](#)      |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Identifies the element (or elements) that describes the object.                                                                                                                                                      |
 | ["aria-details"?](#)          |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Identifies the element that provides a detailed, extended description for the object.                                                                                                                                |
-| ["aria-disabled"?](#)         |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.                                                                                                                 |
+| ["aria-disabled"?](#)         |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.                                                                                                                 |
 | ["aria-dropeffect"?](#)       |           | 'none' \| 'copy' \| 'execute' \| 'link' \| 'move' \| 'popup' \| undefined                                                                                                               | _(Optional)_ Indicates what functions can be performed when a dragged object is released on the drop target.                                                                                                                      |
 | ["aria-errormessage"?](#)     |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Identifies the element that provides an error message for the object.                                                                                                                                                |
-| ["aria-expanded"?](#)         |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.                                                                                                          |
+| ["aria-expanded"?](#)         |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.                                                                                                          |
 | ["aria-flowto"?](#)           |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order. |
-| ["aria-grabbed"?](#)          |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates an element's "grabbed" state in a drag-and-drop operation.                                                                                                                                                 |
+| ["aria-grabbed"?](#)          |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates an element's "grabbed" state in a drag-and-drop operation.                                                                                                                                                 |
 | ["aria-haspopup"?](#)         |           | boolean \| 'false' \| 'true' \| 'menu' \| 'listbox' \| 'tree' \| 'grid' \| 'dialog' \| undefined                                                                                        | _(Optional)_ Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.                                                                                       |
-| ["aria-hidden"?](#)           |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates whether the element is exposed to an accessibility API.                                                                                                                                                    |
+| ["aria-hidden"?](#)           |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates whether the element is exposed to an accessibility API.                                                                                                                                                    |
 | ["aria-invalid"?](#)          |           | boolean \| 'false' \| 'true' \| 'grammar' \| 'spelling' \| undefined                                                                                                                    | _(Optional)_ Indicates the entered value does not conform to the format expected by the application.                                                                                                                              |
 | ["aria-keyshortcuts"?](#)     |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.                                                                                                                 |
 | ["aria-label"?](#)            |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Defines a string value that labels the current element.                                                                                                                                                              |
 | ["aria-labelledby"?](#)       |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Identifies the element (or elements) that labels the current element.                                                                                                                                                |
 | ["aria-level"?](#)            |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines the hierarchical level of an element within a structure.                                                                                                                                                     |
 | ["aria-live"?](#)             |           | 'off' \| 'assertive' \| 'polite' \| undefined                                                                                                                                           | _(Optional)_ Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.                                                     |
-| ["aria-modal"?](#)            |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates whether an element is modal when displayed.                                                                                                                                                                |
-| ["aria-multiline"?](#)        |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates whether a text box accepts multiple lines of input or only a single line.                                                                                                                                  |
-| ["aria-multiselectable"?](#)  |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates that the user may select more than one item from the current selectable descendants.                                                                                                                       |
+| ["aria-modal"?](#)            |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates whether an element is modal when displayed.                                                                                                                                                                |
+| ["aria-multiline"?](#)        |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates whether a text box accepts multiple lines of input or only a single line.                                                                                                                                  |
+| ["aria-multiselectable"?](#)  |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates that the user may select more than one item from the current selectable descendants.                                                                                                                       |
 | ["aria-orientation"?](#)      |           | 'horizontal' \| 'vertical' \| undefined                                                                                                                                                 | _(Optional)_ Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.                                                                                                                           |
 | ["aria-owns"?](#)             |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent the relationship.      |
 | ["aria-placeholder"?](#)      |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format.                  |
 | ["aria-posinset"?](#)         |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.                                                                |
 | ["aria-pressed"?](#)          |           | boolean \| 'false' \| 'mixed' \| 'true' \| undefined                                                                                                                                    | _(Optional)_ Indicates the current "pressed" state of toggle buttons.                                                                                                                                                             |
-| ["aria-readonly"?](#)         |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates that the element is not editable, but is otherwise operable.                                                                                                                                               |
+| ["aria-readonly"?](#)         |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates that the element is not editable, but is otherwise operable.                                                                                                                                               |
 | ["aria-relevant"?](#)         |           | 'additions' \| 'additions removals' \| 'additions text' \| 'all' \| 'removals' \| 'removals additions' \| 'removals text' \| 'text' \| 'text additions' \| 'text removals' \| undefined | _(Optional)_ Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.                                                                                               |
-| ["aria-required"?](#)         |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates that user input is required on the element before a form may be submitted.                                                                                                                                 |
+| ["aria-required"?](#)         |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates that user input is required on the element before a form may be submitted.                                                                                                                                 |
 | ["aria-roledescription"?](#)  |           | string \| undefined                                                                                                                                                                     | _(Optional)_ Defines a human-readable, author-localized description for the role of an element.                                                                                                                                   |
 | ["aria-rowcount"?](#)         |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines the total number of rows in a table, grid, or treegrid.                                                                                                                                                      |
 | ["aria-rowindex"?](#)         |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.                                                                                               |
 | ["aria-rowspan"?](#)          |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.                                                                                                                          |
-| ["aria-selected"?](#)         |           | Booleanish \| undefined                                                                                                                                                                 | _(Optional)_ Indicates the current "selected" state of various widgets.                                                                                                                                                           |
+| ["aria-selected"?](#)         |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                  | _(Optional)_ Indicates the current "selected" state of various widgets.                                                                                                                                                           |
 | ["aria-setsize"?](#)          |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.                                                                            |
 | ["aria-sort"?](#)             |           | 'none' \| 'ascending' \| 'descending' \| 'other' \| undefined                                                                                                                           | _(Optional)_ Indicates if items in a table or grid are sorted in ascending or descending order.                                                                                                                                   |
 | ["aria-valuemax"?](#)         |           | number \| undefined                                                                                                                                                                     | _(Optional)_ Defines the maximum allowed value for a range widget.                                                                                                                                                                |
@@ -159,6 +217,78 @@ export type AriaRole =
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
+## AudioHTMLAttributes
+
+```typescript
+export interface AudioHTMLAttributes<T extends Element> extends MediaHTMLAttributes<T>
+```
+
+**Extends:** [MediaHTMLAttributes](#mediahtmlattributes)&lt;T&gt;
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## BaseHTMLAttributes
+
+```typescript
+export interface BaseHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                | Description  |
+| -------------- | --------- | ------------------- | ------------ |
+| [children?](#) |           | undefined           | _(Optional)_ |
+| [href?](#)     |           | string \| undefined | _(Optional)_ |
+| [target?](#)   |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## BlockquoteHTMLAttributes
+
+```typescript
+export interface BlockquoteHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                | Description  |
+| ---------- | --------- | ------------------- | ------------ |
+| [cite?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## Booleanish
+
+```typescript
+export type Booleanish = boolean | `${boolean}`;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## ButtonHTMLAttributes
+
+```typescript
+export interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property             | Modifiers | Type                                                         | Description  |
+| -------------------- | --------- | ------------------------------------------------------------ | ------------ |
+| [autoFocus?](#)      |           | boolean \| undefined                                         | _(Optional)_ |
+| [disabled?](#)       |           | boolean \| undefined                                         | _(Optional)_ |
+| [form?](#)           |           | string \| undefined                                          | _(Optional)_ |
+| [formAction?](#)     |           | string \| undefined                                          | _(Optional)_ |
+| [formEncType?](#)    |           | string \| undefined                                          | _(Optional)_ |
+| [formMethod?](#)     |           | string \| undefined                                          | _(Optional)_ |
+| [formNoValidate?](#) |           | boolean \| undefined                                         | _(Optional)_ |
+| [formTarget?](#)     |           | string \| undefined                                          | _(Optional)_ |
+| [name?](#)           |           | string \| undefined                                          | _(Optional)_ |
+| [type?](#)           |           | 'submit' \| 'reset' \| 'button' \| undefined                 | _(Optional)_ |
+| [value?](#)          |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## cache
 
 ```typescript
@@ -172,6 +302,21 @@ cache(policyOrMilliseconds: number | 'immutable'): void;
 **Returns:**
 
 void
+
+## CanvasHTMLAttributes
+
+```typescript
+export interface CanvasHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property     | Modifiers | Type                       | Description  |
+| ------------ | --------- | -------------------------- | ------------ |
+| [height?](#) |           | [Size](#size) \| undefined | _(Optional)_ |
+| [width?](#)  |           | [Size](#size) \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## ClassList
 
@@ -190,6 +335,36 @@ cleanup(): void;
 **Returns:**
 
 void
+
+## ColgroupHTMLAttributes
+
+```typescript
+export interface ColgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                | Description  |
+| ---------- | --------- | ------------------- | ------------ |
+| [span?](#) |           | number \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## ColHTMLAttributes
+
+```typescript
+export interface ColHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                       | Description  |
+| -------------- | --------- | -------------------------- | ------------ |
+| [children?](#) |           | undefined                  | _(Optional)_ |
+| [span?](#)     |           | number \| undefined        | _(Optional)_ |
+| [width?](#)    |           | [Size](#size) \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## Component
 
@@ -468,6 +643,78 @@ export interface CSSProperties extends CSS.Properties<string | number>, CSS.Prop
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
+## DataHTMLAttributes
+
+```typescript
+export interface DataHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property    | Modifiers | Type                                                         | Description  |
+| ----------- | --------- | ------------------------------------------------------------ | ------------ |
+| [value?](#) |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## DelHTMLAttributes
+
+```typescript
+export interface DelHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                | Description  |
+| -------------- | --------- | ------------------- | ------------ |
+| [cite?](#)     |           | string \| undefined | _(Optional)_ |
+| [dateTime?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## DetailsHTMLAttributes
+
+```typescript
+export interface DetailsHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                 | Description  |
+| ---------- | --------- | -------------------- | ------------ |
+| [open?](#) |           | boolean \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## DevJSX
+
+```typescript
+export interface DevJSX
+```
+
+| Property          | Modifiers | Type   | Description  |
+| ----------------- | --------- | ------ | ------------ |
+| [columnNumber](#) |           | number |              |
+| [fileName](#)     |           | string |              |
+| [lineNumber](#)   |           | number |              |
+| [stack?](#)       |           | string | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-node.ts)
+
+## DialogHTMLAttributes
+
+```typescript
+export interface DialogHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                 | Description  |
+| ---------- | --------- | -------------------- | ------------ |
+| [open?](#) |           | boolean \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## DOMAttributes
 
 ```typescript
@@ -509,6 +756,24 @@ interface ElementChildrenAttribute
 | -------------- | --------- | ---- | ------------ |
 | [children?](#) |           | any  | _(Optional)_ |
 
+## EmbedHTMLAttributes
+
+```typescript
+export interface EmbedHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                       | Description  |
+| -------------- | --------- | -------------------------- | ------------ |
+| [children?](#) |           | undefined                  | _(Optional)_ |
+| [height?](#)   |           | [Size](#size) \| undefined | _(Optional)_ |
+| [src?](#)      |           | string \| undefined        | _(Optional)_ |
+| [type?](#)     |           | string \| undefined        | _(Optional)_ |
+| [width?](#)    |           | [Size](#size) \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## ErrorBoundaryStore
 
 ```typescript
@@ -536,6 +801,43 @@ eventQrl: <T,>(qrl: QRL<T>) => QRL<T>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts)
+
+## FieldsetHTMLAttributes
+
+```typescript
+export interface FieldsetHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                 | Description  |
+| -------------- | --------- | -------------------- | ------------ |
+| [disabled?](#) |           | boolean \| undefined | _(Optional)_ |
+| [form?](#)     |           | string \| undefined  | _(Optional)_ |
+| [name?](#)     |           | string \| undefined  | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## FormHTMLAttributes
+
+```typescript
+export interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property            | Modifiers | Type                                                            | Description  |
+| ------------------- | --------- | --------------------------------------------------------------- | ------------ |
+| [acceptCharset?](#) |           | string \| undefined                                             | _(Optional)_ |
+| [action?](#)        |           | string \| undefined                                             | _(Optional)_ |
+| [autoComplete?](#)  |           | 'on' \| 'off' \| Omit&lt;'on' \| 'off', string&gt; \| undefined | _(Optional)_ |
+| [encType?](#)       |           | string \| undefined                                             | _(Optional)_ |
+| [method?](#)        |           | string \| undefined                                             | _(Optional)_ |
+| [name?](#)          |           | string \| undefined                                             | _(Optional)_ |
+| [noValidate?](#)    |           | boolean \| undefined                                            | _(Optional)_ |
+| [target?](#)        |           | string \| undefined                                             | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## Fragment
 
@@ -658,6 +960,50 @@ export declare namespace h
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/factory.ts)
 
+## HrHTMLAttributes
+
+```typescript
+export interface HrHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type      | Description  |
+| -------------- | --------- | --------- | ------------ |
+| [children?](#) |           | undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## HTMLAttributeAnchorTarget
+
+```typescript
+export type HTMLAttributeAnchorTarget =
+  | "_self"
+  | "_blank"
+  | "_parent"
+  | "_top"
+  | (string & {});
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## HTMLAttributeReferrerPolicy
+
+```typescript
+export type HTMLAttributeReferrerPolicy =
+  | ""
+  | "no-referrer"
+  | "no-referrer-when-downgrade"
+  | "origin"
+  | "origin-when-cross-origin"
+  | "same-origin"
+  | "strict-origin"
+  | "strict-origin-when-cross-origin"
+  | "unsafe-url";
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## HTMLAttributes
 
 ```typescript
@@ -710,6 +1056,18 @@ export interface HTMLAttributes<T extends Element> extends AriaAttributes, DOMAt
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
+## HTMLCrossOriginAttribute
+
+```typescript
+export type HTMLCrossOriginAttribute =
+  | "anonymous"
+  | "use-credentials"
+  | ""
+  | undefined;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## HTMLFragment
 
 ```typescript
@@ -719,6 +1077,162 @@ HTMLFragment: FunctionComponent<{
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/jsx-runtime.ts)
+
+## HtmlHTMLAttributes
+
+```typescript
+export interface HtmlHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                | Description  |
+| -------------- | --------- | ------------------- | ------------ |
+| [manifest?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## HTMLInputAutocompleteAttribute
+
+```typescript
+export type HTMLInputAutocompleteAttribute =
+  | "on"
+  | "off"
+  | "billing"
+  | "shipping"
+  | "name"
+  | "honorific-prefix"
+  | "given-name"
+  | "additional-name"
+  | "family-name"
+  | "honorific-suffix"
+  | "nickname"
+  | "username"
+  | "new-password"
+  | "current-password"
+  | "one-time-code"
+  | "organization-title"
+  | "organization"
+  | "street-address"
+  | "address-line1"
+  | "address-line2"
+  | "address-line3"
+  | "address-level4"
+  | "address-level3"
+  | "address-level2"
+  | "address-level1"
+  | "country"
+  | "country-name"
+  | "postal-code"
+  | "cc-name"
+  | "cc-given-name"
+  | "cc-additional-name"
+  | "cc-family-name"
+  | "cc-number"
+  | "cc-exp"
+  | "cc-exp-month"
+  | "cc-exp-year"
+  | "cc-csc"
+  | "cc-type"
+  | "transaction-currency"
+  | "transaction-amount"
+  | "language"
+  | "bday"
+  | "bday-day"
+  | "bday-month"
+  | "bday-year"
+  | "sex"
+  | "url"
+  | "photo";
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## HTMLInputTypeAttribute
+
+```typescript
+export type HTMLInputTypeAttribute =
+  | "button"
+  | "checkbox"
+  | "color"
+  | "date"
+  | "datetime-local"
+  | "email"
+  | "file"
+  | "hidden"
+  | "image"
+  | "month"
+  | "number"
+  | "password"
+  | "radio"
+  | "range"
+  | "reset"
+  | "search"
+  | "submit"
+  | "tel"
+  | "text"
+  | "time"
+  | "url"
+  | "week"
+  | (string & {});
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## IframeHTMLAttributes
+
+```typescript
+export interface IframeHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property                | Modifiers | Type                                                                     | Description  |
+| ----------------------- | --------- | ------------------------------------------------------------------------ | ------------ |
+| [allow?](#)             |           | string \| undefined                                                      | _(Optional)_ |
+| [allowFullScreen?](#)   |           | boolean \| undefined                                                     | _(Optional)_ |
+| [allowTransparency?](#) |           | boolean \| undefined                                                     | _(Optional)_ |
+| [children?](#)          |           | undefined                                                                | _(Optional)_ |
+| [frameBorder?](#)       |           | number \| string \| undefined                                            | _(Optional)_ |
+| [height?](#)            |           | [Size](#size) \| undefined                                               | _(Optional)_ |
+| [loading?](#)           |           | 'eager' \| 'lazy' \| undefined                                           | _(Optional)_ |
+| [marginHeight?](#)      |           | number \| undefined                                                      | _(Optional)_ |
+| [marginWidth?](#)       |           | number \| undefined                                                      | _(Optional)_ |
+| [name?](#)              |           | string \| undefined                                                      | _(Optional)_ |
+| [referrerPolicy?](#)    |           | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \| undefined | _(Optional)_ |
+| [sandbox?](#)           |           | string \| undefined                                                      | _(Optional)_ |
+| [scrolling?](#)         |           | string \| undefined                                                      | _(Optional)_ |
+| [seamless?](#)          |           | boolean \| undefined                                                     | _(Optional)_ |
+| [src?](#)               |           | string \| undefined                                                      | _(Optional)_ |
+| [srcDoc?](#)            |           | string \| undefined                                                      | _(Optional)_ |
+| [width?](#)             |           | [Size](#size) \| undefined                                               | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## ImgHTMLAttributes
+
+```typescript
+export interface ImgHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property             | Modifiers | Type                                                                     | Description                                           |
+| -------------------- | --------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [alt?](#)            |           | string \| undefined                                                      | _(Optional)_                                          |
+| [children?](#)       |           | undefined                                                                | _(Optional)_                                          |
+| [crossOrigin?](#)    |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute)                    | _(Optional)_                                          |
+| [decoding?](#)       |           | 'async' \| 'auto' \| 'sync' \| undefined                                 | _(Optional)_                                          |
+| [height?](#)         |           | [Numberish](#numberish) \| undefined                                     | _(Optional)_ Intrinsic height of the image in pixels. |
+| [loading?](#)        |           | 'eager' \| 'lazy' \| undefined                                           | _(Optional)_                                          |
+| [referrerPolicy?](#) |           | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \| undefined | _(Optional)_                                          |
+| [sizes?](#)          |           | string \| undefined                                                      | _(Optional)_                                          |
+| [src?](#)            |           | string \| undefined                                                      | _(Optional)_                                          |
+| [srcSet?](#)         |           | string \| undefined                                                      | _(Optional)_                                          |
+| [useMap?](#)         |           | string \| undefined                                                      | _(Optional)_                                          |
+| [width?](#)          |           | [Numberish](#numberish) \| undefined                                     | _(Optional)_ Intrinsic width of the image in pixels.  |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## implicit$FirstArg
 
@@ -761,6 +1275,70 @@ implicit$FirstArg: <FIRST, REST extends any[], RET>(
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/util/implicit_dollar.ts)
 
+## InputHTMLAttributes
+
+```typescript
+export interface InputHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property                                               | Modifiers | Type                                                                                                                                                                    | Description  |
+| ------------------------------------------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| ["bind:checked"?](#inputhtmlattributes-_bind_checked_) |           | [Signal](#signal)&lt;boolean \| undefined&gt;                                                                                                                           | _(Optional)_ |
+| ["bind:value"?](#inputhtmlattributes-_bind_value_)     |           | [Signal](#signal)&lt;string \| undefined&gt;                                                                                                                            | _(Optional)_ |
+| [accept?](#)                                           |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [alt?](#)                                              |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [autoComplete?](#)                                     |           | [HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute) \| Omit&lt;[HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute), string&gt; \| undefined | _(Optional)_ |
+| [autoFocus?](#)                                        |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [capture?](#)                                          |           | boolean \| 'user' \| 'environment' \| undefined                                                                                                                         | _(Optional)_ |
+| [checked?](#)                                          |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [children?](#)                                         |           | undefined                                                                                                                                                               | _(Optional)_ |
+| [crossOrigin?](#)                                      |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute)                                                                                                                   | _(Optional)_ |
+| [disabled?](#)                                         |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [enterKeyHint?](#)                                     |           | 'enter' \| 'done' \| 'go' \| 'next' \| 'previous' \| 'search' \| 'send' \| undefined                                                                                    | _(Optional)_ |
+| [form?](#)                                             |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [formAction?](#)                                       |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [formEncType?](#)                                      |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [formMethod?](#)                                       |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [formNoValidate?](#)                                   |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [formTarget?](#)                                       |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [height?](#)                                           |           | [Size](#size) \| undefined                                                                                                                                              | _(Optional)_ |
+| [list?](#)                                             |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [max?](#)                                              |           | number \| string \| undefined                                                                                                                                           | _(Optional)_ |
+| [maxLength?](#)                                        |           | number \| undefined                                                                                                                                                     | _(Optional)_ |
+| [min?](#)                                              |           | number \| string \| undefined                                                                                                                                           | _(Optional)_ |
+| [minLength?](#)                                        |           | number \| undefined                                                                                                                                                     | _(Optional)_ |
+| [multiple?](#)                                         |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [name?](#)                                             |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [pattern?](#)                                          |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [placeholder?](#)                                      |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [readOnly?](#)                                         |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [required?](#)                                         |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [size?](#)                                             |           | number \| undefined                                                                                                                                                     | _(Optional)_ |
+| [src?](#)                                              |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [step?](#)                                             |           | number \| string \| undefined                                                                                                                                           | _(Optional)_ |
+| [type?](#)                                             |           | [HTMLInputTypeAttribute](#htmlinputtypeattribute) \| undefined                                                                                                          | _(Optional)_ |
+| [value?](#)                                            |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined \| null \| FormDataEntryValue                                                                              | _(Optional)_ |
+| [width?](#)                                            |           | [Size](#size) \| undefined                                                                                                                                              | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## InsHTMLAttributes
+
+```typescript
+export interface InsHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                | Description  |
+| -------------- | --------- | ------------------- | ------------ |
+| [cite?](#)     |           | string \| undefined | _(Optional)_ |
+| [dateTime?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## IntrinsicAttributes
 
 ```typescript
@@ -776,6 +1354,203 @@ interface IntrinsicElements extends QwikJSX.IntrinsicElements
 ```
 
 **Extends:** [QwikJSX.IntrinsicElements](#)
+
+## IntrinsicHTMLElements
+
+```typescript
+export interface IntrinsicHTMLElements
+```
+
+| Property        | Modifiers | Type                                                                         | Description |
+| --------------- | --------- | ---------------------------------------------------------------------------- | ----------- |
+| [a](#)          |           | [AnchorHTMLAttributes](#anchorhtmlattributes)&lt;HTMLAnchorElement&gt;       |             |
+| [abbr](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [address](#)    |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [area](#)       |           | [AreaHTMLAttributes](#areahtmlattributes)&lt;HTMLAreaElement&gt;             |             |
+| [article](#)    |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [aside](#)      |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [audio](#)      |           | [AudioHTMLAttributes](#audiohtmlattributes)&lt;HTMLAudioElement&gt;          |             |
+| [b](#)          |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [base](#)       |           | [BaseHTMLAttributes](#basehtmlattributes)&lt;HTMLBaseElement&gt;             |             |
+| [bdi](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [bdo](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [big](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [blockquote](#) |           | [BlockquoteHTMLAttributes](#blockquotehtmlattributes)&lt;HTMLElement&gt;     |             |
+| [body](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLBodyElement&gt;                     |             |
+| [br](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLBRElement&gt;                       |             |
+| [button](#)     |           | [ButtonHTMLAttributes](#buttonhtmlattributes)&lt;HTMLButtonElement&gt;       |             |
+| [canvas](#)     |           | [CanvasHTMLAttributes](#canvashtmlattributes)&lt;HTMLCanvasElement&gt;       |             |
+| [caption](#)    |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [cite](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [code](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [col](#)        |           | [ColHTMLAttributes](#colhtmlattributes)&lt;HTMLTableColElement&gt;           |             |
+| [colgroup](#)   |           | [ColgroupHTMLAttributes](#colgrouphtmlattributes)&lt;HTMLTableColElement&gt; |             |
+| [data](#)       |           | [DataHTMLAttributes](#datahtmlattributes)&lt;HTMLDataElement&gt;             |             |
+| [datalist](#)   |           | [HTMLAttributes](#htmlattributes)&lt;HTMLDataListElement&gt;                 |             |
+| [dd](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [del](#)        |           | [DelHTMLAttributes](#delhtmlattributes)&lt;HTMLElement&gt;                   |             |
+| [details](#)    |           | [DetailsHTMLAttributes](#detailshtmlattributes)&lt;HTMLElement&gt;           |             |
+| [dfn](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [dialog](#)     |           | [DialogHTMLAttributes](#dialoghtmlattributes)&lt;HTMLDialogElement&gt;       |             |
+| [div](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLDivElement&gt;                      |             |
+| [dl](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLDListElement&gt;                    |             |
+| [dt](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [em](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [embed](#)      |           | [EmbedHTMLAttributes](#embedhtmlattributes)&lt;HTMLEmbedElement&gt;          |             |
+| [fieldset](#)   |           | [FieldsetHTMLAttributes](#fieldsethtmlattributes)&lt;HTMLFieldSetElement&gt; |             |
+| [figcaption](#) |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [figure](#)     |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [footer](#)     |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [form](#)       |           | [FormHTMLAttributes](#formhtmlattributes)&lt;HTMLFormElement&gt;             |             |
+| [h1](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLHeadingElement&gt;                  |             |
+| [h2](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLHeadingElement&gt;                  |             |
+| [h3](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLHeadingElement&gt;                  |             |
+| [h4](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLHeadingElement&gt;                  |             |
+| [h5](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLHeadingElement&gt;                  |             |
+| [h6](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLHeadingElement&gt;                  |             |
+| [head](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLHeadElement&gt;                     |             |
+| [header](#)     |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [hgroup](#)     |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [hr](#)         |           | [HrHTMLAttributes](#hrhtmlattributes)&lt;HTMLHRElement&gt;                   |             |
+| [html](#)       |           | [HtmlHTMLAttributes](#htmlhtmlattributes)&lt;HTMLHtmlElement&gt;             |             |
+| [i](#)          |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [iframe](#)     |           | [IframeHTMLAttributes](#iframehtmlattributes)&lt;HTMLIFrameElement&gt;       |             |
+| [img](#)        |           | [ImgHTMLAttributes](#imghtmlattributes)&lt;HTMLImageElement&gt;              |             |
+| [input](#)      |           | [InputHTMLAttributes](#inputhtmlattributes)&lt;HTMLInputElement&gt;          |             |
+| [ins](#)        |           | [InsHTMLAttributes](#inshtmlattributes)&lt;HTMLModElement&gt;                |             |
+| [kbd](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [keygen](#)     |           | [KeygenHTMLAttributes](#keygenhtmlattributes)&lt;HTMLElement&gt;             |             |
+| [label](#)      |           | [LabelHTMLAttributes](#labelhtmlattributes)&lt;HTMLLabelElement&gt;          |             |
+| [legend](#)     |           | [HTMLAttributes](#htmlattributes)&lt;HTMLLegendElement&gt;                   |             |
+| [li](#)         |           | [LiHTMLAttributes](#lihtmlattributes)&lt;HTMLLIElement&gt;                   |             |
+| [link](#)       |           | [LinkHTMLAttributes](#linkhtmlattributes)&lt;HTMLLinkElement&gt;             |             |
+| [main](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [map](#)        |           | [MapHTMLAttributes](#maphtmlattributes)&lt;HTMLMapElement&gt;                |             |
+| [mark](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [menu](#)       |           | [MenuHTMLAttributes](#menuhtmlattributes)&lt;HTMLElement&gt;                 |             |
+| [menuitem](#)   |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [meta](#)       |           | [MetaHTMLAttributes](#metahtmlattributes)&lt;HTMLMetaElement&gt;             |             |
+| [meter](#)      |           | [MeterHTMLAttributes](#meterhtmlattributes)&lt;HTMLElement&gt;               |             |
+| [nav](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [noindex](#)    |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [noscript](#)   |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [object](#)     |           | [ObjectHTMLAttributes](#objecthtmlattributes)&lt;HTMLObjectElement&gt;       |             |
+| [ol](#)         |           | [OlHTMLAttributes](#olhtmlattributes)&lt;HTMLOListElement&gt;                |             |
+| [optgroup](#)   |           | [OptgroupHTMLAttributes](#optgrouphtmlattributes)&lt;HTMLOptGroupElement&gt; |             |
+| [option](#)     |           | [OptionHTMLAttributes](#optionhtmlattributes)&lt;HTMLOptionElement&gt;       |             |
+| [output](#)     |           | [OutputHTMLAttributes](#outputhtmlattributes)&lt;HTMLElement&gt;             |             |
+| [p](#)          |           | [HTMLAttributes](#htmlattributes)&lt;HTMLParagraphElement&gt;                |             |
+| [param](#)      |           | [ParamHTMLAttributes](#paramhtmlattributes)&lt;HTMLParamElement&gt;          |             |
+| [picture](#)    |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [pre](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLPreElement&gt;                      |             |
+| [progress](#)   |           | [ProgressHTMLAttributes](#progresshtmlattributes)&lt;HTMLProgressElement&gt; |             |
+| [q](#)          |           | [QuoteHTMLAttributes](#quotehtmlattributes)&lt;HTMLQuoteElement&gt;          |             |
+| [rp](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [rt](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [ruby](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [s](#)          |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [samp](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [script](#)     |           | [ScriptHTMLAttributes](#scripthtmlattributes)&lt;HTMLScriptElement&gt;       |             |
+| [section](#)    |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [select](#)     |           | [SelectHTMLAttributes](#selecthtmlattributes)&lt;HTMLSelectElement&gt;       |             |
+| [slot](#)       |           | [SlotHTMLAttributes](#slothtmlattributes)&lt;HTMLSlotElement&gt;             |             |
+| [small](#)      |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [source](#)     |           | [SourceHTMLAttributes](#sourcehtmlattributes)&lt;HTMLSourceElement&gt;       |             |
+| [span](#)       |           | [HTMLAttributes](#htmlattributes)&lt;HTMLSpanElement&gt;                     |             |
+| [strong](#)     |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [style](#)      |           | [StyleHTMLAttributes](#stylehtmlattributes)&lt;HTMLStyleElement&gt;          |             |
+| [sub](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [summary](#)    |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [sup](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [table](#)      |           | [TableHTMLAttributes](#tablehtmlattributes)&lt;HTMLTableElement&gt;          |             |
+| [tbody](#)      |           | [HTMLAttributes](#htmlattributes)&lt;HTMLTableSectionElement&gt;             |             |
+| [td](#)         |           | [TdHTMLAttributes](#tdhtmlattributes)&lt;HTMLTableDataCellElement&gt;        |             |
+| [template](#)   |           | [HTMLAttributes](#htmlattributes)&lt;HTMLTemplateElement&gt;                 |             |
+| [textarea](#)   |           | [TextareaHTMLAttributes](#textareahtmlattributes)&lt;HTMLTextAreaElement&gt; |             |
+| [tfoot](#)      |           | [HTMLAttributes](#htmlattributes)&lt;HTMLTableSectionElement&gt;             |             |
+| [th](#)         |           | [ThHTMLAttributes](#thhtmlattributes)&lt;HTMLTableHeaderCellElement&gt;      |             |
+| [thead](#)      |           | [HTMLAttributes](#htmlattributes)&lt;HTMLTableSectionElement&gt;             |             |
+| [time](#)       |           | [TimeHTMLAttributes](#timehtmlattributes)&lt;HTMLElement&gt;                 |             |
+| [title](#)      |           | [TitleHTMLAttributes](#titlehtmlattributes)&lt;HTMLTitleElement&gt;          |             |
+| [tr](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLTableRowElement&gt;                 |             |
+| [track](#)      |           | [TrackHTMLAttributes](#trackhtmlattributes)&lt;HTMLTrackElement&gt;          |             |
+| [tt](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [u](#)          |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [ul](#)         |           | [HTMLAttributes](#htmlattributes)&lt;HTMLUListElement&gt;                    |             |
+| [video](#)      |           | [VideoHTMLAttributes](#videohtmlattributes)&lt;HTMLVideoElement&gt;          |             |
+| [wbr](#)        |           | [HTMLAttributes](#htmlattributes)&lt;HTMLElement&gt;                         |             |
+| [webview](#)    |           | [WebViewHTMLAttributes](#webviewhtmlattributes)&lt;HTMLWebViewElement&gt;    |             |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## IntrinsicSVGElements
+
+```typescript
+export interface IntrinsicSVGElements
+```
+
+| Property                 | Modifiers | Type                                                       | Description |
+| ------------------------ | --------- | ---------------------------------------------------------- | ----------- |
+| [animate](#)             |           | [SVGProps](#svgprops)&lt;SVGElement&gt;                    |             |
+| [animateMotion](#)       |           | [SVGProps](#svgprops)&lt;SVGElement&gt;                    |             |
+| [animateTransform](#)    |           | [SVGProps](#svgprops)&lt;SVGElement&gt;                    |             |
+| [circle](#)              |           | [SVGProps](#svgprops)&lt;SVGCircleElement&gt;              |             |
+| [clipPath](#)            |           | [SVGProps](#svgprops)&lt;SVGClipPathElement&gt;            |             |
+| [defs](#)                |           | [SVGProps](#svgprops)&lt;SVGDefsElement&gt;                |             |
+| [desc](#)                |           | [SVGProps](#svgprops)&lt;SVGDescElement&gt;                |             |
+| [ellipse](#)             |           | [SVGProps](#svgprops)&lt;SVGEllipseElement&gt;             |             |
+| [feBlend](#)             |           | [SVGProps](#svgprops)&lt;SVGFEBlendElement&gt;             |             |
+| [feColorMatrix](#)       |           | [SVGProps](#svgprops)&lt;SVGFEColorMatrixElement&gt;       |             |
+| [feComponentTransfer](#) |           | [SVGProps](#svgprops)&lt;SVGFEComponentTransferElement&gt; |             |
+| [feComposite](#)         |           | [SVGProps](#svgprops)&lt;SVGFECompositeElement&gt;         |             |
+| [feConvolveMatrix](#)    |           | [SVGProps](#svgprops)&lt;SVGFEConvolveMatrixElement&gt;    |             |
+| [feDiffuseLighting](#)   |           | [SVGProps](#svgprops)&lt;SVGFEDiffuseLightingElement&gt;   |             |
+| [feDisplacementMap](#)   |           | [SVGProps](#svgprops)&lt;SVGFEDisplacementMapElement&gt;   |             |
+| [feDistantLight](#)      |           | [SVGProps](#svgprops)&lt;SVGFEDistantLightElement&gt;      |             |
+| [feDropShadow](#)        |           | [SVGProps](#svgprops)&lt;SVGFEDropShadowElement&gt;        |             |
+| [feFlood](#)             |           | [SVGProps](#svgprops)&lt;SVGFEFloodElement&gt;             |             |
+| [feFuncA](#)             |           | [SVGProps](#svgprops)&lt;SVGFEFuncAElement&gt;             |             |
+| [feFuncB](#)             |           | [SVGProps](#svgprops)&lt;SVGFEFuncBElement&gt;             |             |
+| [feFuncG](#)             |           | [SVGProps](#svgprops)&lt;SVGFEFuncGElement&gt;             |             |
+| [feFuncR](#)             |           | [SVGProps](#svgprops)&lt;SVGFEFuncRElement&gt;             |             |
+| [feGaussianBlur](#)      |           | [SVGProps](#svgprops)&lt;SVGFEGaussianBlurElement&gt;      |             |
+| [feImage](#)             |           | [SVGProps](#svgprops)&lt;SVGFEImageElement&gt;             |             |
+| [feMerge](#)             |           | [SVGProps](#svgprops)&lt;SVGFEMergeElement&gt;             |             |
+| [feMergeNode](#)         |           | [SVGProps](#svgprops)&lt;SVGFEMergeNodeElement&gt;         |             |
+| [feMorphology](#)        |           | [SVGProps](#svgprops)&lt;SVGFEMorphologyElement&gt;        |             |
+| [feOffset](#)            |           | [SVGProps](#svgprops)&lt;SVGFEOffsetElement&gt;            |             |
+| [fePointLight](#)        |           | [SVGProps](#svgprops)&lt;SVGFEPointLightElement&gt;        |             |
+| [feSpecularLighting](#)  |           | [SVGProps](#svgprops)&lt;SVGFESpecularLightingElement&gt;  |             |
+| [feSpotLight](#)         |           | [SVGProps](#svgprops)&lt;SVGFESpotLightElement&gt;         |             |
+| [feTile](#)              |           | [SVGProps](#svgprops)&lt;SVGFETileElement&gt;              |             |
+| [feTurbulence](#)        |           | [SVGProps](#svgprops)&lt;SVGFETurbulenceElement&gt;        |             |
+| [filter](#)              |           | [SVGProps](#svgprops)&lt;SVGFilterElement&gt;              |             |
+| [foreignObject](#)       |           | [SVGProps](#svgprops)&lt;SVGForeignObjectElement&gt;       |             |
+| [g](#)                   |           | [SVGProps](#svgprops)&lt;SVGGElement&gt;                   |             |
+| [image](#)               |           | [SVGProps](#svgprops)&lt;SVGImageElement&gt;               |             |
+| [line](#)                |           | [SVGProps](#svgprops)&lt;SVGLineElement&gt;                |             |
+| [linearGradient](#)      |           | [SVGProps](#svgprops)&lt;SVGLinearGradientElement&gt;      |             |
+| [marker](#)              |           | [SVGProps](#svgprops)&lt;SVGMarkerElement&gt;              |             |
+| [mask](#)                |           | [SVGProps](#svgprops)&lt;SVGMaskElement&gt;                |             |
+| [metadata](#)            |           | [SVGProps](#svgprops)&lt;SVGMetadataElement&gt;            |             |
+| [mpath](#)               |           | [SVGProps](#svgprops)&lt;SVGElement&gt;                    |             |
+| [path](#)                |           | [SVGProps](#svgprops)&lt;SVGPathElement&gt;                |             |
+| [pattern](#)             |           | [SVGProps](#svgprops)&lt;SVGPatternElement&gt;             |             |
+| [polygon](#)             |           | [SVGProps](#svgprops)&lt;SVGPolygonElement&gt;             |             |
+| [polyline](#)            |           | [SVGProps](#svgprops)&lt;SVGPolylineElement&gt;            |             |
+| [radialGradient](#)      |           | [SVGProps](#svgprops)&lt;SVGRadialGradientElement&gt;      |             |
+| [rect](#)                |           | [SVGProps](#svgprops)&lt;SVGRectElement&gt;                |             |
+| [stop](#)                |           | [SVGProps](#svgprops)&lt;SVGStopElement&gt;                |             |
+| [svg](#)                 |           | [SVGProps](#svgprops)&lt;SVGSVGElement&gt;                 |             |
+| [switch](#)              |           | [SVGProps](#svgprops)&lt;SVGSwitchElement&gt;              |             |
+| [symbol](#)              |           | [SVGProps](#svgprops)&lt;SVGSymbolElement&gt;              |             |
+| [text](#)                |           | [SVGProps](#svgprops)&lt;SVGTextElement&gt;                |             |
+| [textPath](#)            |           | [SVGProps](#svgprops)&lt;SVGTextPathElement&gt;            |             |
+| [tspan](#)               |           | [SVGProps](#svgprops)&lt;SVGTSpanElement&gt;               |             |
+| [use](#)                 |           | [SVGProps](#svgprops)&lt;SVGUseElement&gt;                 |             |
+| [view](#)                |           | [SVGProps](#svgprops)&lt;SVGViewElement&gt;                |             |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## jsx
 
@@ -847,7 +1622,7 @@ export interface JSXNode<T = string | FunctionComponent>
 | Property            | Modifiers | Type                                                                                             | Description  |
 | ------------------- | --------- | ------------------------------------------------------------------------------------------------ | ------------ |
 | [children](#)       |           | any \| null                                                                                      |              |
-| [dev?](#)           |           | DevJSX                                                                                           | _(Optional)_ |
+| [dev?](#)           |           | [DevJSX](#devjsx)                                                                                | _(Optional)_ |
 | [flags](#)          |           | number                                                                                           |              |
 | [immutableProps](#) |           | Record&lt;string, any&gt; \| null                                                                |              |
 | [key](#)            |           | string \| null                                                                                   |              |
@@ -865,6 +1640,173 @@ export type JSXTagName =
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
+
+## KeygenHTMLAttributes
+
+```typescript
+export interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property        | Modifiers | Type                 | Description  |
+| --------------- | --------- | -------------------- | ------------ |
+| [autoFocus?](#) |           | boolean \| undefined | _(Optional)_ |
+| [challenge?](#) |           | string \| undefined  | _(Optional)_ |
+| [children?](#)  |           | undefined            | _(Optional)_ |
+| [disabled?](#)  |           | boolean \| undefined | _(Optional)_ |
+| [form?](#)      |           | string \| undefined  | _(Optional)_ |
+| [keyParams?](#) |           | string \| undefined  | _(Optional)_ |
+| [keyType?](#)   |           | string \| undefined  | _(Optional)_ |
+| [name?](#)      |           | string \| undefined  | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## LabelHTMLAttributes
+
+```typescript
+export interface LabelHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                | Description  |
+| ---------- | --------- | ------------------- | ------------ |
+| [for?](#)  |           | string \| undefined | _(Optional)_ |
+| [form?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## LiHTMLAttributes
+
+```typescript
+export interface LiHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property    | Modifiers | Type                                                         | Description  |
+| ----------- | --------- | ------------------------------------------------------------ | ------------ |
+| [value?](#) |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## LinkHTMLAttributes
+
+```typescript
+export interface LinkHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property             | Modifiers | Type                                                                     | Description  |
+| -------------------- | --------- | ------------------------------------------------------------------------ | ------------ |
+| [as?](#)             |           | string \| undefined                                                      | _(Optional)_ |
+| [charSet?](#)        |           | string \| undefined                                                      | _(Optional)_ |
+| [children?](#)       |           | undefined                                                                | _(Optional)_ |
+| [crossOrigin?](#)    |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute)                    | _(Optional)_ |
+| [href?](#)           |           | string \| undefined                                                      | _(Optional)_ |
+| [hrefLang?](#)       |           | string \| undefined                                                      | _(Optional)_ |
+| [imageSizes?](#)     |           | string \| undefined                                                      | _(Optional)_ |
+| [imageSrcSet?](#)    |           | string \| undefined                                                      | _(Optional)_ |
+| [integrity?](#)      |           | string \| undefined                                                      | _(Optional)_ |
+| [media?](#)          |           | string \| undefined                                                      | _(Optional)_ |
+| [referrerPolicy?](#) |           | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \| undefined | _(Optional)_ |
+| [rel?](#)            |           | string \| undefined                                                      | _(Optional)_ |
+| [sizes?](#)          |           | string \| undefined                                                      | _(Optional)_ |
+| [type?](#)           |           | string \| undefined                                                      | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## MapHTMLAttributes
+
+```typescript
+export interface MapHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                | Description  |
+| ---------- | --------- | ------------------- | ------------ |
+| [name?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## MediaHTMLAttributes
+
+```typescript
+export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property           | Modifiers | Type                                                  | Description  |
+| ------------------ | --------- | ----------------------------------------------------- | ------------ |
+| [autoPlay?](#)     |           | boolean \| undefined                                  | _(Optional)_ |
+| [controls?](#)     |           | boolean \| undefined                                  | _(Optional)_ |
+| [controlsList?](#) |           | string \| undefined                                   | _(Optional)_ |
+| [crossOrigin?](#)  |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |
+| [loop?](#)         |           | boolean \| undefined                                  | _(Optional)_ |
+| [mediaGroup?](#)   |           | string \| undefined                                   | _(Optional)_ |
+| [muted?](#)        |           | boolean \| undefined                                  | _(Optional)_ |
+| [playsInline?](#)  |           | boolean \| undefined                                  | _(Optional)_ |
+| [preload?](#)      |           | string \| undefined                                   | _(Optional)_ |
+| [src?](#)          |           | string \| undefined                                   | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## MenuHTMLAttributes
+
+```typescript
+export interface MenuHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                | Description  |
+| ---------- | --------- | ------------------- | ------------ |
+| [type?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## MetaHTMLAttributes
+
+```typescript
+export interface MetaHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property        | Modifiers | Type                | Description  |
+| --------------- | --------- | ------------------- | ------------ |
+| [charSet?](#)   |           | string \| undefined | _(Optional)_ |
+| [children?](#)  |           | undefined           | _(Optional)_ |
+| [content?](#)   |           | string \| undefined | _(Optional)_ |
+| [httpEquiv?](#) |           | string \| undefined | _(Optional)_ |
+| [media?](#)     |           | string \| undefined | _(Optional)_ |
+| [name?](#)      |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## MeterHTMLAttributes
+
+```typescript
+export interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property      | Modifiers | Type                                                         | Description  |
+| ------------- | --------- | ------------------------------------------------------------ | ------------ |
+| [form?](#)    |           | string \| undefined                                          | _(Optional)_ |
+| [high?](#)    |           | number \| undefined                                          | _(Optional)_ |
+| [low?](#)     |           | number \| undefined                                          | _(Optional)_ |
+| [max?](#)     |           | number \| string \| undefined                                | _(Optional)_ |
+| [min?](#)     |           | number \| string \| undefined                                | _(Optional)_ |
+| [optimum?](#) |           | number \| undefined                                          | _(Optional)_ |
+| [value?](#)   |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## NativeAnimationEvent
 
@@ -994,6 +1936,52 @@ noSerialize: <T extends object | undefined>(input: T) => NoSerialize<T>;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/state/common.ts)
 
+## Numberish
+
+```typescript
+export type Numberish = number | `${number}`;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## ObjectHTMLAttributes
+
+```typescript
+export interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property      | Modifiers | Type                       | Description  |
+| ------------- | --------- | -------------------------- | ------------ |
+| [classID?](#) |           | string \| undefined        | _(Optional)_ |
+| [data?](#)    |           | string \| undefined        | _(Optional)_ |
+| [form?](#)    |           | string \| undefined        | _(Optional)_ |
+| [height?](#)  |           | [Size](#size) \| undefined | _(Optional)_ |
+| [name?](#)    |           | string \| undefined        | _(Optional)_ |
+| [type?](#)    |           | string \| undefined        | _(Optional)_ |
+| [useMap?](#)  |           | string \| undefined        | _(Optional)_ |
+| [width?](#)   |           | [Size](#size) \| undefined | _(Optional)_ |
+| [wmode?](#)   |           | string \| undefined        | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## OlHTMLAttributes
+
+```typescript
+export interface OlHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                                         | Description  |
+| -------------- | --------- | -------------------------------------------- | ------------ |
+| [reversed?](#) |           | boolean \| undefined                         | _(Optional)_ |
+| [start?](#)    |           | number \| undefined                          | _(Optional)_ |
+| [type?](#)     |           | '1' \| 'a' \| 'A' \| 'i' \| 'I' \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## OnRenderFn
 
 ```typescript
@@ -1017,6 +2005,86 @@ export interface OnVisibleTaskOptions
 | [strategy?](#) |           | [VisibleTaskStrategy](#visibletaskstrategy) | <p>_(Optional)_ The strategy to use to determine when the "VisibleTask" should first execute.</p><p>- <code>intersection-observer</code>: the task will first execute when the element is visible in the viewport, under the hood it uses the IntersectionObserver API. - <code>document-ready</code>: the task will first execute when the document is ready, under the hood it uses the document <code>load</code> event. - <code>document-idle</code>: the task will first execute when the document is idle, under the hood it uses the requestIdleCallback API.</p> |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
+
+## OptgroupHTMLAttributes
+
+```typescript
+export interface OptgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                 | Description  |
+| -------------- | --------- | -------------------- | ------------ |
+| [disabled?](#) |           | boolean \| undefined | _(Optional)_ |
+| [label?](#)    |           | string \| undefined  | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## OptionHTMLAttributes
+
+```typescript
+export interface OptionHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                                                         | Description  |
+| -------------- | --------- | ------------------------------------------------------------ | ------------ |
+| [children?](#) |           | string                                                       | _(Optional)_ |
+| [disabled?](#) |           | boolean \| undefined                                         | _(Optional)_ |
+| [label?](#)    |           | string \| undefined                                          | _(Optional)_ |
+| [selected?](#) |           | boolean \| undefined                                         | _(Optional)_ |
+| [value?](#)    |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## OutputHTMLAttributes
+
+```typescript
+export interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                | Description  |
+| ---------- | --------- | ------------------- | ------------ |
+| [for?](#)  |           | string \| undefined | _(Optional)_ |
+| [form?](#) |           | string \| undefined | _(Optional)_ |
+| [name?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## ParamHTMLAttributes
+
+```typescript
+export interface ParamHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                                                         | Description  |
+| -------------- | --------- | ------------------------------------------------------------ | ------------ |
+| [children?](#) |           | undefined                                                    | _(Optional)_ |
+| [name?](#)     |           | string \| undefined                                          | _(Optional)_ |
+| [value?](#)    |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## ProgressHTMLAttributes
+
+```typescript
+export interface ProgressHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property    | Modifiers | Type                                                         | Description  |
+| ----------- | --------- | ------------------------------------------------------------ | ------------ |
+| [max?](#)   |           | number \| string \| undefined                                | _(Optional)_ |
+| [value?](#) |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## PropFnInterface
 
@@ -1124,6 +2192,20 @@ qrl: <T = any,>(
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts)
+
+## QuoteHTMLAttributes
+
+```typescript
+export interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                | Description  |
+| ---------- | --------- | ------------------- | ------------ |
+| [cite?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## QwikAnimationEvent
 
@@ -1246,7 +2328,7 @@ export default component$<WrapperProps>(({ attributes }) => {
 export interface QwikIntrinsicElements extends IntrinsicHTMLElements
 ```
 
-**Extends:** IntrinsicHTMLElements
+**Extends:** [IntrinsicHTMLElements](#intrinsichtmlelements)
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-elements.ts)
 
@@ -1700,6 +2782,52 @@ export type ResourceReturn<T> =
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
 
+## ScriptHTMLAttributes
+
+```typescript
+export interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property             | Modifiers | Type                                                                     | Description  |
+| -------------------- | --------- | ------------------------------------------------------------------------ | ------------ |
+| [async?](#)          |           | boolean \| undefined                                                     | _(Optional)_ |
+| [charSet?](#)        |           | string \| undefined                                                      | _(Optional)_ |
+| [crossOrigin?](#)    |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute)                    | _(Optional)_ |
+| [defer?](#)          |           | boolean \| undefined                                                     | _(Optional)_ |
+| [integrity?](#)      |           | string \| undefined                                                      | _(Optional)_ |
+| [noModule?](#)       |           | boolean \| undefined                                                     | _(Optional)_ |
+| [nonce?](#)          |           | string \| undefined                                                      | _(Optional)_ |
+| [referrerPolicy?](#) |           | [HTMLAttributeReferrerPolicy](#htmlattributereferrerpolicy) \| undefined | _(Optional)_ |
+| [src?](#)            |           | string \| undefined                                                      | _(Optional)_ |
+| [type?](#)           |           | string \| undefined                                                      | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## SelectHTMLAttributes
+
+```typescript
+export interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property           | Modifiers | Type                                                                                                                                                                    | Description  |
+| ------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| ["bind:value"?](#) |           | [Signal](#signal)&lt;string \| undefined&gt;                                                                                                                            | _(Optional)_ |
+| [autoComplete?](#) |           | [HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute) \| Omit&lt;[HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute), string&gt; \| undefined | _(Optional)_ |
+| [autoFocus?](#)    |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [disabled?](#)     |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [form?](#)         |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [multiple?](#)     |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [name?](#)         |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [required?](#)     |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [size?](#)         |           | number \| undefined                                                                                                                                                     | _(Optional)_ |
+| [value?](#)        |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined                                                                                                            | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## setPlatform
 
 Sets the `CorePlatform`.
@@ -1724,6 +2852,14 @@ export interface Signal<T = any>
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/state/signal.ts)
 
+## Size
+
+```typescript
+export type Size = number | string;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## SkipRender
 
 ```typescript
@@ -1743,6 +2879,20 @@ Slot: FunctionComponent<{
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/slot.public.ts)
+
+## SlotHTMLAttributes
+
+```typescript
+export interface SlotHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property   | Modifiers | Type                | Description  |
+| ---------- | --------- | ------------------- | ------------ |
+| [name?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## SnapshotListener
 
@@ -1814,6 +2964,27 @@ export interface SnapshotState
 | [subs](#) |           | any[]                         |             |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/container/container.ts)
+
+## SourceHTMLAttributes
+
+```typescript
+export interface SourceHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                       | Description  |
+| -------------- | --------- | -------------------------- | ------------ |
+| [children?](#) |           | undefined                  | _(Optional)_ |
+| [height?](#)   |           | [Size](#size) \| undefined | _(Optional)_ |
+| [media?](#)    |           | string \| undefined        | _(Optional)_ |
+| [sizes?](#)    |           | string \| undefined        | _(Optional)_ |
+| [src?](#)      |           | string \| undefined        | _(Optional)_ |
+| [srcSet?](#)   |           | string \| undefined        | _(Optional)_ |
+| [type?](#)     |           | string \| undefined        | _(Optional)_ |
+| [width?](#)    |           | [Size](#size) \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## SSRComment
 
@@ -1899,6 +3070,323 @@ export type StreamWriter = {
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/ssr/render-ssr.ts)
 
+## StyleHTMLAttributes
+
+```typescript
+export interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                 | Description  |
+| -------------- | --------- | -------------------- | ------------ |
+| [children?](#) |           | string               | _(Optional)_ |
+| [media?](#)    |           | string \| undefined  | _(Optional)_ |
+| [nonce?](#)    |           | string \| undefined  | _(Optional)_ |
+| [scoped?](#)   |           | boolean \| undefined | _(Optional)_ |
+| [type?](#)     |           | string \| undefined  | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## SVGAttributes
+
+```typescript
+export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T>
+```
+
+**Extends:** [AriaAttributes](#ariaattributes), [DOMAttributes](#domattributes)&lt;T&gt;
+
+| Property                             | Modifiers | Type                                                                                                                                                                                                                | Description  |
+| ------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| ["accent-height"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["alignment-baseline"?](#)           |           | 'auto' \| 'baseline' \| 'before-edge' \| 'text-before-edge' \| 'middle' \| 'central' \| 'after-edge' \| 'text-after-edge' \| 'ideographic' \| 'alphabetic' \| 'hanging' \| 'mathematical' \| 'inherit' \| undefined | _(Optional)_ |
+| ["arabic-form"?](#)                  |           | 'initial' \| 'medial' \| 'terminal' \| 'isolated' \| undefined                                                                                                                                                      | _(Optional)_ |
+| ["baseline-shift"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["cap-height"?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["clip-path"?](#)                    |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["clip-rule"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["color-interpolation-filters"?](#)  |           | 'auto' \| 's-rGB' \| 'linear-rGB' \| 'inherit' \| undefined                                                                                                                                                         | _(Optional)_ |
+| ["color-interpolation"?](#)          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["color-profile"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["color-rendering"?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["dominant-baseline"?](#)            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["edge-mode"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["enable-background"?](#)            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["fill-opacity"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["fill-rule"?](#)                    |           | 'nonzero' \| 'evenodd' \| 'inherit' \| undefined                                                                                                                                                                    | _(Optional)_ |
+| ["flood-color"?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["flood-opacity"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-family"?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["font-size-adjust"?](#)             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-size"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-stretch"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-style"?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-variant"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-weight"?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["glyph-name"?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["glyph-orientation-horizontal"?](#) |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["glyph-orientation-vertical"?](#)   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["horiz-adv-x"?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["horiz-origin-x"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["image-rendering"?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["letter-spacing"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["lighting-color"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["marker-end"?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["marker-mid"?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["marker-start"?](#)                 |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["overline-position"?](#)            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["overline-thickness"?](#)           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["paint-order"?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["pointer-events"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["rendering-intent"?](#)             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["shape-rendering"?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stop-color"?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["stop-opacity"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["strikethrough-position"?](#)       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["strikethrough-thickness"?](#)      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stroke-dasharray"?](#)             |           | string \| number \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stroke-dashoffset"?](#)            |           | string \| number \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stroke-linecap"?](#)               |           | 'butt' \| 'round' \| 'square' \| 'inherit' \| undefined                                                                                                                                                             | _(Optional)_ |
+| ["stroke-linejoin"?](#)              |           | 'miter' \| 'round' \| 'bevel' \| 'inherit' \| undefined                                                                                                                                                             | _(Optional)_ |
+| ["stroke-miterlimit"?](#)            |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["stroke-opacity"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stroke-width"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["text-anchor"?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["text-decoration"?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["text-rendering"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["underline-position"?](#)           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["underline-thickness"?](#)          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["unicode-bidi"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["unicode-range"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["units-per-em"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["v-alphabetic"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["v-hanging"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["v-ideographic"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["v-mathematical"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["vector-effect"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["vert-adv-y"?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["vert-origin-x"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["vert-origin-y"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["word-spacing"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["writing-mode"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["x-channel-selector"?](#)           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["x-height"?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [accumulate?](#)                     |           | 'none' \| 'sum' \| undefined                                                                                                                                                                                        | _(Optional)_ |
+| [additive?](#)                       |           | 'replace' \| 'sum' \| undefined                                                                                                                                                                                     | _(Optional)_ |
+| [allowReorder?](#)                   |           | 'no' \| 'yes' \| undefined                                                                                                                                                                                          | _(Optional)_ |
+| [alphabetic?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [amplitude?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [ascent?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [attributeName?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [attributeType?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [autoReverse?](#)                    |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                                              | _(Optional)_ |
+| [azimuth?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [baseFrequency?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [baseProfile?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [bbox?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [begin?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [bias?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [by?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [calcMode?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [class?](#)                          |           | [ClassList](#classlist) \| undefined                                                                                                                                                                                | _(Optional)_ |
+| [className?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [clip?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [clipPathUnits?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [color?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [contentScriptType?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [contentStyleType?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [crossOrigin?](#)                    |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute)                                                                                                                                                               | _(Optional)_ |
+| [cursor?](#)                         |           | number \| string                                                                                                                                                                                                    | _(Optional)_ |
+| [cx?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [cy?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [d?](#)                              |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [decelerate?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [descent?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [diffuseConstant?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [direction?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [display?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [divisor?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [dur?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [dx?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [dy?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [elevation?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [end?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [exponent?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [externalResourcesRequired?](#)      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [fill?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [filter?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [filterRes?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [filterUnits?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [focusable?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [format?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [fr?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [from?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [fx?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [fy?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [g1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [g2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [glyphRef?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [gradientTransform?](#)              |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [gradientUnits?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [hanging?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [height?](#)                         |           | [Numberish](#numberish) \| undefined                                                                                                                                                                                | _(Optional)_ |
+| [href?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [id?](#)                             |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [ideographic?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [in?](#)                             |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [in2?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [intercept?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k3?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k4?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [kernelMatrix?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [kernelUnitLength?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [kerning?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [keyPoints?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [keySplines?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [keyTimes?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [lang?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [lengthAdjust?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [limitingConeAngle?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [local?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [markerHeight?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [markerUnits?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [markerWidth?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [mask?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [maskContentUnits?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [maskUnits?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [mathematical?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [max?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [media?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [method?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [min?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [mode?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [name?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [numOctaves?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [offset?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [opacity?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [operator?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [order?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [orient?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [orientation?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [origin?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [overflow?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [panose1?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [path?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [pathLength?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [patternContentUnits?](#)            |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [patternTransform?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [patternUnits?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [points?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [pointsAtX?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [pointsAtY?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [pointsAtZ?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [preserveAlpha?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [preserveAspectRatio?](#)            |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [primitiveUnits?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [r?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [radius?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [refX?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [refY?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [repeatCount?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [repeatDur?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [requiredextensions?](#)             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [requiredFeatures?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [restart?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [result?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [role?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [rotate?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [rx?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [ry?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [scale?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [seed?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [slope?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [spacing?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [specularConstant?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [specularExponent?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [speed?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [spreadMethod?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [startOffset?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stdDeviation?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stemh?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stemv?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stitchTiles?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [string?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stroke?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [style?](#)                          |           | [CSSProperties](#cssproperties) \| string \| undefined                                                                                                                                                              | _(Optional)_ |
+| [surfaceScale?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [systemLanguage?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [tabindex?](#)                       |           | number \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [tableValues?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [target?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [targetX?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [targetY?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [textLength?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [to?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [transform?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [type?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [u1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [u2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [unicode?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [values?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [version?](#)                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [viewBox?](#)                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [viewTarget?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [visibility?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [width?](#)                          |           | [Numberish](#numberish) \| undefined                                                                                                                                                                                | _(Optional)_ |
+| [widths?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [x?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [x1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [x2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [xlinkActuate?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xlinkArcrole?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xlinkHref?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xlinkRole?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xlinkShow?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xlinkTitle?](#)                     |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xlinkType?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xmlBase?](#)                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xmlLang?](#)                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xmlns?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [xmlSpace?](#)                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [y?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [y1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [y2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [yChannelSelector?](#)               |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [z?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [zoomAndPan?](#)                     |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## SVGProps
+
+```typescript
+export interface SVGProps<T extends Element> extends SVGAttributes<T>
+```
+
+**Extends:** [SVGAttributes](#svgattributes)&lt;T&gt;
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## TableHTMLAttributes
+
+```typescript
+export interface TableHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property          | Modifiers | Type                          | Description  |
+| ----------------- | --------- | ----------------------------- | ------------ |
+| [cellPadding?](#) |           | number \| string \| undefined | _(Optional)_ |
+| [cellSpacing?](#) |           | number \| string \| undefined | _(Optional)_ |
+| [summary?](#)     |           | string \| undefined           | _(Optional)_ |
+| [width?](#)       |           | [Size](#size) \| undefined    | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## TaskCtx
 
 ```typescript
@@ -1924,6 +3412,106 @@ export type TaskFn = (ctx: TaskCtx) => ValueOrPromise<void | (() => void)>;
 **References:** [TaskCtx](#taskctx), [ValueOrPromise](#valueorpromise)
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
+
+## TdHTMLAttributes
+
+```typescript
+export interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property      | Modifiers | Type                                                              | Description  |
+| ------------- | --------- | ----------------------------------------------------------------- | ------------ |
+| [abbr?](#)    |           | string \| undefined                                               | _(Optional)_ |
+| [align?](#)   |           | 'left' \| 'center' \| 'right' \| 'justify' \| 'char' \| undefined | _(Optional)_ |
+| [colSpan?](#) |           | number \| undefined                                               | _(Optional)_ |
+| [headers?](#) |           | string \| undefined                                               | _(Optional)_ |
+| [height?](#)  |           | [Size](#size) \| undefined                                        | _(Optional)_ |
+| [rowSpan?](#) |           | number \| undefined                                               | _(Optional)_ |
+| [scope?](#)   |           | string \| undefined                                               | _(Optional)_ |
+| [valign?](#)  |           | 'top' \| 'middle' \| 'bottom' \| 'baseline' \| undefined          | _(Optional)_ |
+| [width?](#)   |           | [Size](#size) \| undefined                                        | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## TextareaHTMLAttributes
+
+```typescript
+export interface TextareaHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property           | Modifiers | Type                                                                                                                                                                    | Description  |
+| ------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| ["bind:value"?](#) |           | [Signal](#signal)&lt;string \| undefined&gt;                                                                                                                            | _(Optional)_ |
+| [autoComplete?](#) |           | [HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute) \| Omit&lt;[HTMLInputAutocompleteAttribute](#htmlinputautocompleteattribute), string&gt; \| undefined | _(Optional)_ |
+| [autoFocus?](#)    |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [children?](#)     |           | undefined                                                                                                                                                               | _(Optional)_ |
+| [cols?](#)         |           | number \| undefined                                                                                                                                                     | _(Optional)_ |
+| [dirName?](#)      |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [disabled?](#)     |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [enterKeyHint?](#) |           | 'enter' \| 'done' \| 'go' \| 'next' \| 'previous' \| 'search' \| 'send' \| undefined                                                                                    | _(Optional)_ |
+| [form?](#)         |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [maxLength?](#)    |           | number \| undefined                                                                                                                                                     | _(Optional)_ |
+| [minLength?](#)    |           | number \| undefined                                                                                                                                                     | _(Optional)_ |
+| [name?](#)         |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [placeholder?](#)  |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+| [readOnly?](#)     |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [required?](#)     |           | boolean \| undefined                                                                                                                                                    | _(Optional)_ |
+| [rows?](#)         |           | number \| undefined                                                                                                                                                     | _(Optional)_ |
+| [value?](#)        |           | string \| ReadonlyArray&lt;string&gt; \| number \| undefined                                                                                                            | _(Optional)_ |
+| [wrap?](#)         |           | string \| undefined                                                                                                                                                     | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## ThHTMLAttributes
+
+```typescript
+export interface ThHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property      | Modifiers | Type                                                              | Description  |
+| ------------- | --------- | ----------------------------------------------------------------- | ------------ |
+| [abbr?](#)    |           | string \| undefined                                               | _(Optional)_ |
+| [align?](#)   |           | 'left' \| 'center' \| 'right' \| 'justify' \| 'char' \| undefined | _(Optional)_ |
+| [colSpan?](#) |           | number \| undefined                                               | _(Optional)_ |
+| [headers?](#) |           | string \| undefined                                               | _(Optional)_ |
+| [rowSpan?](#) |           | number \| undefined                                               | _(Optional)_ |
+| [scope?](#)   |           | string \| undefined                                               | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## TimeHTMLAttributes
+
+```typescript
+export interface TimeHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                | Description  |
+| -------------- | --------- | ------------------- | ------------ |
+| [dateTime?](#) |           | string \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## TitleHTMLAttributes
+
+```typescript
+export interface TitleHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type   | Description  |
+| -------------- | --------- | ------ | ------------ |
+| [children?](#) |           | string | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## Tracker
 
@@ -1958,6 +3546,25 @@ export interface Tracker
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
+
+## TrackHTMLAttributes
+
+```typescript
+export interface TrackHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property       | Modifiers | Type                 | Description  |
+| -------------- | --------- | -------------------- | ------------ |
+| [children?](#) |           | undefined            | _(Optional)_ |
+| [default?](#)  |           | boolean \| undefined | _(Optional)_ |
+| [kind?](#)     |           | string \| undefined  | _(Optional)_ |
+| [label?](#)    |           | string \| undefined  | _(Optional)_ |
+| [src?](#)      |           | string \| undefined  | _(Optional)_ |
+| [srcLang?](#)  |           | string \| undefined  | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## untrack
 
@@ -2570,6 +4177,25 @@ version: string;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/version.ts)
 
+## VideoHTMLAttributes
+
+```typescript
+export interface VideoHTMLAttributes<T extends Element> extends MediaHTMLAttributes<T>
+```
+
+**Extends:** [MediaHTMLAttributes](#mediahtmlattributes)&lt;T&gt;
+
+| Property                      | Modifiers | Type                                 | Description  |
+| ----------------------------- | --------- | ------------------------------------ | ------------ |
+| [disablePictureInPicture?](#) |           | boolean \| undefined                 | _(Optional)_ |
+| [disableRemotePlayback?](#)   |           | boolean \| undefined                 | _(Optional)_ |
+| [height?](#)                  |           | [Numberish](#numberish) \| undefined | _(Optional)_ |
+| [playsInline?](#)             |           | boolean \| undefined                 | _(Optional)_ |
+| [poster?](#)                  |           | string \| undefined                  | _(Optional)_ |
+| [width?](#)                   |           | [Numberish](#numberish) \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
 ## VisibleTaskStrategy
 
 ```typescript
@@ -2580,3 +4206,33 @@ export type VisibleTaskStrategy =
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
+
+## WebViewHTMLAttributes
+
+```typescript
+export interface WebViewHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+```
+
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+
+| Property                   | Modifiers | Type                 | Description  |
+| -------------------------- | --------- | -------------------- | ------------ |
+| [allowFullScreen?](#)      |           | boolean \| undefined | _(Optional)_ |
+| [allowpopups?](#)          |           | boolean \| undefined | _(Optional)_ |
+| [autoFocus?](#)            |           | boolean \| undefined | _(Optional)_ |
+| [autosize?](#)             |           | boolean \| undefined | _(Optional)_ |
+| [blinkfeatures?](#)        |           | string \| undefined  | _(Optional)_ |
+| [disableblinkfeatures?](#) |           | string \| undefined  | _(Optional)_ |
+| [disableguestresize?](#)   |           | boolean \| undefined | _(Optional)_ |
+| [disablewebsecurity?](#)   |           | boolean \| undefined | _(Optional)_ |
+| [guestinstance?](#)        |           | string \| undefined  | _(Optional)_ |
+| [httpreferrer?](#)         |           | string \| undefined  | _(Optional)_ |
+| [nodeintegration?](#)      |           | boolean \| undefined | _(Optional)_ |
+| [partition?](#)            |           | string \| undefined  | _(Optional)_ |
+| [plugins?](#)              |           | boolean \| undefined | _(Optional)_ |
+| [preload?](#)              |           | string \| undefined  | _(Optional)_ |
+| [src?](#)                  |           | string \| undefined  | _(Optional)_ |
+| [useragent?](#)            |           | string \| undefined  | _(Optional)_ |
+| [webpreferences?](#)       |           | string \| undefined  | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -10,9 +10,56 @@ import * as CSS_2 from 'csstype';
 export const $: <T>(expression: T) => QRL<T>;
 
 // @public (undocumented)
+export interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    download?: any;
+    // (undocumented)
+    href?: string | undefined;
+    // (undocumented)
+    hrefLang?: string | undefined;
+    // (undocumented)
+    media?: string | undefined;
+    // (undocumented)
+    ping?: string | undefined;
+    // (undocumented)
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    // (undocumented)
+    rel?: string | undefined;
+    // (undocumented)
+    target?: HTMLAttributeAnchorTarget | undefined;
+    // (undocumented)
+    type?: string | undefined;
+}
+
+// @public (undocumented)
+export interface AreaHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    alt?: string | undefined;
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    coords?: string | undefined;
+    // (undocumented)
+    download?: any;
+    // (undocumented)
+    href?: string | undefined;
+    // (undocumented)
+    hrefLang?: string | undefined;
+    // (undocumented)
+    media?: string | undefined;
+    // (undocumented)
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    // (undocumented)
+    rel?: string | undefined;
+    // (undocumented)
+    shape?: string | undefined;
+    // (undocumented)
+    target?: string | undefined;
+}
+
+// @public (undocumented)
 export interface AriaAttributes {
     'aria-activedescendant'?: string | undefined;
-    // Warning: (ae-forgotten-export) The symbol "Booleanish" needs to be exported by the entry point index.d.ts
     'aria-atomic'?: Booleanish | undefined;
     'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined;
     'aria-busy'?: Booleanish | undefined;
@@ -67,10 +114,83 @@ export interface AriaAttributes {
 // @public (undocumented)
 export type AriaRole = 'alert' | 'alertdialog' | 'application' | 'article' | 'banner' | 'button' | 'cell' | 'checkbox' | 'columnheader' | 'combobox' | 'complementary' | 'contentinfo' | 'definition' | 'dialog' | 'directory' | 'document' | 'feed' | 'figure' | 'form' | 'grid' | 'gridcell' | 'group' | 'heading' | 'img' | 'link' | 'list' | 'listbox' | 'listitem' | 'log' | 'main' | 'marquee' | 'math' | 'menu' | 'menubar' | 'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'navigation' | 'none' | 'note' | 'option' | 'presentation' | 'progressbar' | 'radio' | 'radiogroup' | 'region' | 'row' | 'rowgroup' | 'rowheader' | 'scrollbar' | 'search' | 'searchbox' | 'separator' | 'slider' | 'spinbutton' | 'status' | 'switch' | 'tab' | 'table' | 'tablist' | 'tabpanel' | 'term' | 'textbox' | 'timer' | 'toolbar' | 'tooltip' | 'tree' | 'treegrid' | 'treeitem' | (string & {});
 
+// @public (undocumented)
+export interface AudioHTMLAttributes<T extends Element> extends MediaHTMLAttributes<T> {
+}
+
+// @public (undocumented)
+export interface BaseHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    href?: string | undefined;
+    // (undocumented)
+    target?: string | undefined;
+}
+
+// @public (undocumented)
+export interface BlockquoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    cite?: string | undefined;
+}
+
+// @public (undocumented)
+export type Booleanish = boolean | `${boolean}`;
+
+// @public (undocumented)
+export interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    autoFocus?: boolean | undefined;
+    // (undocumented)
+    disabled?: boolean | undefined;
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    formAction?: string | undefined;
+    // (undocumented)
+    formEncType?: string | undefined;
+    // (undocumented)
+    formMethod?: string | undefined;
+    // (undocumented)
+    formNoValidate?: boolean | undefined;
+    // (undocumented)
+    formTarget?: string | undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    type?: 'submit' | 'reset' | 'button' | undefined;
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
+}
+
+// @public (undocumented)
+export interface CanvasHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    height?: Size | undefined;
+    // (undocumented)
+    width?: Size | undefined;
+}
+
 // Warning: (ae-forgotten-export) The symbol "BaseClassList" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type ClassList = BaseClassList | BaseClassList[];
+
+// @public (undocumented)
+export interface ColgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    span?: number | undefined;
+}
+
+// @public (undocumented)
+export interface ColHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    span?: number | undefined;
+    // (undocumented)
+    width?: Size | undefined;
+}
 
 // @public
 export const component$: <PROPS = unknown, ARG extends {} = PROPS extends {} ? PropFunctionProps<PROPS> : {}>(onMount: OnRenderFn<ARG>) => Component<PROPS extends {} ? PROPS : ARG>;
@@ -112,8 +232,46 @@ export interface CSSProperties extends CSS_2.Properties<string | number>, CSS_2.
     [v: `--${string}`]: string | number | undefined;
 }
 
+// @public (undocumented)
+export interface DataHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
+}
+
+// @public (undocumented)
+export interface DelHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    cite?: string | undefined;
+    // (undocumented)
+    dateTime?: string | undefined;
+}
+
 // @internal (undocumented)
 export const _deserializeData: (data: string, element?: unknown) => any;
+
+// @public (undocumented)
+export interface DetailsHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    open?: boolean | undefined;
+}
+
+// @public (undocumented)
+export interface DevJSX {
+    // (undocumented)
+    columnNumber: number;
+    // (undocumented)
+    fileName: string;
+    // (undocumented)
+    lineNumber: number;
+    // (undocumented)
+    stack?: string;
+}
+
+// @public (undocumented)
+export interface DialogHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    open?: boolean | undefined;
+}
 
 // Warning: (ae-forgotten-export) The symbol "QwikProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "QwikEvents" needs to be exported by the entry point index.d.ts
@@ -130,6 +288,20 @@ export interface DOMAttributes<T extends Element> extends QwikProps<T>, QwikEven
 export type EagernessOptions = 'visible' | 'load' | 'idle';
 
 // @public (undocumented)
+export interface EmbedHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    height?: Size | undefined;
+    // (undocumented)
+    src?: string | undefined;
+    // (undocumented)
+    type?: string | undefined;
+    // (undocumented)
+    width?: Size | undefined;
+}
+
+// @public (undocumented)
 export interface ErrorBoundaryStore {
     // (undocumented)
     error: any | undefined;
@@ -141,10 +313,40 @@ export const event$: <T>(first: T) => QRL<T>;
 // @public (undocumented)
 export const eventQrl: <T>(qrl: QRL<T>) => QRL<T>;
 
+// @public (undocumented)
+export interface FieldsetHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    disabled?: boolean | undefined;
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    name?: string | undefined;
+}
+
 // Warning: (ae-forgotten-export) The symbol "SignalDerived" needs to be exported by the entry point index.d.ts
 //
 // @internal (undocumented)
 export const _fnSignal: <T extends (...args: any[]) => any>(fn: T, args: any[], fnStr?: string) => SignalDerived<any, any[]>;
+
+// @public (undocumented)
+export interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    acceptCharset?: string | undefined;
+    // (undocumented)
+    action?: string | undefined;
+    // (undocumented)
+    autoComplete?: 'on' | 'off' | Omit<'on' | 'off', string> | undefined;
+    // (undocumented)
+    encType?: string | undefined;
+    // (undocumented)
+    method?: string | undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    noValidate?: boolean | undefined;
+    // (undocumented)
+    target?: string | undefined;
+}
 
 // @public (undocumented)
 export const Fragment: FunctionComponent<{
@@ -154,8 +356,6 @@ export const Fragment: FunctionComponent<{
 
 // @public (undocumented)
 export interface FunctionComponent<P = Record<string, any>> {
-    // Warning: (ae-forgotten-export) The symbol "DevJSX" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     (props: P, key: string | null, flags: number, dev?: DevJSX): JSXNode | null;
 }
@@ -213,6 +413,18 @@ namespace h {
 }
 export { h as createElement }
 export { h }
+
+// @public (undocumented)
+export interface HrHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: undefined;
+}
+
+// @public (undocumented)
+export type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {});
+
+// @public (undocumented)
+export type HTMLAttributeReferrerPolicy = '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url';
 
 // @public (undocumented)
 export interface HTMLAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> {
@@ -295,12 +507,91 @@ export interface HTMLAttributes<T extends Element> extends AriaAttributes, DOMAt
 }
 
 // @public (undocumented)
+export type HTMLCrossOriginAttribute = 'anonymous' | 'use-credentials' | '' | undefined;
+
+// @public (undocumented)
 export const HTMLFragment: FunctionComponent<{
     dangerouslySetInnerHTML: string;
 }>;
 
+// @public (undocumented)
+export interface HtmlHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    manifest?: string | undefined;
+}
+
+// @public (undocumented)
+export type HTMLInputAutocompleteAttribute = 'on' | 'off' | 'billing' | 'shipping' | 'name' | 'honorific-prefix' | 'given-name' | 'additional-name' | 'family-name' | 'honorific-suffix' | 'nickname' | 'username' | 'new-password' | 'current-password' | 'one-time-code' | 'organization-title' | 'organization' | 'street-address' | 'address-line1' | 'address-line2' | 'address-line3' | 'address-level4' | 'address-level3' | 'address-level2' | 'address-level1' | 'country' | 'country-name' | 'postal-code' | 'cc-name' | 'cc-given-name' | 'cc-additional-name' | 'cc-family-name' | 'cc-number' | 'cc-exp' | 'cc-exp-month' | 'cc-exp-year' | 'cc-csc' | 'cc-type' | 'transaction-currency' | 'transaction-amount' | 'language' | 'bday' | 'bday-day' | 'bday-month' | 'bday-year' | 'sex' | 'url' | 'photo';
+
+// @public (undocumented)
+export type HTMLInputTypeAttribute = 'button' | 'checkbox' | 'color' | 'date' | 'datetime-local' | 'email' | 'file' | 'hidden' | 'image' | 'month' | 'number' | 'password' | 'radio' | 'range' | 'reset' | 'search' | 'submit' | 'tel' | 'text' | 'time' | 'url' | 'week' | (string & {});
+
 // @internal
 export const _hW: () => void;
+
+// @public (undocumented)
+export interface IframeHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    allow?: string | undefined;
+    // (undocumented)
+    allowFullScreen?: boolean | undefined;
+    // (undocumented)
+    allowTransparency?: boolean | undefined;
+    // (undocumented)
+    children?: undefined;
+    // @deprecated (undocumented)
+    frameBorder?: number | string | undefined;
+    // (undocumented)
+    height?: Size | undefined;
+    // (undocumented)
+    loading?: 'eager' | 'lazy' | undefined;
+    // @deprecated (undocumented)
+    marginHeight?: number | undefined;
+    // @deprecated (undocumented)
+    marginWidth?: number | undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    // (undocumented)
+    sandbox?: string | undefined;
+    // @deprecated (undocumented)
+    scrolling?: string | undefined;
+    // (undocumented)
+    seamless?: boolean | undefined;
+    // (undocumented)
+    src?: string | undefined;
+    // (undocumented)
+    srcDoc?: string | undefined;
+    // (undocumented)
+    width?: Size | undefined;
+}
+
+// @public (undocumented)
+export interface ImgHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    alt?: string | undefined;
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    crossOrigin?: HTMLCrossOriginAttribute;
+    // (undocumented)
+    decoding?: 'async' | 'auto' | 'sync' | undefined;
+    height?: Numberish | undefined;
+    // (undocumented)
+    loading?: 'eager' | 'lazy' | undefined;
+    // (undocumented)
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    // (undocumented)
+    sizes?: string | undefined;
+    // (undocumented)
+    src?: string | undefined;
+    // (undocumented)
+    srcSet?: string | undefined;
+    // (undocumented)
+    useMap?: string | undefined;
+    width?: Numberish | undefined;
+}
 
 // @internal (undocumented)
 export const _IMMUTABLE: unique symbol;
@@ -318,6 +609,454 @@ export const inlinedQrl: <T>(symbol: T, symbolName: string, lexicalScopeCapture?
 //
 // @internal (undocumented)
 export const inlinedQrlDEV: <T = any>(symbol: T, symbolName: string, opts: QRLDev, lexicalScopeCapture?: any[]) => QRL<T>;
+
+// @public (undocumented)
+export interface InputHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    'bind:checked'?: Signal<boolean | undefined>;
+    // (undocumented)
+    'bind:value'?: Signal<string | undefined>;
+    // (undocumented)
+    accept?: string | undefined;
+    // (undocumented)
+    alt?: string | undefined;
+    // (undocumented)
+    autoComplete?: HTMLInputAutocompleteAttribute | Omit<HTMLInputAutocompleteAttribute, string> | undefined;
+    // (undocumented)
+    autoFocus?: boolean | undefined;
+    // (undocumented)
+    capture?: boolean | 'user' | 'environment' | undefined;
+    // (undocumented)
+    checked?: boolean | undefined;
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    crossOrigin?: HTMLCrossOriginAttribute;
+    // (undocumented)
+    disabled?: boolean | undefined;
+    // (undocumented)
+    enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    formAction?: string | undefined;
+    // (undocumented)
+    formEncType?: string | undefined;
+    // (undocumented)
+    formMethod?: string | undefined;
+    // (undocumented)
+    formNoValidate?: boolean | undefined;
+    // (undocumented)
+    formTarget?: string | undefined;
+    // (undocumented)
+    height?: Size | undefined;
+    // (undocumented)
+    list?: string | undefined;
+    // (undocumented)
+    max?: number | string | undefined;
+    // (undocumented)
+    maxLength?: number | undefined;
+    // (undocumented)
+    min?: number | string | undefined;
+    // (undocumented)
+    minLength?: number | undefined;
+    // (undocumented)
+    multiple?: boolean | undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    pattern?: string | undefined;
+    // (undocumented)
+    placeholder?: string | undefined;
+    // (undocumented)
+    readOnly?: boolean | undefined;
+    // (undocumented)
+    required?: boolean | undefined;
+    // (undocumented)
+    size?: number | undefined;
+    // (undocumented)
+    src?: string | undefined;
+    // (undocumented)
+    step?: number | string | undefined;
+    // (undocumented)
+    type?: HTMLInputTypeAttribute | undefined;
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined | null | FormDataEntryValue;
+    // (undocumented)
+    width?: Size | undefined;
+}
+
+// @public (undocumented)
+export interface InsHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    cite?: string | undefined;
+    // (undocumented)
+    dateTime?: string | undefined;
+}
+
+// @public (undocumented)
+export interface IntrinsicElements extends IntrinsicHTMLElements, IntrinsicSVGElements {
+}
+
+// @public (undocumented)
+export interface IntrinsicHTMLElements {
+    // (undocumented)
+    a: AnchorHTMLAttributes<HTMLAnchorElement>;
+    // (undocumented)
+    abbr: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    address: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    area: AreaHTMLAttributes<HTMLAreaElement>;
+    // (undocumented)
+    article: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    aside: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    audio: AudioHTMLAttributes<HTMLAudioElement>;
+    // (undocumented)
+    b: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    base: BaseHTMLAttributes<HTMLBaseElement>;
+    // (undocumented)
+    bdi: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    bdo: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    big: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    blockquote: BlockquoteHTMLAttributes<HTMLElement>;
+    // (undocumented)
+    body: HTMLAttributes<HTMLBodyElement>;
+    // (undocumented)
+    br: HTMLAttributes<HTMLBRElement>;
+    // (undocumented)
+    button: ButtonHTMLAttributes<HTMLButtonElement>;
+    // (undocumented)
+    canvas: CanvasHTMLAttributes<HTMLCanvasElement>;
+    // (undocumented)
+    caption: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    cite: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    code: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    col: ColHTMLAttributes<HTMLTableColElement>;
+    // (undocumented)
+    colgroup: ColgroupHTMLAttributes<HTMLTableColElement>;
+    // (undocumented)
+    data: DataHTMLAttributes<HTMLDataElement>;
+    // (undocumented)
+    datalist: HTMLAttributes<HTMLDataListElement>;
+    // (undocumented)
+    dd: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    del: DelHTMLAttributes<HTMLElement>;
+    // (undocumented)
+    details: DetailsHTMLAttributes<HTMLElement>;
+    // (undocumented)
+    dfn: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    dialog: DialogHTMLAttributes<HTMLDialogElement>;
+    // (undocumented)
+    div: HTMLAttributes<HTMLDivElement>;
+    // (undocumented)
+    dl: HTMLAttributes<HTMLDListElement>;
+    // (undocumented)
+    dt: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    em: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    embed: EmbedHTMLAttributes<HTMLEmbedElement>;
+    // (undocumented)
+    fieldset: FieldsetHTMLAttributes<HTMLFieldSetElement>;
+    // (undocumented)
+    figcaption: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    figure: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    footer: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    form: FormHTMLAttributes<HTMLFormElement>;
+    // (undocumented)
+    h1: HTMLAttributes<HTMLHeadingElement>;
+    // (undocumented)
+    h2: HTMLAttributes<HTMLHeadingElement>;
+    // (undocumented)
+    h3: HTMLAttributes<HTMLHeadingElement>;
+    // (undocumented)
+    h4: HTMLAttributes<HTMLHeadingElement>;
+    // (undocumented)
+    h5: HTMLAttributes<HTMLHeadingElement>;
+    // (undocumented)
+    h6: HTMLAttributes<HTMLHeadingElement>;
+    // (undocumented)
+    head: HTMLAttributes<HTMLHeadElement>;
+    // (undocumented)
+    header: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    hgroup: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    hr: HrHTMLAttributes<HTMLHRElement>;
+    // (undocumented)
+    html: HtmlHTMLAttributes<HTMLHtmlElement>;
+    // (undocumented)
+    i: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    iframe: IframeHTMLAttributes<HTMLIFrameElement>;
+    // (undocumented)
+    img: ImgHTMLAttributes<HTMLImageElement>;
+    // (undocumented)
+    input: InputHTMLAttributes<HTMLInputElement>;
+    // (undocumented)
+    ins: InsHTMLAttributes<HTMLModElement>;
+    // (undocumented)
+    kbd: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    keygen: KeygenHTMLAttributes<HTMLElement>;
+    // (undocumented)
+    label: LabelHTMLAttributes<HTMLLabelElement>;
+    // (undocumented)
+    legend: HTMLAttributes<HTMLLegendElement>;
+    // (undocumented)
+    li: LiHTMLAttributes<HTMLLIElement>;
+    // (undocumented)
+    link: LinkHTMLAttributes<HTMLLinkElement>;
+    // (undocumented)
+    main: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    map: MapHTMLAttributes<HTMLMapElement>;
+    // (undocumented)
+    mark: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    menu: MenuHTMLAttributes<HTMLElement>;
+    // (undocumented)
+    menuitem: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    meta: MetaHTMLAttributes<HTMLMetaElement>;
+    // (undocumented)
+    meter: MeterHTMLAttributes<HTMLElement>;
+    // (undocumented)
+    nav: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    noindex: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    noscript: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    object: ObjectHTMLAttributes<HTMLObjectElement>;
+    // (undocumented)
+    ol: OlHTMLAttributes<HTMLOListElement>;
+    // (undocumented)
+    optgroup: OptgroupHTMLAttributes<HTMLOptGroupElement>;
+    // (undocumented)
+    option: OptionHTMLAttributes<HTMLOptionElement>;
+    // (undocumented)
+    output: OutputHTMLAttributes<HTMLElement>;
+    // (undocumented)
+    p: HTMLAttributes<HTMLParagraphElement>;
+    // (undocumented)
+    param: ParamHTMLAttributes<HTMLParamElement>;
+    // (undocumented)
+    picture: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    pre: HTMLAttributes<HTMLPreElement>;
+    // (undocumented)
+    progress: ProgressHTMLAttributes<HTMLProgressElement>;
+    // (undocumented)
+    q: QuoteHTMLAttributes<HTMLQuoteElement>;
+    // (undocumented)
+    rp: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    rt: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    ruby: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    s: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    samp: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    script: ScriptHTMLAttributes<HTMLScriptElement>;
+    // (undocumented)
+    section: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    select: SelectHTMLAttributes<HTMLSelectElement>;
+    // (undocumented)
+    slot: SlotHTMLAttributes<HTMLSlotElement>;
+    // (undocumented)
+    small: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    source: SourceHTMLAttributes<HTMLSourceElement>;
+    // (undocumented)
+    span: HTMLAttributes<HTMLSpanElement>;
+    // (undocumented)
+    strong: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    style: StyleHTMLAttributes<HTMLStyleElement>;
+    // (undocumented)
+    sub: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    summary: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    sup: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    table: TableHTMLAttributes<HTMLTableElement>;
+    // (undocumented)
+    tbody: HTMLAttributes<HTMLTableSectionElement>;
+    // (undocumented)
+    td: TdHTMLAttributes<HTMLTableDataCellElement>;
+    // (undocumented)
+    template: HTMLAttributes<HTMLTemplateElement>;
+    // (undocumented)
+    textarea: TextareaHTMLAttributes<HTMLTextAreaElement>;
+    // (undocumented)
+    tfoot: HTMLAttributes<HTMLTableSectionElement>;
+    // (undocumented)
+    th: ThHTMLAttributes<HTMLTableHeaderCellElement>;
+    // (undocumented)
+    thead: HTMLAttributes<HTMLTableSectionElement>;
+    // (undocumented)
+    time: TimeHTMLAttributes<HTMLElement>;
+    // (undocumented)
+    title: TitleHTMLAttributes<HTMLTitleElement>;
+    // (undocumented)
+    tr: HTMLAttributes<HTMLTableRowElement>;
+    // (undocumented)
+    track: TrackHTMLAttributes<HTMLTrackElement>;
+    // (undocumented)
+    tt: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    u: HTMLAttributes<HTMLElement>;
+    // (undocumented)
+    ul: HTMLAttributes<HTMLUListElement>;
+    // (undocumented)
+    video: VideoHTMLAttributes<HTMLVideoElement>;
+    // (undocumented)
+    wbr: HTMLAttributes<HTMLElement>;
+    // Warning: (ae-forgotten-export) The symbol "HTMLWebViewElement" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    webview: WebViewHTMLAttributes<HTMLWebViewElement>;
+}
+
+// @public (undocumented)
+export interface IntrinsicSVGElements {
+    // (undocumented)
+    animate: SVGProps<SVGElement>;
+    // (undocumented)
+    animateMotion: SVGProps<SVGElement>;
+    // (undocumented)
+    animateTransform: SVGProps<SVGElement>;
+    // (undocumented)
+    circle: SVGProps<SVGCircleElement>;
+    // (undocumented)
+    clipPath: SVGProps<SVGClipPathElement>;
+    // (undocumented)
+    defs: SVGProps<SVGDefsElement>;
+    // (undocumented)
+    desc: SVGProps<SVGDescElement>;
+    // (undocumented)
+    ellipse: SVGProps<SVGEllipseElement>;
+    // (undocumented)
+    feBlend: SVGProps<SVGFEBlendElement>;
+    // (undocumented)
+    feColorMatrix: SVGProps<SVGFEColorMatrixElement>;
+    // (undocumented)
+    feComponentTransfer: SVGProps<SVGFEComponentTransferElement>;
+    // (undocumented)
+    feComposite: SVGProps<SVGFECompositeElement>;
+    // (undocumented)
+    feConvolveMatrix: SVGProps<SVGFEConvolveMatrixElement>;
+    // (undocumented)
+    feDiffuseLighting: SVGProps<SVGFEDiffuseLightingElement>;
+    // (undocumented)
+    feDisplacementMap: SVGProps<SVGFEDisplacementMapElement>;
+    // (undocumented)
+    feDistantLight: SVGProps<SVGFEDistantLightElement>;
+    // (undocumented)
+    feDropShadow: SVGProps<SVGFEDropShadowElement>;
+    // (undocumented)
+    feFlood: SVGProps<SVGFEFloodElement>;
+    // (undocumented)
+    feFuncA: SVGProps<SVGFEFuncAElement>;
+    // (undocumented)
+    feFuncB: SVGProps<SVGFEFuncBElement>;
+    // (undocumented)
+    feFuncG: SVGProps<SVGFEFuncGElement>;
+    // (undocumented)
+    feFuncR: SVGProps<SVGFEFuncRElement>;
+    // (undocumented)
+    feGaussianBlur: SVGProps<SVGFEGaussianBlurElement>;
+    // (undocumented)
+    feImage: SVGProps<SVGFEImageElement>;
+    // (undocumented)
+    feMerge: SVGProps<SVGFEMergeElement>;
+    // (undocumented)
+    feMergeNode: SVGProps<SVGFEMergeNodeElement>;
+    // (undocumented)
+    feMorphology: SVGProps<SVGFEMorphologyElement>;
+    // (undocumented)
+    feOffset: SVGProps<SVGFEOffsetElement>;
+    // (undocumented)
+    fePointLight: SVGProps<SVGFEPointLightElement>;
+    // (undocumented)
+    feSpecularLighting: SVGProps<SVGFESpecularLightingElement>;
+    // (undocumented)
+    feSpotLight: SVGProps<SVGFESpotLightElement>;
+    // (undocumented)
+    feTile: SVGProps<SVGFETileElement>;
+    // (undocumented)
+    feTurbulence: SVGProps<SVGFETurbulenceElement>;
+    // (undocumented)
+    filter: SVGProps<SVGFilterElement>;
+    // (undocumented)
+    foreignObject: SVGProps<SVGForeignObjectElement>;
+    // (undocumented)
+    g: SVGProps<SVGGElement>;
+    // (undocumented)
+    image: SVGProps<SVGImageElement>;
+    // (undocumented)
+    line: SVGProps<SVGLineElement>;
+    // (undocumented)
+    linearGradient: SVGProps<SVGLinearGradientElement>;
+    // (undocumented)
+    marker: SVGProps<SVGMarkerElement>;
+    // (undocumented)
+    mask: SVGProps<SVGMaskElement>;
+    // (undocumented)
+    metadata: SVGProps<SVGMetadataElement>;
+    // (undocumented)
+    mpath: SVGProps<SVGElement>;
+    // (undocumented)
+    path: SVGProps<SVGPathElement>;
+    // (undocumented)
+    pattern: SVGProps<SVGPatternElement>;
+    // (undocumented)
+    polygon: SVGProps<SVGPolygonElement>;
+    // (undocumented)
+    polyline: SVGProps<SVGPolylineElement>;
+    // (undocumented)
+    radialGradient: SVGProps<SVGRadialGradientElement>;
+    // (undocumented)
+    rect: SVGProps<SVGRectElement>;
+    // (undocumented)
+    stop: SVGProps<SVGStopElement>;
+    // (undocumented)
+    svg: SVGProps<SVGSVGElement>;
+    // (undocumented)
+    switch: SVGProps<SVGSwitchElement>;
+    // (undocumented)
+    symbol: SVGProps<SVGSymbolElement>;
+    // (undocumented)
+    text: SVGProps<SVGTextElement>;
+    // (undocumented)
+    textPath: SVGProps<SVGTextPathElement>;
+    // (undocumented)
+    tspan: SVGProps<SVGTSpanElement>;
+    // (undocumented)
+    use: SVGProps<SVGUseElement>;
+    // (undocumented)
+    view: SVGProps<SVGViewElement>;
+}
 
 // @public (undocumented)
 const jsx: <T extends string | FunctionComponent<any>>(type: T, props: T extends FunctionComponent<infer PROPS> ? PROPS : Record<string, any>, key?: string | number | null) => JSXNode<T>;
@@ -364,6 +1103,142 @@ export const _jsxS: <T extends string>(type: T, mutableProps: (T extends Functio
 
 // @public (undocumented)
 export type JSXTagName = keyof HTMLElementTagNameMap | Omit<string, keyof HTMLElementTagNameMap>;
+
+// @public (undocumented)
+export interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    autoFocus?: boolean | undefined;
+    // (undocumented)
+    challenge?: string | undefined;
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    disabled?: boolean | undefined;
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    keyParams?: string | undefined;
+    // (undocumented)
+    keyType?: string | undefined;
+    // (undocumented)
+    name?: string | undefined;
+}
+
+// @public (undocumented)
+export interface LabelHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    for?: string | undefined;
+    // (undocumented)
+    form?: string | undefined;
+}
+
+// @public (undocumented)
+export interface LiHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
+}
+
+// @public (undocumented)
+export interface LinkHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    as?: string | undefined;
+    // (undocumented)
+    charSet?: string | undefined;
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    crossOrigin?: HTMLCrossOriginAttribute;
+    // (undocumented)
+    href?: string | undefined;
+    // (undocumented)
+    hrefLang?: string | undefined;
+    // (undocumented)
+    imageSizes?: string | undefined;
+    // (undocumented)
+    imageSrcSet?: string | undefined;
+    // (undocumented)
+    integrity?: string | undefined;
+    // (undocumented)
+    media?: string | undefined;
+    // (undocumented)
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    // (undocumented)
+    rel?: string | undefined;
+    // (undocumented)
+    sizes?: string | undefined;
+    // (undocumented)
+    type?: string | undefined;
+}
+
+// @public (undocumented)
+export interface MapHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    name?: string | undefined;
+}
+
+// @public (undocumented)
+export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    autoPlay?: boolean | undefined;
+    // (undocumented)
+    controls?: boolean | undefined;
+    // (undocumented)
+    controlsList?: string | undefined;
+    // (undocumented)
+    crossOrigin?: HTMLCrossOriginAttribute;
+    // (undocumented)
+    loop?: boolean | undefined;
+    // (undocumented)
+    mediaGroup?: string | undefined;
+    // (undocumented)
+    muted?: boolean | undefined;
+    // (undocumented)
+    playsInline?: boolean | undefined;
+    // (undocumented)
+    preload?: string | undefined;
+    // (undocumented)
+    src?: string | undefined;
+}
+
+// @public (undocumented)
+export interface MenuHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    type?: string | undefined;
+}
+
+// @public (undocumented)
+export interface MetaHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    charSet?: string | undefined;
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    content?: string | undefined;
+    // (undocumented)
+    httpEquiv?: string | undefined;
+    // (undocumented)
+    media?: string | undefined;
+    // (undocumented)
+    name?: string | undefined;
+}
+
+// @public (undocumented)
+export interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    high?: number | undefined;
+    // (undocumented)
+    low?: number | undefined;
+    // (undocumented)
+    max?: number | string | undefined;
+    // (undocumented)
+    min?: number | string | undefined;
+    // (undocumented)
+    optimum?: number | undefined;
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
+}
 
 // @public (undocumented)
 export type NativeAnimationEvent = AnimationEvent;
@@ -413,11 +1288,88 @@ export type NoSerialize<T> = (T & {
 export const noSerialize: <T extends object | undefined>(input: T) => NoSerialize<T>;
 
 // @public (undocumented)
+export type Numberish = number | `${number}`;
+
+// @public (undocumented)
+export interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    classID?: string | undefined;
+    // (undocumented)
+    data?: string | undefined;
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    height?: Size | undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    type?: string | undefined;
+    // (undocumented)
+    useMap?: string | undefined;
+    // (undocumented)
+    width?: Size | undefined;
+    // (undocumented)
+    wmode?: string | undefined;
+}
+
+// @public (undocumented)
+export interface OlHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    reversed?: boolean | undefined;
+    // (undocumented)
+    start?: number | undefined;
+    // (undocumented)
+    type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined;
+}
+
+// @public (undocumented)
 export type OnRenderFn<PROPS extends {}> = (props: PROPS) => JSXNode<any> | null;
 
 // @public (undocumented)
 export interface OnVisibleTaskOptions {
     strategy?: VisibleTaskStrategy;
+}
+
+// @public (undocumented)
+export interface OptgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    disabled?: boolean | undefined;
+    // (undocumented)
+    label?: string | undefined;
+}
+
+// @public (undocumented)
+export interface OptionHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: string;
+    // (undocumented)
+    disabled?: boolean | undefined;
+    // (undocumented)
+    label?: string | undefined;
+    // (undocumented)
+    selected?: boolean | undefined;
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
+}
+
+// @public (undocumented)
+export interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    for?: string | undefined;
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    name?: string | undefined;
+}
+
+// @public (undocumented)
+export interface ParamHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
 }
 
 // Warning: (ae-forgotten-export) The symbol "QContext" needs to be exported by the entry point index.d.ts
@@ -426,6 +1378,14 @@ export interface OnVisibleTaskOptions {
 //
 // @internal (undocumented)
 export const _pauseFromContexts: (allContexts: QContext[], containerState: ContainerState, fallbackGetObjId?: GetObjID, textNodes?: Map<string, string>) => Promise<SnapshotResult>;
+
+// @public (undocumented)
+export interface ProgressHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    max?: number | string | undefined;
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
+}
 
 // @public (undocumented)
 export interface PropFnInterface<ARGS extends any[], RET> {
@@ -476,6 +1436,12 @@ export const qrl: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: st
 // @internal (undocumented)
 export const qrlDEV: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: string, opts: QRLDev, lexicalScopeCapture?: any[]) => QRL<T>;
 
+// @public (undocumented)
+export interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    cite?: string | undefined;
+}
+
 // Warning: (ae-forgotten-export) The symbol "SyntheticEvent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -524,8 +1490,6 @@ export interface QwikFocusEvent<T = Element> extends SyntheticEvent<T, NativeFoc
     target: EventTarget & T;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IntrinsicHTMLElements" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface QwikIntrinsicElements extends IntrinsicHTMLElements {
     // Warning: (ae-forgotten-export) The symbol "QwikCustomHTMLAttributes" needs to be exported by the entry point index.d.ts
@@ -818,6 +1782,54 @@ export type ResourceReturn<T> = ResourcePending<T> | ResourceResolved<T> | Resou
 // @internal (undocumented)
 export const _restProps: (props: Record<string, any>, omit: string[]) => Record<string, any>;
 
+// @public (undocumented)
+export interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    async?: boolean | undefined;
+    // @deprecated (undocumented)
+    charSet?: string | undefined;
+    // (undocumented)
+    crossOrigin?: HTMLCrossOriginAttribute;
+    // (undocumented)
+    defer?: boolean | undefined;
+    // (undocumented)
+    integrity?: string | undefined;
+    // (undocumented)
+    noModule?: boolean | undefined;
+    // (undocumented)
+    nonce?: string | undefined;
+    // (undocumented)
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    // (undocumented)
+    src?: string | undefined;
+    // (undocumented)
+    type?: string | undefined;
+}
+
+// @public (undocumented)
+export interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    'bind:value'?: Signal<string | undefined>;
+    // (undocumented)
+    autoComplete?: HTMLInputAutocompleteAttribute | Omit<HTMLInputAutocompleteAttribute, string> | undefined;
+    // (undocumented)
+    autoFocus?: boolean | undefined;
+    // (undocumented)
+    disabled?: boolean | undefined;
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    multiple?: boolean | undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    required?: boolean | undefined;
+    // (undocumented)
+    size?: number | undefined;
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
+}
+
 // @internal (undocumented)
 export const _serializeData: (data: any, pureQRL?: boolean) => Promise<string>;
 
@@ -831,12 +1843,21 @@ export interface Signal<T = any> {
 }
 
 // @public (undocumented)
+export type Size = number | string;
+
+// @public (undocumented)
 export const SkipRender: JSXNode;
 
 // @public
 export const Slot: FunctionComponent<{
     name?: string;
 }>;
+
+// @public (undocumented)
+export interface SlotHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    name?: string | undefined;
+}
 
 // @public (undocumented)
 export interface SnapshotListener {
@@ -894,6 +1915,26 @@ export interface SnapshotState {
 }
 
 // @public (undocumented)
+export interface SourceHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    height?: Size | undefined;
+    // (undocumented)
+    media?: string | undefined;
+    // (undocumented)
+    sizes?: string | undefined;
+    // (undocumented)
+    src?: string | undefined;
+    // (undocumented)
+    srcSet?: string | undefined;
+    // (undocumented)
+    type?: string | undefined;
+    // (undocumented)
+    width?: Size | undefined;
+}
+
+// @public (undocumented)
 export const SSRComment: FunctionComponent<{
     data: string;
 }>;
@@ -932,6 +1973,558 @@ export type StreamWriter = {
 };
 
 // @public (undocumented)
+export interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: string;
+    // (undocumented)
+    media?: string | undefined;
+    // (undocumented)
+    nonce?: string | undefined;
+    // (undocumented)
+    scoped?: boolean | undefined;
+    // (undocumented)
+    type?: string | undefined;
+}
+
+// @public (undocumented)
+export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> {
+    // (undocumented)
+    'accent-height'?: number | string | undefined;
+    // (undocumented)
+    'alignment-baseline'?: 'auto' | 'baseline' | 'before-edge' | 'text-before-edge' | 'middle' | 'central' | 'after-edge' | 'text-after-edge' | 'ideographic' | 'alphabetic' | 'hanging' | 'mathematical' | 'inherit' | undefined;
+    // (undocumented)
+    'arabic-form'?: 'initial' | 'medial' | 'terminal' | 'isolated' | undefined;
+    // (undocumented)
+    'baseline-shift'?: number | string | undefined;
+    // (undocumented)
+    'cap-height'?: number | string | undefined;
+    // (undocumented)
+    'clip-path'?: string | undefined;
+    // (undocumented)
+    'clip-rule'?: number | string | undefined;
+    // (undocumented)
+    'color-interpolation'?: number | string | undefined;
+    // (undocumented)
+    'color-interpolation-filters'?: 'auto' | 's-rGB' | 'linear-rGB' | 'inherit' | undefined;
+    // (undocumented)
+    'color-profile'?: number | string | undefined;
+    // (undocumented)
+    'color-rendering'?: number | string | undefined;
+    // (undocumented)
+    'dominant-baseline'?: number | string | undefined;
+    // (undocumented)
+    'edge-mode'?: number | string | undefined;
+    // (undocumented)
+    'enable-background'?: number | string | undefined;
+    // (undocumented)
+    'fill-opacity'?: number | string | undefined;
+    // (undocumented)
+    'fill-rule'?: 'nonzero' | 'evenodd' | 'inherit' | undefined;
+    // (undocumented)
+    'flood-color'?: number | string | undefined;
+    // (undocumented)
+    'flood-opacity'?: number | string | undefined;
+    // (undocumented)
+    'font-family'?: string | undefined;
+    // (undocumented)
+    'font-size'?: number | string | undefined;
+    // (undocumented)
+    'font-size-adjust'?: number | string | undefined;
+    // (undocumented)
+    'font-stretch'?: number | string | undefined;
+    // (undocumented)
+    'font-style'?: number | string | undefined;
+    // (undocumented)
+    'font-variant'?: number | string | undefined;
+    // (undocumented)
+    'font-weight'?: number | string | undefined;
+    // (undocumented)
+    'glyph-name'?: number | string | undefined;
+    // (undocumented)
+    'glyph-orientation-horizontal'?: number | string | undefined;
+    // (undocumented)
+    'glyph-orientation-vertical'?: number | string | undefined;
+    // (undocumented)
+    'horiz-adv-x'?: number | string | undefined;
+    // (undocumented)
+    'horiz-origin-x'?: number | string | undefined;
+    // (undocumented)
+    'image-rendering'?: number | string | undefined;
+    // (undocumented)
+    'letter-spacing'?: number | string | undefined;
+    // (undocumented)
+    'lighting-color'?: number | string | undefined;
+    // (undocumented)
+    'marker-end'?: string | undefined;
+    // (undocumented)
+    'marker-mid'?: string | undefined;
+    // (undocumented)
+    'marker-start'?: string | undefined;
+    // (undocumented)
+    'overline-position'?: number | string | undefined;
+    // (undocumented)
+    'overline-thickness'?: number | string | undefined;
+    // (undocumented)
+    'paint-order'?: number | string | undefined;
+    // (undocumented)
+    'pointer-events'?: number | string | undefined;
+    // (undocumented)
+    'rendering-intent'?: number | string | undefined;
+    // (undocumented)
+    'shape-rendering'?: number | string | undefined;
+    // (undocumented)
+    'stop-color'?: string | undefined;
+    // (undocumented)
+    'stop-opacity'?: number | string | undefined;
+    // (undocumented)
+    'strikethrough-position'?: number | string | undefined;
+    // (undocumented)
+    'strikethrough-thickness'?: number | string | undefined;
+    // (undocumented)
+    'stroke-dasharray'?: string | number | undefined;
+    // (undocumented)
+    'stroke-dashoffset'?: string | number | undefined;
+    // (undocumented)
+    'stroke-linecap'?: 'butt' | 'round' | 'square' | 'inherit' | undefined;
+    // (undocumented)
+    'stroke-linejoin'?: 'miter' | 'round' | 'bevel' | 'inherit' | undefined;
+    // (undocumented)
+    'stroke-miterlimit'?: string | undefined;
+    // (undocumented)
+    'stroke-opacity'?: number | string | undefined;
+    // (undocumented)
+    'stroke-width'?: number | string | undefined;
+    // (undocumented)
+    'text-anchor'?: string | undefined;
+    // (undocumented)
+    'text-decoration'?: number | string | undefined;
+    // (undocumented)
+    'text-rendering'?: number | string | undefined;
+    // (undocumented)
+    'underline-position'?: number | string | undefined;
+    // (undocumented)
+    'underline-thickness'?: number | string | undefined;
+    // (undocumented)
+    'unicode-bidi'?: number | string | undefined;
+    // (undocumented)
+    'unicode-range'?: number | string | undefined;
+    // (undocumented)
+    'units-per-em'?: number | string | undefined;
+    // (undocumented)
+    'v-alphabetic'?: number | string | undefined;
+    // (undocumented)
+    'v-hanging'?: number | string | undefined;
+    // (undocumented)
+    'v-ideographic'?: number | string | undefined;
+    // (undocumented)
+    'v-mathematical'?: number | string | undefined;
+    // (undocumented)
+    'vector-effect'?: number | string | undefined;
+    // (undocumented)
+    'vert-adv-y'?: number | string | undefined;
+    // (undocumented)
+    'vert-origin-x'?: number | string | undefined;
+    // (undocumented)
+    'vert-origin-y'?: number | string | undefined;
+    // (undocumented)
+    'word-spacing'?: number | string | undefined;
+    // (undocumented)
+    'writing-mode'?: number | string | undefined;
+    // (undocumented)
+    'x-channel-selector'?: string | undefined;
+    // (undocumented)
+    'x-height'?: number | string | undefined;
+    // (undocumented)
+    accumulate?: 'none' | 'sum' | undefined;
+    // (undocumented)
+    additive?: 'replace' | 'sum' | undefined;
+    // (undocumented)
+    allowReorder?: 'no' | 'yes' | undefined;
+    // (undocumented)
+    alphabetic?: number | string | undefined;
+    // (undocumented)
+    amplitude?: number | string | undefined;
+    // (undocumented)
+    ascent?: number | string | undefined;
+    // (undocumented)
+    attributeName?: string | undefined;
+    // (undocumented)
+    attributeType?: string | undefined;
+    // (undocumented)
+    autoReverse?: Booleanish | undefined;
+    // (undocumented)
+    azimuth?: number | string | undefined;
+    // (undocumented)
+    baseFrequency?: number | string | undefined;
+    // (undocumented)
+    baseProfile?: number | string | undefined;
+    // (undocumented)
+    bbox?: number | string | undefined;
+    // (undocumented)
+    begin?: number | string | undefined;
+    // (undocumented)
+    bias?: number | string | undefined;
+    // (undocumented)
+    by?: number | string | undefined;
+    // (undocumented)
+    calcMode?: number | string | undefined;
+    // (undocumented)
+    class?: ClassList | undefined;
+    // @deprecated (undocumented)
+    className?: string | undefined;
+    // (undocumented)
+    clip?: number | string | undefined;
+    // (undocumented)
+    clipPathUnits?: number | string | undefined;
+    // (undocumented)
+    color?: string | undefined;
+    // (undocumented)
+    contentScriptType?: number | string | undefined;
+    // (undocumented)
+    contentStyleType?: number | string | undefined;
+    // (undocumented)
+    crossOrigin?: HTMLCrossOriginAttribute;
+    // (undocumented)
+    cursor?: number | string;
+    // (undocumented)
+    cx?: number | string | undefined;
+    // (undocumented)
+    cy?: number | string | undefined;
+    // (undocumented)
+    d?: string | undefined;
+    // (undocumented)
+    decelerate?: number | string | undefined;
+    // (undocumented)
+    descent?: number | string | undefined;
+    // (undocumented)
+    diffuseConstant?: number | string | undefined;
+    // (undocumented)
+    direction?: number | string | undefined;
+    // (undocumented)
+    display?: number | string | undefined;
+    // (undocumented)
+    divisor?: number | string | undefined;
+    // (undocumented)
+    dur?: number | string | undefined;
+    // (undocumented)
+    dx?: number | string | undefined;
+    // (undocumented)
+    dy?: number | string | undefined;
+    // (undocumented)
+    elevation?: number | string | undefined;
+    // (undocumented)
+    end?: number | string | undefined;
+    // (undocumented)
+    exponent?: number | string | undefined;
+    // (undocumented)
+    externalResourcesRequired?: number | string | undefined;
+    // (undocumented)
+    fill?: string | undefined;
+    // (undocumented)
+    filter?: string | undefined;
+    // (undocumented)
+    filterRes?: number | string | undefined;
+    // (undocumented)
+    filterUnits?: number | string | undefined;
+    // (undocumented)
+    focusable?: number | string | undefined;
+    // (undocumented)
+    format?: number | string | undefined;
+    // (undocumented)
+    fr?: number | string | undefined;
+    // (undocumented)
+    from?: number | string | undefined;
+    // (undocumented)
+    fx?: number | string | undefined;
+    // (undocumented)
+    fy?: number | string | undefined;
+    // (undocumented)
+    g1?: number | string | undefined;
+    // (undocumented)
+    g2?: number | string | undefined;
+    // (undocumented)
+    glyphRef?: number | string | undefined;
+    // (undocumented)
+    gradientTransform?: string | undefined;
+    // (undocumented)
+    gradientUnits?: string | undefined;
+    // (undocumented)
+    hanging?: number | string | undefined;
+    // (undocumented)
+    height?: Numberish | undefined;
+    // (undocumented)
+    href?: string | undefined;
+    // (undocumented)
+    id?: string | undefined;
+    // (undocumented)
+    ideographic?: number | string | undefined;
+    // (undocumented)
+    in?: string | undefined;
+    // (undocumented)
+    in2?: number | string | undefined;
+    // (undocumented)
+    intercept?: number | string | undefined;
+    // (undocumented)
+    k?: number | string | undefined;
+    // (undocumented)
+    k1?: number | string | undefined;
+    // (undocumented)
+    k2?: number | string | undefined;
+    // (undocumented)
+    k3?: number | string | undefined;
+    // (undocumented)
+    k4?: number | string | undefined;
+    // (undocumented)
+    kernelMatrix?: number | string | undefined;
+    // (undocumented)
+    kernelUnitLength?: number | string | undefined;
+    // (undocumented)
+    kerning?: number | string | undefined;
+    // (undocumented)
+    keyPoints?: number | string | undefined;
+    // (undocumented)
+    keySplines?: number | string | undefined;
+    // (undocumented)
+    keyTimes?: number | string | undefined;
+    // (undocumented)
+    lang?: string | undefined;
+    // (undocumented)
+    lengthAdjust?: number | string | undefined;
+    // (undocumented)
+    limitingConeAngle?: number | string | undefined;
+    // (undocumented)
+    local?: number | string | undefined;
+    // (undocumented)
+    markerHeight?: number | string | undefined;
+    // (undocumented)
+    markerUnits?: number | string | undefined;
+    // (undocumented)
+    markerWidth?: number | string | undefined;
+    // (undocumented)
+    mask?: string | undefined;
+    // (undocumented)
+    maskContentUnits?: number | string | undefined;
+    // (undocumented)
+    maskUnits?: number | string | undefined;
+    // (undocumented)
+    mathematical?: number | string | undefined;
+    // (undocumented)
+    max?: number | string | undefined;
+    // (undocumented)
+    media?: string | undefined;
+    // (undocumented)
+    method?: string | undefined;
+    // (undocumented)
+    min?: number | string | undefined;
+    // (undocumented)
+    mode?: number | string | undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    numOctaves?: number | string | undefined;
+    // (undocumented)
+    offset?: number | string | undefined;
+    // (undocumented)
+    opacity?: number | string | undefined;
+    // (undocumented)
+    operator?: number | string | undefined;
+    // (undocumented)
+    order?: number | string | undefined;
+    // (undocumented)
+    orient?: number | string | undefined;
+    // (undocumented)
+    orientation?: number | string | undefined;
+    // (undocumented)
+    origin?: number | string | undefined;
+    // (undocumented)
+    overflow?: number | string | undefined;
+    // (undocumented)
+    panose1?: number | string | undefined;
+    // (undocumented)
+    path?: string | undefined;
+    // (undocumented)
+    pathLength?: number | string | undefined;
+    // (undocumented)
+    patternContentUnits?: string | undefined;
+    // (undocumented)
+    patternTransform?: number | string | undefined;
+    // (undocumented)
+    patternUnits?: string | undefined;
+    // (undocumented)
+    points?: string | undefined;
+    // (undocumented)
+    pointsAtX?: number | string | undefined;
+    // (undocumented)
+    pointsAtY?: number | string | undefined;
+    // (undocumented)
+    pointsAtZ?: number | string | undefined;
+    // (undocumented)
+    preserveAlpha?: number | string | undefined;
+    // (undocumented)
+    preserveAspectRatio?: string | undefined;
+    // (undocumented)
+    primitiveUnits?: number | string | undefined;
+    // (undocumented)
+    r?: number | string | undefined;
+    // (undocumented)
+    radius?: number | string | undefined;
+    // (undocumented)
+    refX?: number | string | undefined;
+    // (undocumented)
+    refY?: number | string | undefined;
+    // (undocumented)
+    repeatCount?: number | string | undefined;
+    // (undocumented)
+    repeatDur?: number | string | undefined;
+    // (undocumented)
+    requiredextensions?: number | string | undefined;
+    // (undocumented)
+    requiredFeatures?: number | string | undefined;
+    // (undocumented)
+    restart?: number | string | undefined;
+    // (undocumented)
+    result?: string | undefined;
+    // (undocumented)
+    role?: string | undefined;
+    // (undocumented)
+    rotate?: number | string | undefined;
+    // (undocumented)
+    rx?: number | string | undefined;
+    // (undocumented)
+    ry?: number | string | undefined;
+    // (undocumented)
+    scale?: number | string | undefined;
+    // (undocumented)
+    seed?: number | string | undefined;
+    // (undocumented)
+    slope?: number | string | undefined;
+    // (undocumented)
+    spacing?: number | string | undefined;
+    // (undocumented)
+    specularConstant?: number | string | undefined;
+    // (undocumented)
+    specularExponent?: number | string | undefined;
+    // (undocumented)
+    speed?: number | string | undefined;
+    // (undocumented)
+    spreadMethod?: string | undefined;
+    // (undocumented)
+    startOffset?: number | string | undefined;
+    // (undocumented)
+    stdDeviation?: number | string | undefined;
+    // (undocumented)
+    stemh?: number | string | undefined;
+    // (undocumented)
+    stemv?: number | string | undefined;
+    // (undocumented)
+    stitchTiles?: number | string | undefined;
+    // (undocumented)
+    string?: number | string | undefined;
+    // (undocumented)
+    stroke?: string | undefined;
+    // (undocumented)
+    style?: CSSProperties | string | undefined;
+    // (undocumented)
+    surfaceScale?: number | string | undefined;
+    // (undocumented)
+    systemLanguage?: number | string | undefined;
+    // (undocumented)
+    tabindex?: number | undefined;
+    // (undocumented)
+    tableValues?: number | string | undefined;
+    // (undocumented)
+    target?: string | undefined;
+    // (undocumented)
+    targetX?: number | string | undefined;
+    // (undocumented)
+    targetY?: number | string | undefined;
+    // (undocumented)
+    textLength?: number | string | undefined;
+    // (undocumented)
+    to?: number | string | undefined;
+    // (undocumented)
+    transform?: string | undefined;
+    // (undocumented)
+    type?: string | undefined;
+    // (undocumented)
+    u1?: number | string | undefined;
+    // (undocumented)
+    u2?: number | string | undefined;
+    // (undocumented)
+    unicode?: number | string | undefined;
+    // (undocumented)
+    values?: string | undefined;
+    // (undocumented)
+    version?: string | undefined;
+    // (undocumented)
+    viewBox?: string | undefined;
+    // (undocumented)
+    viewTarget?: number | string | undefined;
+    // (undocumented)
+    visibility?: number | string | undefined;
+    // (undocumented)
+    width?: Numberish | undefined;
+    // (undocumented)
+    widths?: number | string | undefined;
+    // (undocumented)
+    x?: number | string | undefined;
+    // (undocumented)
+    x1?: number | string | undefined;
+    // (undocumented)
+    x2?: number | string | undefined;
+    // (undocumented)
+    xlinkActuate?: string | undefined;
+    // (undocumented)
+    xlinkArcrole?: string | undefined;
+    // (undocumented)
+    xlinkHref?: string | undefined;
+    // (undocumented)
+    xlinkRole?: string | undefined;
+    // (undocumented)
+    xlinkShow?: string | undefined;
+    // (undocumented)
+    xlinkTitle?: string | undefined;
+    // (undocumented)
+    xlinkType?: string | undefined;
+    // (undocumented)
+    xmlBase?: string | undefined;
+    // (undocumented)
+    xmlLang?: string | undefined;
+    // (undocumented)
+    xmlns?: string | undefined;
+    // (undocumented)
+    xmlSpace?: string | undefined;
+    // (undocumented)
+    y?: number | string | undefined;
+    // (undocumented)
+    y1?: number | string | undefined;
+    // (undocumented)
+    y2?: number | string | undefined;
+    // (undocumented)
+    yChannelSelector?: string | undefined;
+    // (undocumented)
+    z?: number | string | undefined;
+    // (undocumented)
+    zoomAndPan?: string | undefined;
+}
+
+// @public (undocumented)
+export interface SVGProps<T extends Element> extends SVGAttributes<T> {
+}
+
+// @public (undocumented)
+export interface TableHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    cellPadding?: number | string | undefined;
+    // (undocumented)
+    cellSpacing?: number | string | undefined;
+    // (undocumented)
+    summary?: string | undefined;
+    // (undocumented)
+    width?: Size | undefined;
+}
+
+// @public (undocumented)
 export interface TaskCtx {
     // (undocumented)
     cleanup(callback: () => void): void;
@@ -942,10 +2535,116 @@ export interface TaskCtx {
 // @public (undocumented)
 export type TaskFn = (ctx: TaskCtx) => ValueOrPromise<void | (() => void)>;
 
+// @public (undocumented)
+export interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    abbr?: string | undefined;
+    // (undocumented)
+    align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
+    // (undocumented)
+    colSpan?: number | undefined;
+    // (undocumented)
+    headers?: string | undefined;
+    // (undocumented)
+    height?: Size | undefined;
+    // (undocumented)
+    rowSpan?: number | undefined;
+    // (undocumented)
+    scope?: string | undefined;
+    // (undocumented)
+    valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined;
+    // (undocumented)
+    width?: Size | undefined;
+}
+
+// @public (undocumented)
+export interface TextareaHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    'bind:value'?: Signal<string | undefined>;
+    // (undocumented)
+    autoComplete?: HTMLInputAutocompleteAttribute | Omit<HTMLInputAutocompleteAttribute, string> | undefined;
+    // (undocumented)
+    autoFocus?: boolean | undefined;
+    // @deprecated (undocumented)
+    children?: undefined;
+    // (undocumented)
+    cols?: number | undefined;
+    // (undocumented)
+    dirName?: string | undefined;
+    // (undocumented)
+    disabled?: boolean | undefined;
+    // (undocumented)
+    enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
+    // (undocumented)
+    form?: string | undefined;
+    // (undocumented)
+    maxLength?: number | undefined;
+    // (undocumented)
+    minLength?: number | undefined;
+    // (undocumented)
+    name?: string | undefined;
+    // (undocumented)
+    placeholder?: string | undefined;
+    // (undocumented)
+    readOnly?: boolean | undefined;
+    // (undocumented)
+    required?: boolean | undefined;
+    // (undocumented)
+    rows?: number | undefined;
+    // (undocumented)
+    value?: string | ReadonlyArray<string> | number | undefined;
+    // (undocumented)
+    wrap?: string | undefined;
+}
+
+// @public (undocumented)
+export interface ThHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    abbr?: string | undefined;
+    // (undocumented)
+    align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
+    // (undocumented)
+    colSpan?: number | undefined;
+    // (undocumented)
+    headers?: string | undefined;
+    // (undocumented)
+    rowSpan?: number | undefined;
+    // (undocumented)
+    scope?: string | undefined;
+}
+
+// @public (undocumented)
+export interface TimeHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    dateTime?: string | undefined;
+}
+
+// @public (undocumented)
+export interface TitleHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: string;
+}
+
 // @public
 export interface Tracker {
     <T>(ctx: () => T): T;
     <T extends {}>(obj: T): T;
+}
+
+// @public (undocumented)
+export interface TrackHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    children?: undefined;
+    // (undocumented)
+    default?: boolean | undefined;
+    // (undocumented)
+    kind?: string | undefined;
+    // (undocumented)
+    label?: string | undefined;
+    // (undocumented)
+    src?: string | undefined;
+    // (undocumented)
+    srcLang?: string | undefined;
 }
 
 // @public (undocumented)
@@ -1068,6 +2767,22 @@ export const _verifySerializable: <T>(value: T, preMessage?: string) => T;
 export const version: string;
 
 // @public (undocumented)
+export interface VideoHTMLAttributes<T extends Element> extends MediaHTMLAttributes<T> {
+    // (undocumented)
+    disablePictureInPicture?: boolean | undefined;
+    // (undocumented)
+    disableRemotePlayback?: boolean | undefined;
+    // (undocumented)
+    height?: Numberish | undefined;
+    // (undocumented)
+    playsInline?: boolean | undefined;
+    // (undocumented)
+    poster?: string | undefined;
+    // (undocumented)
+    width?: Numberish | undefined;
+}
+
+// @public (undocumented)
 export type VisibleTaskStrategy = 'intersection-observer' | 'document-ready' | 'document-idle';
 
 // @internal (undocumented)
@@ -1075,6 +2790,44 @@ export const _waitUntilRendered: (elm: Element) => Promise<void>;
 
 // @internal (undocumented)
 export const _weakSerialize: <T extends Record<string, any>>(input: T) => Partial<T>;
+
+// @public (undocumented)
+export interface WebViewHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+    // (undocumented)
+    allowFullScreen?: boolean | undefined;
+    // (undocumented)
+    allowpopups?: boolean | undefined;
+    // (undocumented)
+    autoFocus?: boolean | undefined;
+    // (undocumented)
+    autosize?: boolean | undefined;
+    // (undocumented)
+    blinkfeatures?: string | undefined;
+    // (undocumented)
+    disableblinkfeatures?: string | undefined;
+    // (undocumented)
+    disableguestresize?: boolean | undefined;
+    // (undocumented)
+    disablewebsecurity?: boolean | undefined;
+    // (undocumented)
+    guestinstance?: string | undefined;
+    // (undocumented)
+    httpreferrer?: string | undefined;
+    // (undocumented)
+    nodeintegration?: boolean | undefined;
+    // (undocumented)
+    partition?: string | undefined;
+    // (undocumented)
+    plugins?: boolean | undefined;
+    // (undocumented)
+    preload?: string | undefined;
+    // (undocumented)
+    src?: string | undefined;
+    // (undocumented)
+    useragent?: string | undefined;
+    // (undocumented)
+    webpreferences?: string | undefined;
+}
 
 // Warning: (ae-internal-missing-underscore) The name "withLocale" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -53,12 +53,7 @@ export {
 export type { SSRStreamProps, SSRHintProps } from './render/jsx/utils.public';
 export { Slot } from './render/jsx/slot.public';
 export { Fragment, HTMLFragment, RenderOnce, jsx, jsxDEV, jsxs } from './render/jsx/jsx-runtime';
-export type {
-  CSSProperties,
-  HTMLAttributes,
-  AriaAttributes,
-  AriaRole,
-} from './render/jsx/types/jsx-generated';
+export type * from './render/jsx/types/jsx-generated';
 export type {
   DOMAttributes,
   JSXTagName,
@@ -66,7 +61,7 @@ export type {
   ComponentBaseProps,
   ClassList,
 } from './render/jsx/types/jsx-qwik-attributes';
-export type { FunctionComponent, JSXNode } from './render/jsx/types/jsx-node';
+export type { FunctionComponent, JSXNode, DevJSX } from './render/jsx/types/jsx-node';
 export type { QwikDOMAttributes, QwikJSX } from './render/jsx/types/jsx-qwik';
 export type { QwikIntrinsicElements } from './render/jsx/types/jsx-qwik-elements';
 export { render } from './render/dom/render.public';

--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -2,8 +2,17 @@ import * as CSS from 'csstype';
 import type { Signal } from '../../../state/signal';
 import type { DOMAttributes, ClassList } from './jsx-qwik-attributes';
 interface HTMLWebViewElement extends HTMLElement {}
+/**
+ * @public
+ */
 export type Booleanish = boolean | `${boolean}`;
+/**
+ * @public
+ */
 export type Size = number | string;
+/**
+ * @public
+ */
 export type Numberish = number | `${number}`;
 
 /**
@@ -320,6 +329,9 @@ export type AriaRole =
 /**
  * @public
  */
+/**
+ * @public
+ */
 export interface HTMLAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> {
   accessKey?: string | undefined;
   contentEditable?: 'true' | 'false' | 'inherit' | undefined;
@@ -383,7 +395,13 @@ export interface HTMLAttributes<T extends Element> extends AriaAttributes, DOMAt
    */
   is?: string | undefined;
 }
+/**
+ * @public
+ */
 export type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {});
+/**
+ * @public
+ */
 export type HTMLAttributeReferrerPolicy =
   | ''
   | 'no-referrer'
@@ -394,6 +412,9 @@ export type HTMLAttributeReferrerPolicy =
   | 'strict-origin'
   | 'strict-origin-when-cross-origin'
   | 'unsafe-url';
+/**
+ * @public
+ */
 export interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   download?: any;
   href?: string | undefined;
@@ -405,6 +426,9 @@ export interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<
   type?: string | undefined;
   referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
 }
+/**
+ * @public
+ */
 export interface AreaHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   alt?: string | undefined;
   coords?: string | undefined;
@@ -418,6 +442,9 @@ export interface AreaHTMLAttributes<T extends Element> extends HTMLAttributes<T>
   target?: string | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   autoPlay?: boolean | undefined;
   controls?: boolean | undefined;
@@ -430,15 +457,27 @@ export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T
   preload?: string | undefined;
   src?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface AudioHTMLAttributes<T extends Element> extends MediaHTMLAttributes<T> {}
+/**
+ * @public
+ */
 export interface BaseHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   href?: string | undefined;
   target?: string | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface BlockquoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   cite?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   autoFocus?: boolean | undefined;
   disabled?: boolean | undefined;
@@ -452,32 +491,56 @@ export interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<
   type?: 'submit' | 'reset' | 'button' | undefined;
   value?: string | ReadonlyArray<string> | number | undefined;
 }
+/**
+ * @public
+ */
 export interface CanvasHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   height?: Size | undefined;
   width?: Size | undefined;
 }
+/**
+ * @public
+ */
 export interface ColHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   span?: number | undefined;
   width?: Size | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface ColgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   span?: number | undefined;
 }
+/**
+ * @public
+ */
 export interface DataHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   value?: string | ReadonlyArray<string> | number | undefined;
 }
+/**
+ * @public
+ */
 export interface DelHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   cite?: string | undefined;
   dateTime?: string | undefined;
 }
 
+/**
+ * @public
+ */
 export interface DetailsHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   open?: boolean | undefined;
 }
+/**
+ * @public
+ */
 export interface DialogHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   open?: boolean | undefined;
 }
+/**
+ * @public
+ */
 export interface EmbedHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   height?: Size | undefined;
   src?: string | undefined;
@@ -485,11 +548,17 @@ export interface EmbedHTMLAttributes<T extends Element> extends HTMLAttributes<T
   width?: Size | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface FieldsetHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   disabled?: boolean | undefined;
   form?: string | undefined;
   name?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   acceptCharset?: string | undefined;
   action?: string | undefined;
@@ -500,9 +569,15 @@ export interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T>
   noValidate?: boolean | undefined;
   target?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface HtmlHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   manifest?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface IframeHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   allow?: string | undefined;
   allowFullScreen?: boolean | undefined;
@@ -526,6 +601,9 @@ export interface IframeHTMLAttributes<T extends Element> extends HTMLAttributes<
   width?: Size | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface ImgHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   alt?: string | undefined;
   crossOrigin?: HTMLCrossOriginAttribute;
@@ -549,12 +627,19 @@ export interface ImgHTMLAttributes<T extends Element> extends HTMLAttributes<T> 
   children?: undefined;
 }
 
+/**
+ * @public
+ */
 export interface HrHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   children?: undefined;
 }
-
+/**
+ * @public
+ */
 export type HTMLCrossOriginAttribute = 'anonymous' | 'use-credentials' | '' | undefined;
-
+/**
+ * @public
+ */
 export type HTMLInputTypeAttribute =
   | 'button'
   | 'checkbox'
@@ -580,6 +665,9 @@ export type HTMLInputTypeAttribute =
   | 'week'
   | (string & {});
 
+/**
+ * @public
+ */
 export type HTMLInputAutocompleteAttribute =
   | 'on'
   | 'off'
@@ -630,6 +718,9 @@ export type HTMLInputAutocompleteAttribute =
   | 'url'
   | 'photo';
 
+/**
+ * @public
+ */
 export interface InputHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   accept?: string | undefined;
   alt?: string | undefined;
@@ -671,10 +762,16 @@ export interface InputHTMLAttributes<T extends Element> extends HTMLAttributes<T
   width?: Size | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface InsHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   cite?: string | undefined;
   dateTime?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   autoFocus?: boolean | undefined;
   challenge?: string | undefined;
@@ -685,13 +782,22 @@ export interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<
   name?: string | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface LabelHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   form?: string | undefined;
   for?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface LiHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   value?: string | ReadonlyArray<string> | number | undefined;
 }
+/**
+ * @public
+ */
 export interface LinkHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   as?: string | undefined;
   crossOrigin?: HTMLCrossOriginAttribute;
@@ -708,12 +814,21 @@ export interface LinkHTMLAttributes<T extends Element> extends HTMLAttributes<T>
   charSet?: string | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface MapHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   name?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface MenuHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   type?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface MetaHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   charSet?: string | undefined;
   content?: string | undefined;
@@ -722,6 +837,9 @@ export interface MetaHTMLAttributes<T extends Element> extends HTMLAttributes<T>
   media?: string | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   form?: string | undefined;
   high?: number | undefined;
@@ -731,6 +849,9 @@ export interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T
   optimum?: number | undefined;
   value?: string | ReadonlyArray<string> | number | undefined;
 }
+/**
+ * @public
+ */
 export interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   classID?: string | undefined;
   data?: string | undefined;
@@ -742,15 +863,24 @@ export interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<
   width?: Size | undefined;
   wmode?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface OlHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   reversed?: boolean | undefined;
   start?: number | undefined;
   type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined;
 }
+/**
+ * @public
+ */
 export interface OptgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   disabled?: boolean | undefined;
   label?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface OptionHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   disabled?: boolean | undefined;
   label?: string | undefined;
@@ -758,26 +888,44 @@ export interface OptionHTMLAttributes<T extends Element> extends HTMLAttributes<
   value?: string | ReadonlyArray<string> | number | undefined;
   children?: string;
 }
+/**
+ * @public
+ */
 export interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   form?: string | undefined;
   for?: string | undefined;
   name?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface ParamHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   name?: string | undefined;
   value?: string | ReadonlyArray<string> | number | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface ProgressHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   max?: number | string | undefined;
   value?: string | ReadonlyArray<string> | number | undefined;
 }
+/**
+ * @public
+ */
 export interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   cite?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface SlotHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   name?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   async?: boolean | undefined;
   /** @deprecated Deprecated */
@@ -791,6 +939,9 @@ export interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<
   src?: string | undefined;
   type?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   autoComplete?:
     | HTMLInputAutocompleteAttribute
@@ -806,6 +957,9 @@ export interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<
   value?: string | ReadonlyArray<string> | number | undefined;
   'bind:value'?: Signal<string | undefined>;
 }
+/**
+ * @public
+ */
 export interface SourceHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   height?: Size | undefined;
   media?: string | undefined;
@@ -816,6 +970,9 @@ export interface SourceHTMLAttributes<T extends Element> extends HTMLAttributes<
   width?: Size | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   media?: string | undefined;
   nonce?: string | undefined;
@@ -823,12 +980,18 @@ export interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T
   type?: string | undefined;
   children?: string;
 }
+/**
+ * @public
+ */
 export interface TableHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   cellPadding?: number | string | undefined;
   cellSpacing?: number | string | undefined;
   summary?: string | undefined;
   width?: Size | undefined;
 }
+/**
+ * @public
+ */
 export interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
   colSpan?: number | undefined;
@@ -840,6 +1003,9 @@ export interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   width?: Size | undefined;
   valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined;
 }
+/**
+ * @public
+ */
 export interface TextareaHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   autoComplete?:
     | HTMLInputAutocompleteAttribute
@@ -865,6 +1031,9 @@ export interface TextareaHTMLAttributes<T extends Element> extends HTMLAttribute
   /** @deprecated - Use the `value` property instead */
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface ThHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
   colSpan?: number | undefined;
@@ -873,12 +1042,21 @@ export interface ThHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   scope?: string | undefined;
   abbr?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface TimeHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   dateTime?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface TitleHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   children?: string;
 }
+/**
+ * @public
+ */
 export interface TrackHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   default?: boolean | undefined;
   kind?: string | undefined;
@@ -887,6 +1065,9 @@ export interface TrackHTMLAttributes<T extends Element> extends HTMLAttributes<T
   srcLang?: string | undefined;
   children?: undefined;
 }
+/**
+ * @public
+ */
 export interface VideoHTMLAttributes<T extends Element> extends MediaHTMLAttributes<T> {
   height?: Numberish | undefined;
   playsInline?: boolean | undefined;
@@ -895,6 +1076,9 @@ export interface VideoHTMLAttributes<T extends Element> extends MediaHTMLAttribu
   disablePictureInPicture?: boolean | undefined;
   disableRemotePlayback?: boolean | undefined;
 }
+/**
+ * @public
+ */
 export interface WebViewHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
   allowFullScreen?: boolean | undefined;
   allowpopups?: boolean | undefined;
@@ -914,6 +1098,9 @@ export interface WebViewHTMLAttributes<T extends Element> extends HTMLAttributes
   useragent?: string | undefined;
   webpreferences?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> {
   class?: ClassList | undefined;
   /** @deprecated - Use `class` instead */
@@ -1192,9 +1379,17 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
   z?: number | string | undefined;
   zoomAndPan?: string | undefined;
 }
+/**
+ * @public
+ */
 export interface SVGProps<T extends Element> extends SVGAttributes<T> {}
-
+/**
+ * @public
+ */
 export interface IntrinsicElements extends IntrinsicHTMLElements, IntrinsicSVGElements {}
+/**
+ * @public
+ */
 export interface IntrinsicHTMLElements {
   a: AnchorHTMLAttributes<HTMLAnchorElement>;
   abbr: HTMLAttributes<HTMLElement>;
@@ -1315,6 +1510,9 @@ export interface IntrinsicHTMLElements {
   webview: WebViewHTMLAttributes<HTMLWebViewElement>;
 }
 
+/**
+ * @public
+ */
 export interface IntrinsicSVGElements {
   svg: SVGProps<SVGSVGElement>;
   animate: SVGProps<SVGElement>;

--- a/packages/qwik/src/core/render/jsx/types/jsx-node.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-node.ts
@@ -4,7 +4,9 @@
 export interface FunctionComponent<P = Record<string, any>> {
   (props: P, key: string | null, flags: number, dev?: DevJSX): JSXNode | null;
 }
-
+/**
+ * @public
+ */
 export interface DevJSX {
   fileName: string;
   lineNumber: number;


### PR DESCRIPTION
# fix #5140

# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests / types / typos

# Description

When creating a UI library for Qwik and strong typing the properties using QwikIntrinsicElement used like

export type MyLabelProp = QwikIntrinsicElement['label']

that results in a TS4023 issue.

Reproduction 
https://github.com/gparlakov/qwik-lib-TS4023-issue-repro


Suggest exporting all from the jsx-generated.ts file instead of just the few types currently exported.

Previously libraries have done that like https://github.com/ngrx/platform/pull/1118 or guessing what was done to fix https://github.com/BuilderIO/qwik/issues/2783

TS issue https://github.com/microsoft/TypeScript/issues/5711# 

Here's the real world use case from qwik-ui

- DevJSX ends needed to be exported - https://github.com/qwikifiers/qwik-ui/blob/main/packages/kit-headless/src/components/combobox/combobox.tsx#L31
- Label Attributes ends up needed to be exported - https://github.com/qwikifiers/qwik-ui/blob/main/packages/kit-headless/src/components/combobox/combobox-label.tsx

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
