### PR TITLE
Feature/leaflet map integration adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     }
   ],
   "dependencies": {
+    "@builder.io/qwik": "^1.2.10",
+    "@builder.io/qwik-city": "^1.2.10",
     "esbuild-plugin-raw": "^0.1.7"
   },
   "devDependencies": {

--- a/packages/docs/src/routes/docs/integrations/leaflet-map/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/leaflet-map/index.mdx
@@ -1,0 +1,68 @@
+---
+title: LeafletJS Map | Integrations
+keywords: 'map, interactive maps'
+contributors:
+  - mugan86
+---
+
+# LeafletJS Map
+
+Leaflet is the leading open-source JavaScript library for mobile-friendly interactive maps. 
+Weighing just about 42 KB of JS, it has all the mapping features most developers ever need.
+
+Leaflet is designed with simplicity, performance and usability in mind. 
+It works efficiently across all major desktop and mobile platforms, can be extended with lots of plugins, has a beautiful, easy to use and well-documented API and a simple, readable source code that is a joy to contribute to. [LeafletJS Map Website](https://leafletjs.com/)
+
+## Usage
+
+You can add LeafletJS Map easily by using the following Qwik starter script:
+
+```shell
+npm run qwik add leaflet-map
+```
+
+The previous command updates your app with the necessary dependencies.
+
+- `leaflet@1.9.4`
+- `@types/leaflet@1.9.4`
+
+It also adds new files inside to your project folder:
+
+- `src/helpers/boundary-box.tsx`: Check map area boundaries function.
+- `src/models/location.ts`: Model to define locations info elements to uso in props.
+- `src/models/map.ts`: Model to define map info to uso in props.
+- `src/components/leaflet-map/index.tsx`: Leaflet map simple map features component.
+- `src/routes/basic-map/index.tsx`: Example to consume Leaflet Map component with demo data
+
+## Consideration to take into account
+
+### Working with `npm` or `Yarn`:
+
+In the `src/components/leaflet-map/index.tsx` file you must have references to the CSS styles so that the maps are displayed correctly. By default it is added, but if for some reason the map looks strange when displayed, check that it is correctly referencing the CSS file within node_modules in the `leaflet` package.
+
+```bash
+node_modules/leaflet/dist/leaflet.css
+```
+
+### Working with `pnpm`:
+
+```
+node_modules/.pnpm/leaflet@1.9.4/node_modules/leaflet/dist/leaflet.css
+```
+
+## Interesting info about LeafletJS Map:
+
+### Official
+
+- `Tutorials`: Examples step by step to reference to create new features using Documentation. [Reference](https://leafletjs.com/examples.html).
+- `Docs`: All necessary info to work with LeafletJS. [Reference](https://leafletjs.com/reference.html)
+
+### Community
+
+#### English
+
+- Pending to take contributions
+
+#### Spanish
+
+- Pending to take contributions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
 
   .:
     dependencies:
+      '@builder.io/qwik':
+        specifier: ^1.2.10
+        version: 1.2.10(undici@5.22.1)
+      '@builder.io/qwik-city':
+        specifier: ^1.2.10
+        version: 1.2.10(rollup@3.26.3)
       esbuild-plugin-raw:
         specifier: ^0.1.7
         version: 0.1.7(esbuild@0.18.17)
@@ -221,10 +227,10 @@ importers:
         version: 0.8.0
       '@builder.io/qwik':
         specifier: github:BuilderIo/qwik-build#main
-        version: github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef(undici@5.22.1)
+        version: github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110(undici@5.22.1)
       '@builder.io/qwik-city':
         specifier: github:BuilderIo/qwik-city-build#main
-        version: github.com/BuilderIo/qwik-city-build/5bd84238e9d94736ff2075b77cbd1c49f8af8de7(rollup@3.26.3)
+        version: github.com/BuilderIo/qwik-city-build/da90f34fa48e1ed2f846120997f86310480c4c22(rollup@3.26.3)
       '@builder.io/qwik-labs':
         specifier: github:BuilderIo/qwik-labs-build#a487845dd5039e3e178f69755f603cbc2edef2c2
         version: github.com/BuilderIo/qwik-labs-build/a487845dd5039e3e178f69755f603cbc2edef2c2
@@ -245,7 +251,7 @@ importers:
         version: 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.17)(react@18.2.0)
       '@modular-forms/qwik':
         specifier: ^0.12.0
-        version: 0.12.0(@builder.io/qwik-city@1.2.10-dev20230903073808)(@builder.io/qwik@1.2.10)
+        version: 0.12.0(@builder.io/qwik-city@1.2.10-dev20230911173253)(@builder.io/qwik@1.2.10)
       '@mui/material':
         specifier: ^5.13.0
         version: 5.13.0(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)
@@ -372,13 +378,13 @@ importers:
         version: 0.7.1
       '@builder.io/qwik-auth':
         specifier: 0.1.0
-        version: 0.1.0(@auth/core@0.7.1)(@builder.io/qwik-city@1.2.10-dev20230903073808)(@builder.io/qwik@1.2.10)
+        version: 0.1.0(@auth/core@0.7.1)(@builder.io/qwik-city@1.2.10-dev20230911173253)(@builder.io/qwik@1.2.10)
       '@libsql/client':
         specifier: ^0.3.1
         version: 0.3.1
       '@modular-forms/qwik':
         specifier: ^0.12.0
-        version: 0.12.0(@builder.io/qwik-city@1.2.10-dev20230903073808)(@builder.io/qwik@1.2.10)
+        version: 0.12.0(@builder.io/qwik-city@1.2.10-dev20230911173253)(@builder.io/qwik@1.2.10)
       '@typescript/analyze-trace':
         specifier: ^0.10.0
         version: 0.10.0
@@ -400,10 +406,10 @@ importers:
     devDependencies:
       '@builder.io/qwik':
         specifier: github:BuilderIo/qwik-build#main
-        version: github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef(undici@5.22.1)
+        version: github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110(undici@5.22.1)
       '@builder.io/qwik-city':
         specifier: github:BuilderIo/qwik-city-build#main
-        version: github.com/BuilderIo/qwik-city-build/5bd84238e9d94736ff2075b77cbd1c49f8af8de7(rollup@3.26.3)
+        version: github.com/BuilderIo/qwik-city-build/da90f34fa48e1ed2f846120997f86310480c4c22(rollup@3.26.3)
       '@builder.io/qwik-labs':
         specifier: workspace:*
         version: link:../qwik-labs
@@ -1317,7 +1323,7 @@ packages:
     hasBin: true
     dev: true
 
-  /@builder.io/qwik-auth@0.1.0(@auth/core@0.7.1)(@builder.io/qwik-city@1.2.10-dev20230903073808)(@builder.io/qwik@1.2.10):
+  /@builder.io/qwik-auth@0.1.0(@auth/core@0.7.1)(@builder.io/qwik-city@1.2.10-dev20230911173253)(@builder.io/qwik@1.2.10):
     resolution: {integrity: sha512-uwwVbam6yQs9evtmof/+SpRT7DzoxD+2DSwsndGcm9JBU4Sh1xMyzll6F9QbivKVboglx+4X05OzJG7QTttWMQ==}
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
     peerDependencies:
@@ -1326,8 +1332,8 @@ packages:
       '@builder.io/qwik-city': '>=0.6.0'
     dependencies:
       '@auth/core': 0.7.1
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef(undici@5.22.1)
-      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/5bd84238e9d94736ff2075b77cbd1c49f8af8de7(rollup@3.26.3)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110(undici@5.22.1)
+      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/da90f34fa48e1ed2f846120997f86310480c4c22(rollup@3.26.3)
     dev: false
 
   /@builder.io/qwik-city@1.2.10(rollup@3.26.3):
@@ -1344,7 +1350,6 @@ packages:
     transitivePeerDependencies:
       - rollup
       - supports-color
-    dev: true
 
   /@builder.io/qwik-react@0.5.0(@builder.io/qwik@1.2.10)(@types/react-dom@18.2.7)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JdJWQWOJGv7ddQqEZwzR8wPh0IoCQZwD9qo75+reiQaLp6eH+Pjsm/kn1LaMQt6u72pCCNjnj5kEn/bnbfnIjQ==}
@@ -1356,7 +1361,7 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
     dependencies:
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef(undici@5.22.1)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110(undici@5.22.1)
       '@types/react': 18.2.17
       '@types/react-dom': 18.2.7
       react: 18.2.0
@@ -1372,7 +1377,6 @@ packages:
     dependencies:
       csstype: 3.1.2
       undici: 5.22.1
-    dev: true
 
   /@builder.io/qwik@1.2.6(undici@5.22.1):
     resolution: {integrity: sha512-Cm1sLAimML55I5T1RI80R1lLgI4cnSeQt5obQtcMKa8wMmf2/luEyQaEkeN2fV3sp/gaVXCfAuKaddXK6ONdww==}
@@ -1390,7 +1394,7 @@ packages:
     peerDependencies:
       '@builder.io/qwik': '>=1.0.0'
     dependencies:
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef(undici@5.22.1)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110(undici@5.22.1)
     dev: true
 
   /@builder.io/vite-plugin-macro@0.0.7(@types/node@20.4.5)(rollup@3.26.3)(terser@5.19.2):
@@ -2739,14 +2743,14 @@ packages:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
-  /@modular-forms/qwik@0.12.0(@builder.io/qwik-city@1.2.10-dev20230903073808)(@builder.io/qwik@1.2.10):
+  /@modular-forms/qwik@0.12.0(@builder.io/qwik-city@1.2.10-dev20230911173253)(@builder.io/qwik@1.2.10):
     resolution: {integrity: sha512-IJi5Uvm1Z1tJZLOpYM8jWza40Viac6tblnMre0pdrslVv7tW3MnXFgQgO539YksooOsn1Jn1KjVUVmhiMuXXuA==}
     peerDependencies:
       '@builder.io/qwik': ^1.0.0
       '@builder.io/qwik-city': ^1.0.0
     dependencies:
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef(undici@5.22.1)
-      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/5bd84238e9d94736ff2075b77cbd1c49f8af8de7(rollup@3.26.3)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110(undici@5.22.1)
+      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/da90f34fa48e1ed2f846120997f86310480c4c22(rollup@3.26.3)
 
   /@mui/base@5.0.0-beta.0(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ap+juKvt8R8n3cBqd/pGtZydQ4v2I/hgJKnvJRGjpSh3RvsvnDHO4rXov8MHQlH6VqpOekwgilFLGxMZjNTucA==}
@@ -5553,7 +5557,7 @@ packages:
     peerDependencies:
       '@builder.io/qwik': '*'
     dependencies:
-      '@builder.io/qwik': github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef(undici@5.22.1)
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110(undici@5.22.1)
     dev: true
 
   /@vercel/nft@0.22.6(supports-color@9.4.0):
@@ -19011,9 +19015,9 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef(undici@5.22.1):
-    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-build/tar.gz/a22f5ecae8dd8eb125f96f59edb8431c08f446ef}
-    id: github.com/BuilderIo/qwik-build/a22f5ecae8dd8eb125f96f59edb8431c08f446ef
+  github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110(undici@5.22.1):
+    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-build/tar.gz/4d4509af4baf2ef88a99c4280ba24dd22d2a7110}
+    id: github.com/BuilderIo/qwik-build/4d4509af4baf2ef88a99c4280ba24dd22d2a7110
     name: '@builder.io/qwik'
     version: 1.2.10
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
@@ -19024,11 +19028,11 @@ packages:
       csstype: 3.1.2
       undici: 5.22.1
 
