### PR TITLE
docs: Add Component library `ionic-qwik` to community projects on docs.

### DIFF
--- a/packages/docs/src/routes/community/projects/index.mdx
+++ b/packages/docs/src/routes/community/projects/index.mdx
@@ -27,6 +27,13 @@ contributors:
   </a>
 </div>
 
+<div class="card-grid">
+  <a class="card card-center" href="https://github.com/juergenie/ionic-qwik/">
+    <p class="icon" align="center"><img src="https://raw.githubusercontent.com/juergenie/ionic-qwik/main/logo.svg" width="172px"/></p>
+    <h3>Ionic-qwik - The cross-platform web-components [`@ionic/core`](https://ionicframework.com/)'s wrapper for qwik.</h3>
+  </a>
+</div>
+
 ### Form libraries
 
 <div class="card-grid">


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

I have added [`ionic-qwik`](https://github.com/juergenie/ionic-qwik) to the community projects on the docs page. It's a third-party wrapper for `@ionic/core`.
