### PR TITLE
refactor: remove extraneous isElement call

### DIFF
--- a/packages/qwik/src/core/state/context.ts
+++ b/packages/qwik/src/core/state/context.ts
@@ -11,7 +11,7 @@ import { getDomListeners, type Listener } from './listeners';
 import { seal } from '../util/qdev';
 import { directGetAttribute } from '../render/fast-calls';
 import { isElement } from '../../testing/html';
-import { assertQwikElement, assertTrue } from '../error/assert';
+import { assertQwikElement } from '../error/assert';
 import { QScopedStyle } from '../util/markers';
 import { createPropsState, createProxy, setObjectFlags } from './store';
 import { _IMMUTABLE, _IMMUTABLE_PREFIX, QObjectImmutable } from './constants';
@@ -68,7 +68,6 @@ export const getContext = (el: QwikElement, containerState: ContainerState): QCo
       if (isElement(el)) {
         const refMap = refs[elementID];
         if (refMap) {
-          assertTrue(isElement(el), 'el must be an actual DOM element');
           elCtx.$refMap$ = refMap.split(' ').map(getObject);
           elCtx.li = getDomListeners(elCtx, containerState.$containerEl$);
         }


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

isElement is always true

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
