### PR TITLE
docs(integrations): add valibot to modular forms guide

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -16,7 +16,7 @@
     "@docsearch/css": "3.3.4",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@modular-forms/qwik": "^0.12.0",
+    "@modular-forms/qwik": "^0.21.0",
     "@mui/material": "^5.13.0",
     "@mui/x-data-grid": "^6.4.0",
     "@supabase/supabase-js": "^2.33.1",
@@ -46,6 +46,7 @@
     "typescript": "5.1.6",
     "undici": "5.22.1",
     "uvu": "0.5.6",
+    "valibot": "^0.17.1",
     "vite": "4.4.7",
     "vite-plugin-inspect": "^0.7.33",
     "wrangler": "^3.3.0"

--- a/packages/docs/src/routes/demo/integration/modular-forms/index.tsx
+++ b/packages/docs/src/routes/demo/integration/modular-forms/index.tsx
@@ -1,22 +1,23 @@
 // @ts-nocheck
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { $, component$ } from '@builder.io/qwik';
-import { routeLoader$, z } from '@builder.io/qwik-city';
+import { routeLoader$ } from '@builder.io/qwik-city';
 import type { InitialValues, SubmitHandler } from '@modular-forms/qwik';
-import { formAction$, useForm, zodForm$ } from '@modular-forms/qwik';
+import { formAction$, useForm, valiForm$ } from '@modular-forms/qwik';
+import { email, type Input, minLength, object, string } from 'valibot';
 
