### PR TITLE
fix: CF pages polyfill also when shimmed

### DIFF
--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -16,6 +16,7 @@ import { setServerPlatform } from '@builder.io/qwik/server';
 /** @public */
 export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
   try {
+    // https://developers.cloudflare.com/workers/configuration/compatibility-dates/#streams-constructors
     // this will throw if CF compatibility_date < 2022-11-30
     new globalThis.TextEncoderStream();
   } catch (e) {


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

Another patch related to #5400 – depending on the `compatibility_date`, Cloudflare was shimming the streams API and throwing a "Not Implemented" exception when instantiated, this PR makes the polyfill logic more robust by actually trying to instantiate the class instead of simply checking the name exists.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
