### PR TITLE
fix(qwik-city): parseBody should not clone Request

### DIFF
--- a/packages/qwik-city/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/middleware/request-handler/request-event.ts
@@ -314,17 +314,16 @@ const parseRequest = async (
   sharedMap: Map<string, any>,
   qwikSerializer: QwikSerializer
 ): Promise<JSONValue | undefined> => {
-  const req = request.clone();
   const type = request.headers.get('content-type')?.split(/[;,]/, 1)[0].trim() ?? '';
   if (type === 'application/x-www-form-urlencoded' || type === 'multipart/form-data') {
-    const formData = await req.formData();
+    const formData = await request.formData();
     sharedMap.set(RequestEvSharedActionFormData, formData);
     return formToObj(formData);
   } else if (type === 'application/json') {
-    const data = await req.json();
+    const data = await request.json();
     return data;
   } else if (type === 'application/qwik-json') {
-    return qwikSerializer._deserializeData(await req.text());
+    return qwikSerializer._deserializeData(await request.text());
   }
   return undefined;
 };


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

The `parseBody` qwik-city method on `Request` is cloning the request stream unnecessarily. This PR changes it to use the original `Request` object instead.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

qwik-city provides a `parseBody` method on `Request` which checks the headers for certain parseable content-types and returns the data if it can parse it. The `parseBody` is a wrapper around `parseRequest` that caches the returned data (so a second call to `parseBody` won't parse it again)

`parseRequest` currently clones the request object, which is wasteful and raises a warning under some platforms (like Cloudflare) as only this new stream gets read (and only if the content type is parseable)

`parseBody` seems to be the main way the framework reads the request body when needed and is itself safe to call multiple times, so this change seems safe enough.

The only issue would be if there's an expectation that the original `Request` object body is never used but it feels like making the userland code use the `parseBody` method provided by the framework is the right way regardless, plus the cases in which qwik-city reads the body are very limited to begin with (actions and server$ rpc functions) and only if the content type is correct.

# Use cases and why

- Removes an unnecessary stream copy, which should slightly increase performance and reduce memory usage
- Gets rid of cloudflare warning:

"Your worker created multiple branches of a single stream (for instance, by calling `response.clone()` or `request.clone()`) but did not read the body of both branches. This is wasteful, as it forces the system to buffer the entire stream of data in memory, rather than streaming it through. This may cause your worker to be unexpectedly terminated for going over the memory limit. If you only meant to copy the request or response headers and metadata (e.g. in order to be able to modify them), use the appropriate constructors instead (for instance, `new Response(response.body, response)`, `new Request(request)`, etc)."

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
