### PR TITLE
docs: updated phrasing for clarity

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/tasks/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/tasks/index.mdx
@@ -144,7 +144,7 @@ Use `useTask$()` when you need to:
 
 ### On mount
 
-There is not an specific "on-mount" hook in Qwik because `useTask$()` without tracking effectively behaves like a `mount` hook.
+Qwik does not have a specific "on-mount" hook because useTask$() without track() effectively behaves like a mount hook.
 
 This is because `useTask$` runs always at least once when the component is first mounted.
 


### PR DESCRIPTION
docs: Documentation clarity change on reference about no on-mount hook.

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Hello Qwik team! I was studying Tasks and Lifecycles and found the following line confusing and hard to understand: `"There is not an specific "on-mount" hook in Qwik because ..."`

I rephrased it to: "`Qwik does not have a specific "on-mount" hook because useTask$() without track() effectively behaves like a mount hook.`" I think it is more succinct and clearer to understand. Hope you see what I mean. 

Thank you for creating such an amazing thing!

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

-- Not applicable.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
