### PR TITLE
fix: @builder.io/qwik/build should not SSR render

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -309,6 +309,9 @@ const shouldSsrRender = (req: IncomingMessage, url: URL) => {
   if (InternalPrefixRE.test(url.pathname)) {
     return false;
   }
+  if (pathname.includes('@builder.io/qwik/build')) {
+    return false;
+  }
   const acceptHeader = req.headers.accept || '';
   const accepts = acceptHeader.split(',').map((accept) => accept.split(';')[0]);
   if (accepts.length == 1 && accepts.includes('*/*')) {


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

As per bug #5325 `@builder.io/qwik/build` is a special url that should not ssr render. #5234 introduced new logic on `shouldSsrRender` that causes it to ssr render, which breaks things.

fix #5325 

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

This PR adds a new conditional to `shouldSsrRender` similar to the existing ones for `vite-ping`, `html-proxy` and `__open-in-editor` for `@builder.io/qwik/build` that fixes the issue.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

As per #5325, the library starter template throws an error when interacting with any client side code on v1.2.13

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
