### PR TITLE
chore(qwik-insights): use clientOutDir if provided

### DIFF
--- a/packages/docs/src/routes/api/qwik-optimizer/api.json
+++ b/packages/docs/src/routes/api/qwik-optimizer/api.json
@@ -498,7 +498,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface QwikVitePluginApi \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [getClientOutDir](#) |  | () =&gt; string \\| null |  |\n|  [getClientPublicOutDir](#) |  | () =&gt; string \\| null |  |\n|  [getInsightsManifest](#) |  | () =&gt; Promise&lt;[InsightManifest](#insightmanifest) \\| null&gt; |  |\n|  [getManifest](#) |  | () =&gt; [QwikManifest](#qwikmanifest) \\| null |  |\n|  [getOptimizer](#) |  | () =&gt; [Optimizer](#optimizer) \\| null |  |\n|  [getOptions](#) |  | () =&gt; NormalizedQwikPluginOptions |  |\n|  [getRootDir](#) |  | () =&gt; string \\| null |  |",
+      "content": "```typescript\nexport interface QwikVitePluginApi \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [getClientOutDir](#) |  | () =&gt; string \\| null |  |\n|  [getClientPublicOutDir](#) |  | () =&gt; string \\| null |  |\n|  [getInsightsManifest](#) |  | (clientOutDir?: string \\| null) =&gt; Promise&lt;[InsightManifest](#insightmanifest) \\| null&gt; |  |\n|  [getManifest](#) |  | () =&gt; [QwikManifest](#qwikmanifest) \\| null |  |\n|  [getOptimizer](#) |  | () =&gt; [Optimizer](#optimizer) \\| null |  |\n|  [getOptions](#) |  | () =&gt; NormalizedQwikPluginOptions |  |\n|  [getRootDir](#) |  | () =&gt; string \\| null |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/optimizer/src/plugins/vite.ts",
       "mdFile": "qwik.qwikvitepluginapi.md"
     },

