### PR TITLE
fix(comment): Updated firebase entry comments to reference Firebase correctly

### DIFF
--- a/starters/adapters/firebase/src/entry-firebase.tsx
+++ b/starters/adapters/firebase/src/entry-firebase.tsx
@@ -3,7 +3,7 @@
  *
  * It's the entry point for Firbease when building for production.
  *
- * Learn more about the Netlify integration here:
+ * Learn more about the Firebase integration here:
  * - https://qwik.builder.io/docs/deployments/firebase/
  *
  */


### PR DESCRIPTION
# Overview

Comment in firebase entry file was incorrectly referencing `Netlify` instead of `Firebase`

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
