### PR TITLE
feat(core): auto px addition to css properties for unitless numbers

### DIFF
--- a/packages/qwik/src/core/util/unitless_number.ts
+++ b/packages/qwik/src/core/util/unitless_number.ts
@@ -1,0 +1,51 @@
+/** CSS properties which accept numbers but are not in units of "px". */
+const unitlessNumbers = new Set([
+  'animationIterationCount',
+  'aspectRatio',
+  'borderImageOutset',
+  'borderImageSlice',
+  'borderImageWidth',
+  'boxFlex',
+  'boxFlexGroup',
+  'boxOrdinalGroup',
+  'columnCount',
+  'columns',
+  'flex',
+  'flexGrow',
+  'flexShrink',
+  'gridArea',
+  'gridRow',
+  'gridRowEnd',
+  'gridRowStart',
+  'gridColumn',
+  'gridColumnEnd',
+  'gridColumnStart',
+  'fontWeight',
+  'lineClamp',
+  'lineHeight',
+  'opacity',
+  'order',
+  'orphans',
+  'scale',
+  'tabSize',
+  'widows',
+  'zIndex',
+  'zoom',
+  'MozAnimationIterationCount', // Known Prefixed Properties
+  'MozBoxFlex', // TODO: Remove these since they shouldn't be used in modern code
+  'msFlex',
+  'msFlexPositive',
+  'WebkitAnimationIterationCount',
+  'WebkitBoxFlex',
+  'WebkitBoxOrdinalGroup',
+  'WebkitColumnCount',
+  'WebkitColumns',
+  'WebkitFlex',
+  'WebkitFlexGrow',
+  'WebkitFlexShrink',
+  'WebkitLineClamp',
+]);
+
+export const isUnitlessNumber = (name: string): boolean => {
+  return unitlessNumbers.has(name);
+};


### PR DESCRIPTION
# Overview
This PR adds support for auto-addition of 'px' to CSS properties so that unitless numbers can also be passed to CSS properties under style prop.
<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Ref: #5419 

With this change, we will automatically add 'px' to unitless numbers provided under the style prop.

```jsx
<h1 style={{ fontSize: 50 }}> Hello World </h1>
```

this resolves to `font-size: 50px`.

I've referred and taken inspiration from React-DOM's implementation, reference attached below:
- https://github.com/facebook/react/blob/432b9f1d9729aaea010730d546bda89b9842eaa1/packages/react-dom-bindings/src/client/CSSPropertyOperations.js#L90
- Referred to [this](https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/shared/isUnitlessNumber.js) for getting all CSS properties that support numbers and don't require units. I've trimmed it down to the ones that we support.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

1. As of now if I add a style prop to a JSX component in Qwik and pass in let's say a fontSize with a number (`style={{ fontSize: 20 }}`) this will not throw any error and will be picked up by CSS types but this actually breaks in our page because no units are mentioned.
2. This will make React to Qwik migrations very easy as React/Next.js support this by default

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
