### PR TITLE
fix: cache max-age vite.config for dev mode

### DIFF
--- a/packages/docs/src/routes/docs/integrations/authjs/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/authjs/index.mdx
@@ -44,6 +44,11 @@ After installing the auth package using `npm run qwik add auth` the `@auth/core`
 export default defineConfig(() => {
   return {
     plugins: [qwikCity(), qwikVite(), tsconfigPaths()],
+    dev: {
+      headers: {
+        'Cache-Control': 'public, max-age=0',
+      },
+    },
     preview: {
       headers: {
         'Cache-Control': 'public, max-age=600',

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -16,6 +16,11 @@ export default defineConfig(async () => {
 
   const routesDir = resolve('src', 'routes');
   return {
+    dev: {
+      headers: {
+        'Cache-Control': 'public, max-age=0',
+      },
+    },
     preview: {
       headers: {
         'Cache-Control': 'public, max-age=600',

--- a/packages/insights/vite.config.ts
+++ b/packages/insights/vite.config.ts
@@ -15,6 +15,11 @@ export default defineConfig(async () => {
       tsconfigPaths({ projects: ['.'] }),
       qwikInsights({ publicApiKey: loadEnv('', '.', '').PUBLIC_QWIK_INSIGHTS_KEY }),
     ],
+    dev: {
+      headers: {
+        'Cache-Control': 'public, max-age=0',
+      },
+    },
     preview: {
       headers: {
         'Cache-Control': 'public, max-age=600',

--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -6,6 +6,11 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig(() => {
   return {
     plugins: [qwikCity(), qwikVite(), tsconfigPaths()],
+    dev: {
+      headers: {
+        "Cache-Control": "public, max-age=0",
+      },
+    },
     preview: {
       headers: {
         "Cache-Control": "public, max-age=600",


### PR DESCRIPTION
# Overview

Component Link in client side navigation, returns cached data in dev mode

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Screw default seems to be 31536000

# Use cases and why

Before click Link component
![pre link clicked](https://github.com/BuilderIO/qwik/assets/28485062/2dbf7102-43e6-4ac7-82fa-5a42f2fdf7fb)
After click Link component
![link clicked](https://github.com/BuilderIO/qwik/assets/28485062/f07dbf46-4272-4239-b8b1-27dc000b3b0a)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
