### PR TITLE
fix(cli): parseTemplatePath doesn't work in windows

### DIFF
--- a/packages/qwik/src/cli/utils/templates.ts
+++ b/packages/qwik/src/cli/utils/templates.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import type { TemplateSet } from '../types';
 import { getFilesDeep } from './utils';
 
@@ -58,10 +58,7 @@ export async function readTemplates(rootDir: string) {
 }
 
 function parseTemplatePath(path: string, type: string) {
-  let parts = path.split(`/${type}/`);
-  if (parts.length == 1) {
-    parts = path.split(`\\${type}\\`);
-  }
+  const parts = path.split(sep + type + sep);
 
   return {
     absolute: path,

--- a/packages/qwik/src/cli/utils/templates.ts
+++ b/packages/qwik/src/cli/utils/templates.ts
@@ -58,7 +58,10 @@ export async function readTemplates(rootDir: string) {
 }
 
 function parseTemplatePath(path: string, type: string) {
-  const parts = path.split(`/${type}/`);
+  let parts = path.split(`/${type}/`);
+  if (parts.length == 1) {
+    parts = path.split(`\\${type}\\`);
+  }
 
   return {
     absolute: path,


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

in windows path split with \,which makes parseTemplatePath does not work.

# Use cases and why

qwik new does not work in windows

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