--- a/packages/docs/src/routes/api/qwik-optimizer/index.md
+++ b/packages/docs/src/routes/api/qwik-optimizer/index.md
@@ -515,15 +515,15 @@ export interface QwikVitePlugin
 export interface QwikVitePluginApi
 ```
 
-| Property                   | Modifiers | Type                                                                | Description |
-| -------------------------- | --------- | ------------------------------------------------------------------- | ----------- |
-| [getClientOutDir](#)       |           | () =&gt; string \| null                                             |             |
-| [getClientPublicOutDir](#) |           | () =&gt; string \| null                                             |             |
-| [getInsightsManifest](#)   |           | () =&gt; Promise&lt;[InsightManifest](#insightmanifest) \| null&gt; |             |
-| [getManifest](#)           |           | () =&gt; [QwikManifest](#qwikmanifest) \| null                      |             |
-| [getOptimizer](#)          |           | () =&gt; [Optimizer](#optimizer) \| null                            |             |
-| [getOptions](#)            |           | () =&gt; NormalizedQwikPluginOptions                                |             |
-| [getRootDir](#)            |           | () =&gt; string \| null                                             |             |
+| Property                   | Modifiers | Type                                                                                             | Description |
+| -------------------------- | --------- | ------------------------------------------------------------------------------------------------ | ----------- |
+| [getClientOutDir](#)       |           | () =&gt; string \| null                                                                          |             |
+| [getClientPublicOutDir](#) |           | () =&gt; string \| null                                                                          |             |
+| [getInsightsManifest](#)   |           | (clientOutDir?: string \| null) =&gt; Promise&lt;[InsightManifest](#insightmanifest) \| null&gt; |             |
+| [getManifest](#)           |           | () =&gt; [QwikManifest](#qwikmanifest) \| null                                                   |             |
+| [getOptimizer](#)          |           | () =&gt; [Optimizer](#optimizer) \| null                                                         |             |
+| [getOptions](#)            |           | () =&gt; NormalizedQwikPluginOptions                                                             |             |
+| [getRootDir](#)            |           | () =&gt; string \| null                                                                          |             |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/optimizer/src/plugins/vite.ts)
 

--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -258,8 +258,8 @@ function qwikCityPlugin(userOpts?: QwikCityVitePluginOptions): any {
         if (ctx?.target === 'ssr') {
           // ssr build
           const manifest = qwikPlugin!.api.getManifest();
-          const insightsManifest = await qwikPlugin!.api.getInsightsManifest();
           const clientOutDir = qwikPlugin!.api.getClientOutDir();
+          const insightsManifest = await qwikPlugin!.api.getInsightsManifest(clientOutDir);
 
           if (manifest && clientOutDir) {
             const basePathRelDir = api.getBasePathname().replace(/^\/|\/$/, '');

--- a/packages/qwik-labs/src-vite/insights/index.ts
+++ b/packages/qwik-labs/src-vite/insights/index.ts
@@ -34,7 +34,7 @@ export async function qwikInsights(qwikInsightsOpts: {
           logWarn('fail to fetch manifest from Insights DB');
         }
         if (!existsSync(join(process.cwd(), outDir))) {
-          mkdirSync(join(process.cwd(), outDir));
+          mkdirSync(join(process.cwd(), outDir), { recursive: true });
         }
         await writeFile(join(process.cwd(), outDir, 'q-insights.json'), JSON.stringify(qManifest));
       }

--- a/packages/qwik/src/optimizer/src/api.md
+++ b/packages/qwik/src/optimizer/src/api.md
@@ -315,7 +315,7 @@ export interface QwikVitePluginApi {
     // (undocumented)
     getClientPublicOutDir: () => string | null;
     // (undocumented)
-    getInsightsManifest: () => Promise<InsightManifest | null>;
+    getInsightsManifest: (clientOutDir?: string | null) => Promise<InsightManifest | null>;
     // (undocumented)
     getManifest: () => QwikManifest | null;
     // (undocumented)

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -56,10 +56,10 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
   const injections: GlobalInjections[] = [];
   const qwikPlugin = createPlugin(qwikViteOpts.optimizerOptions);
 
-  async function loadQwikInsights(): Promise<InsightManifest | null> {
+  async function loadQwikInsights(clientOutDir?: string | null): Promise<InsightManifest | null> {
     const sys = qwikPlugin.getSys();
     const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
-    const path = sys.path.join(process.cwd(), 'dist', 'q-insights.json');
+    const path = sys.path.join(process.cwd(), clientOutDir ?? 'dist', 'q-insights.json');
     if (fs.existsSync(path)) {
       return JSON.parse(await fs.promises.readFile(path, 'utf-8')) as InsightManifest;
     }
@@ -70,7 +70,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
     getOptimizer: () => qwikPlugin.getOptimizer(),
     getOptions: () => qwikPlugin.getOptions(),
     getManifest: () => manifestInput,
-    getInsightsManifest: () => loadQwikInsights(),
+    getInsightsManifest: (clientOutDir?: string | null) => loadQwikInsights(clientOutDir),
     getRootDir: () => qwikPlugin.getOptions().rootDir,
     getClientOutDir: () => clientOutDir,
     getClientPublicOutDir: () => clientPublicOutDir,
@@ -118,7 +118,9 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
 
       if (sys.env === 'node' && !qwikViteOpts.entryStrategy) {
         try {
-          const entryStrategy = await loadQwikInsights();
+          const entryStrategy = await loadQwikInsights(
+            !qwikViteOpts.csr ? qwikViteOpts.client?.outDir : undefined
+          );
           if (entryStrategy) {
             qwikViteOpts.entryStrategy = entryStrategy;
           }
@@ -871,7 +873,7 @@ export interface QwikVitePluginApi {
   getOptimizer: () => Optimizer | null;
   getOptions: () => NormalizedQwikPluginOptions;
   getManifest: () => QwikManifest | null;
-  getInsightsManifest: () => Promise<InsightManifest | null>;
+  getInsightsManifest: (clientOutDir?: string | null) => Promise<InsightManifest | null>;
   getRootDir: () => string | null;
   getClientOutDir: () => string | null;
   getClientPublicOutDir: () => string | null;


### PR DESCRIPTION
# Overview
Solves my issue with using qwikInsights within an NX repository: https://github.com/BuilderIO/qwik/issues/5337

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

- Fixed directory creation not being recursive and q-insights.json failing to be created until it's already created
- Added usage of clientOutDir within qwikVite plugin when reading the q-insights.json file

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. If you use something like qwik-nx where you have multiple apps, you'll have a different directory structure for where your code goes and currently we just assume everything is directly within /dist

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
