### PR TITLE
chore(contributing.md): remove unnecessary step to test against docs …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,28 +210,17 @@ To use your build in your project, follow these steps:
     yarn link @builder.io/qwik @builder.io/qwik-city
    ```
 
-If you can't use package linking (npm link) just copy the contents of `package/qwik/dist` into your projects' `node_modules/@builder.io/qwik` folder.
+If you can't use package linking (npm link) just copy the contents of `packages/qwik/dist` into your projects' `node_modules/@builder.io/qwik` folder.
 
 ### Test against the docs site:
 
-1. Go to `packages/docs/package.json` and update:
-
-   ```diff
-
-   -- "@builder.io/qwik": "0.17.4",
-   -- "@builder.io/qwik-city": "0.1.0-beta13",
-
-   ++ "@builder.io/qwik": "workspace:*",
-   ++ "@builder.io/qwik-city": "workspace:*",
-   ```
-
-2. At the root of the Qwik repo folder run:
+1. At the root of the Qwik repo folder run:
 
 ```shell
 pnpm install
 ```
 
-3. Run the docs site:
+2. Run the docs site:
 
 ```shell
 cd packages/docs && pnpm start


### PR DESCRIPTION
…site

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

removed 

```
1. Go to `packages/docs/package.json` and update:

   ```diff

   -- "@builder.io/qwik": "0.17.4",
   -- "@builder.io/qwik-city": "0.1.0-beta13",

   ++ "@builder.io/qwik": "workspace:*",
   ++ "@builder.io/qwik-city": "workspace:*",
```

as packages/docs/package.json uses

```
    "@builder.io/qwik": "github:BuilderIo/qwik-build#main",
    "@builder.io/qwik-city": "github:BuilderIo/qwik-city-build#main",
```

and I could test against the docs site without that first step.

Also fixed a small typo...

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
