### PR TITLE
docs: use import .css?inline instead of .css

### DIFF
--- a/packages/docs/src/repl/monaco.tsx
+++ b/packages/docs/src/repl/monaco.tsx
@@ -333,7 +333,8 @@ const MONACO_VS_URL = getCdnUrl('monaco-editor', MONACO_VERSION, '/min/vs');
 const MONACO_LOADER_URL = `${MONACO_VS_URL}/loader.js`;
 
 const CLIENT_LIB = `
-declare module '*.css' {
+declare module '*.css' {}
+declare module '*.css?inline' {
   const css: string
   export default css
 }

--- a/packages/docs/src/repl/worker/app-bundle-client.ts
+++ b/packages/docs/src/repl/worker/app-bundle-client.ts
@@ -128,7 +128,7 @@ export const getInputs = (options: ReplInputOptions) => {
   });
 };
 
-const MODULE_EXTS = ['.tsx', '.ts', '.js', '.jsx', '.mjs'];
+const MODULE_EXTS = ['.tsx', '.ts', '.js', '.jsx', '.mjs', '.css'];
 
 export const getOutput = (o: OutputChunk | OutputAsset) => {
   const f: ReplModuleOutput = {

--- a/packages/docs/src/repl/worker/repl-plugins.ts
+++ b/packages/docs/src/repl/worker/repl-plugins.ts
@@ -115,7 +115,8 @@ const getRuntimeBundle = (runtimeBundle: string) => {
 };
 
 export const replCss = (options: ReplInputOptions): Plugin => {
-  const isStylesheet = (id: string) => ['.css', '.scss', '.sass'].some((ext) => id.endsWith(ext));
+  const isStylesheet = (id: string) =>
+    ['.css', '.scss', '.sass'].some((ext) => id.endsWith(`${ext}?inline`));
 
   return {
     name: 'repl-css',
@@ -129,7 +130,7 @@ export const replCss = (options: ReplInputOptions): Plugin => {
 
     load(id) {
       if (isStylesheet(id)) {
-        const input = options.srcInputs.find((i) => i.path.endsWith(id));
+        const input = options.srcInputs.find((i) => i.path.endsWith(id.replace(/\?inline$/, '')));
         if (input && typeof input.code === 'string') {
           return `const css = ${JSON.stringify(input.code)}; export default css;`;
         }

--- a/packages/docs/src/routes/examples/apps/visibility/clock/app.tsx
+++ b/packages/docs/src/routes/examples/apps/visibility/clock/app.tsx
@@ -1,5 +1,5 @@
 import { component$, useStore, useStyles$, useVisibleTask$ } from '@builder.io/qwik';
-import styles from './clock.css';
+import styles from './clock.css?inline';
 
 export default component$(() => {
   const items = new Array(60).fill(null).map((_, index) => 'item ' + index);

--- a/packages/docs/src/routes/tutorial/hooks/use-visible-task/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-visible-task/solution/app.tsx
@@ -1,5 +1,5 @@
 import { component$, useStore, useStyles$, useVisibleTask$ } from '@builder.io/qwik';
-import styles from './clock.css';
+import styles from './clock.css?inline';
 
 interface ClockStore {
   hour: number;


### PR DESCRIPTION

# Overview

This PR replaces `.css` with `.css?inline`.

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Replaced `.css` with `.css?inline` and tweaked the REPL so that `.css?inline` is resolved.

# Use cases and why

The default export of css is deprecated since Vite 4 and will be removed in Vite 5.
This will make vite-ecosystem-ci pass after https://github.com/vitejs/vite/pull/14125 is merged (the PR that removes the deprecated css default export).

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
