### PR TITLE
fix: action redirect accidentally stripped searchparams

### DIFF
--- a/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/middleware/request-handler/resolve-request-handlers.ts
@@ -377,10 +377,20 @@ export function isLastModulePageRoute(routeModules: RouteModule[]) {
 }
 
 export function getPathname(url: URL, trailingSlash: boolean | undefined) {
+  url = new URL(url);
   if (url.pathname.endsWith(QDATA_JSON)) {
-    return url.pathname.slice(0, -QDATA_JSON.length + (trailingSlash ? 1 : 0)) + url.search;
+    url.pathname = url.pathname.slice(0, -QDATA_JSON.length);
   }
-  return url.pathname;
+  if (trailingSlash) {
+    if (!url.pathname.endsWith('/')) {
+      url.pathname += '/';
+    }
+  } else {
+    if (url.pathname.endsWith('/')) {
+      url.pathname = url.pathname.slice(0, -1);
+    }
+  }
+  return url.toString().substring(url.origin.length);
 }
 
 export const encoder = /*#__PURE__*/ new TextEncoder();

--- a/packages/qwik-city/middleware/request-handler/resolve-request-handlers.unit.ts
+++ b/packages/qwik-city/middleware/request-handler/resolve-request-handlers.unit.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getPathname } from './resolve-request-handlers';
+
+describe('resolve-request-handler', () => {
+  describe('getPathname', () => {
+    it('should remove q-data.json', () => {
+      expect(getPathname(new URL('http://server/path/q-data.json?foo=bar#hash'), true)).toBe(
+        '/path/?foo=bar#hash'
+      );
+      expect(getPathname(new URL('http://server/path/q-data.json?foo=bar#hash'), false)).toBe(
+        '/path?foo=bar#hash'
+      );
+    });
+
+    it('should pass non q-data.json through', () => {
+      expect(getPathname(new URL('http://server/path?foo=bar#hash'), true)).toBe(
+        '/path/?foo=bar#hash'
+      );
+      expect(getPathname(new URL('http://server/path/?foo=bar#hash'), false)).toBe(
+        '/path?foo=bar#hash'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fix #5342

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
