### PR TITLE
fix: cf pages polyfill only if needed

### DIFF
--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -15,7 +15,9 @@ import { setServerPlatform } from '@builder.io/qwik/server';
 
 /** @public */
 export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
-  (globalThis as any).TextEncoderStream = TextEncoderStream;
+  if (typeof globalThis.TextEncoderStream === 'undefined') {
+    (globalThis as any).TextEncoderStream = TextEncoderStream;
+  }
   const qwikSerializer = {
     _deserializeData,
     _serializeData,


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

As discussed in #5400, the previous patch to remove the CF Pages Stream polyfill was causing trouble for people with older pages apps as Cloudflare does not make new APIs available by default, they instead preserve backwards compatibility by making it opt-in – so it was only working correctly for apps less than a year old.

This patch checks whether the TextEncoderStream class is available before replacing it, preferring the native version if so, but keeps the polyfill for backwards compatibility

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
