### PR TITLE
fix(cli): casing for component and mdx route creation

### DIFF
--- a/packages/qwik/src/cli/new/run-new-command.ts
+++ b/packages/qwik/src/cli/new/run-new-command.ts
@@ -95,11 +95,7 @@ export async function runNewCommand(app: AppCommand) {
 
     const fileOutput = await writeToFile(name, slug, template, outDir);
 
-    if (typeArg === 'markdown') {
-      log.success(`${green(`Markdown route "${name}" created!`)}`);
-    } else {
-      log.success(`${green(`${toPascal([typeArg])} "${name}" created!`)}`);
-    }
+    log.success(`${green(`${toPascal([typeArg])} "${slug}" created!`)}`);
     log.message(`Emitted in ${dim(fileOutput)}`);
   } catch (e) {
     log.error(String(e));
@@ -160,17 +156,19 @@ async function selectName(type: 'route' | 'component' | 'markdown' | 'mdx') {
     bye();
   }
 
-  if (type === 'route' && !(nameAnswer as string).startsWith('/')) {
-    return `/${nameAnswer as string}`;
-  }
-  if (type === 'markdown' && !(nameAnswer as string).startsWith('/')) {
-    return `/${nameAnswer.replace(MARKDOWN_SUFFIX, '') as string}`;
-  }
-  if (type === 'mdx' && !(nameAnswer as string).startsWith('/')) {
-    return `/${nameAnswer.replace(MDX_SUFFIX, '') as string}`;
+  let result = nameAnswer;
+
+  if (type !== 'component' && !nameAnswer.startsWith('/')) {
+    result = `/${result}`;
   }
 
-  return nameAnswer.replace(MARKDOWN_SUFFIX, '') as string;
+  if (type === 'markdown') {
+    result = result.replace(MARKDOWN_SUFFIX, '');
+  } else if (type === 'mdx') {
+    result = result.replace(MDX_SUFFIX, '');
+  }
+
+  return result;
 }
 
 async function selectTemplate(typeArg: (typeof POSSIBLE_TYPES)[number]) {
@@ -251,9 +249,9 @@ function parseInputName(input: string) {
 }
 
 function toSlug(list: string[]) {
-  return list.join('-').toLowerCase();
+  return list.join('-');
 }
 
 function toPascal(list: string[]) {
-  return list.map((p) => p[0].toUpperCase() + p.substring(1).toLowerCase()).join('');
+  return list.map((p) => p[0].toUpperCase() + p.substring(1)).join('');
 }


### PR DESCRIPTION
# Overview

This fixes the `qwik new` command to:
- preserve `CamelCased` components
- wrong `/route/newRoute` console.success
- mdx route creation provided with `.mdx` created wrong route
<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Bug

# Description

Improves/fixes:

1. Enhanced the `toPascal` and `toSlug` functions to better accommodate varying casings. For instance, if we input `new-component` as the name, it will correctly transform it into `NewComponent`. However, if we provide `NewComponent`, the default behavior (or no change) is expected, but currently, it converts it to `Newcomponent`. (Ref: #5282)
2. When generating an MDX route and supplying it with a `.mdx` extension, the resulting route appears as `/route/pagex`. The issue arises as `!(nameAnswer as string).startsWith('/')` is false if we already provide it starting `/`. This fails to differentiate between .md and .mdx extensions, leading to unexpected routes as it blindly replaces `.md` in the file, this leaves the `x` behind.
3. When logging our success message, it used `name` which transformed kebab casing to pascal casing which in turn outputted wrong route names. (For example, if we create route `/some/new-route` this outputs, `Route "/some/newRoute" created!`.

Fixes: #5282

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
