### PR TITLE
fix(core): Fill the holes of the sparse array with `undefined`

### DIFF
--- a/packages/qwik/src/core/state/common.ts
+++ b/packages/qwik/src/core/state/common.ts
@@ -1,5 +1,4 @@
 import { assertFail, assertTrue } from '../error/assert';
-import { qError, QError_verifySerializable } from '../error/error';
 import { isNode } from '../util/element';
 import { seal } from '../util/qdev';
 import { isArray, isFunction, isObject, isSerializableObject } from '../util/types';
@@ -64,7 +63,10 @@ const _verifySerializable = <T>(value: T, seen: Set<any>, ctx: string, preMessag
           // Make sure the array has no holes
           unwrapped.forEach((v, i) => {
             if (i !== expectIndex) {
-              throw qError(QError_verifySerializable, unwrapped);
+              const array = value as any[];
+              for (let j = expectIndex; j < i; j++) {
+                array[j] = undefined;
+              }
             }
             _verifySerializable(v, seen, ctx + '[' + i + ']');
             expectIndex = i + 1;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

To fix the issue #5333 fill the holes of the sparse array with `undefined` in order to serialize any arrays.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->
Please see the issue #5333 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
