### PR TITLE
feat(qwik): Experimental support for synchronous QRLs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,7 @@
       "internalConsoleOptions": "neverOpen",
       "program": "${workspaceFolder}/./node_modules/vitest/vitest.mjs",
       "cwd": "${workspaceFolder}",
-      "args": ["--threads=false", "packages/qwik/src/core/container/render.unit.tsx"]
+      "args": ["--threads=false", "${file}"]
     }
   ]
 }

--- a/packages/docs/src/routes/api/qwik-testing/api.json
+++ b/packages/docs/src/routes/api/qwik-testing/api.json
@@ -12,7 +12,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "CreatePlatform and CreateDocument\n\n\n```typescript\ncreateDOM: () => Promise<{\n    render: (jsxElement: JSXNode) => Promise<import(\"@builder.io/qwik\").RenderResult>;\n    screen: HTMLElement;\n    userEvent: (queryOrElement: string | Element | keyof HTMLElementTagNameMap | null, eventNameCamel: string | keyof WindowEventMap, eventPayload?: any) => Promise<void>;\n}>\n```",
+      "content": "CreatePlatform and CreateDocument\n\n\n```typescript\ncreateDOM: ({ html }?: {\n    html?: string | undefined;\n}) => Promise<{\n    render: (jsxElement: JSXNode) => Promise<import(\"@builder.io/qwik\").RenderResult>;\n    screen: HTMLElement;\n    userEvent: (queryOrElement: string | Element | keyof HTMLElementTagNameMap | null, eventNameCamel: string | keyof WindowEventMap, eventPayload?: any) => Promise<void>;\n}>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/testing/library.ts",
       "mdFile": "qwik.createdom.md"
     }

--- a/packages/docs/src/routes/api/qwik-testing/index.md
+++ b/packages/docs/src/routes/api/qwik-testing/index.md
@@ -9,7 +9,7 @@ title: \@builder.io/qwik/testing API Reference
 CreatePlatform and CreateDocument
 
 ```typescript
-createDOM: () =>
+createDOM: ({ html }?: { html?: string | undefined }) =>
   Promise<{
     render: (
       jsxElement: JSXNode,

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -3,6 +3,20 @@
   "package": "@builder.io/qwik",
   "members": [
     {
+      "name": "_qrlSync",
+      "id": "_qrlsync",
+      "hierarchy": [
+        {
+          "name": "_qrlSync",
+          "id": "_qrlsync"
+        }
+      ],
+      "kind": "Variable",
+      "content": "> This API is provided as an alpha preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.\n> \n\nExtract function into a synchronously loadable QRL.\n\nNOTE: Synchronous QRLs functions can't close over any variables, including exports.\n\n\n```typescript\n_qrlSync: <TYPE extends Function>(fn: TYPE, serializedFn?: string) => SyncQRL<TYPE>\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts",
+      "mdFile": "qwik._qrlsync.md"
+    },
+    {
       "name": "\"q:slot\"",
       "id": "componentbaseprops-_q_slot_",
       "hierarchy": [
@@ -32,6 +46,20 @@
       "content": "Qwik Optimizer marker function.\n\nUse `$(...)` to tell Qwik Optimizer to extract the expression in `$(...)` into a lazy-loadable resource referenced by `QRL`<!-- -->.\n\n\n```typescript\n$: <T>(expression: T) => QRL<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts",
       "mdFile": "qwik._.md"
+    },
+    {
+      "name": "$sync",
+      "id": "_sync",
+      "hierarchy": [
+        {
+          "name": "$sync",
+          "id": "_sync"
+        }
+      ],
+      "kind": "Variable",
+      "content": "> This API is provided as an alpha preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.\n> \n\nExtract function into a synchronously loadable QRL.\n\nNOTE: Synchronous QRLs functions can't close over any variables, including exports.\n\n\n```typescript\n$sync: <T extends Function>(fn: T) => SyncQRL<T>\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts",
+      "mdFile": "qwik._sync.md"
     },
     {
       "name": "AnchorHTMLAttributes",

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -4,6 +4,21 @@ title: \@builder.io/qwik API Reference
 
 # [API](/api) &rsaquo; @builder.io/qwik
 
+## \_qrlSync
+
+> This API is provided as an alpha preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+
+Extract function into a synchronously loadable QRL.
+
+NOTE: Synchronous QRLs functions can't close over any variables, including exports.
+
+```typescript
+_qrlSync: <TYPE extends Function>(fn: TYPE, serializedFn?: string) =>
+  SyncQRL<TYPE>;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts)
+
 ## "q:slot"
 
 ```typescript
@@ -18,6 +33,20 @@ Use `$(...)` to tell Qwik Optimizer to extract the expression in `$(...)` into a
 
 ```typescript
 $: <T>(expression: T) => QRL<T>;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts)
+
+## $sync
+
+> This API is provided as an alpha preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+
+Extract function into a synchronously loadable QRL.
+
+NOTE: Synchronous QRLs functions can't close over any variables, including exports.
+
+```typescript
+$sync: <T extends Function>(fn: T) => SyncQRL<T>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts)

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -10,6 +10,11 @@ import type { ServerRequestEvent } from '@builder.io/qwik-city/middleware/reques
 // @public
 export const $: <T>(expression: T) => QRL<T>;
 
+// Warning: (ae-forgotten-export) The symbol "SyncQRL" needs to be exported by the entry point index.d.ts
+//
+// @alpha
+export const $sync: <T extends Function>(fn: T) => SyncQRL<T>;
+
 // Warning: (ae-forgotten-export) The symbol "AnchorAttrs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -692,6 +697,9 @@ export const qrl: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: st
 //
 // @internal (undocumented)
 export const qrlDEV: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: string, opts: QRLDev, lexicalScopeCapture?: any[]) => QRL<T>;
