### PR TITLE
fix: remove cf pages stream polyfill

### DIFF
--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -15,7 +15,6 @@ import { setServerPlatform } from '@builder.io/qwik/server';
 
 /** @public */
 export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
-  (globalThis as any).TextEncoderStream = TextEncoderStream;
   const qwikSerializer = {
     _deserializeData,
     _serializeData,
@@ -131,40 +130,4 @@ export interface PlatformCloudflarePages {
   request: Request;
   env?: Record<string, any>;
   ctx: { waitUntil: (promise: Promise<any>) => void };
-}
-
-const resolved = Promise.resolve();
-
-class TextEncoderStream {
-  // minimal polyfill implementation of TextEncoderStream
-  // since Cloudflare Pages doesn't support readable.pipeTo()
-  _writer: any;
-  readable: any;
-  writable: any;
-
-  constructor() {
-    this._writer = null;
-    this.readable = {
-      pipeTo: (writableStream: any) => {
-        this._writer = writableStream.getWriter();
-      },
-    };
-    this.writable = {
-      getWriter: () => {
-        if (!this._writer) {
-          throw new Error('No writable stream');
-        }
-        const encoder = new TextEncoder();
-        return {
-          write: async (chunk: any) => {
-            if (chunk != null) {
-              await this._writer.write(encoder.encode(chunk));
-            }
-          },
-          close: () => this._writer.close(),
-          ready: resolved,
-        };
-      },
-    };
-  }
 }


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

Removes the CF pages `TextEncoderStream` polyfill, not needed anymore since CF implemented the standard API as documented in this blog post https://blog.cloudflare.com/standards-compliant-workers-api/

fix #3269 
fix #3449

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I've marked this as a bug since the polyfill had bugs as documented in issue #3269, the native API fixes this as well as other potential problems

Have tested that the native implementation works without any other code changes in both wrangler (miniflare) and a production environment.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
