### PR TITLE
docs: fix component types in examples

### DIFF
--- a/packages/docs/src/routes/examples/apps/partial/hackernews-index/app.tsx
+++ b/packages/docs/src/routes/examples/apps/partial/hackernews-index/app.tsx
@@ -55,7 +55,7 @@ export const Nav = component$(() => {
   );
 });
 
-export const Stories = component$((props: { data: any }) => {
+export const Stories = component$<{ data: any }>((props) => {
   const page = 1;
   const type = 'list';
   const stories = props.data;
@@ -95,7 +95,7 @@ export const Stories = component$((props: { data: any }) => {
   );
 });
 
-export const StoryPreview = component$((props: { story: IStory }) => {
+export const StoryPreview = component$<{ story: IStory }>((props) => {
   return (
     <li class="news-item">
       <span class="score">{props.story.points}</span>

--- a/starters/apps/e2e/src/components/watch/watch.tsx
+++ b/starters/apps/e2e/src/components/watch/watch.tsx
@@ -80,7 +80,7 @@ export const WatchShell = component$(
   },
 );
 
-export const Child = component$((props: { state: State }) => {
+export const Child = component$<{ state: State }>((props) => {
   console.log("CHILD renders");
   return (
     <div>
@@ -92,7 +92,7 @@ export const Child = component$((props: { state: State }) => {
   );
 });
 
-export const GrandChild = component$((props: { state: State }) => {
+export const GrandChild = component$<{ state: State }>((props) => {
   console.log("GrandChild renders");
   return <div id="debounced">Debounced: {props.state.debounced}</div>;
 });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Small fix to types in the examples to not be marked as errors in the Repl editor (see on the live examples [page](https://qwik.builder.io/examples/reactivity/task/)).

| Before | After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/BuilderIO/qwik/assets/1355455/4845d406-5d89-4e45-a0d5-a338a37adbea"> | <img width="300" alt="image" src="https://github.com/BuilderIO/qwik/assets/1355455/bd0ece6c-a473-4255-aff9-e67443c9475d"> | 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
