### PR TITLE
style(starter templates): updates to starter templates names

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -47,7 +47,7 @@ To get started with Qwik locally, you need the following:
 
 ## Create an app using the CLI
 
-First, create a Qwik application with the Qwik CLI, which generates a blank starter so that you can quickly familiarize yourself with it.
+First, create a Qwik application with the Qwik CLI, which generates a blank starter so that you can quickly familiarize yourself with it. You can use this same command to create either Qwik or Qwik City project.
 
 Run the Qwik CLI in your shell. Qwik supports npm, yarn, pnpm and bun. Choose the package manager you prefer and run one of the following commands:
 

--- a/packages/docs/src/routes/docs/(qwikcity)/qwikcity/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/qwikcity/index.mdx
@@ -42,6 +42,17 @@ Qwik (core) and Qwik City (routing) solve problems at two layers of abstraction.
 
 Use Qwik City to build an e-commerce website, blog site, or any other website that needs routing, layouts, or data retrieval/updates. Qwik City is built on Qwik, and therefore Qwik City sites are resumable and only download the minimal amount of JavaScript with fine-grained lazy loading.
 
+## Getting Started with Qwik City
+
+Visit [Create an app using the CLI](/docs/getting-started/#create-an-app-using-the-cli) to see how to create a new Qwik City starter project. It is as simple as:
+
+```shell
+npm create qwik@latest
+pnpm create qwik@latest
+yarn create qwik
+bun create qwik@latest
+```
+
 ## High Level API Overview
 
 This table shows which file (`index.tsx` vs `layout.tsx`) the respective feature should be implemented in.

--- a/starters/apps/basic/package.json
+++ b/starters/apps/basic/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "__qwik__": {
     "priority": 2,
-    "displayName": "Basic App (Qwik City)",
+    "displayName": "Basic App (Qwik City + Qwik)",
     "qwikCity": true,
     "docs": [
       "https://qwik.builder.io/docs/getting-started/"

--- a/starters/apps/basic/package.json
+++ b/starters/apps/basic/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "__qwik__": {
     "priority": 2,
-    "displayName": "Basic App",
+    "displayName": "Basic App (Qwik City)",
     "qwikCity": true,
     "docs": [
       "https://qwik.builder.io/docs/getting-started/"

--- a/starters/apps/empty/package.json
+++ b/starters/apps/empty/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "__qwik__": {
     "priority": 1,
-    "displayName": "Empty App",
+    "displayName": "Empty App (Qwik City)",
     "qwikCity": true,
     "docs": [
       "https://qwik.builder.io/docs/getting-started/"

--- a/starters/apps/empty/package.json
+++ b/starters/apps/empty/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "__qwik__": {
     "priority": 1,
-    "displayName": "Empty App (Qwik City)",
+    "displayName": "Empty App (Qwik City + Qwik)",
     "qwikCity": true,
     "docs": [
       "https://qwik.builder.io/docs/getting-started/"

--- a/starters/apps/library/package.json
+++ b/starters/apps/library/package.json
@@ -48,7 +48,7 @@
     "vite-tsconfig-paths": "^4.2.1"
   },
   "__qwik__": {
-    "displayName": "Component library",
+    "displayName": "Component library (Qwik)",
     "priority": -1,
     "docs": [
       "https://qwik.builder.io/docs/getting-started/"

--- a/starters/apps/site-with-visual-cms/package.json
+++ b/starters/apps/site-with-visual-cms/package.json
@@ -11,7 +11,7 @@
     "docs": [
       "https://www.builder.io/c/docs/quickstart"
     ],
-    "displayName": "Site with Visual CMS",
+    "displayName": "Site with Visual CMS (Qwik City)",
     "qwikCity": true
   }
 }

--- a/starters/apps/site-with-visual-cms/package.json
+++ b/starters/apps/site-with-visual-cms/package.json
@@ -11,7 +11,7 @@
     "docs": [
       "https://www.builder.io/c/docs/quickstart"
     ],
-    "displayName": "Site with Visual CMS (Qwik City)",
+    "displayName": "Site with Visual CMS (Qwik City + Qwik)",
     "qwikCity": true
   }
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Following the conversation from Discord ([message](https://discord.com/channels/842438759945601056/842438761287254019/1178146319353794622)) it is not entirely clear how one initializes a Qwik City projects, compared to a pure Qwik project.

So, the docs are improved by connecting the two sections - the one for running the CLI tool to bootstrap a project, and a Qwik City section.

Additional changes include additional "tags" to started templates to clearly help distinguish what type of app it's being made, by adding `(Qwik City)` or `(Qwik)` tag next to it.

I'm happy to reconsider any of these changes.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
