### PR TITLE
fix(starter): localize container attribute

### DIFF
--- a/starters/features/localize/src/entry.ssr.tsx
+++ b/starters/features/localize/src/entry.ssr.tsx
@@ -25,7 +25,7 @@ export default function (opts: RenderToStreamOptions) {
     base: extractBase, // determine the base URL for the client code
     // Use container attributes to set attributes on the html tag.
     containerAttributes: {
-      lang: "en-us",
+      lang: opts.serverData?.locale ?? "en-us",
       ...opts.containerAttributes,
     },
   });


### PR DESCRIPTION
I changed the lang of the container attributes to serverData.locale with fallback en-us

# Overview


# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Just added the container attribute for locale

# Use cases and why


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
