### PR TITLE
fix: Pass the missing props for Spinner component

### DIFF
--- a/starters/features/bootstrap/src/routes/bootstrap/spinners/index.tsx
+++ b/starters/features/bootstrap/src/routes/bootstrap/spinners/index.tsx
@@ -14,6 +14,7 @@ export default component$(() => {
           <Spinner
             key={`${index + 1}_${colorVariant}`}
             colorVariant={colorVariant}
+            growing={false}
           />
           <span class="me-3"></span>
         </>


### PR DESCRIPTION
# Overview
Pass the missing props for Spinner component in Bootstrap starter

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

As the `growing` props is missing in the bootstrap starter template `Spinner` component it is causing the issue in production build while testing after adding the bootstrap.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- The dev build works and the spinners are appering as expected
- But the production build fails without the `growing` props

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
