### PR TITLE
docs: Update SSG documentation to run build instead of preview

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
@@ -45,10 +45,10 @@ Running the above command will make the following changes to your project:
 
 Your build files will be generated into the `dist` folder.
 
-You can build and preview your static site using:
+You can build your static site using:
 
 ```shell
-npm run preview
+npm run build
 ```
 
 ### SSG Config


### PR DESCRIPTION
# Overview
This PR aims to correct the documentation for SSG, specifically to suggest running build instead of preview.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

This PR updates the SSG documentation to replace the recommendation of using the preview command with the build command for generating static pages. This change is important to highlight because the preview command currently does not generate any HTML static files, whereas the build command does. This ensures developers are fully aware of what each command will yield.

# Use cases and why

- Clarity: The documentation should accurately guide the developer in generating static pages, which is achieved by using build.
- Avoiding Confusion: Mentioning that preview does not generate HTML static files clarifies its limitations.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
