### PR TITLE
docs(state): Add 'key' prop to list items

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
@@ -26,6 +26,7 @@ contributors:
   - AnthonyPAlicea
   - sreeisalso
   - wmertens
+  - nicvazquez
 ---
 
 import CodeSandbox from '../../../../../components/code-sandbox/index.tsx';
@@ -123,8 +124,8 @@ export default component$(() => {
         Add to list
       </button>
       <ul>
-        {store.list.map((item) => (
-          <li>{item}</li>
+        {store.list.map((item, index) => (
+          <li key={`items-${index}`}>{item}</li>
         ))}
       </ul>
     </>


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

This PR includes a modification to improve the rendering of a list in the code. It adds a 'key' prop to each list item to enhance Qwik's performance and prevent potential issues with list item reordering. The 'key' is generated based on the item's index.

**Motivation:**

- The change enhances Qwik performance when rendering the list.
- It ensures that each list item has a unique identifier, which is important for Qwik's reconciliation process when items are added, removed, or reordered.

**Dependencies:**

None.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Improved rendering performance of lists.
- 2. Ensured that list items have unique identifiers for efficient Qwik updates.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