-const loginSchema = z.object({
-  email: z
-    .string()
-    .min(1, 'Please enter your email.')
-    .email('The email address is badly formatted.'),
-  password: z
-    .string()
-    .min(1, 'Please enter your password.')
-    .min(8, 'You password must have 8 characters or more.'),
+const LoginSchema = object({
+  email: string([
+    minLength(1, 'Please enter your email.'),
+    email('The email address is badly formatted.'),
+  ]),
+  password: string([
+    minLength(1, 'Please enter your password.'),
+    minLength(8, 'Your password must have 8 characters or more.'),
+  ]),
 });
 
-type LoginForm = z.infer<typeof loginSchema>;
+type LoginForm = Input<typeof LoginSchema>;
 
 export const useFormLoader = routeLoader$<InitialValues<LoginForm>>(() => ({
   email: '',
@@ -25,13 +26,13 @@ export const useFormLoader = routeLoader$<InitialValues<LoginForm>>(() => ({
 
 export const useFormAction = formAction$<LoginForm>((values) => {
   // Runs on server
-}, zodForm$(loginSchema));
+}, valiForm$(LoginSchema));
 
 export default component$(() => {
   const [loginForm, { Form, Field }] = useForm<LoginForm>({
     loader: useFormLoader(),
     action: useFormAction(),
-    validate: zodForm$(loginSchema),
+    validate: valiForm$(LoginSchema),
   });
 
   const handleSubmit: SubmitHandler<LoginForm> = $((values, event) => {

--- a/packages/docs/src/routes/docs/(qwik)/components/events/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/events/index.mdx
@@ -144,14 +144,14 @@ import { component$ } from '@builder.io/qwik';
 export default component$(() => {
   return (
     <a
-      href="/about"
+      href="/docs"
       preventdefault:click // This will prevent the default behavior of the "click" event.
       onClick$={() => {
         // event.PreventDefault() will not work here, because handler is dispatched asynchronously.
         alert('Do something else to simulate navigation...');
       }}
     >
-      Go to about page
+      Go to docs page
     </a>
   );
 });

--- a/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
@@ -221,7 +221,12 @@ In a microfrontends setup, where multiple fragments run concurrently, `useId()` 
 
 <CodeSandbox src="/src/routes/demo/component/useId/index.tsx" style={{ height: '10em' }}>
 ```tsx /const outputRef = useSignal<Element>();/ /ref={outputRef}/
-import { component$, useId, useSignal, useVisibleTask$ } from '@builder.io/qwik';
+import {
+  component$,
+  useId,
+  useSignal,
+  useVisibleTask$,
+} from '@builder.io/qwik';
 
 export default component$(() => {
   const elemIdSignal = useSignal<string | null>(null);

--- a/packages/docs/src/routes/docs/cookbook/mediaController/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/mediaController/index.mdx
@@ -49,7 +49,7 @@ import { useLocation } from '@builder.io/qwik-city';
 const AUDIO_SRC =
   'https://cdn.builder.io/o/assets%2F5b8073f890b043be81574f96cfd1250b%2Fafe011812da146a5b2263196cb25f263?alt=media&token=c017cd87-0598-4af2-8afd-e9b5a3fba078&apiKey=5b8073f890b043be81574f96cfd1250b';
 const VIDEO_SRC =
-  'https://cdn.builder.io/o/assets%2F5b8073f890b043be81574f96cfd1250b%2F06f32f252e7d46a48954e5939b7292e1%2Fcompressed?apiKey=5b8073f890b043be81574f96cfd1250b&token=06f32f252e7d46a48954e5939b7292e1&alt=media&optimized=true';
+  'https://cdn.builder.io/o/assets%2F5b8073f890b043be81574f96cfd1250b%2F8b210c56974440649a0a78d4a3a0ddc5%2Fcompressed?apiKey=5b8073f890b043be81574f96cfd1250b&token=8b210c56974440649a0a78d4a3a0ddc5&alt=media&optimized=true';
 
 export default component$(() => {
   const audioElementSignal = useSignal<HTMLAudioElement | undefined>();

--- a/packages/docs/src/routes/docs/cookbook/portal/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/portal/index.mdx
@@ -65,7 +65,7 @@ import {
   useStylesScoped$,
   useTask$,
 } from '@builder.io/qwik';
-import { PortalCloseAPI, PortalAPI } from './portal-provider';
+import { PortalCloseAPIContextId, PortalAPI } from './portal-provider';
 import PopupExampleCSS from './popup-example.css?inline';
 import { useLocation } from '@builder.io/qwik-city';
 
@@ -96,7 +96,7 @@ export default component$(() => {
 export const PopupExample = component$<{ name: string }>(({ name }) => {
   useStylesScoped$(PopupExampleCSS);
   // To close a portal retrieve the close API.
-  const portalClose = useContext(PortalCloseAPI);
+  const portalClose = useContext(PortalCloseAPIContextId);
   return (
     <div class="popup-example">
       <h1>MODAL</h1>
@@ -188,11 +188,11 @@ export const PortalAPI = createContextId<
 export type ContextPair<T> = { id: ContextId<T>; value: T };
 
 // Define public API for closing Portals
-export const PortalCloseAPI =
+export const PortalCloseAPIContextId =
   createContextId<QRL<() => void>>('PortalCloseAPI');
 
 // internal context for managing portals
-const Portals = createContextId<Signal<Portal[]>>('Portals');
+const PortalsContextId = createContextId<Signal<Portal[]>>('Portals');
 
 interface Portal {
   name: string;
@@ -203,7 +203,7 @@ interface Portal {
 
 export const PortalProvider = component$(() => {
   const portals = useSignal<Portal[]>([]);
-  useContextProvider(Portals, portals);
+  useContextProvider(PortalsContextId, portals);
 
   // Provide the public API for the PopupManager for other components.
   useContextProvider(
@@ -218,7 +218,10 @@ export const PortalProvider = component$(() => {
       portal.close = $(() => {
         portals.value = portals.value.filter((p) => p !== portal);
       });
-      portal.contexts.push({ id: PortalCloseAPI, value: portal.close });
+      portal.contexts.push({
+        id: PortalCloseAPIContextId,
+        value: portal.close,
+      });
       portals.value = [...portals.value, portal];
       return portal.close;
     })
@@ -233,13 +236,13 @@ export const PortalProvider = component$(() => {
  * to return back to the <Portal/> after it has been streamed to the client.)
  */
 export const Portal = component$<{ name: string }>(({ name }) => {
-  const portals = useContext(Portals);
+  const portals = useContext(PortalsContextId);
   useStylesScoped$(CSS);
   const myPortals = portals.value.filter((portal) => portal.name === name);
   return (
     <>
       {myPortals.map((portal) => (
-        <div class="modal">
+        <div data-portal={name}>
           <WrapJsxInContext jsx={portal.jsx} contexts={portal.contexts} />
         </div>
       ))}

--- a/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
@@ -28,22 +28,26 @@ type LoginForm = {
 };
 ```
 
-Since Modular Forms supports Zod for input validation, you can optionally derive the type definition from a schema.
+Since Modular Forms supports [Valibot](https://valibot.dev/) and [Zod](https://zod.dev/) for input validation, you can optionally derive the type definition from a schema.
 
 ```ts
-const loginSchema = z.object({
-  email: z
-    .string()
-    .min(1, 'Please enter your email.')
-    .email('The email address is badly formatted.'),
-  password: z
-    .string()
-    .min(1, 'Please enter your password.')
-    .min(8, 'You password must have 8 characters or more.'),
+import { email, type Input, minLength, object, string } from 'valibot';
+
+const LoginSchema = object({
+  email: string([
+    minLength(1, 'Please enter your email.'),
+    email('The email address is badly formatted.'),
+  ]),
+  password: string([
+    minLength(1, 'Please enter your password.'),
+    minLength(8, 'Your password must have 8 characters or more.'),
+  ]),
 });
 
-type LoginForm = z.infer<typeof loginSchema>;
+type LoginForm = Input<typeof LoginSchema>;
 ```
+
+If you're wondering why this guide favors Valibot over Zod, I recommend reading this [announcement post](https://www.builder.io/blog/introducing-valibot).
 
 ## Set initial values
 
@@ -108,12 +112,14 @@ This API design results in a fully type-safe form. Furthermore, it gives you ful
 
 ## Input validation
 
-One of the core functionalities of Modular Forms is input validation. You can use a Zod schema for this or our internal validation functions. To keep this guide simple, we use the Zod schema we created earlier and pass it to the `useForm` hook.
+One of the core functionalities of Modular Forms is input validation. You can use a Valibot or Zod schema for this or our internal validation functions. To keep this guide simple, we use the Valibot schema we created earlier and pass it to the `useForm` hook.
+
+> `valiForm$` is an adapter that converts Valibot's error messages to the format expected by Modular Forms. For Zod use `zodForm$` instead.
 
 ```ts
 const [loginForm, { Form, Field, FieldArray }] = useForm<LoginForm>({
   loader: useFormLoader(),
-  validate: zodForm$(loginSchema),
+  validate: valiForm$(LoginSchema),
 });
 ```
 
@@ -137,13 +143,13 @@ In the last step you only have to access the values via a function when submitti
 ```tsx
 export const useFormAction = formAction$<LoginForm>((values) => {
   // Runs on server
-}, zodForm$(loginSchema));
+}, valiForm$(LoginSchema));
 
 export default component$(() => {
   const [loginForm, { Form, Field }] = useForm<LoginForm>({
     loader: useFormLoader(),
     action: useFormAction(),
-    validate: zodForm$(loginSchema),
+    validate: valiForm$(LoginSchema),
   });
 
   const handleSubmit = $<SubmitHandler<LoginForm>>((values, event) => {
@@ -167,22 +173,23 @@ If we now put all the building blocks together, we get a working login form. Bel
 // @ts-nocheck
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { $, component$ } from '@builder.io/qwik';
-import { routeLoader$, z } from '@builder.io/qwik-city';
+import { routeLoader$ } from '@builder.io/qwik-city';
 import type { InitialValues, SubmitHandler } from '@modular-forms/qwik';
-import { formAction$, useForm, zodForm$ } from '@modular-forms/qwik';
+import { formAction$, useForm, valiForm$ } from '@modular-forms/qwik';
+import { email, type Input, minLength, object, string } from 'valibot';
 
-const loginSchema = z.object({
-  email: z
-    .string()
-    .min(1, 'Please enter your email.')
-    .email('The email address is badly formatted.'),
-  password: z
-    .string()
-    .min(1, 'Please enter your password.')
-    .min(8, 'You password must have 8 characters or more.'),
+const LoginSchema = object({
+  email: string([
+    minLength(1, 'Please enter your email.'),
+    email('The email address is badly formatted.'),
+  ]),
+  password: string([
+    minLength(1, 'Please enter your password.'),
+    minLength(8, 'Your password must have 8 characters or more.'),
+  ]),
 });
 
-type LoginForm = z.infer<typeof loginSchema>;
+type LoginForm = Input<typeof LoginSchema>;
 
 export const useFormLoader = routeLoader$<InitialValues<LoginForm>>(() => ({
   email: '',
@@ -191,16 +198,16 @@ export const useFormLoader = routeLoader$<InitialValues<LoginForm>>(() => ({
 
 export const useFormAction = formAction$<LoginForm>((values) => {
   // Runs on server
-}, zodForm$(loginSchema));
+}, valiForm$(LoginSchema));
 
 export default component$(() => {
   const [loginForm, { Form, Field }] = useForm<LoginForm>({
     loader: useFormLoader(),
     action: useFormAction(),
-    validate: zodForm$(loginSchema),
+    validate: valiForm$(LoginSchema),
   });
 
-  const handleSubmit = $<SubmitHandler<LoginForm>>((values, event) => {
+  const handleSubmit: SubmitHandler<LoginForm> = $((values, event) => {
     // Runs on client
     console.log(values);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,8 +244,8 @@ importers:
         specifier: ^11.11.0
         version: 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.17)(react@18.2.0)
       '@modular-forms/qwik':
-        specifier: ^0.12.0
-        version: 0.12.0(@builder.io/qwik-city@1.2.11-dev20230915194738)(@builder.io/qwik@1.2.11)
+        specifier: ^0.21.0
+        version: 0.21.0(@builder.io/qwik-city@1.2.11-dev20230915194738)(@builder.io/qwik@1.2.11)
       '@mui/material':
         specifier: ^5.13.0
         version: 5.13.0(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)
@@ -333,6 +333,9 @@ importers:
       uvu:
         specifier: 0.5.6
         version: 0.5.6
+      valibot:
+        specifier: ^0.17.1
+        version: 0.17.1
       vite:
         specifier: 4.4.7
         version: 4.4.7(@types/node@20.4.5)(terser@5.19.2)
@@ -2747,6 +2750,17 @@ packages:
     dependencies:
       '@builder.io/qwik': github.com/BuilderIo/qwik-build/48c1524f9b8dc7a356b1694e5468d389aee7daca(undici@5.22.1)
       '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/80b973155c27bf23f16aaf6430aa6bc3170ce414(rollup@3.26.3)
+    dev: false
+
+  /@modular-forms/qwik@0.21.0(@builder.io/qwik-city@1.2.11-dev20230915194738)(@builder.io/qwik@1.2.11):
+    resolution: {integrity: sha512-PJnGnXfAI9JStXZbgAByGOsTTuSkVhjb8FRDgrdHa33zoHOvC5PkA2ymxN7JK1LodKd4FC3c7ZlFv5goYFCKDA==}
+    peerDependencies:
+      '@builder.io/qwik': ^1.2.4
+      '@builder.io/qwik-city': ^1.2.4
+    dependencies:
+      '@builder.io/qwik': github.com/BuilderIo/qwik-build/48c1524f9b8dc7a356b1694e5468d389aee7daca(undici@5.22.1)
+      '@builder.io/qwik-city': github.com/BuilderIo/qwik-city-build/80b973155c27bf23f16aaf6430aa6bc3170ce414(rollup@3.26.3)
+    dev: true
 
   /@mui/base@5.0.0-beta.0(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ap+juKvt8R8n3cBqd/pGtZydQ4v2I/hgJKnvJRGjpSh3RvsvnDHO4rXov8MHQlH6VqpOekwgilFLGxMZjNTucA==}
@@ -11975,6 +11989,7 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    requiresBuild: true
     dev: true
 
   /json-stable-stringify-without-jsonify@1.0.1:
@@ -16037,6 +16052,7 @@ packages:
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dev: true
 
   /require-in-the-middle@6.0.0(supports-color@9.4.0):
@@ -18227,6 +18243,10 @@ packages:
   /vali-date@1.0.0:
     resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /valibot@0.17.1:
+    resolution: {integrity: sha512-yfft6fqeB059vNZEdar4tcfU3ZOn4raEec790PTQe1SVfJz5CkZOlMNabkW5MA9Z10SCjUWmxBRz1SMYTGU5yg==}
     dev: true
 
   /validate-npm-package-license@3.0.4:


### PR DESCRIPTION
# Overview

I added Valibot to the Modular Forms integration guide and synced the CodeSandbox code in the docs with the demo code.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

As the author of both libraries, I prefer to use Valibot with Modular Forms because of the smaller bundle size.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
