### PR TITLE
fix: WIP UNTESTED add invoke context to qwikcity

### DIFF
--- a/packages/qwik-city/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/middleware/request-handler/request-event.ts
@@ -26,6 +26,7 @@ import type { ValueOrPromise } from '@builder.io/qwik';
 import type { QwikManifest, ResolvedManifest } from '@builder.io/qwik/optimizer';
 import { IsQData, QDATA_JSON, QDATA_JSON_LEN } from './user-response';
 import { isPromise } from './../../runtime/src/utils';
+import { invoke, newInvokeContext } from 'packages/qwik/src/core/use/use-core';
 
 const RequestEvLoaders = Symbol('RequestEvLoaders');
 const RequestEvMode = Symbol('RequestEvMode');
@@ -67,13 +68,14 @@ export function createRequestEvent(
   let requestData: Promise<JSONValue | undefined> | undefined = undefined;
   let locale = serverRequestEv.locale;
   let status = 200;
+  const invokeCtx = newInvokeContext(locale, undefined, undefined, serverRequestEv, url);
 
   const next = async () => {
     routeModuleIndex++;
 
     while (routeModuleIndex < requestHandlers.length) {
       const moduleRequestHandler = requestHandlers[routeModuleIndex];
-      const result = moduleRequestHandler(requestEv);
+      const result = invoke(invokeCtx, moduleRequestHandler, requestEv);
       if (isPromise(result)) {
         await result;
       }

--- a/packages/qwik-city/middleware/request-handler/request-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/request-handler.ts
@@ -5,7 +5,11 @@ import { getRouteMatchPathname, type QwikCityRun, runQwikCity } from './user-res
 import { renderQwikMiddleware, resolveRequestHandlers } from './resolve-request-handlers';
 import { loadRoute } from '../../runtime/src/routing';
 
-/** @public */
+/**
+ * The request handler for QwikCity. Called by every integration.
+ *
+ * @public
+ */
 export async function requestHandler<T = unknown>(
   serverRequestEv: ServerRequestEvent<T>,
   opts: ServerRenderOptions,

--- a/packages/qwik-city/middleware/request-handler/types.ts
+++ b/packages/qwik-city/middleware/request-handler/types.ts
@@ -20,11 +20,11 @@ export interface ClientConn {
  * @public
  * Request event created by the server.
  */
-export interface ServerRequestEvent<T = any> {
+export interface ServerRequestEvent<T = unknown> {
   mode: ServerRequestMode;
   url: URL;
   locale: string | undefined;
-  platform: any;
+  platform: QwikCityPlatform;
   request: Request;
   env: EnvGetter;
   getClientConn: () => ClientConn;

--- a/packages/qwik/src/core/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/qrl/qrl-class.ts
@@ -68,7 +68,7 @@ export const createQRL = <TYPE>(
 
   let _containerEl: Element | undefined;
 
-  const qrl = async function (this: any, ...args: any) {
+  const qrl = async function (this: unknown, ...args: unknown[]) {
     const fn = invokeFn.call(this, tryGetInvokeContext());
     const result = await fn(...args);
     return result;

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -32,6 +32,7 @@ import {
   type ReadonlySignal,
 } from '../state/signal';
 import { QObjectManagerSymbol } from '../state/constants';
+import { ComputedEvent, TaskEvent } from '../util/markers';
 
 export const TaskFlagsIsVisibleTask = 1 << 0;
 export const TaskFlagsIsTask = 1 << 1;
@@ -505,7 +506,7 @@ export const runResource = <T>(
   cleanupTask(task);
 
   const el = task.$el$;
-  const iCtx = newInvokeContext(rCtx.$static$.$locale$, el, undefined, 'TaskEvent');
+  const iCtx = newInvokeContext(rCtx.$static$.$locale$, el, undefined, TaskEvent);
   const { $subsManager$: subsManager } = containerState;
   iCtx.$renderCtx$ = rCtx;
   const taskFn = task.$qrl$.getFn(iCtx, () => {
@@ -634,7 +635,7 @@ export const runTask = (
 
   cleanupTask(task);
   const hostElement = task.$el$;
-  const iCtx = newInvokeContext(rCtx.$static$.$locale$, hostElement, undefined, 'TaskEvent');
+  const iCtx = newInvokeContext(rCtx.$static$.$locale$, hostElement, undefined, TaskEvent);
   iCtx.$renderCtx$ = rCtx;
   const { $subsManager$: subsManager } = containerState;
   const taskFn = task.$qrl$.getFn(iCtx, () => {
@@ -691,7 +692,7 @@ export const runComputed = (
   task.$flags$ &= ~TaskFlagsIsDirty;
   cleanupTask(task);
   const hostElement = task.$el$;
-  const iCtx = newInvokeContext(rCtx.$static$.$locale$, hostElement, undefined, 'ComputedEvent');
+  const iCtx = newInvokeContext(rCtx.$static$.$locale$, hostElement, undefined, ComputedEvent);
   iCtx.$subscriber$ = [0, task];
   iCtx.$renderCtx$ = rCtx;
 

--- a/packages/qwik/src/core/util/markers.ts
+++ b/packages/qwik/src/core/util/markers.ts
@@ -28,6 +28,8 @@ export const QContainerSelector = '[q\\:container]';
 export const ResourceEvent = 'qResource';
 export const ComputedEvent = 'qComputed';
 export const RenderEvent = 'qRender';
+export const TaskEvent = 'qTask';
+
 /** `<q:slot name="...">` */
 export const QSlotInertName = '\u0000';
 


### PR DESCRIPTION
Co-authored-by: Giorgio Boa <gioboa@users.noreply.github.com>

This hopefully makes getLocale work in server calls

NOTE: I got stuck trying to share async localstorage between qwik and qwik-city, but now I realized that qwik-city can probably keep it on its side only. Will revisit at some point.