### PR TITLE
fix: should SSR render if accept header includes */*

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -310,7 +310,7 @@ const shouldSsrRender = (req: IncomingMessage, url: URL) => {
     return false;
   }
   const acceptHeader = req.headers.accept || '';
-  if (!acceptHeader.includes('text/html')) {
+  if (!acceptHeader.includes('text/html') && !acceptHeader.includes('*/*')) {
     return false;
   }
   return true;


### PR DESCRIPTION
# Overview

If I start a Qwik app and use `curl` to make a GET request to the home page, Qwik returns a 404.

```
❯ curl -vv http://localhost:5173
*   Trying 127.0.0.1:5173...
* connect to 127.0.0.1 port 5173 failed: Connection refused
*   Trying [::1]:5173...
* Connected to localhost (::1) port 5173 (#0)
> GET / HTTP/1.1
> Host: localhost:5173
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Access-Control-Allow-Origin: *
< cache-control: max-age=5, stale-while-revalidate=604800
< Content-Security-Policy: default-src 'none'
< X-Content-Type-Options: nosniff
< Content-Type: text/html; charset=utf-8
< Content-Length: 139
< Date: Thu, 28 Sep 2023 13:53:22 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< 
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /</pre>
</body>
</html>
```

The reason is that curl uses `Accept: */*` by default, which is not caught by the middleware because `shouldSsrRender()` returns false in that case.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

See `Overview`

# Use cases and why

When running `curl -vv http://localhost:5173` to get the home page of your Qwik app, I expect that it returns the html instead of a 404. Currently that only works if you run `curl -vv -H "Accept: text/html" http://localhost:5173`.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality