### PR TITLE
docs: fix edit this page for deprecated features

### DIFF
--- a/packages/docs/src/components/on-this-page/on-this-page.tsx
+++ b/packages/docs/src/components/on-this-page/on-this-page.tsx
@@ -8,7 +8,14 @@ import { EditIcon } from '../svgs/edit-icon';
 import { GlobalStore } from '../../context';
 import { AlertIcon } from '../svgs/alert-icon';
 
-const QWIK_GROUP = ['components', 'concepts', 'faq', 'getting-started', 'think-qwik'];
+const QWIK_GROUP = [
+  'components',
+  'concepts',
+  'faq',
+  'getting-started',
+  'think-qwik',
+  'deprecated-features',
+];
 
 const QWIK_ADVANCED_GROUP = [
   'containers',
@@ -35,7 +42,6 @@ const QWIKCITY_GROUP = [
   'pages',
   'project-structure',
   'qwikcity',
-  'qwikcity-deprecated-features',
   'route-loader',
   'routing',
   'server$',


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

When try to use "edit this page" on deprecated feature page, the link was broken

Before
![image](https://github.com/BuilderIO/qwik/assets/7875216/1b380ef1-3fbc-400e-92aa-40248bf98c43)

After
![image](https://github.com/BuilderIO/qwik/assets/7875216/def3b1a8-3488-4a01-8f98-fcb545ad78d5)


# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
