### PR TITLE
feat(core): Allow useContext in same elem as provider

### DIFF
--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -1001,6 +1001,15 @@ renderSSRSuite('component useContextProvider()', async () => {
   );
 });
 
+renderSSRSuite('component useContextProvider() + useContext()', async () => {
+  await testSSR(
+    <ContextWithValueAndUse value="hello bye" />,
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+      <!--qv q:id=0 q:key=sX:-->hello bye<!--/qv-->
+    </html>`
+  );
+});
+
 renderSSRSuite('component slotted context', async () => {
   await testSSR(
     <body>
@@ -1732,6 +1741,15 @@ export const ContextWithValue = component$((props: { value: string }) => {
       <Slot />
     </>
   );
+});
+
+export const ContextWithValueAndUse = component$((props: { value: string }) => {
+  const value = {
+    value: props.value,
+  };
+  useContextProvider(CTX_VALUE, value);
+  const ctx = useContext(CTX_VALUE);
+  return <>{ctx.value}</>;
 });
 
 export const Context = component$(() => {

--- a/packages/qwik/src/core/use/use-context.ts
+++ b/packages/qwik/src/core/use/use-context.ts
@@ -322,30 +322,26 @@ export const resolveContext = <STATE extends object>(
   containerState: ContainerState
 ): STATE | undefined => {
   const contextID = context.id;
-  if (hostCtx) {
-    let hostElement: QwikElement = hostCtx.$element$;
-    let ctx = hostCtx.$slotParent$ ?? hostCtx.$parent$;
-    while (ctx) {
-      hostElement = ctx.$element$;
-      if (ctx.$contexts$) {
-        const found = ctx.$contexts$.get(contextID);
-        if (found) {
-          return found;
-        }
-        if (ctx.$contexts$.get('_') === true) {
-          break;
-        }
-      }
-      ctx = ctx.$slotParent$ ?? ctx.$parent$;
-    }
-    if ((hostElement as any).closest) {
-      const value = queryContextFromDom(hostElement, containerState, contextID);
-      if (value !== undefined) {
-        return value;
-      }
-    }
+  if (!hostCtx) {
+    return;
   }
-  return undefined;
+  let hostElement: QwikElement;
+  let ctx: QContext | null = hostCtx;
+  while (ctx) {
+    hostElement = ctx.$element$;
+    if (ctx.$contexts$) {
+      const found = ctx.$contexts$.get(contextID);
+      if (found) {
+        return found;
+      }
+      if (ctx.$contexts$.get('_') === true) {
+        break;
+      }
+    }
+    ctx = ctx.$slotParent$ ?? ctx.$parent$;
+  }
+  const value = queryContextFromDom(hostElement!, containerState, contextID);
+  return value;
 };
 
 export const queryContextFromDom = (

--- a/starters/apps/e2e/src/components/context/context.tsx
+++ b/starters/apps/e2e/src/components/context/context.tsx
@@ -72,12 +72,14 @@ export const ContextFromSlot = component$(() => {
 // This code will not work because its async before reading subs
 export const Level2 = component$(() => {
   const level2State1 = useStore({ displayName: "Level2 / state1", count: 0 });
+  // read context1 before changing it
+  const state1 = useContext(Context1);
+  // change context1
   useContextProvider(Context1, level2State1);
 
   const state3 = useStore({ displayName: "Level2 / state3", count: 0 });
   useContextProvider(Context3, state3);
 
-  const state1 = useContext(Context1);
   const state2 = useContext(Context2);
   const stateSlot = useContext(ContextSlot);
 


### PR DESCRIPTION
# Overview

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

This allows `useContext()` within the same component that already ran `useContextProvider()`.

# Use cases and why

This is useful for terseness, code reuse, and it eliminates an element of surprise.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
