### PR TITLE
fix(labs): exclude `(group layouts)` from route types

### DIFF
--- a/packages/qwik-labs/src/qwik-types/public-api.ts
+++ b/packages/qwik-labs/src/qwik-types/public-api.ts
@@ -15,6 +15,9 @@ export const untypedAppUrl = function appUrl(
       const value = params ? params[paramsPrefix + key] || params[key] : '';
       path[i] = isSpread ? value : encodeURIComponent(value);
     }
+    if (segment.startsWith("(") && segment.endsWith(")")) {
+      path.splice(i, 1);
+    }
   }
   return path.join('/');
 };


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

The change omits pathless routes aka. group layout segments from the `path -> route` mapping.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Actual: `some/(grouped)/route/index.tsx` -> `some/(grouped)/route` 
Expected: `some/(grouped)/route/index.tsx` -> `some/route` 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
