### PR TITLE
fix: disable Vite modulepreload

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -302,7 +302,10 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         },
         build: {
           modulePreload: {
-            polyfill: false,
+            resolveDependencies() {
+              // Your list of preloaded deps.
+              return [];
+            },
           },
           dynamicImportVarsOptions: {
             exclude: [/./],

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -301,12 +301,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
           ],
         },
         build: {
-          modulePreload: {
-            resolveDependencies() {
-              // Your list of preloaded deps.
-              return [];
-            },
-          },
+          modulePreload: false,
           dynamicImportVarsOptions: {
             exclude: [/./],
           },


### PR DESCRIPTION
Closed: #5478 

Vite automatically injects links to preload to load eagerly chunks, this PR wants to stop this behaviour.
[Vite modulepreload docs](https://vitejs.dev/config/build-options#build-modulepreload)

