### PR TITLE
fix: Ignore blob URL on getting image info

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/image-size-runtime.html
+++ b/packages/qwik/src/optimizer/src/plugins/image-size-runtime.html
@@ -273,6 +273,9 @@
     let skip = false;
 
     async function _getInfo(originalSrc) {
+      if (originalSrc.startsWith('blob:')) {
+        return undefined;
+      }
       const url = new URL('/__image_info', location.href);
       url.searchParams.set('url', originalSrc);
       const res = await fetch(url);


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I have found that the `<img>` tags having src attributes of the blob URL causes errors in order to request the `__image_info` to the image size server.
Obviously there is no way to get the image info of the blob URLs from the server side, I simply ignored if the URL starting with `blob:`.

# Use cases and why

The blob URL is useful for using images dynamically generated in client side.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
