### PR TITLE
fix(qwik-auth): don't overwrite response headers in qwik auth

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -141,7 +141,7 @@ async function authAction(
     skipCSRFCheck,
   });
   res.headers.forEach((value, key) => {
-    if (!req.headers.has(key)){
+    if (!req.headers.has(key)) {
       req.headers.set(key, value);
     }
   });

--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -141,7 +141,9 @@ async function authAction(
     skipCSRFCheck,
   });
   res.headers.forEach((value, key) => {
-    req.headers.set(key, value);
+    if (!req.headers.has(key)){
+      req.headers.set(key, value);
+    }
   });
   fixCookies(req);
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

In Authjs, we cannot return a custom error currently, the only way is to redirect to a certain URL with the error being injected in the search params. So when we try setting `location` header, it can be missed since when Authjs gives the error it overwrites that `location` header with the CallbackRouteError URL which is not useful for a product or a website.

In this PR, we try checking if we're overwriting what's in the response or no. So we skip it if the header is already there which gives control over the redirecting ability of qwik instead of it being handled by Authjs.
# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Making Redirecting by the `location` property possible in Qwik in the `authorize` function of the Credentials provider of Authjs

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
