### PR TITLE
fix(qwik-city): do not write into a destroyed stream

### DIFF
--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -96,8 +96,8 @@ export async function fromNodeHttp(
       }
       return new WritableStream<Uint8Array>({
         write(chunk) {
-          if (res.closed) {
-            // If the response has already been closed (for example the client has disconnected)
+          if (res.closed || res.destroyed) {
+            // If the response has already been closed or destroyed (for example the client has disconnected)
             // then writing into it will cause an error. So just stop writing since no one
             // is listening.
             return;


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Check if the response is already destroyed similar to checking if the response is closed.

PR https://github.com/BuilderIO/qwik/pull/5074 fixed some of the `Error [ERR_STREAM_DESTROYED]: Cannot call write after a stream was destroyed` errors but sometimes `closed` is undefined and `destroyed` is true.

If checking for `destroyed`, I don't know if that makes checking for `closed` redundant so I kept the `closed` check.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
