### PR TITLE
fix(insight): use relative path

### DIFF
--- a/packages/qwik-labs/src-vite/insights/index.ts
+++ b/packages/qwik-labs/src-vite/insights/index.ts
@@ -40,12 +40,13 @@ export async function qwikInsights(qwikInsightsOpts: {
         } catch (e) {
           logWarn('fail to fetch manifest from Insights DB');
         }
-        if (!existsSync(join(process.cwd(), outDir))) {
-          mkdirSync(join(process.cwd(), outDir), { recursive: true });
+        const cwdRelativePath = join(viteConfig.root || '.', outDir);
+        const cwdRelativePathJson = join(cwdRelativePath, 'q-insights.json');
+        if (!existsSync(join(process.cwd(), cwdRelativePath))) {
+          mkdirSync(join(process.cwd(), cwdRelativePath), { recursive: true });
         }
-        const cwdRelativePath = join(viteConfig.root || '.', outDir, 'q-insights.json');
-        log('Fetched latest Qwik Insight data into: ' + cwdRelativePath);
-        await writeFile(join(process.cwd(), cwdRelativePath), JSON.stringify(qManifest));
+        log('Fetched latest Qwik Insight data into: ' + cwdRelativePathJson);
+        await writeFile(join(process.cwd(), cwdRelativePathJson), JSON.stringify(qManifest));
       }
     },
     closeBundle: async () => {


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Was trying to use the insight fixes from 1.2.17 but was getting an error that the path doesn't yet exist before it writes the q-insights.json to it:
```
qwikInsight(): Fetched latest Qwik Insight data into: dist/apps/myapp/client/q-insights.json
[Error: ENOENT: no such file or directory, open '/Projects/myproject/dist/apps/myapp/client/q-insights.json'] { ... }
```

This makes sure that the same path used later exists, using the same relative path logic

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. I'm using qwik-nx with multiple apps in a single repository and the pathing is weird because it has to go back a couple of directories first:

```
qwikVite({
  client: {
    outDir: '../../dist/apps/myapp/client',
  },
  ssr: {
    outDir: '../../dist/apps/myapp/server',
  },
  tsconfigFileNames: ['tsconfig.app.json'],
}),
qwikInsights({
  outDir: '../../dist/apps/myapp/client',
  publicApiKey: loadEnv('', '.', '').PUBLIC_QWIK_INSIGHTS_KEY,
}),
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

# Patch Package
If you need this right away, this patch-package works:
```
diff --git a/node_modules/@builder.io/qwik-labs/vite/insights/index.js b/node_modules/@builder.io/qwik-labs/vite/insights/index.js
index c537546..ee44b00 100644
--- a/node_modules/@builder.io/qwik-labs/vite/insights/index.js
+++ b/node_modules/@builder.io/qwik-labs/vite/insights/index.js
@@ -31,12 +31,16 @@ async function qwikInsights(qwikInsightsOpts) {
                 catch (e) {
                     logWarn('fail to fetch manifest from Insights DB');
                 }
-                if (!(0, fs_1.existsSync)((0, node_path_1.join)(process.cwd(), outDir))) {
-                    (0, fs_1.mkdirSync)((0, node_path_1.join)(process.cwd(), outDir), { recursive: true });
+
+                const cwdRelativePath = (0, node_path_1.join)(viteConfig.root || '.', outDir);
+                const cwdRelativePathJson = (0, node_path_1.join)(cwdRelativePath, 'q-insights.json');
+
+                if (!(0, fs_1.existsSync)((0, node_path_1.join)(process.cwd(), cwdRelativePath))) {
+                  (0, fs_1.mkdirSync)((0, node_path_1.join)(process.cwd(), cwdRelativePath), { recursive: true });
                 }
-                const cwdRelativePath = (0, node_path_1.join)(viteConfig.root || '.', outDir, 'q-insights.json');
-                log('Fetched latest Qwik Insight data into: ' + cwdRelativePath);
-                await (0, promises_1.writeFile)((0, node_path_1.join)(process.cwd(), cwdRelativePath), JSON.stringify(qManifest));
+
+                log('Fetched latest Qwik Insight data into: ' + cwdRelativePathJson);
+                await (0, promises_1.writeFile)((0, node_path_1.join)(process.cwd(), cwdRelativePathJson), JSON.stringify(qManifest));
             }
         },
         closeBundle: async () => {
```