### PR TITLE
docs: add note about `onRequest` middleware exported from `serverAuth$`

### DIFF
--- a/packages/docs/src/routes/docs/integrations/authjs/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/authjs/index.mdx
@@ -218,6 +218,9 @@ export const { onRequest, useAuthSession, useAuthSignin, useAuthSignout } = serv
   })
 );
 ```
+
+> *IMPORTANT*: Make sure to keep the `onRequest` export as it is used to handle the oAuth flow redirects. Once the user finished oAuth flow, GitHub (or any other provider) will redirect the user back to the application to `/api/auth/callback/github` (or `/api/auth/callback/[otherProvider]`). The `onRequest` middleware function will handle requests to this endpoint and finish the oAuth flow.
+
 3. Create or edit the `.env.local` file at the root of your project to store secrets
 
 ```bash title=".env.local"


### PR DESCRIPTION
# Overview

I had an issue when I removed `onRequest` export because my IDE told me that it was unused. Then, I spent a couple of hours trying to figure out how to handle routes that were coming to `/api/auth/callback/[provider]`. This PR adds a note not to remove `onRequest` export.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Add a note to keep `onRequest` export when using `serverAuth$`

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
