### PR TITLE
chore: ts-ignore vite 5 types issue

### DIFF
--- a/packages/qwik-city/adapters/shared/vite/index.ts
+++ b/packages/qwik-city/adapters/shared/vite/index.ts
@@ -67,6 +67,7 @@ export function viteAdapter(opts: ViteAdapterPluginOptions) {
           );
         }
 
+        // @ts-ignore `format` removed in Vite 5
         if (config.ssr?.format === 'cjs') {
           format = 'cjs';
         }

--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -95,6 +95,7 @@ function qwikCityPlugin(userOpts?: QwikCityVitePluginOptions): any {
         throw new Error('Missing vite-plugin-qwik');
       }
 
+      // @ts-ignore `format` removed in Vite 5
       if (config.ssr?.format === 'cjs') {
         ssrFormat = 'cjs';
       }


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Currently [Qwik in vite-ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6583609019/job/17886921273#step:8:929) is failing in the build step as Vite 5 has removed the `ssr.format` option. This PR fixes it by adding `@ts-ignore` so it works in both Vite 4 and Vite 5.

# Use cases and why

There are a few more PRs coming to Vite 5, and being able to make Qwik green allows us to anticipate potential breaking changes better.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
