### PR TITLE
docs: fix up markdown rendering

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/mdx/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/mdx/index.mdx
@@ -27,7 +27,7 @@ src/
             └── index.mdx    # https://example.com/some/path
 ```
 
-```Markdown title="src/routes/some/path/index.mdx"
+```markdown title="src/routes/some/path/index.mdx"
 ---
 title: Hello World Title
 ---
@@ -53,7 +53,7 @@ src/
             └── index.mdx    # https://example.com/some/path
 ```
 
-```Markdown title="src/routes/some/path/index.mdx"
+```markdown title="src/routes/some/path/index.mdx"
 ---
 title: Hello World Title
 ---
@@ -155,7 +155,7 @@ The above example will generate the following HTML code.
 ## Reading frontmatter data
 Frontmatter keys are accessible by leveraging the `useDocumentHead()` hook.
 
-```Markdown title="src/routes/some/path/index.mdx"
+```markdown title="src/routes/some/path/index.mdx"
 ---
 title: Hello World Title
 tags:


### PR DESCRIPTION
docs(markdown is now rendered correctly. there are now new lines, when new lines are used): rename

use "markdown" instead of "Markdown"

re #5522

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

now the markdown is rendered correctly with new lines
![image](https://github.com/BuilderIO/qwik/assets/19373754/eddfee61-2b33-4460-a6eb-528b82c1ea87)

unlike before
![image](https://github.com/BuilderIO/qwik/assets/19373754/9b238492-47d5-42d6-8a54-5ded2a1c5c8c)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
