### PR TITLE
fix(serializers): fix for serialization of an empty set or map

### DIFF
--- a/packages/qwik/src/core/container/serializers.ts
+++ b/packages/qwik/src/core/container/serializers.ts
@@ -446,7 +446,8 @@ const SetSerializer: Serializer<Set<any>> = {
     const data = (set as any)[DATA];
     (set as any)[DATA] = undefined;
     assertString(data, 'SetSerializer should be defined');
-    for (const id of data.split(' ')) {
+    const items = data.length === 0 ? [] : data.split(' ');
+    for (const id of items) {
       set.add(getObject(id));
     }
   },
@@ -477,7 +478,7 @@ const MapSerializer: Serializer<Map<any, any>> = {
     const data = (set as any)[DATA];
     (set as any)[DATA] = undefined;
     assertString(data, 'SetSerializer should be defined');
-    const items = data.split(' ');
+    const items = data.length === 0 ? [] : data.split(' ');
     assertTrue(items.length % 2 === 0, 'MapSerializer should have even number of items');
     for (let i = 0; i < items.length; i += 2) {
       set.set(getObject(items[i]), getObject(items[i + 1]));


### PR DESCRIPTION
fix #5207, fix #4786

# Overview

Fixes serialization of an empty set or map

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Use cases and why

```ts
  const setData = useComputed$(
    () =>  new Set<string>()
  );
```
```ts
  const mapData = useComputed$(
    () =>  new Map<string, string>()
  );
```
# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
