### PR TITLE
fix(qwik-city): Fix rewrite home route

### DIFF
--- a/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
+++ b/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
@@ -33,7 +33,9 @@ test('translated pathname / with prefix', ({ assertRoute, opts }) => {
   assert.equal(r.segments[0][0].content, 'it');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
   assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/index.tsx'));
 });
 
@@ -49,8 +51,12 @@ test('translated pathname /docs/getting-started with prefix', ({ assertRoute, op
   assert.equal(r.segments[2][0].content, 'per-iniziare');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md')
+  );
 });
 
 test('translated pathname /docs/[category]/[id] with prefix', ({ assertRoute, opts }) => {
@@ -67,8 +73,12 @@ test('translated pathname /docs/[category]/[id] with prefix', ({ assertRoute, op
   assert.equal(r.segments[3][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx')
+  );
 });
 
 test('translated pathname /about-us with prefix', ({ assertRoute, opts }) => {
@@ -82,8 +92,12 @@ test('translated pathname /about-us with prefix', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'informazioni');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx')
+  );
 });
 
 test('translated pathname /products/[id] with prefix', ({ assertRoute, opts }) => {
@@ -98,8 +112,12 @@ test('translated pathname /products/[id] with prefix', ({ assertRoute, opts }) =
   assert.equal(r.segments[2][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx')
+  );
 });
 
 test('translated pathname /docs/getting-started', ({ assertRoute, opts }) => {
@@ -113,8 +131,12 @@ test('translated pathname /docs/getting-started', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'per-iniziare');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md')
+  );
 });
 
 test('translated pathname /docs/[category]/[id]', ({ assertRoute, opts }) => {
@@ -130,8 +152,12 @@ test('translated pathname /docs/[category]/[id]', ({ assertRoute, opts }) => {
   assert.equal(r.segments[2][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx')
+  );
 });
 
 test('translated pathname /about-us', ({ assertRoute, opts }) => {
@@ -144,8 +170,12 @@ test('translated pathname /about-us', ({ assertRoute, opts }) => {
   assert.equal(r.segments[0][0].content, 'informazioni');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx')
+  );
 });
 
 test('translated pathname /products/[id]', ({ assertRoute, opts }) => {
@@ -159,8 +189,12 @@ test('translated pathname /products/[id]', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
-  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx'));
+  assert.ok(
+    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
+  );
+  assert.ok(
+    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx')
+  );
 });
 
 test.run();

--- a/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
+++ b/packages/qwik-city/buildtime/build-pages-rewrited.unit.ts
@@ -23,6 +23,20 @@ const test = testAppSuite('Build Pages Rewrited', {
   ],
 });
 
+test('translated pathname / with prefix', ({ assertRoute, opts }) => {
+  const r = assertRoute('/it/');
+  assert.equal(r.id, 'CommonRouteIT');
+  assert.equal(r.pathname, '/it/');
+  assert.equal(r.routeName, 'it/');
+  assert.equal(r.pattern, /^\/it\/$/);
+  assert.equal(r.paramNames.length, 0);
+  assert.equal(r.segments[0][0].content, 'it');
+  assert.equal(r.layouts.length, 2);
+  assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/index.tsx'));
+});
+
 test('translated pathname /docs/getting-started with prefix', ({ assertRoute, opts }) => {
   const r = assertRoute('/it/documentazione/per-iniziare/');
   assert.equal(r.id, 'DocsGettingstartedRouteIT');
@@ -35,12 +49,8 @@ test('translated pathname /docs/getting-started with prefix', ({ assertRoute, op
   assert.equal(r.segments[2][0].content, 'per-iniziare');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(
-    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
-  );
-  assert.ok(
-    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md')
-  );
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md'));
 });
 
 test('translated pathname /docs/[category]/[id] with prefix', ({ assertRoute, opts }) => {
@@ -57,12 +67,8 @@ test('translated pathname /docs/[category]/[id] with prefix', ({ assertRoute, op
   assert.equal(r.segments[3][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(
-    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
-  );
-  assert.ok(
-    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx')
-  );
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx'));
 });
 
 test('translated pathname /about-us with prefix', ({ assertRoute, opts }) => {
@@ -76,12 +82,8 @@ test('translated pathname /about-us with prefix', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'informazioni');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(
-    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
-  );
-  assert.ok(
-    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx')
-  );
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx'));
 });
 
 test('translated pathname /products/[id] with prefix', ({ assertRoute, opts }) => {
@@ -96,12 +98,8 @@ test('translated pathname /products/[id] with prefix', ({ assertRoute, opts }) =
   assert.equal(r.segments[2][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(
-    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
-  );
-  assert.ok(
-    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx')
-  );
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx'));
 });
 
 test('translated pathname /docs/getting-started', ({ assertRoute, opts }) => {
@@ -115,12 +113,8 @@ test('translated pathname /docs/getting-started', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'per-iniziare');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(
-    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
-  );
-  assert.ok(
-    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md')
-  );
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/getting-started/index.md'));
 });
 
 test('translated pathname /docs/[category]/[id]', ({ assertRoute, opts }) => {
@@ -136,12 +130,8 @@ test('translated pathname /docs/[category]/[id]', ({ assertRoute, opts }) => {
   assert.equal(r.segments[2][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(
-    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx')
-  );
-  assert.ok(
-    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx')
-  );
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/docs/[category]/[id]/index.tsx'));
 });
 
 test('translated pathname /about-us', ({ assertRoute, opts }) => {
@@ -154,12 +144,8 @@ test('translated pathname /about-us', ({ assertRoute, opts }) => {
   assert.equal(r.segments[0][0].content, 'informazioni');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(
-    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
-  );
-  assert.ok(
-    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx')
-  );
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/about-us/index.tsx'));
 });
 
 test('translated pathname /products/[id]', ({ assertRoute, opts }) => {
@@ -173,12 +159,8 @@ test('translated pathname /products/[id]', ({ assertRoute, opts }) => {
   assert.equal(r.segments[1][0].content, 'id');
   assert.equal(r.layouts.length, 2);
   assert.ok(r.layouts[0].filePath.endsWith('starters/apps/qwikcity-test/src/routes/layout.tsx'));
-  assert.ok(
-    r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx')
-  );
-  assert.ok(
-    r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx')
-  );
+  assert.ok(r.layouts[1].filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/layout.tsx'));
+  assert.ok(r.filePath.endsWith('starters/apps/qwikcity-test/src/routes/(common)/products/[id]/index.tsx'));
 });
 
 test.run();

--- a/packages/qwik-city/buildtime/build.ts
+++ b/packages/qwik-city/buildtime/build.ts
@@ -51,9 +51,10 @@ function rewriteRoutes(ctx: BuildContext, resolved: ReturnType<typeof resolveSou
   if (ctx.opts.rewriteRoutes) {
     ctx.opts.rewriteRoutes.forEach((rewriteOpt, rewriteIndex) => {
       const rewriteFrom = Object.keys(rewriteOpt.paths || {});
-      const rewriteRoutes = (resolved.routes || []).filter((route) =>
-        rewriteFrom.some((from) => route.pathname.split('/').includes(from)) ||
-          (rewriteOpt.prefix && (route.pathname === '/'))
+      const rewriteRoutes = (resolved.routes || []).filter(
+        (route) =>
+          rewriteFrom.some((from) => route.pathname.split('/').includes(from)) ||
+          (rewriteOpt.prefix && route.pathname === '/')
       );
 
       const replacePath = (part: string) => (rewriteOpt.paths || {})[part] ?? part;
@@ -81,7 +82,7 @@ function rewriteRoutes(ctx: BuildContext, resolved: ReturnType<typeof resolveSou
         const translatedPatternString = translatedPatternParts.join('\\/');
         const translatedRegExp = translatedPatternString.substring(
           1,
-          (rewriteRoute.pathname === '/')
+          rewriteRoute.pathname === '/'
             ? translatedPatternString.length - 1
             : translatedPatternString.length - 2
         );
@@ -100,8 +101,8 @@ function rewriteRoutes(ctx: BuildContext, resolved: ReturnType<typeof resolveSou
           ]);
         }
 
-        const translatedPath = translatedPathParts.join('/')
-        const translatedRoute = translatedRouteParts.join('/')
+        const translatedPath = translatedPathParts.join('/');
+        const translatedRoute = translatedRouteParts.join('/');
 
         resolved.routes.push({
           ...rewriteRoute,


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests / types / typos

# Description

The home route is not translated if rewriteRoutes config is provided. 
If there is a prefix in a rewriteRoute item the home page as well needs to be translated.

# Use cases and why

- Actual: I need to translate the homepage to `/it-IT/` but the corresponding route is not created.
- Expected: If i add a rewriteRoute with the prefix `it-IT` i want the `/it-IT/` route to be created.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality
