### PR TITLE
fix(propfunctionprops): prevent 'undefined', 'null', 'never' conversion to PropFnInterface

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -1624,7 +1624,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type PropFunctionProps<PROPS extends {}> = {\n    [K in keyof PROPS]: PROPS[K] extends null | undefined | never ? PROPS[K] : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];\n};\n```\n**References:** [PropFnInterface](#propfninterface)",
+      "content": "```typescript\nexport type PropFunctionProps<PROPS extends {}> = {\n    [K in keyof PROPS]: PROPS[K] extends undefined ? undefined : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];\n};\n```\n**References:** [PropFnInterface](#propfninterface)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.propfunctionprops.md"
     },

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -1624,7 +1624,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type PropFunctionProps<PROPS extends {}> = {\n    [K in keyof PROPS]: NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];\n};\n```\n**References:** [PropFnInterface](#propfninterface)",
+      "content": "```typescript\nexport type PropFunctionProps<PROPS extends {}> = {\n    [K in keyof PROPS]: PROPS[K] extends null | undefined | never ? PROPS[K] : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];\n};\n```\n**References:** [PropFnInterface](#propfninterface)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.propfunctionprops.md"
     },

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -1624,7 +1624,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type PropFunctionProps<PROPS extends {}> = {\n    [K in keyof PROPS]: PROPS[K] extends undefined ? undefined : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];\n};\n```\n**References:** [PropFnInterface](#propfninterface)",
+      "content": "```typescript\nexport type PropFunctionProps<PROPS extends {}> = {\n    [K in keyof PROPS]: PROPS[K] extends undefined ? PROPS[K] : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];\n};\n```\n**References:** [PropFnInterface](#propfninterface)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.propfunctionprops.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -2123,9 +2123,9 @@ export type PropFunction<T extends Function = (...args: any[]) => any> =
 
 ```typescript
 export type PropFunctionProps<PROPS extends {}> = {
-  [K in keyof PROPS]: NonNullable<PROPS[K]> extends (
-    ...args: infer ARGS
-  ) => infer RET
+  [K in keyof PROPS]: PROPS[K] extends null | undefined | never
+    ? PROPS[K]
+    : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET
     ? PropFnInterface<ARGS, Awaited<RET>>
     : PROPS[K];
 };

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -2124,7 +2124,7 @@ export type PropFunction<T extends Function = (...args: any[]) => any> =
 ```typescript
 export type PropFunctionProps<PROPS extends {}> = {
   [K in keyof PROPS]: PROPS[K] extends undefined
-    ? undefined
+    ? PROPS[K]
     : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined
     ? PropFnInterface<ARGS, Awaited<RET>>
     : PROPS[K];

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -2123,9 +2123,9 @@ export type PropFunction<T extends Function = (...args: any[]) => any> =
 
 ```typescript
 export type PropFunctionProps<PROPS extends {}> = {
-  [K in keyof PROPS]: PROPS[K] extends null | undefined | never
-    ? PROPS[K]
-    : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET
+  [K in keyof PROPS]: PROPS[K] extends undefined
+    ? undefined
+    : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined
     ? PropFnInterface<ARGS, Awaited<RET>>
     : PROPS[K];
 };

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -1401,7 +1401,7 @@ export type PropFunction<T extends Function = (...args: any[]) => any> = T exten
 
 // @public (undocumented)
 export type PropFunctionProps<PROPS extends {}> = {
-    [K in keyof PROPS]: NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];
+    [K in keyof PROPS]: PROPS[K] extends null | undefined | never ? PROPS[K] : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];
 };
 
 // @public

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -1401,7 +1401,7 @@ export type PropFunction<T extends Function = (...args: any[]) => any> = T exten
 
 // @public (undocumented)
 export type PropFunctionProps<PROPS extends {}> = {
-    [K in keyof PROPS]: PROPS[K] extends null | undefined | never ? PROPS[K] : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];
+    [K in keyof PROPS]: PROPS[K] extends undefined ? undefined : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];
 };
 
 // @public

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -1401,7 +1401,7 @@ export type PropFunction<T extends Function = (...args: any[]) => any> = T exten
 
 // @public (undocumented)
 export type PropFunctionProps<PROPS extends {}> = {
-    [K in keyof PROPS]: PROPS[K] extends undefined ? undefined : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];
+    [K in keyof PROPS]: PROPS[K] extends undefined ? PROPS[K] : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined ? PropFnInterface<ARGS, Awaited<RET>> : PROPS[K];
 };
 
 // @public

--- a/packages/qwik/src/core/component/component.public.ts
+++ b/packages/qwik/src/core/component/component.public.ts
@@ -162,9 +162,9 @@ export const isQwikComponent = (component: any): component is Component<any> => 
 
 /** @public */
 export type PropFunctionProps<PROPS extends {}> = {
-  [K in keyof PROPS]: PROPS[K] extends null | undefined | never
-    ? PROPS[K]
-    : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET
+  [K in keyof PROPS]: PROPS[K] extends undefined
+    ? undefined
+    : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined
     ? PropFnInterface<ARGS, Awaited<RET>>
     : PROPS[K];
 };

--- a/packages/qwik/src/core/component/component.public.ts
+++ b/packages/qwik/src/core/component/component.public.ts
@@ -162,7 +162,9 @@ export const isQwikComponent = (component: any): component is Component<any> => 
 
 /** @public */
 export type PropFunctionProps<PROPS extends {}> = {
-  [K in keyof PROPS]: NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET
+  [K in keyof PROPS]: PROPS[K] extends null | undefined | never
+    ? PROPS[K]
+    : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET
     ? PropFnInterface<ARGS, Awaited<RET>>
     : PROPS[K];
 };

--- a/packages/qwik/src/core/component/component.public.ts
+++ b/packages/qwik/src/core/component/component.public.ts
@@ -163,7 +163,7 @@ export const isQwikComponent = (component: any): component is Component<any> => 
 /** @public */
 export type PropFunctionProps<PROPS extends {}> = {
   [K in keyof PROPS]: PROPS[K] extends undefined
-    ? undefined
+    ? PROPS[K]
     : PROPS[K] extends ((...args: infer ARGS) => infer RET) | undefined
     ? PropFnInterface<ARGS, Awaited<RET>>
     : PROPS[K];

--- a/packages/qwik/src/core/component/component.unit.tsx
+++ b/packages/qwik/src/core/component/component.unit.tsx
@@ -2,10 +2,11 @@ import { createDOM } from '../../testing/library';
 import { expectDOM } from '../../testing/expect-dom';
 import { inlinedQrl } from '../qrl/qrl';
 import { useStylesQrl } from '../use/use-styles';
-import { type PropsOf, component$ } from './component.public';
+import { type PropsOf, component$, type PropFunctionProps } from './component.public';
 import { useStore } from '../use/use-store.public';
 import { useLexicalScope } from '../use/use-lexical-scope.public';
 import { describe, test } from 'vitest';
+import type { HTMLAttributes } from '../render/jsx/types/jsx-generated';
 
 describe('q-component', () => {
   /**
@@ -112,6 +113,49 @@ describe('q-component', () => {
     </host>
     `
     );
+  });
+
+  test('types work as expected', () => {
+    const Input0 = component$((props) => {
+      return <input {...props} />;
+    });
+
+    const Input1 = component$((props: HTMLAttributes<HTMLInputElement>) => {
+      return <input {...props} />;
+    });
+
+    const Input2 = component$((props: PropFunctionProps<HTMLInputElement>) => {
+      return <input {...props} />;
+    });
+
+    const Input3 = component$((props: Partial<HTMLAttributes<HTMLInputElement>>) => {
+      return <input {...props} />;
+    });
+
+    const Input4 = component$((props: Partial<PropFunctionProps<HTMLInputElement>>) => {
+      return <input {...props} />;
+    });
+
+    type Input5Props = {
+      type: 'text' | 'number';
+    } & Partial<HTMLAttributes<HTMLInputElement>>;
+
+    const Input5 = component$<Input5Props>(({ type, ...props }) => {
+      return <input type={type} {...props} />;
+    });
+
+    component$(() => {
+      return (
+        <>
+          <Input0 value="0" />
+          <Input1 value="1" />
+          <Input2 value="2" />
+          <Input3 value="3" />
+          <Input4 value="4" />
+          <Input5 value="5" type="text" />
+        </>
+      );
+    });
   });
 });
 

--- a/packages/qwik/src/core/component/component.unit.tsx
+++ b/packages/qwik/src/core/component/component.unit.tsx
@@ -6,7 +6,8 @@ import { type PropsOf, component$, type PropFunctionProps } from './component.pu
 import { useStore } from '../use/use-store.public';
 import { useLexicalScope } from '../use/use-lexical-scope.public';
 import { describe, test } from 'vitest';
-import type { HTMLAttributes } from '../render/jsx/types/jsx-generated';
+import type { InputHTMLAttributes } from '../render/jsx/types/jsx-generated';
+import type { QwikIntrinsicElements } from '../render/jsx/types/jsx-qwik-elements';
 
 describe('q-component', () => {
   /**
@@ -116,43 +117,53 @@ describe('q-component', () => {
   });
 
   test('types work as expected', () => {
-    const Input0 = component$((props) => {
+    const Input1 = component$<InputHTMLAttributes<HTMLInputElement>>((props) => {
       return <input {...props} />;
     });
 
-    const Input1 = component$((props: HTMLAttributes<HTMLInputElement>) => {
+    const Input2 = component$((props: PropFunctionProps<InputHTMLAttributes<HTMLInputElement>>) => {
       return <input {...props} />;
     });
 
-    const Input2 = component$((props: PropFunctionProps<HTMLInputElement>) => {
+    const Input3 = component$((props: Partial<InputHTMLAttributes<HTMLInputElement>>) => {
       return <input {...props} />;
     });
 
-    const Input3 = component$((props: Partial<HTMLAttributes<HTMLInputElement>>) => {
-      return <input {...props} />;
-    });
-
-    const Input4 = component$((props: Partial<PropFunctionProps<HTMLInputElement>>) => {
-      return <input {...props} />;
-    });
+    const Input4 = component$(
+      (props: Partial<PropFunctionProps<InputHTMLAttributes<HTMLInputElement>>>) => {
+        return <input {...props} />;
+      }
+    );
 
     type Input5Props = {
       type: 'text' | 'number';
-    } & Partial<HTMLAttributes<HTMLInputElement>>;
+    } & Partial<InputHTMLAttributes<HTMLInputElement>>;
 
     const Input5 = component$<Input5Props>(({ type, ...props }) => {
       return <input type={type} {...props} />;
     });
 
+    type Input6Props = {
+      type: 'text' | 'number';
+    } & QwikIntrinsicElements['input'];
+
+    const Input6 = component$<Input6Props>(({ type, ...props }) => {
+      return (
+        <div>
+          <input type={type} {...props} />
+        </div>
+      );
+    });
+
     component$(() => {
       return (
         <>
-          <Input0 value="0" />
           <Input1 value="1" />
           <Input2 value="2" />
           <Input3 value="3" />
           <Input4 value="4" />
           <Input5 value="5" type="text" />
+          <Input6 value="6" type="number" />
         </>
       );
     });


### PR DESCRIPTION
…on to PropFnInterface

fix #4946

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

Added a condition to PropFunctionProps to prevent it from transforming standalone `undefined`, `null`, `never`, into PropFnInterface<unknown[], unknown>.

This mostly fixes ts issues with <input> tags and similar self-closing tags which have a `children: undefined` attribute mismatching the component$ children prop as explained in #4946, but it could also prevent issues with other props that are of the form `prop: null` or `prop: never`.

### Examples and manual tests:

Let's define a sample object

```tsx
type SampleObject = {
  numProp: number | undefined;
  strProp: string | null;
  boolProp: boolean | never;
  nullProp: null;
  undefinedProp: undefined;
  neverProp: never;
  anyProp: any;
  unknownProp: unknown;
  funcProp: (x: number, y: string) => boolean;
};
```

And apply the PropFunctionProps transforms to it

```tsx
type TransformedSampleObject = PropFunctionProps<SampleObject>;
```

With the current version of PropFunctionProps

```tsx
export type PropFunctionProps<PROPS extends {}> = {
  [K in keyof PROPS]: NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET
    ? PropFnInterface<ARGS, Awaited<RET>>
    : PROPS[K];
};
```

TransformedSampleObject will become

```tsx
type TransformedSampleObject = {
    numProp: number | undefined;
    strProp: string | null;
    boolProp: boolean | never;
    nullProp: PropFnInterface<unknown[], unknown>;
    undefinedProp: PropFnInterface<unknown[], unknown>;
    neverProp: PropFnInterface<unknown[], unknown>;
    anyProp: any;
    unknownProp: unknown;
    funcProp: PropFnInterface<[x: number, y: string], boolean>;
}
```

But with my proposed changes, 

```tsx
/** @public */
export type PropFunctionProps<PROPS extends {}> = {
  [K in keyof PROPS]: PROPS[K] extends null | undefined | never
    ? PROPS[K]
    : NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET
    ? PropFnInterface<ARGS, Awaited<RET>>
    : PROPS[K];
};

```

it will be

```tsx
type TransformedSampleObject = {
    numProp: number | undefined;
    strProp: string | null;
    boolProp: boolean | never;
    nullProp: null;
    undefinedProp: undefined;
    neverProp: never;
    anyProp: any;
    unknownProp: unknown;
    funcProp: PropFnInterface<[x: number, y: string], boolean>;
}
```

I have tested this with more complex types and only **standalone**  `undefined`, `null`, `never` seem to be affected by this change. They will stay what they are instead of becoming  `PropFnInterface<unknown[], unknown>`

### Explanation

If my understanding is correct, @manucorporat added PropFunctionProps in #4088 to remove the need to use PropFunction for creating custom async events. 

To do that, NonNullable seems to be required to attach `PropFnInterface<ARGS, RET>` to custom events, which I guess is required for the optimizer to turn the event into a lazy-loadable and importable symbol. 

The problem is that NonNullable will also convert standalone `undefined` and `null` to `never` which is a subtype of all types and therefore passes the `NonNullable<PROPS[K]> extends (...args: infer ARGS) => infer RET` condition, thus transforming `undefined`, `null`, and `never` to `PropFnInterface<unknown[], unknown>`.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
