### PR TITLE
chore: update firebase starter to contemplate dist folder

### DIFF
--- a/starters/adapters/firebase/firebase.json
+++ b/starters/adapters/firebase/firebase.json
@@ -12,6 +12,7 @@
     }
   ],
   "hosting": {
+    "public": "dist",
     "rewrites": [
       {
         "source": "**",


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Related to https://github.com/BuilderIO/qwik/issues/5205

A configuration was added to firebase to include the dist folder, since at the moment of publishing it gave error in the service worker, see issue for more information.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
