### PR TITLE
fix: Wrap function in cleanup function instead of returning it

### DIFF
--- a/packages/docs/src/routes/tutorial/events/synchronous/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/events/synchronous/solution/app.tsx
@@ -2,13 +2,13 @@ import { component$, useVisibleTask$, useSignal } from '@builder.io/qwik';
 
 export default component$(() => {
   const aHref = useSignal<Element>();
-  useVisibleTask$(() => {
+  useVisibleTask$(({cleanup}) => {
     const handler = (event: Event) => {
       event.preventDefault();
       window.open('http://qwik.builder.io');
     };
     aHref.value!.addEventListener('click', handler);
-    return () => aHref.value!.removeEventListener('click', handler);
+    cleanup(() => aHref.value!.removeEventListener('click', handler));
   });
 
   return (


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Updates the tutorial example for synchronous events with using the cleanup function instead of returning a function.