### PR TITLE
fix(qwik-auth): allow multiple set-cookie headers

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -141,7 +141,7 @@ async function authAction(
     skipCSRFCheck,
   });
   res.headers.forEach((value, key) => {
-    if (!req.headers.has(key)) {
+    if (!req.headers.has(key) || key === 'set-cookie') {
       req.headers.set(key, value);
     }
   });

--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -141,6 +141,10 @@ async function authAction(
     skipCSRFCheck,
   });
   res.headers.forEach((value, key) => {
+    /**
+     * Do not set the header if already set accept in the case of set-cookie which is allowed
+     * https://httpwg.org/specs/rfc6265.html#rfc.section.3
+     */
     if (!req.headers.has(key) || key === 'set-cookie') {
       req.headers.set(key, value);
     }


### PR DESCRIPTION
# Overview

In PKCE OAuth authentication @auth/core sets two cookies (callback url and pkce code_verifier), but the second one was failing because of the condition added in #5180, which checked to see if the header already existed. This may be fine for most headers, but not for 'set-cookie' headers, in which multiple are allowed.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
