### PR TITLE
qwik-city: Link - Handle option clicks

### DIFF
--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -19,7 +19,12 @@ export const Link = component$<LinkProps>((props) => {
           prefetchLinkResources(elm as HTMLAnchorElement, ev.type === 'qvisible')
         )
       : undefined;
-  const handleClick = event$(async (_: any, elm: HTMLAnchorElement) => {
+  const handleClick = event$(async (ev: any, elm: HTMLAnchorElement) => {
+    if (ev.ctrlKey || ev.metaKey) {
+      // Do not enter the nav pipeline if any option key is pressed.
+      return;
+    }
+
     if (!elm.hasAttribute('preventdefault:click')) {
       // Do not enter the nav pipeline if this is not a clientNavPath.
       return;


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Escape client side routing for modifier/option click. Ctrl on Windows, CMD on macOS.

# Use cases and why

1. When users click on `<a>` in the `<Link>` component with a modifier key active, we want to allow user preferred behaviour. Usually open in new tab etc. Currently, we always prevent default which results in client render in the same window/frame.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