-  github.com/BuilderIo/qwik-city-build/5bd84238e9d94736ff2075b77cbd1c49f8af8de7(rollup@3.26.3):
-    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-city-build/tar.gz/5bd84238e9d94736ff2075b77cbd1c49f8af8de7}
-    id: github.com/BuilderIo/qwik-city-build/5bd84238e9d94736ff2075b77cbd1c49f8af8de7
+  github.com/BuilderIo/qwik-city-build/da90f34fa48e1ed2f846120997f86310480c4c22(rollup@3.26.3):
+    resolution: {tarball: https://codeload.github.com/BuilderIo/qwik-city-build/tar.gz/da90f34fa48e1ed2f846120997f86310480c4c22}
+    id: github.com/BuilderIo/qwik-city-build/da90f34fa48e1ed2f846120997f86310480c4c22
     name: '@builder.io/qwik-city'
-    version: 1.2.10-dev20230903073808
+    version: 1.2.10-dev20230911173253
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
     dependencies:
       '@mdx-js/mdx': 2.3.0

--- a/starters/features/leaflet-map/package.json
+++ b/starters/features/leaflet-map/package.json
@@ -1,0 +1,19 @@
+{
+    "description": "Use Leaflet Maps in your Qwik app",
+    "__qwik__": {
+      "displayName": "Integration: Leaflet Maps",
+      "priority": -10,
+      "viteConfig": {},
+      "docs": [
+        "https://leafletjs.com/reference.html",
+        "https://leafletjs.com/examples/quick-start/"
+      ]
+    },
+    "dependencies": {
+        "leaflet": "1.9.4"
+    },
+    "devDependencies": {
+      "@types/leaflet": "1.9.4"
+    }
+  }
+  

--- a/starters/features/leaflet-map/package.json
+++ b/starters/features/leaflet-map/package.json
@@ -6,7 +6,8 @@
       "viteConfig": {},
       "docs": [
         "https://leafletjs.com/reference.html",
-        "https://leafletjs.com/examples/quick-start/"
+        "https://leafletjs.com/examples/quick-start/",
+        "https://www.youtube.com/watch?v=_rQH9EwUwn4&list=PLaaTcPGicjqgLAUhR_grKBGCXbyKaP7qR"
       ]
     },
     "dependencies": {

--- a/starters/features/leaflet-map/src/components/leaflet-map/index.tsx
+++ b/starters/features/leaflet-map/src/components/leaflet-map/index.tsx
@@ -22,7 +22,7 @@ export const LeafletMap = component$<MapProps>(({ location }: MapProps) => {
   useVisibleTask$(async ({ track }) => {
     track(location);
 
-    const { tileLayer, marker, bindPopup } = await import("leaflet");
+    const { tileLayer, marker } = await import("leaflet");
 
     const { getBoundaryBox } = await import("../../helpers/boundary-box");
 
@@ -50,7 +50,7 @@ export const LeafletMap = component$<MapProps>(({ location }: MapProps) => {
       }).addTo(map);
 
       // Assign select boundary box to use in OSM API if you want
-      location.boundaryBox = getBoundaryBox(map);
+      locationData.boundaryBox = getBoundaryBox(map);
 
       locationData.marker &&
         marker(centerPosition).bindPopup(`Soraluze (Gipuzkoa) :)`).addTo(map);

--- a/starters/features/leaflet-map/src/components/leaflet-map/index.tsx
+++ b/starters/features/leaflet-map/src/components/leaflet-map/index.tsx
@@ -1,60 +1,62 @@
 import {
-    component$,
-    noSerialize,
-    useSignal,
-    useStyles$,
-    useVisibleTask$,
-  } from '@builder.io/qwik';
-  import { Map} from 'leaflet';
-  
-  export const LeafletMap = component$(({ location }: any) => {
-    useStyles$(`
-      #map {
-          width: 100%;
-          height: 350px;
-        }
-      `);
-  
-    const mapContainer$ = useSignal<Map>();
-  
-    useVisibleTask$(async ({ track }) => {
-      track(location);
+  component$,
+  noSerialize,
+  useSignal,
+  useStyles$,
+  useVisibleTask$,
+} from '@builder.io/qwik';
+import { Map } from 'leaflet';
+import { MapProps } from './../../models/map';
 
-      const { tileLayer, marker } = await import ('leaflet');
+export const LeafletMap = component$<MapProps>(({ location }: MapProps) => {
+  // Modify with your preferences. By default take all screen
+  useStyles$(`
+    #map {
+      width: 100%;
+      height: 100vh;
+    }
+  `);
 
-  
-      const { getBoundaryBox } = await import('../../helpers/boundary-box');
-  
-      if (location && window) {
-        if (mapContainer$.value) {
-          mapContainer$.value.remove();
-        }
-  
-        const { value: locationData } = location;
-  
-        const centerPosition: [number, number] = locationData.point as [
-          number,
-          number
-        ];
-  
-        const map: any = new Map('map').setView(
-          centerPosition,
-          locationData.zoom || 14
-        );
-  
-        tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-          maxZoom: 19,
-          attribution:
-            '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-        }).addTo(map);
-  
-        // Assign select boundary box to use in OSM API if you want
-        location.boundaryBox = getBoundaryBox(map);
-  
-        locationData.marker && marker(centerPosition).addTo(map);
-  
-        mapContainer$.value = noSerialize(map);
+  const mapContainer$ = useSignal<Map>();
+
+  useVisibleTask$(async ({ track }) => {
+    track(location);
+
+    const { tileLayer, marker, bindPopup } = await import('leaflet');
+
+    const { getBoundaryBox } = await import('../../helpers/boundary-box');
+
+    if (location && window) {
+      if (mapContainer$.value) {
+        mapContainer$.value.remove();
       }
-    });
-    return <div id='map'></div>;
+
+      const { value: locationData } = location;
+
+      const centerPosition: [number, number] = locationData.point as [
+        number,
+        number
+      ];
+
+      const map: any = new Map('map').setView(
+        centerPosition,
+        locationData.zoom || 14
+      );
+
+      tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution:
+          '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      }).addTo(map);
+
+      // Assign select boundary box to use in OSM API if you want
+      location.boundaryBox = getBoundaryBox(map);
+
+      locationData.marker &&
+        marker(centerPosition).bindPopup(`Soraluze (Gipuzkoa) :)`).addTo(map);
+
+      mapContainer$.value = noSerialize(map);
+    }
   });
+  return <div id='map'></div>;
+});

--- a/starters/features/leaflet-map/src/components/leaflet-map/index.tsx
+++ b/starters/features/leaflet-map/src/components/leaflet-map/index.tsx
@@ -4,9 +4,9 @@ import {
   useSignal,
   useStyles$,
   useVisibleTask$,
-} from '@builder.io/qwik';
-import { Map } from 'leaflet';
-import { MapProps } from './../../models/map';
+} from "@builder.io/qwik";
+import { Map } from "leaflet";
+import { MapProps } from "~/models/map";
 
 export const LeafletMap = component$<MapProps>(({ location }: MapProps) => {
   // Modify with your preferences. By default take all screen
@@ -22,9 +22,9 @@ export const LeafletMap = component$<MapProps>(({ location }: MapProps) => {
   useVisibleTask$(async ({ track }) => {
     track(location);
 
-    const { tileLayer, marker, bindPopup } = await import('leaflet');
+    const { tileLayer, marker, bindPopup } = await import("leaflet");
 
-    const { getBoundaryBox } = await import('../../helpers/boundary-box');
+    const { getBoundaryBox } = await import("../../helpers/boundary-box");
 
     if (location && window) {
       if (mapContainer$.value) {
@@ -35,15 +35,15 @@ export const LeafletMap = component$<MapProps>(({ location }: MapProps) => {
 
       const centerPosition: [number, number] = locationData.point as [
         number,
-        number
+        number,
       ];
 
-      const map: any = new Map('map').setView(
+      const map: any = new Map("map").setView(
         centerPosition,
-        locationData.zoom || 14
+        locationData.zoom || 14,
       );
 
-      tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
         maxZoom: 19,
         attribution:
           '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
@@ -58,5 +58,5 @@ export const LeafletMap = component$<MapProps>(({ location }: MapProps) => {
       mapContainer$.value = noSerialize(map);
     }
   });
-  return <div id='map'></div>;
+  return <div id="map"></div>;
 });

--- a/starters/features/leaflet-map/src/components/leaflet-map/index.tsx
+++ b/starters/features/leaflet-map/src/components/leaflet-map/index.tsx
@@ -1,0 +1,60 @@
+import {
+    component$,
+    noSerialize,
+    useSignal,
+    useStyles$,
+    useVisibleTask$,
+  } from '@builder.io/qwik';
+  import { Map} from 'leaflet';
+  
+  export const LeafletMap = component$(({ location }: any) => {
+    useStyles$(`
+      #map {
+          width: 100%;
+          height: 350px;
+        }
+      `);
+  
+    const mapContainer$ = useSignal<Map>();
+  
+    useVisibleTask$(async ({ track }) => {
+      track(location);
+
+      const { tileLayer, marker } = await import ('leaflet');
+
+  
+      const { getBoundaryBox } = await import('../../helpers/boundary-box');
+  
+      if (location && window) {
+        if (mapContainer$.value) {
+          mapContainer$.value.remove();
+        }
+  
+        const { value: locationData } = location;
+  
+        const centerPosition: [number, number] = locationData.point as [
+          number,
+          number
+        ];
+  
+        const map: any = new Map('map').setView(
+          centerPosition,
+          locationData.zoom || 14
+        );
+  
+        tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 19,
+          attribution:
+            '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        }).addTo(map);
+  
+        // Assign select boundary box to use in OSM API if you want
+        location.boundaryBox = getBoundaryBox(map);
+  
+        locationData.marker && marker(centerPosition).addTo(map);
+  
+        mapContainer$.value = noSerialize(map);
+      }
+    });
+    return <div id='map'></div>;
+  });

--- a/starters/features/leaflet-map/src/helpers/boundary-box.tsx
+++ b/starters/features/leaflet-map/src/helpers/boundary-box.tsx
@@ -1,10 +1,11 @@
-import type { Map } from 'leaflet';
+import type { Map } from "leaflet";
 export const getBoundaryBox = (map: Map, log: boolean = false) => {
-    const northEast = map.getBounds().getNorthEast();
-    const southWest = map.getBounds().getSouthWest();
+  const northEast = map.getBounds().getNorthEast();
+  const southWest = map.getBounds().getSouthWest();
 
-    log && console.log(
-        `${southWest.lat},${southWest.lng},${northEast.lat},${northEast.lng}`
+  log &&
+    console.log(
+      `${southWest.lat},${southWest.lng},${northEast.lat},${northEast.lng}`,
     );
-    return `${southWest.lat},${southWest.lng},${northEast.lat},${northEast.lng}`;
+  return `${southWest.lat},${southWest.lng},${northEast.lat},${northEast.lng}`;
 };

--- a/starters/features/leaflet-map/src/helpers/boundary-box.tsx
+++ b/starters/features/leaflet-map/src/helpers/boundary-box.tsx
@@ -1,0 +1,10 @@
+import type { Map } from 'leaflet';
+export const getBoundaryBox = (map: Map, log: boolean = false) => {
+    const northEast = map.getBounds().getNorthEast();
+    const southWest = map.getBounds().getSouthWest();
+
+    log && console.log(
+        `${southWest.lat},${southWest.lng},${northEast.lat},${northEast.lng}`
+    );
+    return `${southWest.lat},${southWest.lng},${northEast.lat},${northEast.lng}`;
+};

--- a/starters/features/leaflet-map/src/models/location.ts
+++ b/starters/features/leaflet-map/src/models/location.ts
@@ -1,0 +1,9 @@
+export interface LocationsProps {
+    name: string;
+    // latitude , longitude
+    point: [number, number];
+    // Southwest lat, South West Lng, North East lat,  North East lng
+    boundaryBox: string;
+    zoom: number;
+    marker: boolean;
+}

--- a/starters/features/leaflet-map/src/models/map.ts
+++ b/starters/features/leaflet-map/src/models/map.ts
@@ -1,0 +1,7 @@
+import { LocationsProps } from "./location";
+import { type Signal } from "@builder.io/qwik";
+export interface MapProps {
+    // default options
+    location: Signal<LocationsProps>;
+    // add other options to customization map
+}

--- a/starters/features/leaflet-map/src/routes/basic-map/index.tsx
+++ b/starters/features/leaflet-map/src/routes/basic-map/index.tsx
@@ -1,0 +1,24 @@
+import { component$, useStyles$ } from "@builder.io/qwik";
+
+// Need import from node_modules to add correct styles by default to show map
+// change path depending our level component respect node_modules
+import leafletStyles from "./../node_modules/leaflet/dist/leaflet.css?inline";
+import { LeafletMap } from "../../components/leaflet-map";
+
+export default component$(() => {
+    useStyles$(leafletStyles);
+    const currentLocation = {
+        name: "Soraluze",
+        point: [43.17478, -2.41172],
+        // Southwest lat, South West Lng, North East lat,  North East lng
+        boundaryBox:
+            "43.14658914559456,-2.4765586853027344,43.202923523094725,-2.3467826843261723",
+        zoom: 13,
+        marker: true,
+    };
+
+    return (
+        currentLocation ? <LeafletMap location={currentLocation} /> : <div>Loading map...</div>
+        
+    );
+})

--- a/starters/features/leaflet-map/src/routes/basic-map/index.tsx
+++ b/starters/features/leaflet-map/src/routes/basic-map/index.tsx
@@ -1,23 +1,23 @@
-import { component$, useStyles$, useSignal } from '@builder.io/qwik';
+import { component$, useStyles$, useSignal } from "@builder.io/qwik";
 
 // Need import from node_modules to add correct styles by default to show map
 // change path depending our level component respect node_modules
 // If you use PNPM to install
 // import leafletStyles from './../../../node_modules/.pnpm/leaflet@1.9.4/node_modules/leaflet/dist/leaflet.css?inline';
 // If you use NPM or Yarn
-import leafletStyles from './../../../node_modules/leaflet/dist/leaflet.css?inline';
+import leafletStyles from "./../../../node_modules/leaflet/dist/leaflet.css?inline";
 
-import { LeafletMap } from '../../components/leaflet-map';
-import { LocationsProps } from './../../models/location';
+import { LeafletMap } from "~/components/leaflet-map";
+import { LocationsProps } from "~/models/location";
 
 export default component$(() => {
   useStyles$(leafletStyles);
   const currentLocation = useSignal<LocationsProps>({
-    name: 'Soraluze',
+    name: "Soraluze",
     point: [43.17478, -2.41172],
     // Southwest lat, South West Lng, North East lat,  North East lng
     boundaryBox:
-      '43.14658914559456,-2.4765586853027344,43.202923523094725,-2.3467826843261723',
+      "43.14658914559456,-2.4765586853027344,43.202923523094725,-2.3467826843261723",
     zoom: 9,
     marker: true,
   });

--- a/starters/features/leaflet-map/src/routes/basic-map/index.tsx
+++ b/starters/features/leaflet-map/src/routes/basic-map/index.tsx
@@ -1,24 +1,29 @@
-import { component$, useStyles$ } from "@builder.io/qwik";
+import { component$, useStyles$, useSignal } from '@builder.io/qwik';
 
 // Need import from node_modules to add correct styles by default to show map
 // change path depending our level component respect node_modules
-import leafletStyles from "./../node_modules/leaflet/dist/leaflet.css?inline";
-import { LeafletMap } from "../../components/leaflet-map";
+// If you use PNPM to install
+// import leafletStyles from './../../../node_modules/.pnpm/leaflet@1.9.4/node_modules/leaflet/dist/leaflet.css?inline';
+// If you use NPM or Yarn
+import leafletStyles from './../../../node_modules/leaflet/dist/leaflet.css?inline';
+
+import { LeafletMap } from '../../components/leaflet-map';
+import { LocationsProps } from './../../models/location';
 
 export default component$(() => {
-    useStyles$(leafletStyles);
-    const currentLocation = {
-        name: "Soraluze",
-        point: [43.17478, -2.41172],
-        // Southwest lat, South West Lng, North East lat,  North East lng
-        boundaryBox:
-            "43.14658914559456,-2.4765586853027344,43.202923523094725,-2.3467826843261723",
-        zoom: 13,
-        marker: true,
-    };
-
-    return (
-        currentLocation ? <LeafletMap location={currentLocation} /> : <div>Loading map...</div>
-        
-    );
-})
+  useStyles$(leafletStyles);
+  const currentLocation = useSignal<LocationsProps>({
+    name: 'Soraluze',
+    point: [43.17478, -2.41172],
+    // Southwest lat, South West Lng, North East lat,  North East lng
+    boundaryBox:
+      '43.14658914559456,-2.4765586853027344,43.202923523094725,-2.3467826843261723',
+    zoom: 9,
+    marker: true,
+  });
+  return currentLocation ? (
+    <LeafletMap location={currentLocation} />
+  ) : (
+    <div>Loading map...</div>
+  );
+});

--- a/starters/features/leaflet-map/src/routes/basic-map/index.tsx
+++ b/starters/features/leaflet-map/src/routes/basic-map/index.tsx
@@ -15,7 +15,11 @@ export default component$(() => {
   const currentLocation = useSignal<LocationsProps>({
     name: "Soraluze",
     point: [43.17478, -2.41172],
-    // Southwest lat, South West Lng, North East lat,  North East lng
+    /**
+     * Define rectangle with: Southwest lat, South West Lng, North East lat,  North East lng points.
+     * Very interesting when use to filter in OpenStreetMap API to take POIs
+     * Example: https://qwik-osm-poc.netlify.app/
+     */
     boundaryBox:
       "43.14658914559456,-2.4765586853027344,43.202923523094725,-2.3467826843261723",
     zoom: 9,


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

In this functionality I want to facilitate the process to start working with Maps in Qwik using the LeafletJS Map library, which will be used to carry out projects like the following example:

https://qwik-osm-poc.netlify.app/

A basic map has been added with some simple functions such as adding a marker with a popup in a specific location leaving it open to many improvements, such as dynamic resizing, dynamic id to put more than one map per page, adding plugins,... .

For this, I have added main information of the LeafletJS API regarding the official documentation and example tutorials to learn interesting things.

To execute this integration, we must have the project prepared and the latest changes compiled

Complete Compilation:
`pnpm build.full`

Create the symbolic link with the news:
`pnpm link.dist`

And creating a new Qwik project we install those dependencies of what we just added, to be able to run the script with `npm run qwik add` to show the entire list or directly execute the proposed integration with `npm run qwik add leaflet- map`.

When executed, we will have the following:

![image](https://github.com/BuilderIO/qwik/assets/105705996/c5ffb473-a31e-4413-8b6d-79dc49e5609d)

And once integrated, if we start the project and access the /basic-map route we can see a full screen map like the following one, which will be available to make changes such as zoom, location (it is currently located in my town, north of Spain),...

![image](https://github.com/BuilderIO/qwik/assets/105705996/7df04d53-2eb0-489d-a434-b6c718a7e3e1)

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