+
+// @alpha
+export const _qrlSync: <TYPE extends Function>(fn: TYPE, serializedFn?: string) => SyncQRL<TYPE>;
 
 // @public (undocumented)
 export interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> {

--- a/packages/qwik/src/core/container/container.ts
+++ b/packages/qwik/src/core/container/container.ts
@@ -90,20 +90,21 @@ export interface ContainerState {
   $styleMoved$: boolean;
   readonly $styleIds$: Set<string>;
   readonly $events$: Set<string>;
+  readonly $inlineFns$: Map<Function, number>;
 }
 
 const CONTAINER_STATE = Symbol('ContainerState');
 
 /** @internal */
 export const _getContainerState = (containerEl: Element): ContainerState => {
-  let set = (containerEl as any)[CONTAINER_STATE] as ContainerState;
-  if (!set) {
-    (containerEl as any)[CONTAINER_STATE] = set = createContainerState(
+  let state = (containerEl as any)[CONTAINER_STATE] as ContainerState;
+  if (!state) {
+    (containerEl as any)[CONTAINER_STATE] = state = createContainerState(
       containerEl,
       directGetAttribute(containerEl, 'q:base') ?? '/'
     );
   }
-  return set;
+  return state;
 };
 
 export const createContainerState = (containerEl: Element, base: string) => {
@@ -132,6 +133,7 @@ export const createContainerState = (containerEl: Element, base: string) => {
     $hostsRendering$: undefined,
     $pauseCtx$: undefined,
     $subsManager$: null as any,
+    $inlineFns$: new Map(),
   };
   seal(containerState);
   containerState.$subsManager$ = createSubscriptionManager(containerState);
@@ -179,3 +181,8 @@ export const getEventName = (attribute: string) => {
     return attribute;
   }
 };
+
+export interface QContainerElement {
+  qFuncs?: Function[];
+  _qwikjson_?: any;
+}

--- a/packages/qwik/src/core/container/pause.ts
+++ b/packages/qwik/src/core/container/pause.ts
@@ -171,7 +171,7 @@ export const pauseContainer = async (
     if (isElement(elm) && listeners.length > 0) {
       const groups = groupListeners(listeners);
       for (const listener of groups) {
-        elm.setAttribute(listener[0], serializeQRLs(listener[1], elCtx));
+        elm.setAttribute(listener[0], serializeQRLs(listener[1], containerState, elCtx));
       }
     }
   }
@@ -621,13 +621,20 @@ const collectProps = (elCtx: QContext, collector: Collector) => {
 };
 
 const createCollector = (containerState: ContainerState): Collector => {
+  const inlinedFunctions: string[] = [];
+  containerState.$inlineFns$.forEach((id, fn) => {
+    while (inlinedFunctions.length <= id) {
+      inlinedFunctions.push('');
+    }
+    inlinedFunctions[id] = fn.toString();
+  });
   return {
     $containerState$: containerState,
     $seen$: new Set(),
     $objSet$: new Set(),
     $prefetch$: 0,
     $noSerialize$: [],
-    $inlinedFunctions$: [],
+    $inlinedFunctions$: inlinedFunctions,
     $resources$: [],
     $elements$: [],
     $qrls$: [],

--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -17,6 +17,7 @@ import {
   SHOW_COMMENT,
   type SnapshotState,
   strToInt,
+  type QContainerElement,
 } from './container';
 import { getVirtualElement } from '../render/dom/virtual-element';
 import { getSubscriptionManager, parseSubscription, type Subscriptions } from '../state/common';
@@ -110,7 +111,7 @@ export const resumeContainer = (containerEl: Element) => {
     }
   }
 
-  const inlinedFunctions = getQwikInlinedFuncs(parentJSON);
+  const inlinedFunctions = getQwikInlinedFuncs(containerEl);
   const containerState = _getContainerState(containerEl);
 
   // Collect all elements
@@ -311,12 +312,8 @@ const unescapeText = (str: string) => {
   return str.replace(/\\x3C(\/?script)/g, '<$1');
 };
 
-interface ExtraScript extends HTMLScriptElement {
-  qFuncs?: Function[];
-}
-export const getQwikInlinedFuncs = (parentElm: Element): Function[] => {
-  const elm = getQwikJSON(parentElm, 'q:func') as ExtraScript | undefined;
-  return elm?.qFuncs ?? EMPTY_ARRAY;
+export const getQwikInlinedFuncs = (containerEl: Element): Function[] => {
+  return (containerEl as QContainerElement).qFuncs ?? EMPTY_ARRAY;
 };
 
 export const getQwikJSON = (

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -25,7 +25,7 @@ export type {
 //////////////////////////////////////////////////////////////////////////////////////////
 // Internal Runtime
 //////////////////////////////////////////////////////////////////////////////////////////
-export { $ } from './qrl/qrl.public';
+export { $, $sync, _qrlSync } from './qrl/qrl.public';
 export { event$, eventQrl } from './qrl/qrl.public';
 
 export { qrl, inlinedQrl, inlinedQrlDEV, qrlDEV } from './qrl/qrl';

--- a/packages/qwik/src/core/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/qrl/qrl-class.ts
@@ -1,14 +1,16 @@
+import type { QContainerElement } from '../container/container';
+import { assertDefined } from '../error/assert';
 import { qError, QError_qrlIsNotFunction } from '../error/error';
 import { getPlatform, isServerPlatform } from '../platform/platform';
 import { verifySerializable } from '../state/common';
 import { isSignal, type SignalInternal } from '../state/signal';
 import {
-  type InvokeContext,
-  newInvokeContext,
   invoke,
-  type InvokeTuple,
+  newInvokeContext,
   newInvokeContextFromTuple,
   tryGetInvokeContext,
+  type InvokeContext,
+  type InvokeTuple,
 } from '../use/use-core';
 import { maybeThen } from '../util/promises';
 import { qDev, qSerialize, qTest, seal } from '../util/qdev';
@@ -18,6 +20,13 @@ import type { QRL, QrlArgs, QrlReturn } from './qrl.public';
 
 export const isQrl = <T = unknown>(value: unknown): value is QRLInternal<T> => {
   return typeof value === 'function' && typeof (value as any).getSymbol === 'function';
+};
+
+export const SYNC_QRL = '<sync>';
+
+/** Sync QRL is a function which is serialized into `<script q:func="qwik/json">` tag. */
+export const isSyncQrl = (value: any): value is QRLInternal => {
+  return isQrl(value) && value.$symbol$ == SYNC_QRL;
 };
 
 export type QRLInternalMethods<TYPE> = {
@@ -85,6 +94,12 @@ export const createQRL = <TYPE>(
   const resolve = async (containerEl?: Element): Promise<TYPE> => {
     if (containerEl) {
       setContainer(containerEl);
+    }
+    if (chunk == '') {
+      // Sync QRL
+      assertDefined(_containerEl, 'Sync QRL must have container element');
+      const qFuncs = (_containerEl as QContainerElement).qFuncs || [];
+      symbolRef = qFuncs[Number(symbol)] as TYPE;
     }
     if (symbolRef !== null) {
       return symbolRef;
@@ -163,9 +178,11 @@ export const createQRL = <TYPE>(
     $capture$: capture,
     $captureRef$: captureRef,
     dev: null,
-    resolved: undefined,
+    resolved: symbol == SYNC_QRL ? symbolRef : undefined,
   });
-  seal(qrl);
+  if (qDev) {
+    seal(qrl);
+  }
   return qrl;
 };
 

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -1,7 +1,7 @@
 import { implicit$FirstArg } from '../util/implicit_dollar';
 import { qDev, qRuntimeQrl } from '../util/qdev';
 import type { QRLDev } from './qrl';
-import { createQRL } from './qrl-class';
+import { SYNC_QRL, createQRL } from './qrl-class';
 
 // We use `unknown` instead of `never` when it's not a function so we allow assigning QRL<function> to QRL<any>
 export type QrlArgs<T> = T extends (...args: infer ARGS) => any ? ARGS : unknown[];
@@ -265,3 +265,64 @@ export const eventQrl = <T>(qrl: QRL<T>): QRL<T> => {
 
 /** @public */
 export const event$ = implicit$FirstArg(eventQrl);
+
+export interface SyncQRL<TYPE extends Function = any> extends QRL<TYPE> {
+  __brand__SyncQRL__: TYPE;
+
+  /**
+   * Resolve the QRL of closure and invoke it.
+   *
+   * @param args - Closure arguments.
+   * @returns A return value of the closure.
+   */
+  (
+    ...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never
+  ): TYPE extends (...args: any[]) => infer RETURN ? RETURN : never;
+
+  resolved: TYPE;
+  dev: QRLDev | null;
+}
+
+/**
+ * Extract function into a synchronously loadable QRL.
+ *
+ * NOTE: Synchronous QRLs functions can't close over any variables, including exports.
+ *
+ * @param fn - Function to extract.
+ * @returns
+ * @alpha
+ */
+export const $sync = <T extends Function>(fn: T): SyncQRL<T> => {
+  if (!qRuntimeQrl && qDev) {
+    throw new Error(
+      'Optimizer should replace all usages of $sync() with some special syntax. If you need to create a QRL manually, use inlinedSyncQrl() instead.'
+    );
+  }
+  if (qDev) {
+    // To make sure that in dev mode we don't accidentally capture context in `$sync()` we serialize and deserialize the function.
+    // eslint-disable-next-line no-new-func
+    fn = new Function('return ' + fn.toString())() as any;
+  }
+
+  return createQRL<T>('', SYNC_QRL, fn, null, null, null, null) as any;
+};
+
+/**
+ * Extract function into a synchronously loadable QRL.
+ *
+ * NOTE: Synchronous QRLs functions can't close over any variables, including exports.
+ *
+ * @param fn - Extracted function
+ * @param serializedFn - Serialized function in string form.
+ * @returns
+ * @alpha
+ */
+export const _qrlSync = function <TYPE extends Function>(
+  fn: TYPE,
+  serializedFn?: string
+): SyncQRL<TYPE> {
+  if (serializedFn === undefined) {
+    serializedFn = fn.toString();
+  }
+  return createQRL<TYPE>('', SYNC_QRL, fn, null, null, null, null) as any;
+};

--- a/packages/qwik/src/core/qrl/qrl.ts
+++ b/packages/qwik/src/core/qrl/qrl.ts
@@ -1,6 +1,13 @@
 import { EMPTY_ARRAY } from '../util/flyweight';
 import type { QRL } from './qrl.public';
-import { assertQrl, createQRL, emitEvent, getSymbolHash, type QRLInternal } from './qrl-class';
+import {
+  assertQrl,
+  createQRL,
+  emitEvent,
+  getSymbolHash,
+  isSyncQrl,
+  type QRLInternal,
+} from './qrl-class';
 import { isFunction, isString } from '../util/types';
 import {
   qError,
@@ -11,9 +18,10 @@ import {
 import { qRuntimeQrl, qSerialize } from '../util/qdev';
 import { getPlatform } from '../platform/platform';
 import { assertDefined, assertTrue, assertElement } from '../error/assert';
-import type { MustGetObjID } from '../container/container';
+import type { ContainerState, MustGetObjID } from '../container/container';
 import type { QContext } from '../state/context';
 import { mapJoin } from '../container/pause';
+import { throwErrorAndStop } from '../util/log';
 
 // https://regexr.com/68v72
 const EXTRACT_IMPORT_PATH = /\(\s*(['"])([^\1]+)\1\s*\)/;
@@ -142,6 +150,7 @@ export const inlinedQrlDEV = <T = any>(
 export interface QRLSerializeOptions {
   $getObjId$?: MustGetObjID;
   $addRefMap$?: (obj: any) => string;
+  $containerState$?: ContainerState;
 }
 
 export const serializeQRL = (qrl: QRLInternal, opts: QRLSerializeOptions = {}) => {
@@ -162,15 +171,29 @@ export const serializeQRL = (qrl: QRLInternal, opts: QRLSerializeOptions = {}) =
     }
   }
 
-  if (qRuntimeQrl && !chunk) {
+  if (qRuntimeQrl && chunk == null) {
     chunk = '/runtimeQRL';
     symbol = '_';
   }
-  if (!chunk) {
+  if (chunk == null) {
     throw qError(QError_qrlMissingChunk, qrl.$symbol$);
   }
   if (chunk.startsWith('./')) {
     chunk = chunk.slice(2);
+  }
+  if (isSyncQrl(qrl)) {
+    if (opts.$containerState$) {
+      const fn = qrl.resolved;
+      const containerState = opts.$containerState$;
+      let id = containerState.$inlineFns$.get(fn as any);
+      if (id === undefined) {
+        id = containerState.$inlineFns$.size;
+        containerState.$inlineFns$.set(fn as any, id);
+      }
+      symbol = String(id);
+    } else {
+      throwErrorAndStop('Sync QRL without containerState');
+    }
   }
   let output = `${chunk}#${symbol}`;
   const capture = qrl.$capture$;
@@ -187,9 +210,14 @@ export const serializeQRL = (qrl: QRLInternal, opts: QRLSerializeOptions = {}) =
   return output;
 };
 
-export const serializeQRLs = (existingQRLs: QRLInternal<any>[], elCtx: QContext): string => {
+export const serializeQRLs = (
+  existingQRLs: QRLInternal<any>[],
+  containerState: ContainerState,
+  elCtx: QContext
+): string => {
   assertElement(elCtx.$element$);
   const opts: QRLSerializeOptions = {
+    $containerState$: containerState,
     $addRefMap$: (obj) => addToArray(elCtx.$refMap$, obj),
   };
   return mapJoin(existingQRLs, (qrl) => serializeQRL(qrl, opts), '\n');

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -460,7 +460,11 @@ const renderSSRComponent = (
           const groups = groupListeners(listeners);
           for (const listener of groups) {
             const eventName = normalizeInvisibleEvents(listener[0]);
-            attributes[eventName] = serializeQRLs(listener[1], placeholderCtx);
+            attributes[eventName] = serializeQRLs(
+              listener[1],
+              rCtx.$static$.$containerState$,
+              placeholderCtx
+            );
             registerQwikEvent(eventName, rCtx.$static$.$containerState$);
           }
           renderNodeElementSync('script', attributes, stream);
@@ -731,7 +735,12 @@ This goes against the HTML spec: https://html.spec.whatwg.org/multipage/dom.html
       const isInvisible = (flags & IS_INVISIBLE) !== 0;
       for (const listener of groups) {
         const eventName = isInvisible ? normalizeInvisibleEvents(listener[0]) : listener[0];
-        openingElement += ' ' + eventName + '="' + serializeQRLs(listener[1], elCtx) + '"';
+        openingElement +=
+          ' ' +
+          eventName +
+          '="' +
+          serializeQRLs(listener[1], rCtx.$static$.$containerState$, elCtx) +
+          '"';
         registerQwikEvent(eventName, rCtx.$static$.$containerState$);
       }
     }

--- a/packages/qwik/src/core/render/sync-qrl.unit.tsx
+++ b/packages/qwik/src/core/render/sync-qrl.unit.tsx
@@ -1,0 +1,63 @@
+import { assert, suite, test } from 'vitest';
+import { createDOM } from '../../testing/library';
+import { $sync } from '../qrl/qrl.public';
+import { renderToString } from '../../server/render';
+
+suite('sync-qrl', () => {
+  test('default updates the checkbox', async () => {
+    const { screen, render } = await createDOM();
+    await render(<input type="checkbox" checked={false} />);
+    const input = screen.querySelector('input')!;
+    assert.equal(input.checked, false);
+    input.click();
+    assert.equal(input.checked, true);
+  });
+
+  test('default prevents updates the checkbox', async () => {
+    const { screen, userEvent, render } = await createDOM();
+    await render(
+      <input
+        type="checkbox"
+        onclick$={[
+          $sync((e: Event, target: Element) => {
+            if (target.getAttribute('shouldPreventDefault')) {
+              e.preventDefault();
+            }
+            target.setAttribute('prevented', String(e.defaultPrevented));
+          }),
+        ]}
+      />
+    );
+    const input = screen.querySelector('input')!;
+    await userEvent(input, 'click');
+    assert.equal(input.getAttribute('prevented'), 'false');
+    input.setAttribute('shouldPreventDefault', 'true');
+    await userEvent(input, 'click');
+    assert.equal(input.getAttribute('prevented'), 'true');
+  });
+
+  test('render SSR', async () => {
+    const response = await renderToString(
+      <input
+        type="checkbox"
+        onclick$={[
+          $sync(function (e: Event, target: Element) {
+            if (target.getAttribute('shouldPreventDefault')) {
+              e.preventDefault();
+            }
+            target.setAttribute('prevented', String(e.defaultPrevented));
+          }),
+        ]}
+      />,
+      { containerTagName: 'container' }
+    );
+
+    const { screen, userEvent } = await createDOM({ html: response.html });
+    const input = screen.querySelector('input')!;
+    await userEvent(input, 'click');
+    assert.equal(input.getAttribute('prevented'), 'false');
+    input.setAttribute('shouldPreventDefault', 'true');
+    await userEvent(input, 'click');
+    assert.equal(input.getAttribute('prevented'), 'true');
+  });
+});

--- a/packages/qwik/src/core/util/element.ts
+++ b/packages/qwik/src/core/util/element.ts
@@ -26,6 +26,10 @@ export const isVirtualElement = (value: Node | VirtualElement): value is Virtual
   return value.nodeType === 111;
 };
 
+export const isVirtualElementOpenComment = (value: Node | VirtualElement): value is Comment => {
+  return isComment(value) && value.data.startsWith('qv ');
+};
+
 export const isText = (value: Node | QwikElement): value is Text => {
   return value.nodeType === 3;
 };

--- a/packages/qwik/src/optimizer/core/src/inlined_fn.rs
+++ b/packages/qwik/src/optimizer/core/src/inlined_fn.rs
@@ -177,7 +177,7 @@ impl VisitMut for ReplaceIdentifiers {
     }
 }
 
-fn render_expr(expr: &ast::Expr) -> String {
+pub fn render_expr(expr: &ast::Expr) -> String {
     let mut expr = expr.clone();
     let mut buf = Vec::new();
     let source_map = Lrc::new(SourceMap::default());

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_of_synchronous_qrl.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_of_synchronous_qrl.snap
@@ -1,0 +1,83 @@
+---
+source: packages/qwik/src/optimizer/core/src/test.rs
+expression: output
+---
+==INPUT==
+
+
+        import { $sync, component$ } from "@builder.io/qwik";
+
+        export default component$(() => {
+        return (
+            <>
+                <input onClick$={$sync(function(event, target) {
+                    // comment should be removed
+                    event.preventDefault();
+                })}/>
+                <input onClick$={$sync((event, target) => {
+                    event.preventDefault();
+                })}/>
+                <input onClick$={$sync((event, target) => event.preventDefault())}/>
+            </>
+        );
+        });
+        
+============================= test.js ==
+
+import { componentQrl } from "@builder.io/qwik";
+import { qrl } from "@builder.io/qwik";
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGQ,6BAAe,0GAaZ\"}")
+============================= test_component_luxexe0dqrg.js (ENTRY POINT)==
+
+import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
+import { _jsxC } from "@builder.io/qwik";
+import { _jsxQ } from "@builder.io/qwik";
+import { _qrlSync } from "@builder.io/qwik";
+export const test_component_LUXeXe0DQrg = ()=>{
+    return /*#__PURE__*/ _jsxC(_Fragment, {
+        children: [
+            /*#__PURE__*/ _jsxQ("input", {
+                onClick$: _qrlSync(function(event, target) {
+                    // comment should be removed
+                    event.preventDefault();
+                }, "function(event,target){event.preventDefault();}")
+            }, null, null, 2, null),
+            /*#__PURE__*/ _jsxQ("input", {
+                onClick$: _qrlSync((event, target)=>{
+                    event.preventDefault();
+                }, "(event,target)=>{event.preventDefault();}")
+            }, null, null, 2, null),
+            /*#__PURE__*/ _jsxQ("input", {
+                onClick$: _qrlSync((event, target)=>event.preventDefault(), "(event,target)=>event.preventDefault()")
+            }, null, null, 2, null)
+        ]
+    }, 1, "u6_0");
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;0CAGkC,IAAM;IAChC,qBACI;;0BACI,MAAC;gBAAM,QAAQ,WAAQ,SAAS,KAAK,EAAE,MAAM,EAAE;oBAC3C,4BAA4B;oBAC5B,MAAM,cAAc;gBACxB;;0BACA,MAAC;gBAAM,QAAQ,WAAQ,CAAC,OAAO,SAAW;oBACtC,MAAM,cAAc;gBACxB;;0BACA,MAAC;gBAAM,QAAQ,WAAQ,CAAC,OAAO,SAAW,MAAM,cAAc;;;;AAGtE\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "test_component_LUXeXe0DQrg",
+  "entry": null,
+  "displayName": "test_component",
+  "hash": "LUXeXe0DQrg",
+  "canonicalFilename": "test_component_luxexe0dqrg",
+  "extension": "js",
+  "parent": null,
+  "ctxKind": "function",
+  "ctxName": "component$",
+  "captures": false,
+  "loc": [
+    99,
+    566
+  ]
+}
+*/
+== DIAGNOSTICS ==
+
+[]

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -3448,6 +3448,56 @@ fn issue_5008() {
     });
 }
 
+#[test]
+fn example_of_synchronous_qrl() {
+    test_input!(TestInput {
+        code: r#"
+        import { $sync, component$ } from "@builder.io/qwik";
+
+        export default component$(() => {
+        return (
+            <>
+                <input onClick$={$sync(function(event, target) {
+                    // comment should be removed
+                    event.preventDefault();
+                })}/>
+                <input onClick$={$sync((event, target) => {
+                    event.preventDefault();
+                })}/>
+                <input onClick$={$sync((event, target) => event.preventDefault())}/>
+            </>
+        );
+        });
+        "#
+        .to_string(),
+        transpile_ts: true,
+        transpile_jsx: true,
+        ..TestInput::default()
+    });
+}
+
+// TODO(misko): Make this test work by implementing strict serialization.
+// #[test]
+// fn example_of_synchronous_qrl_that_cant_be_serialized() {
+//     test_input!(TestInput {
+//         code: r#"
+//         import { $sync, component$ } from "@builder.io/qwik";
+
+//         export default component$(() => {
+//         return (
+//             <input onClick$={$sync(function(event, target) {
+//                 console.log(component$);
+//             })}/>
+//         );
+//         });
+//         "#
+//         .to_string(),
+//         transpile_ts: true,
+//         transpile_jsx: true,
+//         ..TestInput::default()
+//     });
+// }
+
 fn get_hash(name: &str) -> String {
     name.split('_').last().unwrap().into()
 }

--- a/packages/qwik/src/optimizer/core/src/words.rs
+++ b/packages/qwik/src/optimizer/core/src/words.rs
@@ -17,7 +17,7 @@ lazy_static! {
     pub static ref _NOOP_QRL: JsWord = JsWord::from("_noopQrl");
     pub static ref _REST_PROPS: JsWord = JsWord::from("_restProps");
     pub static ref QHOOK: JsWord = JsWord::from("$");
-    pub static ref QQHOOK: JsWord = JsWord::from("$$");
+    pub static ref Q_SYNC: JsWord = JsWord::from("$sync");
     pub static ref QWIK_INTERNAL: JsWord = JsWord::from("qwik");
     pub static ref BUILDER_IO_QWIK: JsWord = JsWord::from("@builder.io/qwik");
     pub static ref BUILDER_IO_QWIK_BUILD: JsWord = JsWord::from("@builder.io/qwik/build");
@@ -37,6 +37,7 @@ lazy_static! {
     pub static ref COMPONENT: JsWord = JsWord::from("component$");
     pub static ref _REG_SYMBOL: JsWord = JsWord::from("_regSymbol");
     pub static ref _JSX_BRANCH: JsWord = JsWord::from("_jsxBranch");
+    pub static ref _QRL_SYNC: JsWord = JsWord::from("_qrlSync");
     pub static ref _WRAP_PROP: JsWord = JsWord::from("_wrapProp");
     pub static ref _WRAP_SIGNAL: JsWord = JsWord::from("_wrapSignal");
     pub static ref _JSX_Q: JsWord = JsWord::from("_jsxQ");

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -1,4 +1,5 @@
 import type { QwikSymbolEvent, QwikVisibleEvent } from './core/render/jsx/types/jsx-qwik-events';
+import type { QContainerElement } from './core/container/container';
 import type { QContext } from './core/state/context';
 
 /**
@@ -30,12 +31,12 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
   };
 
   const resolveContainer = (containerEl: Element) => {
-    if ((containerEl as any)['_qwikjson_'] === undefined) {
+    if ((containerEl as QContainerElement)['_qwikjson_'] === undefined) {
       const parentJSON = containerEl === doc.documentElement ? doc.body : containerEl;
       let script = parentJSON.lastElementChild;
       while (script) {
         if (script.tagName === 'SCRIPT' && getAttribute(script, 'type') === 'qwik/json') {
-          (containerEl as any)['_qwikjson_'] = JSON.parse(
+          (containerEl as QContainerElement)['_qwikjson_'] = JSON.parse(
             script.textContent!.replace(/\\x3C(\/?script)/g, '<$1')
           );
           break;
@@ -71,18 +72,25 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
         const url = new URL(qrl, base);
         const symbolName = url.hash.replace(/^#?([^?[|]*).*$/, '$1') || 'default';
         const reqTime = performance.now();
-        const module = import(/* @vite-ignore */ url.href.split('#')[0]);
-        resolveContainer(container);
-        const handler = (await module)[symbolName];
+        let handler: any;
+        const isSync = qrl.startsWith('#');
+        if (isSync) {
+          handler = ((container as QContainerElement).qFuncs || [])[Number.parseInt(symbolName)];
+        } else {
+          const module = import(/* @vite-ignore */ url.href.split('#')[0]);
+          resolveContainer(container);
+          handler = (await module)[symbolName];
+        }
         const previousCtx = (doc as any)[Q_CONTEXT];
         if (element.isConnected) {
           try {
             (doc as any)[Q_CONTEXT] = [element, ev, url];
-            emitEvent<QwikSymbolEvent>('qsymbol', {
-              symbol: symbolName,
-              element: element,
-              reqTime,
-            });
+            isSync ||
+              emitEvent<QwikSymbolEvent>('qsymbol', {
+                symbol: symbolName,
+                element: element,
+                reqTime,
+              });
             await handler(ev, element);
           } finally {
             (doc as any)[Q_CONTEXT] = previousCtx;

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -322,6 +322,8 @@ function collectRenderSymbols(renderSymbols: string[], elements: QContext[]) {
   }
 }
 
+export const Q_FUNCS_PREFIX = 'document.currentScript.closest("[q\\\\:container]").qFuncs=';
+
 function serializeFunctions(funcs: string[]) {
-  return `document.currentScript.qFuncs=[${funcs.join(',\n')}]`;
+  return Q_FUNCS_PREFIX + `[${funcs.join(',\n')}]`;
 }

--- a/packages/qwik/src/testing/api.md
+++ b/packages/qwik/src/testing/api.md
@@ -8,7 +8,9 @@ import type { JSXNode } from '@builder.io/qwik/jsx-runtime';
 import { RenderResult } from '@builder.io/qwik';
 
 // @public
-export const createDOM: () => Promise<{
+export const createDOM: ({ html }?: {
+    html?: string | undefined;
+}) => Promise<{
     render: (jsxElement: JSXNode) => Promise<RenderResult>;
     screen: HTMLElement;
     userEvent: (queryOrElement: string | Element | keyof HTMLElementTagNameMap | null, eventNameCamel: string | keyof WindowEventMap, eventPayload?: any) => Promise<void>;

--- a/packages/qwik/src/testing/element-fixture.ts
+++ b/packages/qwik/src/testing/element-fixture.ts
@@ -1,11 +1,18 @@
+import { resumeIfNeeded } from '../core/container/resume';
+import { assertDefined } from '../core/error/assert';
+import { parseQRL } from '../core/qrl/qrl';
+import type { QRLInternal } from '../core/qrl/qrl-class';
+import { isSyncQrl } from '../core/qrl/qrl-class';
+import { directGetAttribute } from '../core/render/fast-calls';
+import { tryGetContext, type QContext } from '../core/state/context';
+import { normalizeOnProp, PREVENT_DEFAULT } from '../core/state/listeners';
+import { getWrappingContainer } from '../core/use/use-core';
 import { fromCamelToKebabCase } from '../core/util/case';
+import { QContainerSelector } from '../core/util/markers';
+import { Q_FUNCS_PREFIX } from '../server/render';
 import { createWindow } from './document';
 import { getTestPlatform } from './platform';
 import type { MockDocument, MockWindow } from './types';
-import { getWrappingContainer } from '../core/use/use-core';
-import { assertDefined } from '../core/error/assert';
-import { tryGetContext, type QContext } from '../core/state/context';
-import { normalizeOnProp } from '../core/state/listeners';
 
 /**
  * Creates a simple DOM structure for testing components.
@@ -32,19 +39,35 @@ export class ElementFixture {
     this.window = createWindow();
     this.document = this.window.document;
     this.superParent = this.document.createElement('super-parent');
-    this.parent = this.document.createElement('parent');
-    this.host = this.document.createElement(options.tagName || 'host');
-    this.child = this.document.createElement('child');
-    this.superParent.appendChild(this.parent);
-    this.parent.appendChild(this.host);
-    this.host.appendChild(this.child);
     this.document.body.appendChild(this.superParent);
+    this.parent = this.document.createElement('parent');
+    this.superParent.appendChild(this.parent);
+    if (options.html) {
+      this.parent.innerHTML = options.html;
+      this.host = this.parent.firstElementChild as HTMLElement;
+      assertDefined(this.host, 'host element must be defined');
+      this.host.querySelectorAll('script[q\\:func="qwik/json"]').forEach((script) => {
+        const code = script.textContent;
+        if (code?.startsWith(Q_FUNCS_PREFIX)) {
+          const qFuncs = eval(code.substring(Q_FUNCS_PREFIX.length));
+          const container = this.host.closest(QContainerSelector);
+          (container as any as { qFuncs?: Function[] }).qFuncs = qFuncs;
+        }
+      });
+      this.child = null!;
+    } else {
+      this.host = this.document.createElement(options.tagName || 'host');
+      this.child = this.document.createElement('child');
+      this.parent.appendChild(this.host);
+      this.host.appendChild(this.child);
+    }
   }
 }
 
 /** @public */
 export interface ElementFixtureOptions {
   tagName?: string;
+  html?: string;
 }
 
 /**
@@ -60,12 +83,19 @@ export interface ElementFixtureOptions {
  */
 export async function trigger(
   root: Element,
-  selector: string,
-  eventNameCamel: string
+  queryOrElement: string | Element | keyof HTMLElementTagNameMap | null,
+  eventNameCamel: string,
+  eventPayload: any = {}
 ): Promise<void> {
-  for (const element of Array.from(root.querySelectorAll(selector))) {
+  const elements =
+    typeof queryOrElement === 'string'
+      ? Array.from(root.querySelectorAll(queryOrElement))
+      : [queryOrElement];
+  for (const element of elements) {
     const kebabEventName = fromCamelToKebabCase(eventNameCamel);
-    const event = { type: kebabEventName };
+    const event = root.ownerDocument.createEvent('Event');
+    event.initEvent(kebabEventName, true, true);
+    Object.assign(event, eventPayload);
     const attrName = 'on:' + kebabEventName;
     await dispatch(element, attrName, event);
   }
@@ -75,21 +105,46 @@ export async function trigger(
 /**
  * Dispatch
  *
- * @param root
+ * @param element
  * @param attrName
- * @param ev
+ * @param event
  */
-export const dispatch = async (root: Element | null, attrName: string, ev: any) => {
-  while (root) {
-    const elm = root;
-    const ctx = tryGetContext(elm);
-    const qrls = ctx?.li.filter((li) => li[0] === attrName);
-    if (qrls && qrls.length > 0) {
-      for (const q of qrls) {
-        await q[1].getFn([elm, ev], () => elm.isConnected)(ev, elm);
-      }
+export const dispatch = async (element: Element | null, attrName: string, event: any) => {
+  const preventAttributeName = PREVENT_DEFAULT + event.type;
+  const collectListeners: { element: Element; qrl: QRLInternal }[] = [];
+  const containerEl = element?.closest(QContainerSelector);
+  containerEl && resumeIfNeeded(containerEl);
+  while (element) {
+    const preventDefault = element.hasAttribute(preventAttributeName);
+    if (preventDefault) {
+      event.preventDefault();
     }
-    root = elm.parentElement;
+    const ctx = tryGetContext(element);
+    if (ctx) {
+      for (const li of ctx.li) {
+        if (li[0] === attrName) {
+          // Ensure this is correct event type
+          const qrl = li[1];
+          if (isSyncQrl(qrl)) {
+            qrl(event, element);
+          } else {
+            collectListeners.push({ element, qrl: qrl });
+          }
+        }
+      }
+    } else if (element.hasAttribute(attrName)) {
+      directGetAttribute(element, attrName)!
+        .split('/n')
+        .map((qrl) => parseQRL(qrl, containerEl || undefined))
+        .forEach((qrl) => {
+          qrl(event, element);
+        });
+    }
+    element = element.parentElement;
+  }
+  for (let i = 0; i < collectListeners.length; i++) {
+    const { element, qrl } = collectListeners[i];
+    await (qrl.getFn([element, event], () => element.isConnected) as Function)(event, element);
   }
 };
 export function getEvent(elCtx: QContext, prop: string): any {

--- a/packages/qwik/src/testing/library.ts
+++ b/packages/qwik/src/testing/library.ts
@@ -1,37 +1,16 @@
-import { fromCamelToKebabCase } from './../core/util/case';
-import { ElementFixture, dispatch } from './element-fixture';
-import { setTestPlatform, getTestPlatform } from './platform';
 import type { JSXNode } from '@builder.io/qwik/jsx-runtime';
-
-/**
- * @param root
- * @param selector
- * @param eventNameCamel
- */
-async function triggerUserEvent(
-  root: Element,
-  selector: string,
-  eventNameCamel: string,
-  eventPayload: any = {}
-): Promise<void> {
-  for (const element of Array.from(root.querySelectorAll(selector))) {
-    const kebabEventName = fromCamelToKebabCase(eventNameCamel);
-    const event = { type: kebabEventName, ...eventPayload };
-    const attrName = 'on:' + kebabEventName;
-    await dispatch(element, attrName, event);
-  }
-  await getTestPlatform().flush();
-}
+import { ElementFixture, trigger } from './element-fixture';
+import { setTestPlatform } from './platform';
 
 /**
  * CreatePlatform and CreateDocument
  *
  * @public
  */
-export const createDOM = async function () {
+export const createDOM = async function ({ html }: { html?: string } = {}) {
   const qwik = await getQwik();
   setTestPlatform(qwik.setPlatform);
-  const host = new ElementFixture().host;
+  const host = new ElementFixture({ html }).host;
   return {
     render: function (jsxElement: JSXNode) {
       return qwik.render(host, jsxElement);
@@ -42,14 +21,7 @@ export const createDOM = async function () {
       eventNameCamel: string | keyof WindowEventMap,
       eventPayload: any = {}
     ) {
-      if (typeof queryOrElement === 'string') {
-        return triggerUserEvent(host, queryOrElement, eventNameCamel, eventPayload);
-      }
-      const kebabEventName = fromCamelToKebabCase(eventNameCamel);
-      const event = { type: kebabEventName, ...eventPayload };
-      const attrName = 'on:' + kebabEventName;
-      await dispatch(queryOrElement, attrName, event);
-      await getTestPlatform().flush();
+      return trigger(host, queryOrElement, eventNameCamel, eventPayload);
     },
   };
 };

--- a/starters/apps/e2e/src/components/resuming/sync-qrl.tsx
+++ b/starters/apps/e2e/src/components/resuming/sync-qrl.tsx
@@ -1,0 +1,22 @@
+import { component$, $sync } from "@builder.io/qwik";
+
+export const SyncQRL = component$(() => {
+  return (
+    <div>
+      <h1>PreventDefault</h1>
+      <input
+        id="preventDefaultInput"
+        type="checkbox"
+        onclick$={[
+          $sync((e: Event, target: Element) => {
+            if (target.getAttribute("shouldPreventDefault")) {
+              e.preventDefault();
+            }
+            target.setAttribute("prevented", String(e.defaultPrevented));
+          }),
+        ]}
+      />
+      <hr />
+    </div>
+  );
+});

--- a/starters/apps/e2e/src/entry.ssr.tsx
+++ b/starters/apps/e2e/src/entry.ssr.tsx
@@ -35,6 +35,7 @@ import { TwoListeners } from "./components/two-listeners/twolisteners";
 import { UseId } from "./components/useid/useid";
 import { Watch } from "./components/watch/watch";
 import { Root } from "./root";
+import { SyncQRL } from "./components/resuming/sync-qrl";
 
 /**
  * Entry point for server-side pre-rendering.
@@ -73,6 +74,7 @@ export default function (opts: RenderToStreamOptions) {
     "/e2e/events-client": () => <EventsClient />,
     "/e2e/no-resume": () => <NoResume />,
     "/e2e/resuming": () => <Resuming1 />,
+    "/e2e/sync-qrl": () => <SyncQRL />,
     "/e2e/computed": () => <ComputedRoot />,
     "/e2e/build-variables": () => <BuildVariables />,
   };

--- a/starters/e2e/e2e.sync-qrl.spec.ts
+++ b/starters/e2e/e2e.sync-qrl.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("resuming", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/e2e/sync-qrl");
+    page.on("pageerror", (err) => expect(err).toEqual(undefined));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        expect(msg.text()).toEqual(undefined);
+      }
+    });
+  });
+
+  test("should synchronously prevent default", async ({ page }) => {
+    const input = page.locator("#preventDefaultInput");
+
+    await expect(input).not.toBeChecked();
+    // clicking checkbox toggles the checked state.
+    await input.click();
+    await expect(input).toBeChecked();
+
+    await input.evaluate((el) =>
+      el.setAttribute("shouldPreventDefault", "true"),
+    );
+
+    // clicking checkbox does not toggles the checked state, because default is prevented.
+    await input.click();
+    await expect(input).toBeChecked();
+    await expect(await input.getAttribute("prevented")).toBeDefined();
+  });
+});


### PR DESCRIPTION
# Overview

feat(qwik): Experimental support for synchronous QRL `$sync()`.

It is often desirable to have call API on events synchronously. For example, `event.preventDefault()` and `event.stopPropagation()` must be called synchronously in order to have a helpful effect.

```TypeScript
  <button onClick$={[
    $sync(event => event.preventDefault()),
    $(() => {
      // normal behavior.
    })
  ]}>Click Me</button>
```

The idea is that `$sync()` will be inlined into HTML. For this reason, the function, `$sync()`, must not only be a pure function but also can not depend on any external code, such as imports.

The best way to think about it is that the function inside `$sync()` must be able to survive `fn.toString()` and then be reconstructed from the string into a proper function.

In practice, this means that the function must be a simple function which can't:
- Close over any state.
- Close over any imports.

Fix #5322
Fix #4496



# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
