### PR TITLE
fix(cli): set args on interactive cli

### DIFF
--- a/packages/qwik-city/adapters/vercel-edge/vite/index.ts
+++ b/packages/qwik-city/adapters/vercel-edge/vite/index.ts
@@ -134,8 +134,8 @@ export interface VercelEdgeAdapterOptions extends ServerAdapterOptions {
   /**
    * Define the `target` proeprty in the `ssr` property in the `vite.config.ts` file.
    *
-   * Defaults to `webworker` for not having a breaking change. But `node` will become the default
-   * in an upcoming release.
+   * Defaults to `webworker` for not having a breaking change. But `node` will become the default in
+   * an upcoming release.
    */
   target?: 'webworker' | 'node';
 }

--- a/packages/qwik/src/cli/run.ts
+++ b/packages/qwik/src/cli/run.ts
@@ -151,8 +151,8 @@ async function printHelp(app: AppCommand) {
   if (isCancel(command)) {
     bye();
   }
-
-  await runCommand(Object.assign(app, { task: command as string }));
+  const args = command.split(' ');
+  await runCommand(Object.assign(app, { task: args[0] as string, args }));
 }
 
 function printVersion() {

--- a/packages/qwik/src/cli/run.ts
+++ b/packages/qwik/src/cli/run.ts
@@ -152,7 +152,7 @@ async function printHelp(app: AppCommand) {
     bye();
   }
   const args = (command as string).split(' ');
-  await runCommand(Object.assign(app, { task: args[0] as string, args }));
+  await runCommand(Object.assign(app, { task: args[0], args }));
 }
 
 function printVersion() {

--- a/packages/qwik/src/cli/run.ts
+++ b/packages/qwik/src/cli/run.ts
@@ -151,7 +151,7 @@ async function printHelp(app: AppCommand) {
   if (isCancel(command)) {
     bye();
   }
-  const args = command.split(' ');
+  const args = (command as string).split(' ');
   await runCommand(Object.assign(app, { task: args[0] as string, args }));
 }
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->
When using the interactive CLI mode, the build preview option was in the help commands list but wasn't working, selecting it would return you back to the interactive help.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

The `build preview` option wasn't working as the command runner expects the task to be named `build` with preview being an extra argument.

Initially considered adding it as a special case to the `runCommand` switch statement, but this fix is actually better as it will work more consistently if other two word commands are added, and it prevents unexpected behaviour. 

For instance, without the fix, if you run `qwik preview` (unrecognized command) and when the interactive help shows up you select the production build option it would still run a preview build as the args are inherited from your initial commands.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
