### PR TITLE
docs: Add a missing link to qrl docs

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/advanced/qrl/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/qrl/index.mdx
@@ -147,4 +147,4 @@ Because of the above differences, Qwik introduces QRLs as a mechanism for lazy l
 
 ## See Also
 
-- `qrl`: API used to create QRLs.
+- [qrl: API used to create QRLs.](https://qwik.builder.io/api/qwik/#qrl)

--- a/packages/docs/src/routes/docs/(qwik)/advanced/qrl/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/qrl/index.mdx
@@ -147,4 +147,4 @@ Because of the above differences, Qwik introduces QRLs as a mechanism for lazy l
 
 ## See Also
 
-- [qrl: API used to create QRLs.](https://qwik.builder.io/api/qwik/#qrl)
+- [`qrl`: API used to create QRLs.](https://qwik.builder.io/api/qwik/#qrl)


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

I used a descriptive link as that's good for screen readers.

Closes #5305.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
