### PR TITLE
fix: Bump pandacss version to a Qwik compatible one

### DIFF
--- a/starters/features/pandacss/package.json
+++ b/starters/features/pandacss/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@builder.io/vite-plugin-macro": "~0.0.7",
-    "@pandacss/dev": "^0.15.5"
+    "@pandacss/dev": "^0.16.0"
   },
   "scripts": {
     "prebuild.pandacss": "panda codegen --silent"


### PR DESCRIPTION
I fixed the [issue](https://github.com/chakra-ui/panda/issues/1507) in pandacss, now we just need to bump the Qwik starter package – for any future users 😃 