### PR TITLE
docs: fix broken link

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/index.mdx
@@ -13,4 +13,4 @@ A cookbook contains a collection of useful patterns for solving common problems 
 Examples:
 - [Modal Dialog Pop-Up](./portal/)
 - [Media Controller with iOS Support](./mediaController/)
-- [Theme Managment](./theme-managment/)
+- [Theme Managment](./theme-management/)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Fix link to theme-management route

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
