### PR TITLE
fix: Pr local dev docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,3 +10,6 @@ RUN rustup update; \
     cargo install wasm-pack; \
     rustup component add clippy; \
     corepack enable --install-directory ~/bin
+
+RUN mkdir /home/circleci/store; \
+    pnpm config set store-dir /home/circleci/store

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,12 @@
-FROM cimg/rust:1.65.0-node
+FROM cimg/rust:1.72.1-node
 
-RUN rustup toolchain install nightly-2022-09-23; \
-    rustup default nightly-2022-09-23; \
-    rustup --version; \
+RUN rustup --version; \
     cargo --version; \
-    rustc --version; \
-    rustup update; \
+    rustc --version; 
+
+RUN rustup update; \
     rustup target add wasm32-unknown-unknown; \
-    cargo install cargo-insta wasm-pack; \
+    cargo install cargo-insta; \
+    cargo install wasm-pack; \
     rustup component add clippy; \
     corepack enable --install-directory ~/bin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ You need to have these tools up and running in your local machine:
 
 If you would like to make use of the devlopment container solution, but don't use VSCode or Dev Containers, you still can do so, by following steps:
 
-- Build development container locally: `cd .devcontainers; docker build -t qwik-container .`
+- Build development container locally: `cd .devcontainer; docker build -t qwik-container .`
 - Run development container from Qwik project root, binding the directory to container: `cd ..; docker run --rm -d --name qwik-container -p 3300:3300 -p 9229:9299 -v $PWD:/home/circleci/project -t qwik-container`
 
 Docker command does:


### PR DESCRIPTION
fixes #5218

# Overview

The dev container Dockerfile was failing, this PR fixes that

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

The nightly version of Rust in the Dockerfile was causing some of the cargo install to fail, also the Dockerfile was set such that pnpm store and node_modules was getting created in the same directory, hence pnpm install was failing in the Dockerfile. 

The fix was to update the Rust version to LTS and setting the directory for pnpm store in Dockerfile.

# Use cases and why

Now the dev container vscode plugin as well as manual docker dev env setup will run successfully.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
