### PR TITLE
fix: Add a missing CSS import to Storybook

### DIFF
--- a/starters/features/storybook/.storybook/preview.tsx
+++ b/starters/features/storybook/.storybook/preview.tsx
@@ -1,5 +1,7 @@
 import { Parameters } from "storybook-framework-qwik";
 
+import "../src/global.css";
+
 export const parameters: Parameters = {
   a11y: {
     config: {},


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I added missing CSS import to Storybook integration. In my quick test, this seems to fix Tailwind with it.

Closes #5304.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. If Tailwind is installed, it should work now

The assumption here is that `global.css` is defined always. Likely a better fix would check if it's there in the user source and write it conditionally.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

I wasn't sure how to test this but it would definitely be good to test if you know how.