### PR TITLE
refactor(package.json): add docs.dev & docs.preview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ pnpm install
 2. Run the docs site:
 
 ```shell
-cd packages/docs && pnpm start
+pnpm docs.dev
 ```
 
 ### To open the test apps for debugging run:

--- a/package.json
+++ b/package.json
@@ -121,6 +121,8 @@
     "cli.validate": "tsm scripts/validate-cli.ts",
     "commit": "git-cz",
     "deps": "pnpm upgrade -i -r --latest",
+    "docs.dev": "cd packages/docs && pnpm dev",
+    "docs.preview": "cd packages/docs && pnpm preview",
     "docs.sync": "tsm scripts/docs_sync/index.ts && pnpm fmt",
     "eslint.update": "tsm scripts/eslint-docs.ts",
     "fmt": "pnpm prettier.fix && pnpm syncpack format",

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -1,5 +1,5 @@
 /**
- * This is the root build scripts module (keep in commonjs). It's only a .js file but will handling
+ * This is the root build scripts module (keep in commonjs). It's only a .js file but will handle
  * registering typescript files with esbuild-register to allow Node.js to build .ts files
  * on-demand.
  */


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Add package.json `docs.dev` & `docs.preview` scripts to improve the DX for contributors. Having to cd manually in packages/docs had me writing root commands in the wrong folder. This can be a bit frustrating and I think `dev` and `preview` commands are common enough that this should slightly improve the DX for contributors.

For those that are used to the workflow, `cd packages/docs && pnpm start` will keep working.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
