### PR TITLE
docs(localization): auto-translation

### DIFF
--- a/packages/docs/src/routes/docs/integrations/i18n/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/i18n/index.mdx
@@ -4,6 +4,7 @@ contributors:
   - mhevery
   - manucorporat
   - gioboa
+  - tzdesign
 ---
 
 # Internationalization
@@ -77,6 +78,24 @@ npm run qwik add localize
 ```
 
 For further reference, please check this [example repo](https://github.com/mhevery/qwik-i18n).
+
+#### Auto translations for $localize with deepl
+
+For auto translations, you can use the [deepl-localize](https://www.npmjs.com/package/deepl-localize) package. It will automatically translate your strings using the [deepl.com](https://deepl.com/) API.
+
+Use the `deepl-localize` command to translate your strings with npx:
+```bash
+npx deepl-localize translate -b src/locales/message-en.json -l de-DE fr-FR -a "YOUR-DEEPL-API-KEY"
+```
+
+Alternatively, you can use the `deepl-localize` command to translate your strings within your script section:
+```json
+{
+  "scripts":{
+    "translate":"deepl-localize translate -b src/locales/message-en.json -l de-DE fr-FR -a 'your-deepl-api-key'"
+  }
+}
+```
 
 ### qwik-speak
 


### PR DESCRIPTION
@mhevery I made a new version of deepl-localize to take `message-` prefix into account.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

I added the information about a package I wrote to automatically $localize with one of the best translation platforms out there

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
