### PR TITLE
feat: add outDir support to qwikInsights

### DIFF
--- a/packages/qwik-city/adapters/vercel-edge/vite/index.ts
+++ b/packages/qwik-city/adapters/vercel-edge/vite/index.ts
@@ -134,8 +134,8 @@ export interface VercelEdgeAdapterOptions extends ServerAdapterOptions {
   /**
    * Define the `target` proeprty in the `ssr` property in the `vite.config.ts` file.
    *
-   * Defaults to `webworker` for not having a breaking change. But `node` will become the default
-   * in an upcoming release.
+   * Defaults to `webworker` for not having a breaking change. But `node` will become the default in
+   * an upcoming release.
    */
   target?: 'webworker' | 'node';
 }

--- a/packages/qwik-labs/src-vite/insights/index.ts
+++ b/packages/qwik-labs/src-vite/insights/index.ts
@@ -13,7 +13,11 @@ export async function qwikInsights(qwikInsightsOpts: {
   baseUrl?: string;
   outDir?: string;
 }): Promise<PluginOption> {
-  const { publicApiKey, baseUrl = 'https://qwik-insights.builder.io', outDir = 'dist' } = qwikInsightsOpts;
+  const {
+    publicApiKey,
+    baseUrl = 'https://qwik-insights.builder.io',
+    outDir = 'dist',
+  } = qwikInsightsOpts;
   let isProd = false;
   const vitePlugin: PluginOption = {
     name: 'vite-plugin-qwik-insights',

--- a/packages/qwik-labs/src-vite/insights/index.ts
+++ b/packages/qwik-labs/src-vite/insights/index.ts
@@ -11,10 +11,10 @@ const logWarn = (message?: any) => {
 export async function qwikInsights(qwikInsightsOpts: {
   publicApiKey: string;
   baseUrl?: string;
+  outDir?: string;
 }): Promise<PluginOption> {
-  const { publicApiKey, baseUrl = 'https://qwik-insights.builder.io' } = qwikInsightsOpts;
+  const { publicApiKey, baseUrl = 'https://qwik-insights.builder.io', outDir = 'dist' } = qwikInsightsOpts;
   let isProd = false;
-  const outDir = 'dist';
   const vitePlugin: PluginOption = {
     name: 'vite-plugin-qwik-insights',
     enforce: 'pre',


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

I'm using qwik-nx which makes use of outDir for both client/server outputs. qwikInsights doesn't yet support it so the file ends up in a different location. Also, the manifest is assumed to exist within dist which isn't true with a qwik-nx project.

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Adds support for outDir, which qwikVite already supports.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. To customise the outDir, which is useful in projects that are generated by qwik-nx where you can have multiple apps.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

# Patch package:

**patches/@builder.io+qwik-labs+0.0.1.patch:**
```
diff --git a/node_modules/@builder.io/qwik-labs/vite/insights/index.d.ts b/node_modules/@builder.io/qwik-labs/vite/insights/index.d.ts
index 6cfa70b..84024fa 100644
--- a/node_modules/@builder.io/qwik-labs/vite/insights/index.d.ts
+++ b/node_modules/@builder.io/qwik-labs/vite/insights/index.d.ts
@@ -2,4 +2,5 @@ import { PluginOption } from 'vite';
 export declare function qwikInsights(qwikInsightsOpts: {
     publicApiKey: string;
     baseUrl?: string;
+    outDir?: string;
 }): Promise<PluginOption>;
diff --git a/node_modules/@builder.io/qwik-labs/vite/insights/index.js b/node_modules/@builder.io/qwik-labs/vite/insights/index.js
index eb72555..cbf7909 100644
--- a/node_modules/@builder.io/qwik-labs/vite/insights/index.js
+++ b/node_modules/@builder.io/qwik-labs/vite/insights/index.js
@@ -8,9 +8,8 @@ const logWarn = (message) => {
     console.warn('\x1b[33m%s\x1b[0m', `\n\nQWIK WARN: ${message}\n`);
 };
 async function qwikInsights(qwikInsightsOpts) {
-    const { publicApiKey, baseUrl = 'https://qwik-insights.builder.io' } = qwikInsightsOpts;
+    const { publicApiKey, baseUrl = 'https://qwik-insights.builder.io', outDir = 'dist' } = qwikInsightsOpts;
     let isProd = false;
-    const outDir = 'dist';
     const vitePlugin = {
         name: 'vite-plugin-qwik-insights',
         enforce: 'pre',
```