### PR TITLE
docs: add `dimension.dev` to showcase

### DIFF
--- a/packages/docs/scripts/pages.json
+++ b/packages/docs/scripts/pages.json
@@ -1,5 +1,9 @@
 [
   {
+    "href": "https://www.dimension.dev",
+    "tags": "saas"
+  },
+  {
     "href": "https://wope.com/",
     "tags": "saas"
   },


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

I don't know you're still adding showcase items but, one of my works has been published and it is built with Qwik. If it is possible, I would like to see it in showcase too :)

![image](https://github.com/BuilderIO/qwik/assets/40025152/1c7bb08d-577e-48b8-a5ef-efd8fb5cfda5)
![image](https://github.com/BuilderIO/qwik/assets/40025152/b6273dc8-0b7e-46f2-a32c-3c490c9d30ee)

https://dimension.dev/

Thank you for all your hard work in Qwik, it is godly! 