### PR TITLE
refactor(types): optimize, QRL props, PropsOf, track(Signal) type, ...

### DIFF
--- a/packages/docs/src/routes/(ecosystem)/ecosystem/menu-items.tsx
+++ b/packages/docs/src/routes/(ecosystem)/ecosystem/menu-items.tsx
@@ -193,10 +193,10 @@ export const MenuItems = () => {
             xmlns="http://www.w3.org/2000/svg"
             aria-hidden="true"
           >
-            <g fill="none" stroke="currentColor" strokeLinejoin="round" strokeWidth="4">
+            <g fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="4">
               <path d="M8 7h32v24H8z"></path>
               <path
-                strokeLinecap="round"
+                stroke-linecap="round"
                 d="M4 7h40M15 41l9-10l9 10M16 13h16m-16 6h12m-12 6h6"
               ></path>
             </g>

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -20,6 +20,193 @@
       "mdFile": "qwik.componentbaseprops._q_slot_.md"
     },
     {
+      "name": "\"xlink:actuate\"",
+      "id": "svgattributes-_xlink_actuate_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xlink_actuate_"
+        },
+        {
+          "name": "\"xlink:actuate\"",
+          "id": "svgattributes-_xlink_actuate_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xlink:actuate'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xlink_actuate_.md"
+    },
+    {
+      "name": "\"xlink:arcrole\"",
+      "id": "svgattributes-_xlink_arcrole_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xlink_arcrole_"
+        },
+        {
+          "name": "\"xlink:arcrole\"",
+          "id": "svgattributes-_xlink_arcrole_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xlink:arcrole'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xlink_arcrole_.md"
+    },
+    {
+      "name": "\"xlink:href\"",
+      "id": "svgattributes-_xlink_href_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xlink_href_"
+        },
+        {
+          "name": "\"xlink:href\"",
+          "id": "svgattributes-_xlink_href_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xlink:href'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xlink_href_.md"
+    },
+    {
+      "name": "\"xlink:role\"",
+      "id": "svgattributes-_xlink_role_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xlink_role_"
+        },
+        {
+          "name": "\"xlink:role\"",
+          "id": "svgattributes-_xlink_role_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xlink:role'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xlink_role_.md"
+    },
+    {
+      "name": "\"xlink:show\"",
+      "id": "svgattributes-_xlink_show_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xlink_show_"
+        },
+        {
+          "name": "\"xlink:show\"",
+          "id": "svgattributes-_xlink_show_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xlink:show'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xlink_show_.md"
+    },
+    {
+      "name": "\"xlink:title\"",
+      "id": "svgattributes-_xlink_title_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xlink_title_"
+        },
+        {
+          "name": "\"xlink:title\"",
+          "id": "svgattributes-_xlink_title_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xlink:title'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xlink_title_.md"
+    },
+    {
+      "name": "\"xlink:type\"",
+      "id": "svgattributes-_xlink_type_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xlink_type_"
+        },
+        {
+          "name": "\"xlink:type\"",
+          "id": "svgattributes-_xlink_type_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xlink:type'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xlink_type_.md"
+    },
+    {
+      "name": "\"xml:base\"",
+      "id": "svgattributes-_xml_base_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xml_base_"
+        },
+        {
+          "name": "\"xml:base\"",
+          "id": "svgattributes-_xml_base_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xml:base'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xml_base_.md"
+    },
+    {
+      "name": "\"xml:lang\"",
+      "id": "svgattributes-_xml_lang_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xml_lang_"
+        },
+        {
+          "name": "\"xml:lang\"",
+          "id": "svgattributes-_xml_lang_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xml:lang'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xml_lang_.md"
+    },
+    {
+      "name": "\"xml:space\"",
+      "id": "svgattributes-_xml_space_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xml_space_"
+        },
+        {
+          "name": "\"xml:space\"",
+          "id": "svgattributes-_xml_space_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xml:space'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xml_space_.md"
+    },
+    {
+      "name": "\"xmlns:xlink\"",
+      "id": "svgattributes-_xmlns_xlink_",
+      "hierarchy": [
+        {
+          "name": "SVGAttributes",
+          "id": "svgattributes-_xmlns_xlink_"
+        },
+        {
+          "name": "\"xmlns:xlink\"",
+          "id": "svgattributes-_xmlns_xlink_"
+        }
+      ],
+      "kind": "PropertySignature",
+      "content": "```typescript\n'xmlns:xlink'?: string | undefined;\n```",
+      "mdFile": "qwik.svgattributes._xmlns_xlink_.md"
+    },
+    {
       "name": "$",
       "id": "_",
       "hierarchy": [
@@ -43,7 +230,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<T>, AnchorAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, AnchorAttrs",
+      "content": "```typescript\nexport interface AnchorHTMLAttributes<T extends Element> extends Attrs<'a', T> \n```\n**Extends:** Attrs&lt;'a', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.anchorhtmlattributes.md"
     },
@@ -57,7 +244,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface AreaHTMLAttributes<T extends Element> extends HTMLAttributes<T, false>, AreaAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, false&gt;, AreaAttrs",
+      "content": "```typescript\nexport interface AreaHTMLAttributes<T extends Element> extends Attrs<'area', T> \n```\n**Extends:** Attrs&lt;'area', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.areahtmlattributes.md"
     },
@@ -99,7 +286,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface AudioHTMLAttributes<T extends Element> extends HTMLAttributes<T>, AudioAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, AudioAttrs",
+      "content": "```typescript\nexport interface AudioHTMLAttributes<T extends Element> extends Attrs<'audio', T> \n```\n**Extends:** Attrs&lt;'audio', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.audiohtmlattributes.md"
     },
@@ -113,7 +300,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface BaseHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, BaseAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, BaseAttrs",
+      "content": "```typescript\nexport interface BaseHTMLAttributes<T extends Element> extends Attrs<'base', T> \n```\n**Extends:** Attrs&lt;'base', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.basehtmlattributes.md"
     },
@@ -127,7 +314,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface BlockquoteHTMLAttributes<T extends Element> extends HTMLAttributes<T>, BlockquoteAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, BlockquoteAttrs",
+      "content": "```typescript\nexport interface BlockquoteHTMLAttributes<T extends Element> extends Attrs<'blockquote', T> \n```\n**Extends:** Attrs&lt;'blockquote', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.blockquotehtmlattributes.md"
     },
@@ -155,7 +342,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ButtonAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, ButtonAttrs",
+      "content": "```typescript\nexport interface ButtonHTMLAttributes<T extends Element> extends Attrs<'button', T> \n```\n**Extends:** Attrs&lt;'button', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.buttonhtmlattributes.md"
     },
@@ -186,7 +373,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface CanvasHTMLAttributes<T extends Element> extends HTMLAttributes<T>, CanvasAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, CanvasAttrs",
+      "content": "```typescript\nexport interface CanvasHTMLAttributes<T extends Element> extends Attrs<'canvas', T> \n```\n**Extends:** Attrs&lt;'canvas', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.canvashtmlattributes.md"
     },
@@ -200,7 +387,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "A class list can be a string, a boolean, an array, or an object.\n\nIf it's an array, each item is a class list and they are all added.\n\nIf it's an object, then the keys are class name strings, and the values are booleans that determine if the class name string should be added or not.\n\n\n```typescript\nexport type ClassList = BaseClassList | BaseClassList[];\n```",
+      "content": "A class list can be a string, a boolean, an array, or an object.\n\nIf it's an array, each item is a class list and they are all added.\n\nIf it's an object, then the keys are class name strings, and the values are booleans that determine if the class name string should be added or not.\n\n\n```typescript\nexport type ClassList = string | undefined | null | false | Record<string, boolean | string | number | null | undefined> | ClassList[];\n```\n**References:** [ClassList](#classlist)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts",
       "mdFile": "qwik.classlist.md"
     },
@@ -231,7 +418,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ColgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [span?](#) |  | number \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface ColgroupHTMLAttributes<T extends Element> extends Attrs<'colgroup', T> \n```\n**Extends:** Attrs&lt;'colgroup', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.colgrouphtmlattributes.md"
     },
@@ -245,7 +432,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ColHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ColAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, ColAttrs",
+      "content": "```typescript\nexport interface ColHTMLAttributes<T extends Element> extends Attrs<'col', T> \n```\n**Extends:** Attrs&lt;'col', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.colhtmlattributes.md"
     },
@@ -259,7 +446,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "Type representing the Qwik component.\n\n`Component` is the type returned by invoking `component$`<!-- -->.\n\n```tsx\ninterface MyComponentProps {\n  someProp: string;\n}\nconst MyComponent: Component<MyComponentProps> = component$((props: MyComponentProps) => {\n  return <span>{props.someProp}</span>;\n});\n```\n\n\n```typescript\nexport type Component<PROPS extends Record<any, any>> = FunctionComponent<PublicProps<PROPS>>;\n```\n**References:** [FunctionComponent](#functioncomponent)<!-- -->, [PublicProps](#publicprops)",
+      "content": "Type representing the Qwik component.\n\n`Component` is the type returned by invoking `component$`<!-- -->.\n\n```tsx\ninterface MyComponentProps {\n  someProp: string;\n}\nconst MyComponent: Component<MyComponentProps> = component$((props: MyComponentProps) => {\n  return <span>{props.someProp}</span>;\n});\n```\n\n\n```typescript\nexport type Component<PROPS extends Record<any, any> = Record<string, unknown>> = FunctionComponent<PublicProps<PROPS>>;\n```\n**References:** [FunctionComponent](#functioncomponent)<!-- -->, [PublicProps](#publicprops)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.component.md"
     },
@@ -334,6 +521,20 @@
       "mdFile": "qwik.coreplatform.md"
     },
     {
+      "name": "CorrectedToggleEvent",
+      "id": "correctedtoggleevent",
+      "hierarchy": [
+        {
+          "name": "CorrectedToggleEvent",
+          "id": "correctedtoggleevent"
+        }
+      ],
+      "kind": "Interface",
+      "content": "This corrects the TS definition for ToggleEvent\n\n\n```typescript\nexport interface CorrectedToggleEvent extends Event \n```\n**Extends:** Event\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [newState](#) | <code>readonly</code> | 'open' \\| 'closed' |  |\n|  [prevState](#) | <code>readonly</code> | 'open' \\| 'closed' |  |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts",
+      "mdFile": "qwik.correctedtoggleevent.md"
+    },
+    {
       "name": "createContextId",
       "id": "createcontextid",
       "hierarchy": [
@@ -371,7 +572,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface DataHTMLAttributes<T extends Element> extends HTMLAttributes<T>, DataAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, DataAttrs",
+      "content": "```typescript\nexport interface DataHTMLAttributes<T extends Element> extends Attrs<'data', T> \n```\n**Extends:** Attrs&lt;'data', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.datahtmlattributes.md"
     },
@@ -385,7 +586,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface DelHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [cite?](#) |  | string \\| undefined | _(Optional)_ |\n|  [dateTime?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface DelHTMLAttributes<T extends Element> extends Attrs<'del', T> \n```\n**Extends:** Attrs&lt;'del', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.delhtmlattributes.md"
     },
@@ -399,7 +600,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface DetailsHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [open?](#) |  | boolean \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface DetailsHTMLAttributes<T extends Element> extends Attrs<'details', T> \n```\n**Extends:** Attrs&lt;'details', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.detailshtmlattributes.md"
     },
@@ -427,7 +628,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface DialogHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [open?](#) |  | boolean \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface DialogHTMLAttributes<T extends Element> extends Attrs<'dialog', T> \n```\n**Extends:** Attrs&lt;'dialog', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.dialoghtmlattributes.md"
     },
@@ -441,7 +642,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface DOMAttributes<T extends Element, Children = JSXChildren> extends QwikProps<T>, QwikEvents<T> \n```\n**Extends:** QwikProps&lt;T&gt;, QwikEvents&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | Children | _(Optional)_ |\n|  [key?](#) |  | string \\| number \\| null \\| undefined | _(Optional)_ |",
+      "content": "The Qwik-specific attributes that DOM elements accept\n\n\n```typescript\nexport interface DOMAttributes<EL extends Element> extends QwikAttributesBase, RefAttr<EL>, QwikEvents<EL> \n```\n**Extends:** QwikAttributesBase, RefAttr&lt;EL&gt;, QwikEvents&lt;EL&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [class?](#) |  | [ClassList](#classlist) \\| [Signal](#signal)<!-- -->&lt;[ClassList](#classlist)<!-- -->&gt; \\| undefined | _(Optional)_ |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts",
       "mdFile": "qwik.domattributes.md"
     },
@@ -502,6 +703,23 @@
       "mdFile": "qwik.h.jsx.elementchildrenattribute.md"
     },
     {
+      "name": "ElementType",
+      "id": "qwikjsx-elementtype",
+      "hierarchy": [
+        {
+          "name": "QwikJSX",
+          "id": "qwikjsx-elementtype"
+        },
+        {
+          "name": "ElementType",
+          "id": "qwikjsx-elementtype"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\ntype ElementType = string | ((...args: any[]) => JSXNode | null);\n```\n**References:** [JSXNode](#jsxnode)",
+      "mdFile": "qwik.qwikjsx.elementtype.md"
+    },
+    {
       "name": "EmbedHTMLAttributes",
       "id": "embedhtmlattributes",
       "hierarchy": [
@@ -511,7 +729,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface EmbedHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, EmbedAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, EmbedAttrs",
+      "content": "```typescript\nexport interface EmbedHTMLAttributes<T extends Element> extends Attrs<'embed', T> \n```\n**Extends:** Attrs&lt;'embed', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.embedhtmlattributes.md"
     },
@@ -567,7 +785,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface FieldsetHTMLAttributes<T extends Element> extends HTMLAttributes<T>, FieldSetAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, FieldSetAttrs",
+      "content": "```typescript\nexport interface FieldsetHTMLAttributes<T extends Element> extends Attrs<'fieldset', T> \n```\n**Extends:** Attrs&lt;'fieldset', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.fieldsethtmlattributes.md"
     },
@@ -581,7 +799,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T>, FormAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, FormAttrs",
+      "content": "```typescript\nexport interface FormHTMLAttributes<T extends Element> extends Attrs<'form', T> \n```\n**Extends:** Attrs&lt;'form', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.formhtmlattributes.md"
     },
@@ -665,7 +883,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface HrHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;",
+      "content": "```typescript\nexport interface HrHTMLAttributes<T extends Element> extends Attrs<'hr', T> \n```\n**Extends:** Attrs&lt;'hr', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.hrhtmlattributes.md"
     },
@@ -707,7 +925,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface HTMLAttributes<E extends Element, Children = JSXChildren> extends HTMLAttributesBase<E, Children>, Partial<Omit<HTMLElement, BadOnes<HTMLElement>>> \n```\n**Extends:** HTMLAttributesBase&lt;E, Children&gt;, Partial&lt;Omit&lt;HTMLElement, BadOnes&lt;HTMLElement&gt;&gt;&gt;",
+      "content": "```typescript\nexport interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E> \n```\n**Extends:** HTMLElementAttrs, [DOMAttributes](#domattributes)<!-- -->&lt;E&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.htmlattributes.md"
     },
@@ -749,7 +967,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface HtmlHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [manifest?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface HtmlHTMLAttributes<T extends Element> extends Attrs<'html', T> \n```\n**Extends:** Attrs&lt;'html', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.htmlhtmlattributes.md"
     },
@@ -791,7 +1009,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface IframeHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, IframeAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, IframeAttrs",
+      "content": "```typescript\nexport interface IframeHTMLAttributes<T extends Element> extends Attrs<'iframe', T> \n```\n**Extends:** Attrs&lt;'iframe', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.iframehtmlattributes.md"
     },
@@ -805,7 +1023,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ImgHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ImgAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, ImgAttrs",
+      "content": "```typescript\nexport interface ImgHTMLAttributes<T extends Element> extends Attrs<'img', T> \n```\n**Extends:** Attrs&lt;'img', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.imghtmlattributes.md"
     },
@@ -832,8 +1050,8 @@
           "id": "inputhtmlattributes"
         }
       ],
-      "kind": "Interface",
-      "content": "```typescript\nexport interface InputHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, InputAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, InputAttrs",
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type InputHTMLAttributes<T extends Element> = Attrs<'input', T, HTMLInputElement>;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.inputhtmlattributes.md"
     },
@@ -847,7 +1065,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface InsHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [cite?](#) |  | string \\| undefined | _(Optional)_ |\n|  [dateTime?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface InsHTMLAttributes<T extends Element> extends Attrs<'ins', T> \n```\n**Extends:** Attrs&lt;'ins', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.inshtmlattributes.md"
     },
@@ -892,34 +1110,6 @@
       "kind": "Interface",
       "content": "```typescript\ninterface IntrinsicElements extends QwikJSX.IntrinsicElements \n```\n**Extends:** [QwikJSX.IntrinsicElements](#)",
       "mdFile": "qwik.h.jsx.intrinsicelements.md"
-    },
-    {
-      "name": "IntrinsicHTMLElements",
-      "id": "intrinsichtmlelements",
-      "hierarchy": [
-        {
-          "name": "IntrinsicHTMLElements",
-          "id": "intrinsichtmlelements"
-        }
-      ],
-      "kind": "Interface",
-      "content": "```typescript\nexport interface IntrinsicHTMLElements extends QwikHTMLExceptions, PlainHTMLElements \n```\n**Extends:** QwikHTMLExceptions, PlainHTMLElements",
-      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
-      "mdFile": "qwik.intrinsichtmlelements.md"
-    },
-    {
-      "name": "IntrinsicSVGElements",
-      "id": "intrinsicsvgelements",
-      "hierarchy": [
-        {
-          "name": "IntrinsicSVGElements",
-          "id": "intrinsicsvgelements"
-        }
-      ],
-      "kind": "TypeAlias",
-      "content": "```typescript\nexport type IntrinsicSVGElements = {\n    [K in keyof Omit<SVGElementTagNameMap, keyof HTMLElementTagNameMap>]: SVGProps<SVGElementTagNameMap[K]>;\n};\n```\n**References:** [SVGProps](#svgprops)",
-      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
-      "mdFile": "qwik.intrinsicsvgelements.md"
     },
     {
       "name": "isSignal",
@@ -1032,9 +1222,23 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [autoFocus?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [challenge?](#) |  | string \\| undefined | _(Optional)_ |\n|  [children?](#) |  | undefined | _(Optional)_ |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [form?](#) |  | string \\| undefined | _(Optional)_ |\n|  [keyParams?](#) |  | string \\| undefined | _(Optional)_ |\n|  [keyType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "> Warning: This API is now obsolete.\n> \n> in html5\n> \n\n\n```typescript\nexport interface KeygenHTMLAttributes<T extends Element> extends Attrs<'base', T> \n```\n**Extends:** Attrs&lt;'base', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.keygenhtmlattributes.md"
+    },
+    {
+      "name": "KnownEventNames",
+      "id": "knowneventnames",
+      "hierarchy": [
+        {
+          "name": "KnownEventNames",
+          "id": "knowneventnames"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "The names of events that Qwik knows about. They are all lowercase, but on the JSX side, they are PascalCase for nicer DX. (`onAuxClick$` vs `onauxclick$`<!-- -->)\n\n\n```typescript\nexport type KnownEventNames = LiteralUnion<AllEventKeys, string>;\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
+      "mdFile": "qwik.knowneventnames.md"
     },
     {
       "name": "LabelHTMLAttributes",
@@ -1046,7 +1250,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface LabelHTMLAttributes<T extends Element> extends HTMLAttributes<T>, LabelAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, LabelAttrs",
+      "content": "```typescript\nexport interface LabelHTMLAttributes<T extends Element> extends Attrs<'label', T> \n```\n**Extends:** Attrs&lt;'label', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.labelhtmlattributes.md"
     },
@@ -1060,7 +1264,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface LiHTMLAttributes<T extends Element> extends HTMLAttributes<T>, LiAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, LiAttrs",
+      "content": "```typescript\nexport interface LiHTMLAttributes<T extends Element> extends Attrs<'li', T> \n```\n**Extends:** Attrs&lt;'li', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.lihtmlattributes.md"
     },
@@ -1074,7 +1278,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface LinkHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, LinkAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, LinkAttrs",
+      "content": "```typescript\nexport interface LinkHTMLAttributes<T extends Element> extends Attrs<'link', T> \n```\n**Extends:** Attrs&lt;'link', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.linkhtmlattributes.md"
     },
@@ -1088,7 +1292,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface MapHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface MapHTMLAttributes<T extends Element> extends Attrs<'map', T> \n```\n**Extends:** Attrs&lt;'map', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.maphtmlattributes.md"
     },
@@ -1102,7 +1306,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T>, MediaAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, MediaAttrs",
+      "content": "```typescript\nexport interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T>, Augmented<HTMLMediaElement, {\n    crossOrigin?: HTMLCrossOriginAttribute;\n}> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, Augmented&lt;HTMLMediaElement, { crossOrigin?: [HTMLCrossOriginAttribute](#htmlcrossoriginattribute)<!-- -->; }&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.mediahtmlattributes.md"
     },
@@ -1116,7 +1320,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface MenuHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface MenuHTMLAttributes<T extends Element> extends Attrs<'menu', T> \n```\n**Extends:** Attrs&lt;'menu', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.menuhtmlattributes.md"
     },
@@ -1130,7 +1334,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface MetaHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, MetaAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, MetaAttrs",
+      "content": "```typescript\nexport interface MetaHTMLAttributes<T extends Element> extends Attrs<'meta', T> \n```\n**Extends:** Attrs&lt;'meta', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.metahtmlattributes.md"
     },
@@ -1144,7 +1348,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T>, MeterAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, MeterAttrs",
+      "content": "```typescript\nexport interface MeterHTMLAttributes<T extends Element> extends Attrs<'meter', T> \n```\n**Extends:** Attrs&lt;'meter', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.meterhtmlattributes.md"
     },
@@ -1368,7 +1572,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ObjectAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, ObjectAttrs",
+      "content": "```typescript\nexport interface ObjectHTMLAttributes<T extends Element> extends Attrs<'object', T> \n```\n**Extends:** Attrs&lt;'object', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.objecthtmlattributes.md"
     },
@@ -1382,7 +1586,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface OlHTMLAttributes<T extends Element> extends HTMLAttributes<T>, OlAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, OlAttrs",
+      "content": "```typescript\nexport interface OlHTMLAttributes<T extends Element> extends Attrs<'ol', T> \n```\n**Extends:** Attrs&lt;'ol', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.olhtmlattributes.md"
     },
@@ -1424,7 +1628,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface OptgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [disabled?](#) |  | boolean \\| undefined | _(Optional)_ |\n|  [label?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface OptgroupHTMLAttributes<T extends Element> extends Attrs<'optgroup', T> \n```\n**Extends:** Attrs&lt;'optgroup', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.optgrouphtmlattributes.md"
     },
@@ -1438,7 +1642,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface OptionHTMLAttributes<T extends Element> extends HTMLAttributes<T, string>, OptionAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, string&gt;, OptionAttrs",
+      "content": "```typescript\nexport interface OptionHTMLAttributes<T extends Element> extends Attrs<'option', T> \n```\n**Extends:** Attrs&lt;'option', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.optionhtmlattributes.md"
     },
@@ -1452,7 +1656,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;",
+      "content": "```typescript\nexport interface OutputHTMLAttributes<T extends Element> extends Attrs<'output', T> \n```\n**Extends:** Attrs&lt;'output', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.outputhtmlattributes.md"
     },
@@ -1466,7 +1670,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "> Warning: This API is now obsolete.\n> \n> Old DOM API\n> \n\n\n```typescript\nexport interface ParamHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ParamAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, ParamAttrs",
+      "content": "> Warning: This API is now obsolete.\n> \n> Old DOM API\n> \n\n\n```typescript\nexport interface ParamHTMLAttributes<T extends Element> extends Attrs<'base', T, HTMLParamElement> \n```\n**Extends:** Attrs&lt;'base', T, HTMLParamElement&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.paramhtmlattributes.md"
     },
@@ -1480,7 +1684,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ProgressHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ProgressAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, ProgressAttrs",
+      "content": "```typescript\nexport interface ProgressHTMLAttributes<T extends Element> extends Attrs<'progress', T> \n```\n**Extends:** Attrs&lt;'progress', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.progresshtmlattributes.md"
     },
@@ -1536,7 +1740,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "Infers `Props` from the component.\n\n```typescript\nexport const OtherComponent = component$(() => {\n  return $(() => <Counter value={100} />);\n});\n```\n\n\n```typescript\nexport type PropsOf<COMP extends Component<any>> = COMP extends Component<infer PROPS> ? NonNullable<PROPS> : never;\n```\n**References:** [Component](#component)",
+      "content": "Infers `Props` from the component.\n\n```typescript\nexport const OtherComponent = component$(() => {\n  return $(() => <Counter value={100} />);\n});\n```\n\n\n```typescript\nexport type PropsOf<COMP> = COMP extends Component<infer PROPS> ? NonNullable<PROPS> : COMP extends FunctionComponent<infer PROPS> ? NonNullable<PublicProps<PROPS>> : COMP extends string ? QwikIntrinsicElements[COMP] : Record<string, unknown>;\n```\n**References:** [Component](#component)<!-- -->, [FunctionComponent](#functioncomponent)<!-- -->, [PublicProps](#publicprops)<!-- -->, [QwikIntrinsicElements](#qwikintrinsicelements)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.propsof.md"
     },
@@ -1592,7 +1796,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [cite?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface QuoteHTMLAttributes<T extends Element> extends Attrs<'q', T> \n```\n**Extends:** Attrs&lt;'q', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.quotehtmlattributes.md"
     },
@@ -1695,6 +1899,48 @@
       "mdFile": "qwik.qwikfocusevent.md"
     },
     {
+      "name": "QwikHTMLElements",
+      "id": "qwikhtmlelements",
+      "hierarchy": [
+        {
+          "name": "QwikHTMLElements",
+          "id": "qwikhtmlelements"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "The DOM props without plain handlers, for use inside functions\n\n\n```typescript\nexport type QwikHTMLElements = {\n    [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> & HTMLElementAttrs & QwikAttributes<HTMLElementTagNameMap[tag]>;\n} & {\n    [unknownTag: string]: {\n        [prop: string]: any;\n    } & HTMLElementAttrs & QwikAttributes<any>;\n};\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.qwikhtmlelements.md"
+    },
+    {
+      "name": "QwikIdleEvent",
+      "id": "qwikidleevent",
+      "hierarchy": [
+        {
+          "name": "QwikIdleEvent",
+          "id": "qwikidleevent"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "Emitted by qwik-loader on document when the document first becomes idle\n\n\n```typescript\nexport type QwikIdleEvent = CustomEvent<{}>;\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
+      "mdFile": "qwik.qwikidleevent.md"
+    },
+    {
+      "name": "QwikInitEvent",
+      "id": "qwikinitevent",
+      "hierarchy": [
+        {
+          "name": "QwikInitEvent",
+          "id": "qwikinitevent"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "Emitted by qwik-loader on document when the document first becomes interactive\n\n\n```typescript\nexport type QwikInitEvent = CustomEvent<{}>;\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
+      "mdFile": "qwik.qwikinitevent.md"
+    },
+    {
       "name": "QwikIntrinsicElements",
       "id": "qwikintrinsicelements",
       "hierarchy": [
@@ -1704,7 +1950,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "The interface holds available attributes of both native DOM elements and custom Qwik elements. An example showing how to define a customizable wrapper component:\n\n```tsx\nimport { component$, Slot, type QwikIntrinsicElements } from \"@builder.io/qwik\";\n\ntype WrapperProps = {\n  attributes?: QwikIntrinsicElements[\"div\"];\n};\n\nexport default component$<WrapperProps>(({ attributes }) => {\n  return (\n    <div {...attributes} class=\"p-2\">\n      <Slot />\n    </div>\n  );\n});\n```\n\n\n```typescript\nexport interface QwikIntrinsicElements extends IntrinsicHTMLElements \n```\n**Extends:** [IntrinsicHTMLElements](#intrinsichtmlelements)",
+      "content": "The interface holds available attributes of both native DOM elements and custom Qwik elements. An example showing how to define a customizable wrapper component:\n\n```tsx\nimport { component$, Slot, type QwikIntrinsicElements } from \"@builder.io/qwik\";\n\ntype WrapperProps = {\n  attributes?: QwikIntrinsicElements[\"div\"];\n};\n\nexport default component$<WrapperProps>(({ attributes }) => {\n  return (\n    <div {...attributes} class=\"p-2\">\n      <Slot />\n    </div>\n  );\n});\n```\nNote: It is shorter to use `PropsOf<'div'>`\n\n\n```typescript\nexport interface QwikIntrinsicElements extends QwikHTMLElements, QwikSVGElements \n```\n**Extends:** [QwikHTMLElements](#qwikhtmlelements)<!-- -->, [QwikSVGElements](#qwiksvgelements)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-elements.ts",
       "mdFile": "qwik.qwikintrinsicelements.md"
     },
@@ -1732,7 +1978,7 @@
         }
       ],
       "kind": "Namespace",
-      "content": "```typescript\nexport declare namespace QwikJSX \n```\n\n\n|  Interface | Description |\n|  --- | --- |\n|  [Element](#) |  |\n|  [ElementChildrenAttribute](#) |  |\n|  [IntrinsicAttributes](#) |  |\n|  [IntrinsicElements](#) |  |",
+      "content": "```typescript\nexport declare namespace QwikJSX \n```\n\n\n|  Interface | Description |\n|  --- | --- |\n|  [Element](#) |  |\n|  [ElementChildrenAttribute](#) |  |\n|  [IntrinsicAttributes](#) |  |\n|  [IntrinsicElements](#) |  |\n\n\n|  Type Alias | Description |\n|  --- | --- |\n|  [ElementType](#qwikjsx-elementtype) |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts",
       "mdFile": "qwik.qwikjsx.md"
     },
@@ -1791,6 +2037,20 @@
       "content": "> Warning: This API is now obsolete.\n> \n> Use `SubmitEvent`\n> \n\n\n```typescript\nexport type QwikSubmitEvent<T = Element> = Event;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwiksubmitevent.md"
+    },
+    {
+      "name": "QwikSVGElements",
+      "id": "qwiksvgelements",
+      "hierarchy": [
+        {
+          "name": "QwikSVGElements",
+          "id": "qwiksvgelements"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "The SVG props without plain handlers, for use inside functions\n\n\n```typescript\nexport type QwikSVGElements = {\n    [K in keyof Omit<SVGElementTagNameMap, keyof HTMLElementTagNameMap>]: SVGProps<SVGElementTagNameMap[K]>;\n};\n```\n**References:** [SVGProps](#svgprops)",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.qwiksvgelements.md"
     },
     {
       "name": "QwikSymbolEvent",
@@ -1970,7 +2230,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "This method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- 'pending' - the data is not yet available. - 'resolved' - the data is available. - 'rejected' - the data is not available due to an error or timeout.\n\n\\#\\#\\# Example\n\nExample showing how `useResource` to perform a fetch to request the weather, whenever the input city name changes.\n\n```tsx\nconst Cmp = component$(() => {\n  const store = useStore({\n    city: '',\n  });\n\n  const weatherResource = useResource$<any>(async ({ track, cleanup }) => {\n    const cityName = track(() => store.city);\n    const abortController = new AbortController();\n    cleanup(() => abortController.abort('cleanup'));\n    const res = await fetch(`http://weatherdata.com?city=${cityName}`, {\n      signal: abortController.signal,\n    });\n    const data = res.json();\n    return data;\n  });\n\n  return (\n    <div>\n      <input name=\"city\" onInput$={(ev: any) => (store.city = ev.target.value)} />\n      <Resource\n        value={weatherResource}\n        onResolved={(weather) => {\n          return <div>Temperature: {weather.temp}</div>;\n        }}\n      />\n    </div>\n  );\n});\n```\n\n\n```typescript\nResource: <T>(props: ResourceProps<T>) => JSXNode\n```",
+      "content": "This method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- 'pending' - the data is not yet available. - 'resolved' - the data is available. - 'rejected' - the data is not available due to an error or timeout.\n\n\\#\\#\\# Example\n\nExample showing how `useResource` to perform a fetch to request the weather, whenever the input city name changes.\n\n```tsx\nconst Cmp = component$(() => {\n  const cityS = useSignal('');\n\n  const weatherResource = useResource$(async ({ track, cleanup }) => {\n    const cityName = track(cityS);\n    const abortController = new AbortController();\n    cleanup(() => abortController.abort('cleanup'));\n    const res = await fetch(`http://weatherdata.com?city=${cityName}`, {\n      signal: abortController.signal,\n    });\n    const data = await res.json();\n    return data as { temp: number };\n  });\n\n  return (\n    <div>\n      <input name=\"city\" bind:value={cityS} />\n      <Resource\n        value={weatherResource}\n        onResolved={(weather) => {\n          return <div>Temperature: {weather.temp}</div>;\n        }}\n      />\n    </div>\n  );\n});\n```\n\n\n```typescript\nResource: <T>(props: ResourceProps<T>) => JSXNode\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts",
       "mdFile": "qwik.resource.md"
     },
@@ -2096,7 +2356,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ScriptAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, ScriptAttrs",
+      "content": "```typescript\nexport interface ScriptHTMLAttributes<T extends Element> extends Attrs<'script', T> \n```\n**Extends:** Attrs&lt;'script', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.scripthtmlattributes.md"
     },
@@ -2110,7 +2370,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<T>, SelectAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, SelectAttrs",
+      "content": "```typescript\nexport interface SelectHTMLAttributes<T extends Element> extends Attrs<'select', T> \n```\n**Extends:** Attrs&lt;'select', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.selecthtmlattributes.md"
     },
@@ -2194,7 +2454,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface SlotHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface SlotHTMLAttributes<T extends Element> extends Attrs<'slot', T> \n```\n**Extends:** Attrs&lt;'slot', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.slothtmlattributes.md"
     },
@@ -2278,7 +2538,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface SourceHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, SourceAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, SourceAttrs",
+      "content": "```typescript\nexport interface SourceHTMLAttributes<T extends Element> extends Attrs<'source', T> \n```\n**Extends:** Attrs&lt;'source', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.sourcehtmlattributes.md"
     },
@@ -2404,7 +2664,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T, string>, StyleAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, string&gt;, StyleAttrs",
+      "content": "```typescript\nexport interface StyleHTMLAttributes<T extends Element> extends Attrs<'style', T> \n```\n**Extends:** Attrs&lt;'style', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.stylehtmlattributes.md"
     },
@@ -2418,7 +2678,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "The TS types don't include the SVG attributes so we have to define them ourselves\n\n\n```typescript\nexport interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> \n```\n**Extends:** [AriaAttributes](#ariaattributes)<!-- -->, [DOMAttributes](#domattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [\"accent-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"alignment-baseline\"?](#) |  | 'auto' \\| 'baseline' \\| 'before-edge' \\| 'text-before-edge' \\| 'middle' \\| 'central' \\| 'after-edge' \\| 'text-after-edge' \\| 'ideographic' \\| 'alphabetic' \\| 'hanging' \\| 'mathematical' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"arabic-form\"?](#) |  | 'initial' \\| 'medial' \\| 'terminal' \\| 'isolated' \\| undefined | _(Optional)_ |\n|  [\"baseline-shift\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"cap-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"clip-path\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"clip-rule\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-interpolation-filters\"?](#) |  | 'auto' \\| 's-rGB' \\| 'linear-rGB' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"color-interpolation\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-profile\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"dominant-baseline\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"edge-mode\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"enable-background\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"fill-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"fill-rule\"?](#) |  | 'nonzero' \\| 'evenodd' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"flood-color\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"flood-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-family\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"font-size-adjust\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-size\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-stretch\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-style\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-variant\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-weight\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-name\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-orientation-horizontal\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-orientation-vertical\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"horiz-adv-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"horiz-origin-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"image-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"letter-spacing\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"lighting-color\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"marker-end\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"marker-mid\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"marker-start\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"overline-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"overline-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"paint-order\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"pointer-events\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"rendering-intent\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"shape-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stop-color\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"stop-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"strikethrough-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"strikethrough-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stroke-dasharray\"?](#) |  | string \\| number \\| undefined | _(Optional)_ |\n|  [\"stroke-dashoffset\"?](#) |  | string \\| number \\| undefined | _(Optional)_ |\n|  [\"stroke-linecap\"?](#) |  | 'butt' \\| 'round' \\| 'square' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"stroke-linejoin\"?](#) |  | 'miter' \\| 'round' \\| 'bevel' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"stroke-miterlimit\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"stroke-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stroke-width\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"text-anchor\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"text-decoration\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"text-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"underline-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"underline-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"unicode-bidi\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"unicode-range\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"units-per-em\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-alphabetic\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-hanging\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-ideographic\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-mathematical\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vector-effect\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-adv-y\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-origin-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-origin-y\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"word-spacing\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"writing-mode\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"x-channel-selector\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"x-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [accumulate?](#) |  | 'none' \\| 'sum' \\| undefined | _(Optional)_ |\n|  [additive?](#) |  | 'replace' \\| 'sum' \\| undefined | _(Optional)_ |\n|  [allowReorder?](#) |  | 'no' \\| 'yes' \\| undefined | _(Optional)_ |\n|  [alphabetic?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [amplitude?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [ascent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [attributeName?](#) |  | string \\| undefined | _(Optional)_ |\n|  [attributeType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [autoReverse?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ |\n|  [azimuth?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [baseFrequency?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [baseProfile?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [bbox?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [begin?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [bias?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [by?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [calcMode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [class?](#) |  | [ClassList](#classlist) \\| undefined | _(Optional)_ |\n|  [clip?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [clipPathUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [color?](#) |  | string \\| undefined | _(Optional)_ |\n|  [contentScriptType?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [contentStyleType?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |\n|  [cursor?](#) |  | number \\| string | _(Optional)_ |\n|  [cx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [cy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [d?](#) |  | string \\| undefined | _(Optional)_ |\n|  [decelerate?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [descent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [diffuseConstant?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [direction?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [display?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [divisor?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dur?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [elevation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [end?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [exponent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [externalResourcesRequired?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fill?](#) |  | string \\| undefined | _(Optional)_ |\n|  [filter?](#) |  | string \\| undefined | _(Optional)_ |\n|  [filterRes?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [filterUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [focusable?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [format?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fr?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [from?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [g1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [g2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [glyphRef?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [gradientTransform?](#) |  | string \\| undefined | _(Optional)_ |\n|  [gradientUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [hanging?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Numberish](#numberish) \\| undefined | _(Optional)_ |\n|  [href?](#) |  | string \\| undefined | _(Optional)_ |\n|  [id?](#) |  | string \\| undefined | _(Optional)_ |\n|  [ideographic?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [in?](#) |  | string \\| undefined | _(Optional)_ |\n|  [in2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [intercept?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k3?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k4?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kernelMatrix?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kernelUnitLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kerning?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keyPoints?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keySplines?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keyTimes?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [lang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [lengthAdjust?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [limitingConeAngle?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [local?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerHeight?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerWidth?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mask?](#) |  | string \\| undefined | _(Optional)_ |\n|  [maskContentUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [maskUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mathematical?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [max?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [method?](#) |  | string \\| undefined | _(Optional)_ |\n|  [min?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [numOctaves?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [offset?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [opacity?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [operator?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [order?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [orient?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [orientation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [origin?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [overflow?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [panose1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [path?](#) |  | string \\| undefined | _(Optional)_ |\n|  [pathLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [patternContentUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [patternTransform?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [patternUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [points?](#) |  | string \\| undefined | _(Optional)_ |\n|  [pointsAtX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [pointsAtY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [pointsAtZ?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [preserveAlpha?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [preserveAspectRatio?](#) |  | string \\| undefined | _(Optional)_ |\n|  [primitiveUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [r?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [radius?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [refX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [refY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [repeatCount?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [repeatDur?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [requiredextensions?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [requiredFeatures?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [restart?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [result?](#) |  | string \\| undefined | _(Optional)_ |\n|  [role?](#) |  | string \\| undefined | _(Optional)_ |\n|  [rotate?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [rx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [ry?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [scale?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [seed?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [slope?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [spacing?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [specularConstant?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [specularExponent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [speed?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [spreadMethod?](#) |  | string \\| undefined | _(Optional)_ |\n|  [startOffset?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stdDeviation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stemh?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stemv?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stitchTiles?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [string?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stroke?](#) |  | string \\| undefined | _(Optional)_ |\n|  [style?](#) |  | [CSSProperties](#cssproperties) \\| string \\| undefined | _(Optional)_ |\n|  [surfaceScale?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [systemLanguage?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [tabindex?](#) |  | number \\| undefined | _(Optional)_ |\n|  [tableValues?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [target?](#) |  | string \\| undefined | _(Optional)_ |\n|  [targetX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [targetY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [textLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [to?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [transform?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |\n|  [u1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [u2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [unicode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [values?](#) |  | string \\| undefined | _(Optional)_ |\n|  [version?](#) |  | string \\| undefined | _(Optional)_ |\n|  [viewBox?](#) |  | string \\| undefined | _(Optional)_ |\n|  [viewTarget?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [visibility?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Numberish](#numberish) \\| undefined | _(Optional)_ |\n|  [widths?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [xlinkActuate?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkArcrole?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkHref?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkRole?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkShow?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkTitle?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xlinkType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xmlBase?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xmlLang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xmlns?](#) |  | string \\| undefined | _(Optional)_ |\n|  [xmlSpace?](#) |  | string \\| undefined | _(Optional)_ |\n|  [y?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [y1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [y2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [yChannelSelector?](#) |  | string \\| undefined | _(Optional)_ |\n|  [z?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [zoomAndPan?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "The TS types don't include the SVG attributes so we have to define them ourselves\n\nNOTE: These props are probably not complete\n\n\n```typescript\nexport interface SVGAttributes<T extends Element = Element> extends AriaAttributes \n```\n**Extends:** [AriaAttributes](#ariaattributes)\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [\"accent-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"alignment-baseline\"?](#) |  | 'auto' \\| 'baseline' \\| 'before-edge' \\| 'text-before-edge' \\| 'middle' \\| 'central' \\| 'after-edge' \\| 'text-after-edge' \\| 'ideographic' \\| 'alphabetic' \\| 'hanging' \\| 'mathematical' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"arabic-form\"?](#) |  | 'initial' \\| 'medial' \\| 'terminal' \\| 'isolated' \\| undefined | _(Optional)_ |\n|  [\"baseline-shift\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"cap-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"clip-path\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"clip-rule\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-interpolation-filters\"?](#) |  | 'auto' \\| 's-rGB' \\| 'linear-rGB' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"color-interpolation\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-profile\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"color-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"dominant-baseline\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"edge-mode\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"enable-background\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"fill-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"fill-rule\"?](#) |  | 'nonzero' \\| 'evenodd' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"flood-color\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"flood-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-family\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"font-size-adjust\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-size\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-stretch\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-style\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-variant\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"font-weight\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-name\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-orientation-horizontal\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"glyph-orientation-vertical\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"horiz-adv-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"horiz-origin-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"image-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"letter-spacing\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"lighting-color\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"marker-end\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"marker-mid\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"marker-start\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"overline-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"overline-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"paint-order\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"pointer-events\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"rendering-intent\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"shape-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stop-color\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"stop-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"strikethrough-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"strikethrough-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stroke-dasharray\"?](#) |  | string \\| number \\| undefined | _(Optional)_ |\n|  [\"stroke-dashoffset\"?](#) |  | string \\| number \\| undefined | _(Optional)_ |\n|  [\"stroke-linecap\"?](#) |  | 'butt' \\| 'round' \\| 'square' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"stroke-linejoin\"?](#) |  | 'miter' \\| 'round' \\| 'bevel' \\| 'inherit' \\| undefined | _(Optional)_ |\n|  [\"stroke-miterlimit\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"stroke-opacity\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"stroke-width\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"text-anchor\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"text-decoration\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"text-rendering\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"underline-position\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"underline-thickness\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"unicode-bidi\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"unicode-range\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"units-per-em\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-alphabetic\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-hanging\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-ideographic\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"v-mathematical\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vector-effect\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-adv-y\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-origin-x\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"vert-origin-y\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"word-spacing\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"writing-mode\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"x-channel-selector\"?](#) |  | string \\| undefined | _(Optional)_ |\n|  [\"x-height\"?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [\"xlink:actuate\"?](#svgattributes-_xlink_actuate_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xlink:arcrole\"?](#svgattributes-_xlink_arcrole_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xlink:href\"?](#svgattributes-_xlink_href_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xlink:role\"?](#svgattributes-_xlink_role_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xlink:show\"?](#svgattributes-_xlink_show_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xlink:title\"?](#svgattributes-_xlink_title_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xlink:type\"?](#svgattributes-_xlink_type_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xml:base\"?](#svgattributes-_xml_base_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xml:lang\"?](#svgattributes-_xml_lang_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xml:space\"?](#svgattributes-_xml_space_) |  | string \\| undefined | _(Optional)_ |\n|  [\"xmlns:xlink\"?](#svgattributes-_xmlns_xlink_) |  | string \\| undefined | _(Optional)_ |\n|  [accumulate?](#) |  | 'none' \\| 'sum' \\| undefined | _(Optional)_ |\n|  [additive?](#) |  | 'replace' \\| 'sum' \\| undefined | _(Optional)_ |\n|  [allowReorder?](#) |  | 'no' \\| 'yes' \\| undefined | _(Optional)_ |\n|  [alphabetic?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [amplitude?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [ascent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [attributeName?](#) |  | string \\| undefined | _(Optional)_ |\n|  [attributeType?](#) |  | string \\| undefined | _(Optional)_ |\n|  [autoReverse?](#) |  | [Booleanish](#booleanish) \\| undefined | _(Optional)_ |\n|  [azimuth?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [baseFrequency?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [baseProfile?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [bbox?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [begin?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [bias?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [by?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [calcMode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [clip?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [clipPathUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [color?](#) |  | string \\| undefined | _(Optional)_ |\n|  [contentScriptType?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [contentStyleType?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [crossOrigin?](#) |  | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |\n|  [cursor?](#) |  | number \\| string | _(Optional)_ |\n|  [cx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [cy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [d?](#) |  | string \\| undefined | _(Optional)_ |\n|  [decelerate?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [descent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [diffuseConstant?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [direction?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [display?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [divisor?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dur?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [dy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [elevation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [end?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [exponent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [externalResourcesRequired?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fill?](#) |  | string \\| undefined | _(Optional)_ |\n|  [filter?](#) |  | string \\| undefined | _(Optional)_ |\n|  [filterRes?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [filterUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [focusable?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [format?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fr?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [from?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [fy?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [g1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [g2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [glyphRef?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [gradientTransform?](#) |  | string \\| undefined | _(Optional)_ |\n|  [gradientUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [hanging?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [height?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [href?](#) |  | string \\| undefined | _(Optional)_ |\n|  [id?](#) |  | string \\| undefined | _(Optional)_ |\n|  [ideographic?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [in?](#) |  | string \\| undefined | _(Optional)_ |\n|  [in2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [intercept?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k3?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [k4?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kernelMatrix?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kernelUnitLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [kerning?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keyPoints?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keySplines?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [keyTimes?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [lang?](#) |  | string \\| undefined | _(Optional)_ |\n|  [lengthAdjust?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [limitingConeAngle?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [local?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerHeight?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [markerWidth?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mask?](#) |  | string \\| undefined | _(Optional)_ |\n|  [maskContentUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [maskUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mathematical?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [max?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [media?](#) |  | string \\| undefined | _(Optional)_ |\n|  [method?](#) |  | string \\| undefined | _(Optional)_ |\n|  [min?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [mode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [name?](#) |  | string \\| undefined | _(Optional)_ |\n|  [numOctaves?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [offset?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [opacity?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [operator?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [order?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [orient?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [orientation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [origin?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [overflow?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [panose1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [path?](#) |  | string \\| undefined | _(Optional)_ |\n|  [pathLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [patternContentUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [patternTransform?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [patternUnits?](#) |  | string \\| undefined | _(Optional)_ |\n|  [points?](#) |  | string \\| undefined | _(Optional)_ |\n|  [pointsAtX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [pointsAtY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [pointsAtZ?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [preserveAlpha?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [preserveAspectRatio?](#) |  | string \\| undefined | _(Optional)_ |\n|  [primitiveUnits?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [r?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [radius?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [refX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [refY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [repeatCount?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [repeatDur?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [requiredextensions?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [requiredFeatures?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [restart?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [result?](#) |  | string \\| undefined | _(Optional)_ |\n|  [role?](#) |  | string \\| undefined | _(Optional)_ |\n|  [rotate?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [rx?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [ry?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [scale?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [seed?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [slope?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [spacing?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [specularConstant?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [specularExponent?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [speed?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [spreadMethod?](#) |  | string \\| undefined | _(Optional)_ |\n|  [startOffset?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stdDeviation?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stemh?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stemv?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stitchTiles?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [string?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [stroke?](#) |  | string \\| undefined | _(Optional)_ |\n|  [style?](#) |  | [CSSProperties](#cssproperties) \\| string \\| undefined | _(Optional)_ |\n|  [surfaceScale?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [systemLanguage?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [tabindex?](#) |  | number \\| undefined | _(Optional)_ |\n|  [tableValues?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [target?](#) |  | string \\| undefined | _(Optional)_ |\n|  [targetX?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [targetY?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [textLength?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [to?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [transform?](#) |  | string \\| undefined | _(Optional)_ |\n|  [type?](#) |  | string \\| undefined | _(Optional)_ |\n|  [u1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [u2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [unicode?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [values?](#) |  | string \\| undefined | _(Optional)_ |\n|  [version?](#) |  | string \\| undefined | _(Optional)_ |\n|  [viewBox?](#) |  | string \\| undefined | _(Optional)_ |\n|  [viewTarget?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [visibility?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [width?](#) |  | [Size](#size) \\| undefined | _(Optional)_ |\n|  [widths?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [x2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [xmlns?](#) |  | string \\| undefined | _(Optional)_ |\n|  [y?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [y1?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [y2?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [yChannelSelector?](#) |  | string \\| undefined | _(Optional)_ |\n|  [z?](#) |  | number \\| string \\| undefined | _(Optional)_ |\n|  [zoomAndPan?](#) |  | string \\| undefined | _(Optional)_ |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.svgattributes.md"
     },
@@ -2432,7 +2692,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface SVGProps<T extends Element> extends SVGAttributes<T> \n```\n**Extends:** [SVGAttributes](#svgattributes)<!-- -->&lt;T&gt;",
+      "content": "```typescript\nexport interface SVGProps<T extends Element> extends SVGAttributes, QwikAttributes<T> \n```\n**Extends:** [SVGAttributes](#svgattributes)<!-- -->, QwikAttributes&lt;T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.svgprops.md"
     },
@@ -2446,7 +2706,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface TableHTMLAttributes<T extends Element> extends HTMLAttributes<T>, TableAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, TableAttrs",
+      "content": "```typescript\nexport interface TableHTMLAttributes<T extends Element> extends Attrs<'table', T> \n```\n**Extends:** Attrs&lt;'table', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.tablehtmlattributes.md"
     },
@@ -2488,7 +2748,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T>, TableCellAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, TableCellAttrs",
+      "content": "```typescript\nexport interface TdHTMLAttributes<T extends Element> extends Attrs<'td', T> \n```\n**Extends:** Attrs&lt;'td', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.tdhtmlattributes.md"
     },
@@ -2502,7 +2762,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface TextareaHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, TextareaAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, TextareaAttrs",
+      "content": "```typescript\nexport interface TextareaHTMLAttributes<T extends Element> extends Attrs<'textarea', T> \n```\n**Extends:** Attrs&lt;'textarea', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.textareahtmlattributes.md"
     },
@@ -2516,7 +2776,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ThHTMLAttributes<T extends Element> extends TdHTMLAttributes<T> \n```\n**Extends:** [TdHTMLAttributes](#tdhtmlattributes)<!-- -->&lt;T&gt;",
+      "content": "```typescript\nexport interface ThHTMLAttributes<T extends Element> extends Attrs<'tr', T> \n```\n**Extends:** Attrs&lt;'tr', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.thhtmlattributes.md"
     },
@@ -2530,7 +2790,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface TimeHTMLAttributes<T extends Element> extends HTMLAttributes<T> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [dateTime?](#) |  | string \\| undefined | _(Optional)_ |",
+      "content": "```typescript\nexport interface TimeHTMLAttributes<T extends Element> extends Attrs<'time', T> \n```\n**Extends:** Attrs&lt;'time', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.timehtmlattributes.md"
     },
@@ -2544,7 +2804,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface TitleHTMLAttributes<T extends Element> extends HTMLAttributes<T, string> \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, string&gt;",
+      "content": "```typescript\nexport interface TitleHTMLAttributes<T extends Element> extends Attrs<'title', T> \n```\n**Extends:** Attrs&lt;'title', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.titlehtmlattributes.md"
     },
@@ -2558,7 +2818,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "Used to signal to Qwik which state should be watched for changes.\n\nThe `Tracker` is passed into the `taskFn` of `useTask`<!-- -->. It is intended to be used to wrap state objects in a read proxy which signals to Qwik which properties should be watched for changes. A change to any of the properties causes the `taskFn` to rerun.\n\n\\#\\#\\# Example\n\nThe `obs` passed into the `taskFn` is used to mark `state.count` as a property of interest. Any changes to the `state.count` property will cause the `taskFn` to rerun.\n\n```tsx\nconst Cmp = component$(() => {\n  const store = useStore({ count: 0, doubleCount: 0 });\n  useTask$(({ track }) => {\n    const count = track(() => store.count);\n    store.doubleCount = 2 * count;\n  });\n  return (\n    <div>\n      <span>\n        {store.count} / {store.doubleCount}\n      </span>\n      <button onClick$={() => store.count++}>+</button>\n    </div>\n  );\n});\n```\n\n\n```typescript\nexport interface Tracker \n```",
+      "content": "Used to signal to Qwik which state should be watched for changes.\n\nThe `Tracker` is passed into the `taskFn` of `useTask`<!-- -->. It is intended to be used to wrap state objects in a read proxy which signals to Qwik which properties should be watched for changes. A change to any of the properties causes the `taskFn` to rerun.\n\n\\#\\#\\# Example\n\nThe `obs` passed into the `taskFn` is used to mark `state.count` as a property of interest. Any changes to the `state.count` property will cause the `taskFn` to rerun.\n\n```tsx\nconst Cmp = component$(() => {\n  const store = useStore({ count: 0, doubleCount: 0 });\n  const signal = useSignal(0);\n  useTask$(({ track }) => {\n    // Any signals or stores accessed inside the task will be tracked\n    const count = track(() => store.count);\n    // You can also pass a signal to track() directly\n    const signalCount = track(signal);\n    store.doubleCount = count + signalCount;\n  });\n  return (\n    <div>\n      <span>\n        {store.count} / {store.doubleCount}\n      </span>\n      <button\n        onClick$={() => {\n          store.count++;\n          signal.value++;\n        }}\n      >\n        +\n      </button>\n    </div>\n  );\n});\n```\n\n\n```typescript\nexport interface Tracker \n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "qwik.tracker.md"
     },
@@ -2572,7 +2832,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface TrackHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, TrackAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T, undefined&gt;, TrackAttrs",
+      "content": "```typescript\nexport interface TrackHTMLAttributes<T extends Element> extends Attrs<'track', T> \n```\n**Extends:** Attrs&lt;'track', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.trackhtmlattributes.md"
     },
@@ -2684,7 +2944,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "Register a listener on the current component's host element.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX. Otherwise, it's adding a JSX listener in the `<div>` is a better idea.\n\n\n```typescript\nuseOn: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void\n```",
+      "content": "Register a listener on the current component's host element.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX. Otherwise, it's adding a JSX listener in the `<div>` is a better idea.\n\n\n```typescript\nuseOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-on.ts",
       "mdFile": "qwik.useon.md"
     },
@@ -2698,7 +2958,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "Register a listener on `document`<!-- -->.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.\n\n\n```typescript\nuseOnDocument: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void\n```",
+      "content": "Register a listener on `document`<!-- -->.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.\n\n\n```typescript\nuseOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-on.ts",
       "mdFile": "qwik.useondocument.md"
     },
@@ -2712,7 +2972,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "Register a listener on `window`<!-- -->.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.\n\n\n```typescript\nuseOnWindow: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void\n```",
+      "content": "Register a listener on `window`<!-- -->.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.\n\n\n```typescript\nuseOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-on.ts",
       "mdFile": "qwik.useonwindow.md"
     },
@@ -2726,7 +2986,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "This method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- 'pending' - the data is not yet available. - 'resolved' - the data is available. - 'rejected' - the data is not available due to an error or timeout.\n\n\\#\\#\\# Example\n\nExample showing how `useResource` to perform a fetch to request the weather, whenever the input city name changes.\n\n```tsx\nconst Cmp = component$(() => {\n  const store = useStore({\n    city: '',\n  });\n\n  const weatherResource = useResource$<any>(async ({ track, cleanup }) => {\n    const cityName = track(() => store.city);\n    const abortController = new AbortController();\n    cleanup(() => abortController.abort('cleanup'));\n    const res = await fetch(`http://weatherdata.com?city=${cityName}`, {\n      signal: abortController.signal,\n    });\n    const data = res.json();\n    return data;\n  });\n\n  return (\n    <div>\n      <input name=\"city\" onInput$={(ev: any) => (store.city = ev.target.value)} />\n      <Resource\n        value={weatherResource}\n        onResolved={(weather) => {\n          return <div>Temperature: {weather.temp}</div>;\n        }}\n      />\n    </div>\n  );\n});\n```\n\n\n```typescript\nuseResource$: <T>(generatorFn: ResourceFn<T>, opts?: ResourceOptions) => ResourceReturn<T>\n```",
+      "content": "This method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- 'pending' - the data is not yet available. - 'resolved' - the data is available. - 'rejected' - the data is not available due to an error or timeout.\n\n\\#\\#\\# Example\n\nExample showing how `useResource` to perform a fetch to request the weather, whenever the input city name changes.\n\n```tsx\nconst Cmp = component$(() => {\n  const cityS = useSignal('');\n\n  const weatherResource = useResource$(async ({ track, cleanup }) => {\n    const cityName = track(cityS);\n    const abortController = new AbortController();\n    cleanup(() => abortController.abort('cleanup'));\n    const res = await fetch(`http://weatherdata.com?city=${cityName}`, {\n      signal: abortController.signal,\n    });\n    const data = await res.json();\n    return data as { temp: number };\n  });\n\n  return (\n    <div>\n      <input name=\"city\" bind:value={cityS} />\n      <Resource\n        value={weatherResource}\n        onResolved={(weather) => {\n          return <div>Temperature: {weather.temp}</div>;\n        }}\n      />\n    </div>\n  );\n});\n```\n\n\n```typescript\nuseResource$: <T>(generatorFn: ResourceFn<T>, opts?: ResourceOptions) => ResourceReturn<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts",
       "mdFile": "qwik.useresource_.md"
     },
@@ -2740,7 +3000,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "This method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- 'pending' - the data is not yet available. - 'resolved' - the data is available. - 'rejected' - the data is not available due to an error or timeout.\n\n\\#\\#\\# Example\n\nExample showing how `useResource` to perform a fetch to request the weather, whenever the input city name changes.\n\n```tsx\nconst Cmp = component$(() => {\n  const store = useStore({\n    city: '',\n  });\n\n  const weatherResource = useResource$<any>(async ({ track, cleanup }) => {\n    const cityName = track(() => store.city);\n    const abortController = new AbortController();\n    cleanup(() => abortController.abort('cleanup'));\n    const res = await fetch(`http://weatherdata.com?city=${cityName}`, {\n      signal: abortController.signal,\n    });\n    const data = res.json();\n    return data;\n  });\n\n  return (\n    <div>\n      <input name=\"city\" onInput$={(ev: any) => (store.city = ev.target.value)} />\n      <Resource\n        value={weatherResource}\n        onResolved={(weather) => {\n          return <div>Temperature: {weather.temp}</div>;\n        }}\n      />\n    </div>\n  );\n});\n```\n\n\n```typescript\nuseResourceQrl: <T>(qrl: QRL<ResourceFn<T>>, opts?: ResourceOptions) => ResourceReturn<T>\n```",
+      "content": "This method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- 'pending' - the data is not yet available. - 'resolved' - the data is available. - 'rejected' - the data is not available due to an error or timeout.\n\n\\#\\#\\# Example\n\nExample showing how `useResource` to perform a fetch to request the weather, whenever the input city name changes.\n\n```tsx\nconst Cmp = component$(() => {\n  const cityS = useSignal('');\n\n  const weatherResource = useResource$(async ({ track, cleanup }) => {\n    const cityName = track(cityS);\n    const abortController = new AbortController();\n    cleanup(() => abortController.abort('cleanup'));\n    const res = await fetch(`http://weatherdata.com?city=${cityName}`, {\n      signal: abortController.signal,\n    });\n    const data = await res.json();\n    return data as { temp: number };\n  });\n\n  return (\n    <div>\n      <input name=\"city\" bind:value={cityS} />\n      <Resource\n        value={weatherResource}\n        onResolved={(weather) => {\n          return <div>Temperature: {weather.temp}</div>;\n        }}\n      />\n    </div>\n  );\n});\n```\n\n\n```typescript\nuseResourceQrl: <T>(qrl: QRL<ResourceFn<T>>, opts?: ResourceOptions) => ResourceReturn<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts",
       "mdFile": "qwik.useresourceqrl.md"
     },
@@ -2992,7 +3252,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface VideoHTMLAttributes<T extends Element> extends HTMLAttributes<T>, VideoAttrs \n```\n**Extends:** [HTMLAttributes](#htmlattributes)<!-- -->&lt;T&gt;, VideoAttrs",
+      "content": "```typescript\nexport interface VideoHTMLAttributes<T extends Element> extends Attrs<'video', T> \n```\n**Extends:** Attrs&lt;'video', T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.videohtmlattributes.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -10,6 +10,72 @@ title: \@builder.io/qwik API Reference
 'q:slot'?: string;
 ```
 
+## "xlink:actuate"
+
+```typescript
+'xlink:actuate'?: string | undefined;
+```
+
+## "xlink:arcrole"
+
+```typescript
+'xlink:arcrole'?: string | undefined;
+```
+
+## "xlink:href"
+
+```typescript
+'xlink:href'?: string | undefined;
+```
+
+## "xlink:role"
+
+```typescript
+'xlink:role'?: string | undefined;
+```
+
+## "xlink:show"
+
+```typescript
+'xlink:show'?: string | undefined;
+```
+
+## "xlink:title"
+
+```typescript
+'xlink:title'?: string | undefined;
+```
+
+## "xlink:type"
+
+```typescript
+'xlink:type'?: string | undefined;
+```
+
+## "xml:base"
+
+```typescript
+'xml:base'?: string | undefined;
+```
+
+## "xml:lang"
+
+```typescript
+'xml:lang'?: string | undefined;
+```
+
+## "xml:space"
+
+```typescript
+'xml:space'?: string | undefined;
+```
+
+## "xmlns:xlink"
+
+```typescript
+'xmlns:xlink'?: string | undefined;
+```
+
 ## $
 
 Qwik Optimizer marker function.
@@ -25,20 +91,20 @@ $: <T>(expression: T) => QRL<T>;
 ## AnchorHTMLAttributes
 
 ```typescript
-export interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<T>, AnchorAttrs
+export interface AnchorHTMLAttributes<T extends Element> extends Attrs<'a', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, AnchorAttrs
+**Extends:** Attrs&lt;'a', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## AreaHTMLAttributes
 
 ```typescript
-export interface AreaHTMLAttributes<T extends Element> extends HTMLAttributes<T, false>, AreaAttrs
+export interface AreaHTMLAttributes<T extends Element> extends Attrs<'area', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, false&gt;, AreaAttrs
+**Extends:** Attrs&lt;'area', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -184,30 +250,30 @@ export type AriaRole =
 ## AudioHTMLAttributes
 
 ```typescript
-export interface AudioHTMLAttributes<T extends Element> extends HTMLAttributes<T>, AudioAttrs
+export interface AudioHTMLAttributes<T extends Element> extends Attrs<'audio', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, AudioAttrs
+**Extends:** Attrs&lt;'audio', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## BaseHTMLAttributes
 
 ```typescript
-export interface BaseHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, BaseAttrs
+export interface BaseHTMLAttributes<T extends Element> extends Attrs<'base', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, BaseAttrs
+**Extends:** Attrs&lt;'base', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## BlockquoteHTMLAttributes
 
 ```typescript
-export interface BlockquoteHTMLAttributes<T extends Element> extends HTMLAttributes<T>, BlockquoteAttrs
+export interface BlockquoteHTMLAttributes<T extends Element> extends Attrs<'blockquote', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, BlockquoteAttrs
+**Extends:** Attrs&lt;'blockquote', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -222,10 +288,10 @@ export type Booleanish = boolean | `${boolean}`;
 ## ButtonHTMLAttributes
 
 ```typescript
-export interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ButtonAttrs
+export interface ButtonHTMLAttributes<T extends Element> extends Attrs<'button', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, ButtonAttrs
+**Extends:** Attrs&lt;'button', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -246,10 +312,10 @@ void
 ## CanvasHTMLAttributes
 
 ```typescript
-export interface CanvasHTMLAttributes<T extends Element> extends HTMLAttributes<T>, CanvasAttrs
+export interface CanvasHTMLAttributes<T extends Element> extends Attrs<'canvas', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, CanvasAttrs
+**Extends:** Attrs&lt;'canvas', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -262,8 +328,16 @@ If it's an array, each item is a class list and they are all added.
 If it's an object, then the keys are class name strings, and the values are booleans that determine if the class name string should be added or not.
 
 ```typescript
-export type ClassList = BaseClassList | BaseClassList[];
+export type ClassList =
+  | string
+  | undefined
+  | null
+  | false
+  | Record<string, boolean | string | number | null | undefined>
+  | ClassList[];
 ```
+
+**References:** [ClassList](#classlist)
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
 
@@ -280,24 +354,20 @@ void
 ## ColgroupHTMLAttributes
 
 ```typescript
-export interface ColgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface ColgroupHTMLAttributes<T extends Element> extends Attrs<'colgroup', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property   | Modifiers | Type                | Description  |
-| ---------- | --------- | ------------------- | ------------ |
-| [span?](#) |           | number \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'colgroup', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## ColHTMLAttributes
 
 ```typescript
-export interface ColHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ColAttrs
+export interface ColHTMLAttributes<T extends Element> extends Attrs<'col', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, ColAttrs
+**Extends:** Attrs&lt;'col', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -319,9 +389,9 @@ const MyComponent: Component<MyComponentProps> = component$(
 ```
 
 ```typescript
-export type Component<PROPS extends Record<any, any>> = FunctionComponent<
-  PublicProps<PROPS>
->;
+export type Component<
+  PROPS extends Record<any, any> = Record<string, unknown>,
+> = FunctionComponent<PublicProps<PROPS>>;
 ```
 
 **References:** [FunctionComponent](#functioncomponent), [PublicProps](#publicprops)
@@ -520,6 +590,23 @@ export interface CorePlatform
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/platform/types.ts)
 
+## CorrectedToggleEvent
+
+This corrects the TS definition for ToggleEvent
+
+```typescript
+export interface CorrectedToggleEvent extends Event
+```
+
+**Extends:** Event
+
+| Property       | Modifiers             | Type               | Description |
+| -------------- | --------------------- | ------------------ | ----------- |
+| [newState](#)  | <code>readonly</code> | 'open' \| 'closed' |             |
+| [prevState](#) | <code>readonly</code> | 'open' \| 'closed' |             |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
+
 ## createContextId
 
 Create a context ID to be used in your application. The name should be written with no spaces.
@@ -583,39 +670,30 @@ export interface CSSProperties extends CSS.Properties<string | number>, CSS.Prop
 ## DataHTMLAttributes
 
 ```typescript
-export interface DataHTMLAttributes<T extends Element> extends HTMLAttributes<T>, DataAttrs
+export interface DataHTMLAttributes<T extends Element> extends Attrs<'data', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, DataAttrs
+**Extends:** Attrs&lt;'data', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## DelHTMLAttributes
 
 ```typescript
-export interface DelHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface DelHTMLAttributes<T extends Element> extends Attrs<'del', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property       | Modifiers | Type                | Description  |
-| -------------- | --------- | ------------------- | ------------ |
-| [cite?](#)     |           | string \| undefined | _(Optional)_ |
-| [dateTime?](#) |           | string \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'del', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## DetailsHTMLAttributes
 
 ```typescript
-export interface DetailsHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface DetailsHTMLAttributes<T extends Element> extends Attrs<'details', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property   | Modifiers | Type                 | Description  |
-| ---------- | --------- | -------------------- | ------------ |
-| [open?](#) |           | boolean \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'details', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -637,29 +715,26 @@ export interface DevJSX
 ## DialogHTMLAttributes
 
 ```typescript
-export interface DialogHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface DialogHTMLAttributes<T extends Element> extends Attrs<'dialog', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property   | Modifiers | Type                 | Description  |
-| ---------- | --------- | -------------------- | ------------ |
-| [open?](#) |           | boolean \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'dialog', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## DOMAttributes
 
+The Qwik-specific attributes that DOM elements accept
+
 ```typescript
-export interface DOMAttributes<T extends Element, Children = JSXChildren> extends QwikProps<T>, QwikEvents<T>
+export interface DOMAttributes<EL extends Element> extends QwikAttributesBase, RefAttr<EL>, QwikEvents<EL>
 ```
 
-**Extends:** QwikProps&lt;T&gt;, QwikEvents&lt;T&gt;
+**Extends:** QwikAttributesBase, RefAttr&lt;EL&gt;, QwikEvents&lt;EL&gt;
 
-| Property       | Modifiers | Type                                  | Description  |
-| -------------- | --------- | ------------------------------------- | ------------ |
-| [children?](#) |           | Children                              | _(Optional)_ |
-| [key?](#)      |           | string \| number \| null \| undefined | _(Optional)_ |
+| Property    | Modifiers | Type                                                                                     | Description  |
+| ----------- | --------- | ---------------------------------------------------------------------------------------- | ------------ |
+| [class?](#) |           | [ClassList](#classlist) \| [Signal](#signal)&lt;[ClassList](#classlist)&gt; \| undefined | _(Optional)_ |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
 
@@ -689,13 +764,21 @@ interface ElementChildrenAttribute
 | -------------- | --------- | ---- | ------------ |
 | [children?](#) |           | any  | _(Optional)_ |
 
+## ElementType
+
+```typescript
+type ElementType = string | ((...args: any[]) => JSXNode | null);
+```
+
+**References:** [JSXNode](#jsxnode)
+
 ## EmbedHTMLAttributes
 
 ```typescript
-export interface EmbedHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, EmbedAttrs
+export interface EmbedHTMLAttributes<T extends Element> extends Attrs<'embed', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, EmbedAttrs
+**Extends:** Attrs&lt;'embed', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -730,20 +813,20 @@ eventQrl: <T>(qrl: QRL<T>) => QRL<T>;
 ## FieldsetHTMLAttributes
 
 ```typescript
-export interface FieldsetHTMLAttributes<T extends Element> extends HTMLAttributes<T>, FieldSetAttrs
+export interface FieldsetHTMLAttributes<T extends Element> extends Attrs<'fieldset', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, FieldSetAttrs
+**Extends:** Attrs&lt;'fieldset', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## FormHTMLAttributes
 
 ```typescript
-export interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T>, FormAttrs
+export interface FormHTMLAttributes<T extends Element> extends Attrs<'form', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, FormAttrs
+**Extends:** Attrs&lt;'form', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -825,10 +908,10 @@ export declare namespace h
 ## HrHTMLAttributes
 
 ```typescript
-export interface HrHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>
+export interface HrHTMLAttributes<T extends Element> extends Attrs<'hr', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;
+**Extends:** Attrs&lt;'hr', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -856,10 +939,10 @@ export type HTMLAttributeReferrerPolicy = ReferrerPolicy;
 ## HTMLAttributes
 
 ```typescript
-export interface HTMLAttributes<E extends Element, Children = JSXChildren> extends HTMLAttributesBase<E, Children>, Partial<Omit<HTMLElement, BadOnes<HTMLElement>>>
+export interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E>
 ```
 
-**Extends:** HTMLAttributesBase&lt;E, Children&gt;, Partial&lt;Omit&lt;HTMLElement, BadOnes&lt;HTMLElement&gt;&gt;&gt;
+**Extends:** HTMLElementAttrs, [DOMAttributes](#domattributes)&lt;E&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -888,14 +971,10 @@ HTMLFragment: FunctionComponent<{
 ## HtmlHTMLAttributes
 
 ```typescript
-export interface HtmlHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface HtmlHTMLAttributes<T extends Element> extends Attrs<'html', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property       | Modifiers | Type                | Description  |
-| -------------- | --------- | ------------------- | ------------ |
-| [manifest?](#) |           | string \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'html', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -989,20 +1068,20 @@ export type HTMLInputTypeAttribute =
 ## IframeHTMLAttributes
 
 ```typescript
-export interface IframeHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, IframeAttrs
+export interface IframeHTMLAttributes<T extends Element> extends Attrs<'iframe', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, IframeAttrs
+**Extends:** Attrs&lt;'iframe', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## ImgHTMLAttributes
 
 ```typescript
-export interface ImgHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ImgAttrs
+export interface ImgHTMLAttributes<T extends Element> extends Attrs<'img', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, ImgAttrs
+**Extends:** Attrs&lt;'img', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -1050,25 +1129,22 @@ implicit$FirstArg: <FIRST, REST extends any[], RET>(
 ## InputHTMLAttributes
 
 ```typescript
-export interface InputHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, InputAttrs
+export type InputHTMLAttributes<T extends Element> = Attrs<
+  "input",
+  T,
+  HTMLInputElement
+>;
 ```
-
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, InputAttrs
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## InsHTMLAttributes
 
 ```typescript
-export interface InsHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface InsHTMLAttributes<T extends Element> extends Attrs<'ins', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property       | Modifiers | Type                | Description  |
-| -------------- | --------- | ------------------- | ------------ |
-| [cite?](#)     |           | string \| undefined | _(Optional)_ |
-| [dateTime?](#) |           | string \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'ins', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -1087,31 +1163,6 @@ interface IntrinsicElements extends QwikJSX.IntrinsicElements
 ```
 
 **Extends:** [QwikJSX.IntrinsicElements](#)
-
-## IntrinsicHTMLElements
-
-```typescript
-export interface IntrinsicHTMLElements extends QwikHTMLExceptions, PlainHTMLElements
-```
-
-**Extends:** QwikHTMLExceptions, PlainHTMLElements
-
-[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
-
-## IntrinsicSVGElements
-
-```typescript
-export type IntrinsicSVGElements = {
-  [K in keyof Omit<
-    SVGElementTagNameMap,
-    keyof HTMLElementTagNameMap
-  >]: SVGProps<SVGElementTagNameMap[K]>;
-};
-```
-
-**References:** [SVGProps](#svgprops)
-
-[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## isSignal
 
@@ -1218,110 +1269,111 @@ export type JSXTagName =
 
 ## KeygenHTMLAttributes
 
+> Warning: This API is now obsolete.
+>
+> in html5
+
 ```typescript
-export interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface KeygenHTMLAttributes<T extends Element> extends Attrs<'base', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property        | Modifiers | Type                 | Description  |
-| --------------- | --------- | -------------------- | ------------ |
-| [autoFocus?](#) |           | boolean \| undefined | _(Optional)_ |
-| [challenge?](#) |           | string \| undefined  | _(Optional)_ |
-| [children?](#)  |           | undefined            | _(Optional)_ |
-| [disabled?](#)  |           | boolean \| undefined | _(Optional)_ |
-| [form?](#)      |           | string \| undefined  | _(Optional)_ |
-| [keyParams?](#) |           | string \| undefined  | _(Optional)_ |
-| [keyType?](#)   |           | string \| undefined  | _(Optional)_ |
-| [name?](#)      |           | string \| undefined  | _(Optional)_ |
+**Extends:** Attrs&lt;'base', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## KnownEventNames
+
+The names of events that Qwik knows about. They are all lowercase, but on the JSX side, they are PascalCase for nicer DX. (`onAuxClick$` vs `onauxclick$`)
+
+```typescript
+export type KnownEventNames = LiteralUnion<AllEventKeys, string>;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts)
 
 ## LabelHTMLAttributes
 
 ```typescript
-export interface LabelHTMLAttributes<T extends Element> extends HTMLAttributes<T>, LabelAttrs
+export interface LabelHTMLAttributes<T extends Element> extends Attrs<'label', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, LabelAttrs
+**Extends:** Attrs&lt;'label', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## LiHTMLAttributes
 
 ```typescript
-export interface LiHTMLAttributes<T extends Element> extends HTMLAttributes<T>, LiAttrs
+export interface LiHTMLAttributes<T extends Element> extends Attrs<'li', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, LiAttrs
+**Extends:** Attrs&lt;'li', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## LinkHTMLAttributes
 
 ```typescript
-export interface LinkHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, LinkAttrs
+export interface LinkHTMLAttributes<T extends Element> extends Attrs<'link', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, LinkAttrs
+**Extends:** Attrs&lt;'link', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## MapHTMLAttributes
 
 ```typescript
-export interface MapHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface MapHTMLAttributes<T extends Element> extends Attrs<'map', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property   | Modifiers | Type                | Description  |
-| ---------- | --------- | ------------------- | ------------ |
-| [name?](#) |           | string \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'map', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## MediaHTMLAttributes
 
 ```typescript
-export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T>, MediaAttrs
+export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T>, Augmented<HTMLMediaElement, {
+    crossOrigin?: HTMLCrossOriginAttribute;
+}>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, MediaAttrs
+**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, Augmented&lt;HTMLMediaElement, { crossOrigin?: [HTMLCrossOriginAttribute](#htmlcrossoriginattribute); }&gt;
+
+| Property          | Modifiers | Type                                                  | Description  |
+| ----------------- | --------- | ----------------------------------------------------- | ------------ |
+| [crossOrigin?](#) |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute) | _(Optional)_ |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## MenuHTMLAttributes
 
 ```typescript
-export interface MenuHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface MenuHTMLAttributes<T extends Element> extends Attrs<'menu', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property   | Modifiers | Type                | Description  |
-| ---------- | --------- | ------------------- | ------------ |
-| [type?](#) |           | string \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'menu', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## MetaHTMLAttributes
 
 ```typescript
-export interface MetaHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, MetaAttrs
+export interface MetaHTMLAttributes<T extends Element> extends Attrs<'meta', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, MetaAttrs
+**Extends:** Attrs&lt;'meta', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## MeterHTMLAttributes
 
 ```typescript
-export interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T>, MeterAttrs
+export interface MeterHTMLAttributes<T extends Element> extends Attrs<'meter', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, MeterAttrs
+**Extends:** Attrs&lt;'meter', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -1512,20 +1564,20 @@ export type Numberish = number | `${number}`;
 ## ObjectHTMLAttributes
 
 ```typescript
-export interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ObjectAttrs
+export interface ObjectHTMLAttributes<T extends Element> extends Attrs<'object', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, ObjectAttrs
+**Extends:** Attrs&lt;'object', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## OlHTMLAttributes
 
 ```typescript
-export interface OlHTMLAttributes<T extends Element> extends HTMLAttributes<T>, OlAttrs
+export interface OlHTMLAttributes<T extends Element> extends Attrs<'ol', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, OlAttrs
+**Extends:** Attrs&lt;'ol', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -1556,35 +1608,30 @@ export interface OnVisibleTaskOptions
 ## OptgroupHTMLAttributes
 
 ```typescript
-export interface OptgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface OptgroupHTMLAttributes<T extends Element> extends Attrs<'optgroup', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property       | Modifiers | Type                 | Description  |
-| -------------- | --------- | -------------------- | ------------ |
-| [disabled?](#) |           | boolean \| undefined | _(Optional)_ |
-| [label?](#)    |           | string \| undefined  | _(Optional)_ |
+**Extends:** Attrs&lt;'optgroup', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## OptionHTMLAttributes
 
 ```typescript
-export interface OptionHTMLAttributes<T extends Element> extends HTMLAttributes<T, string>, OptionAttrs
+export interface OptionHTMLAttributes<T extends Element> extends Attrs<'option', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, string&gt;, OptionAttrs
+**Extends:** Attrs&lt;'option', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## OutputHTMLAttributes
 
 ```typescript
-export interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface OutputHTMLAttributes<T extends Element> extends Attrs<'output', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
+**Extends:** Attrs&lt;'output', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -1595,20 +1642,20 @@ export interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<
 > Old DOM API
 
 ```typescript
-export interface ParamHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ParamAttrs
+export interface ParamHTMLAttributes<T extends Element> extends Attrs<'base', T, HTMLParamElement>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, ParamAttrs
+**Extends:** Attrs&lt;'base', T, HTMLParamElement&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## ProgressHTMLAttributes
 
 ```typescript
-export interface ProgressHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ProgressAttrs
+export interface ProgressHTMLAttributes<T extends Element> extends Attrs<'progress', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, ProgressAttrs
+**Extends:** Attrs&lt;'progress', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -1662,14 +1709,16 @@ export const OtherComponent = component$(() => {
 ```
 
 ```typescript
-export type PropsOf<COMP extends Component<any>> = COMP extends Component<
-  infer PROPS
->
+export type PropsOf<COMP> = COMP extends Component<infer PROPS>
   ? NonNullable<PROPS>
-  : never;
+  : COMP extends FunctionComponent<infer PROPS>
+    ? NonNullable<PublicProps<PROPS>>
+    : COMP extends string
+      ? QwikIntrinsicElements[COMP]
+      : Record<string, unknown>;
 ```
 
-**References:** [Component](#component)
+**References:** [Component](#component), [FunctionComponent](#functioncomponent), [PublicProps](#publicprops), [QwikIntrinsicElements](#qwikintrinsicelements)
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts)
 
@@ -1723,14 +1772,10 @@ qrl: <T = any>(
 ## QuoteHTMLAttributes
 
 ```typescript
-export interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface QuoteHTMLAttributes<T extends Element> extends Attrs<'q', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property   | Modifiers | Type                | Description  |
-| ---------- | --------- | ------------------- | ------------ |
-| [cite?](#) |           | string \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'q', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -1826,6 +1871,48 @@ export type QwikFocusEvent<T = Element> = NativeFocusEvent;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts)
 
+## QwikHTMLElements
+
+The DOM props without plain handlers, for use inside functions
+
+```typescript
+export type QwikHTMLElements = {
+  [tag in keyof HTMLElementTagNameMap]: Augmented<
+    HTMLElementTagNameMap[tag],
+    SpecialAttrs[tag]
+  > &
+    HTMLElementAttrs &
+    QwikAttributes<HTMLElementTagNameMap[tag]>;
+} & {
+  [unknownTag: string]: {
+    [prop: string]: any;
+  } & HTMLElementAttrs &
+    QwikAttributes<any>;
+};
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## QwikIdleEvent
+
+Emitted by qwik-loader on document when the document first becomes idle
+
+```typescript
+export type QwikIdleEvent = CustomEvent<{}>;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts)
+
+## QwikInitEvent
+
+Emitted by qwik-loader on document when the document first becomes interactive
+
+```typescript
+export type QwikInitEvent = CustomEvent<{}>;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts)
+
 ## QwikIntrinsicElements
 
 The interface holds available attributes of both native DOM elements and custom Qwik elements. An example showing how to define a customizable wrapper component:
@@ -1846,11 +1933,13 @@ export default component$<WrapperProps>(({ attributes }) => {
 });
 ```
 
+Note: It is shorter to use `PropsOf<'div'>`
+
 ```typescript
-export interface QwikIntrinsicElements extends IntrinsicHTMLElements
+export interface QwikIntrinsicElements extends QwikHTMLElements, QwikSVGElements
 ```
 
-**Extends:** [IntrinsicHTMLElements](#intrinsichtmlelements)
+**Extends:** [QwikHTMLElements](#qwikhtmlelements), [QwikSVGElements](#qwiksvgelements)
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-elements.ts)
 
@@ -1878,6 +1967,10 @@ export declare namespace QwikJSX
 | [ElementChildrenAttribute](#) |             |
 | [IntrinsicAttributes](#)      |             |
 | [IntrinsicElements](#)        |             |
+
+| Type Alias                          | Description |
+| ----------------------------------- | ----------- |
+| [ElementType](#qwikjsx-elementtype) |             |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts)
 
@@ -1934,6 +2027,23 @@ export type QwikSubmitEvent<T = Element> = Event;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts)
+
+## QwikSVGElements
+
+The SVG props without plain handlers, for use inside functions
+
+```typescript
+export type QwikSVGElements = {
+  [K in keyof Omit<
+    SVGElementTagNameMap,
+    keyof HTMLElementTagNameMap
+  >]: SVGProps<SVGElementTagNameMap[K]>;
+};
+```
+
+**References:** [SVGProps](#svgprops)
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## QwikSymbolEvent
 
@@ -2111,27 +2221,22 @@ Example showing how `useResource` to perform a fetch to request the weather, whe
 
 ```tsx
 const Cmp = component$(() => {
-  const store = useStore({
-    city: "",
-  });
+  const cityS = useSignal("");
 
-  const weatherResource = useResource$<any>(async ({ track, cleanup }) => {
-    const cityName = track(() => store.city);
+  const weatherResource = useResource$(async ({ track, cleanup }) => {
+    const cityName = track(cityS);
     const abortController = new AbortController();
     cleanup(() => abortController.abort("cleanup"));
     const res = await fetch(`http://weatherdata.com?city=${cityName}`, {
       signal: abortController.signal,
     });
-    const data = res.json();
-    return data;
+    const data = await res.json();
+    return data as { temp: number };
   });
 
   return (
     <div>
-      <input
-        name="city"
-        onInput$={(ev: any) => (store.city = ev.target.value)}
-      />
+      <input name="city" bind:value={cityS} />
       <Resource
         value={weatherResource}
         onResolved={(weather) => {
@@ -2261,20 +2366,20 @@ export type ResourceReturn<T> =
 ## ScriptHTMLAttributes
 
 ```typescript
-export interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ScriptAttrs
+export interface ScriptHTMLAttributes<T extends Element> extends Attrs<'script', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, ScriptAttrs
+**Extends:** Attrs&lt;'script', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## SelectHTMLAttributes
 
 ```typescript
-export interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<T>, SelectAttrs
+export interface SelectHTMLAttributes<T extends Element> extends Attrs<'select', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, SelectAttrs
+**Extends:** Attrs&lt;'select', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -2333,14 +2438,10 @@ Slot: FunctionComponent<{
 ## SlotHTMLAttributes
 
 ```typescript
-export interface SlotHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface SlotHTMLAttributes<T extends Element> extends Attrs<'slot', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property   | Modifiers | Type                | Description  |
-| ---------- | --------- | ------------------- | ------------ |
-| [name?](#) |           | string \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'slot', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -2418,10 +2519,10 @@ export interface SnapshotState
 ## SourceHTMLAttributes
 
 ```typescript
-export interface SourceHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, SourceAttrs
+export interface SourceHTMLAttributes<T extends Element> extends Attrs<'source', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, SourceAttrs
+**Extends:** Attrs&lt;'source', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -2513,10 +2614,10 @@ export type StreamWriter = {
 ## StyleHTMLAttributes
 
 ```typescript
-export interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T, string>, StyleAttrs
+export interface StyleHTMLAttributes<T extends Element> extends Attrs<'style', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, string&gt;, StyleAttrs
+**Extends:** Attrs&lt;'style', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -2524,292 +2625,294 @@ export interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T
 
 The TS types don't include the SVG attributes so we have to define them ourselves
 
+NOTE: These props are probably not complete
+
 ```typescript
-export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T>
+export interface SVGAttributes<T extends Element = Element> extends AriaAttributes
 ```
 
-**Extends:** [AriaAttributes](#ariaattributes), [DOMAttributes](#domattributes)&lt;T&gt;
+**Extends:** [AriaAttributes](#ariaattributes)
 
-| Property                             | Modifiers | Type                                                                                                                                                                                                                | Description  |
-| ------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| ["accent-height"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["alignment-baseline"?](#)           |           | 'auto' \| 'baseline' \| 'before-edge' \| 'text-before-edge' \| 'middle' \| 'central' \| 'after-edge' \| 'text-after-edge' \| 'ideographic' \| 'alphabetic' \| 'hanging' \| 'mathematical' \| 'inherit' \| undefined | _(Optional)_ |
-| ["arabic-form"?](#)                  |           | 'initial' \| 'medial' \| 'terminal' \| 'isolated' \| undefined                                                                                                                                                      | _(Optional)_ |
-| ["baseline-shift"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["cap-height"?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["clip-path"?](#)                    |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["clip-rule"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["color-interpolation-filters"?](#)  |           | 'auto' \| 's-rGB' \| 'linear-rGB' \| 'inherit' \| undefined                                                                                                                                                         | _(Optional)_ |
-| ["color-interpolation"?](#)          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["color-profile"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["color-rendering"?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["dominant-baseline"?](#)            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["edge-mode"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["enable-background"?](#)            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["fill-opacity"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["fill-rule"?](#)                    |           | 'nonzero' \| 'evenodd' \| 'inherit' \| undefined                                                                                                                                                                    | _(Optional)_ |
-| ["flood-color"?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["flood-opacity"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["font-family"?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["font-size-adjust"?](#)             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["font-size"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["font-stretch"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["font-style"?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["font-variant"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["font-weight"?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["glyph-name"?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["glyph-orientation-horizontal"?](#) |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["glyph-orientation-vertical"?](#)   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["horiz-adv-x"?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["horiz-origin-x"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["image-rendering"?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["letter-spacing"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["lighting-color"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["marker-end"?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["marker-mid"?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["marker-start"?](#)                 |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["overline-position"?](#)            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["overline-thickness"?](#)           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["paint-order"?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["pointer-events"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["rendering-intent"?](#)             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["shape-rendering"?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["stop-color"?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["stop-opacity"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["strikethrough-position"?](#)       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["strikethrough-thickness"?](#)      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["stroke-dasharray"?](#)             |           | string \| number \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["stroke-dashoffset"?](#)            |           | string \| number \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["stroke-linecap"?](#)               |           | 'butt' \| 'round' \| 'square' \| 'inherit' \| undefined                                                                                                                                                             | _(Optional)_ |
-| ["stroke-linejoin"?](#)              |           | 'miter' \| 'round' \| 'bevel' \| 'inherit' \| undefined                                                                                                                                                             | _(Optional)_ |
-| ["stroke-miterlimit"?](#)            |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["stroke-opacity"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["stroke-width"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["text-anchor"?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["text-decoration"?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["text-rendering"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["underline-position"?](#)           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["underline-thickness"?](#)          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["unicode-bidi"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["unicode-range"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["units-per-em"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["v-alphabetic"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["v-hanging"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["v-ideographic"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["v-mathematical"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["vector-effect"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["vert-adv-y"?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["vert-origin-x"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["vert-origin-y"?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["word-spacing"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["writing-mode"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| ["x-channel-selector"?](#)           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| ["x-height"?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [accumulate?](#)                     |           | 'none' \| 'sum' \| undefined                                                                                                                                                                                        | _(Optional)_ |
-| [additive?](#)                       |           | 'replace' \| 'sum' \| undefined                                                                                                                                                                                     | _(Optional)_ |
-| [allowReorder?](#)                   |           | 'no' \| 'yes' \| undefined                                                                                                                                                                                          | _(Optional)_ |
-| [alphabetic?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [amplitude?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [ascent?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [attributeName?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [attributeType?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [autoReverse?](#)                    |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                                              | _(Optional)_ |
-| [azimuth?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [baseFrequency?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [baseProfile?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [bbox?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [begin?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [bias?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [by?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [calcMode?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [class?](#)                          |           | [ClassList](#classlist) \| undefined                                                                                                                                                                                | _(Optional)_ |
-| [clip?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [clipPathUnits?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [color?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [contentScriptType?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [contentStyleType?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [crossOrigin?](#)                    |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute)                                                                                                                                                               | _(Optional)_ |
-| [cursor?](#)                         |           | number \| string                                                                                                                                                                                                    | _(Optional)_ |
-| [cx?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [cy?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [d?](#)                              |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [decelerate?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [descent?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [diffuseConstant?](#)                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [direction?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [display?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [divisor?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [dur?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [dx?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [dy?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [elevation?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [end?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [exponent?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [externalResourcesRequired?](#)      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [fill?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [filter?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [filterRes?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [filterUnits?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [focusable?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [format?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [fr?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [from?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [fx?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [fy?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [g1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [g2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [glyphRef?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [gradientTransform?](#)              |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [gradientUnits?](#)                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [hanging?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [height?](#)                         |           | [Numberish](#numberish) \| undefined                                                                                                                                                                                | _(Optional)_ |
-| [href?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [id?](#)                             |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [ideographic?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [in?](#)                             |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [in2?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [intercept?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [k?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [k1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [k2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [k3?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [k4?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [kernelMatrix?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [kernelUnitLength?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [kerning?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [keyPoints?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [keySplines?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [keyTimes?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [lang?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [lengthAdjust?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [limitingConeAngle?](#)              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [local?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [markerHeight?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [markerUnits?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [markerWidth?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [mask?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [maskContentUnits?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [maskUnits?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [mathematical?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [max?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [media?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [method?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [min?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [mode?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [name?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [numOctaves?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [offset?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [opacity?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [operator?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [order?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [orient?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [orientation?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [origin?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [overflow?](#)                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [panose1?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [path?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [pathLength?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [patternContentUnits?](#)            |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [patternTransform?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [patternUnits?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [points?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [pointsAtX?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [pointsAtY?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [pointsAtZ?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [preserveAlpha?](#)                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [preserveAspectRatio?](#)            |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [primitiveUnits?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [r?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [radius?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [refX?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [refY?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [repeatCount?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [repeatDur?](#)                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [requiredextensions?](#)             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [requiredFeatures?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [restart?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [result?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [role?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [rotate?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [rx?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [ry?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [scale?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [seed?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [slope?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [spacing?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [specularConstant?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [specularExponent?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [speed?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [spreadMethod?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [startOffset?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [stdDeviation?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [stemh?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [stemv?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [stitchTiles?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [string?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [stroke?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [style?](#)                          |           | [CSSProperties](#cssproperties) \| string \| undefined                                                                                                                                                              | _(Optional)_ |
-| [surfaceScale?](#)                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [systemLanguage?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [tabindex?](#)                       |           | number \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [tableValues?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [target?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [targetX?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [targetY?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [textLength?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [to?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [transform?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [type?](#)                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [u1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [u2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [unicode?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [values?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [version?](#)                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [viewBox?](#)                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [viewTarget?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [visibility?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [width?](#)                          |           | [Numberish](#numberish) \| undefined                                                                                                                                                                                | _(Optional)_ |
-| [widths?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [x?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [x1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [x2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [xlinkActuate?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xlinkArcrole?](#)                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xlinkHref?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xlinkRole?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xlinkShow?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xlinkTitle?](#)                     |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xlinkType?](#)                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xmlBase?](#)                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xmlLang?](#)                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xmlns?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [xmlSpace?](#)                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [y?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [y1?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [y2?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [yChannelSelector?](#)               |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
-| [z?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
-| [zoomAndPan?](#)                     |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| Property                                           | Modifiers | Type                                                                                                                                                                                                                | Description  |
+| -------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| ["accent-height"?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["alignment-baseline"?](#)                         |           | 'auto' \| 'baseline' \| 'before-edge' \| 'text-before-edge' \| 'middle' \| 'central' \| 'after-edge' \| 'text-after-edge' \| 'ideographic' \| 'alphabetic' \| 'hanging' \| 'mathematical' \| 'inherit' \| undefined | _(Optional)_ |
+| ["arabic-form"?](#)                                |           | 'initial' \| 'medial' \| 'terminal' \| 'isolated' \| undefined                                                                                                                                                      | _(Optional)_ |
+| ["baseline-shift"?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["cap-height"?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["clip-path"?](#)                                  |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["clip-rule"?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["color-interpolation-filters"?](#)                |           | 'auto' \| 's-rGB' \| 'linear-rGB' \| 'inherit' \| undefined                                                                                                                                                         | _(Optional)_ |
+| ["color-interpolation"?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["color-profile"?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["color-rendering"?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["dominant-baseline"?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["edge-mode"?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["enable-background"?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["fill-opacity"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["fill-rule"?](#)                                  |           | 'nonzero' \| 'evenodd' \| 'inherit' \| undefined                                                                                                                                                                    | _(Optional)_ |
+| ["flood-color"?](#)                                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["flood-opacity"?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-family"?](#)                                |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["font-size-adjust"?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-size"?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-stretch"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-style"?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-variant"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["font-weight"?](#)                                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["glyph-name"?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["glyph-orientation-horizontal"?](#)               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["glyph-orientation-vertical"?](#)                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["horiz-adv-x"?](#)                                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["horiz-origin-x"?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["image-rendering"?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["letter-spacing"?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["lighting-color"?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["marker-end"?](#)                                 |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["marker-mid"?](#)                                 |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["marker-start"?](#)                               |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["overline-position"?](#)                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["overline-thickness"?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["paint-order"?](#)                                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["pointer-events"?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["rendering-intent"?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["shape-rendering"?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stop-color"?](#)                                 |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["stop-opacity"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["strikethrough-position"?](#)                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["strikethrough-thickness"?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stroke-dasharray"?](#)                           |           | string \| number \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stroke-dashoffset"?](#)                          |           | string \| number \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stroke-linecap"?](#)                             |           | 'butt' \| 'round' \| 'square' \| 'inherit' \| undefined                                                                                                                                                             | _(Optional)_ |
+| ["stroke-linejoin"?](#)                            |           | 'miter' \| 'round' \| 'bevel' \| 'inherit' \| undefined                                                                                                                                                             | _(Optional)_ |
+| ["stroke-miterlimit"?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["stroke-opacity"?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["stroke-width"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["text-anchor"?](#)                                |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["text-decoration"?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["text-rendering"?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["underline-position"?](#)                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["underline-thickness"?](#)                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["unicode-bidi"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["unicode-range"?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["units-per-em"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["v-alphabetic"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["v-hanging"?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["v-ideographic"?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["v-mathematical"?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["vector-effect"?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["vert-adv-y"?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["vert-origin-x"?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["vert-origin-y"?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["word-spacing"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["writing-mode"?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["x-channel-selector"?](#)                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["x-height"?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| ["xlink:actuate"?](#svgattributes-_xlink_actuate_) |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xlink:arcrole"?](#svgattributes-_xlink_arcrole_) |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xlink:href"?](#svgattributes-_xlink_href_)       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xlink:role"?](#svgattributes-_xlink_role_)       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xlink:show"?](#svgattributes-_xlink_show_)       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xlink:title"?](#svgattributes-_xlink_title_)     |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xlink:type"?](#svgattributes-_xlink_type_)       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xml:base"?](#svgattributes-_xml_base_)           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xml:lang"?](#svgattributes-_xml_lang_)           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xml:space"?](#svgattributes-_xml_space_)         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| ["xmlns:xlink"?](#svgattributes-_xmlns_xlink_)     |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [accumulate?](#)                                   |           | 'none' \| 'sum' \| undefined                                                                                                                                                                                        | _(Optional)_ |
+| [additive?](#)                                     |           | 'replace' \| 'sum' \| undefined                                                                                                                                                                                     | _(Optional)_ |
+| [allowReorder?](#)                                 |           | 'no' \| 'yes' \| undefined                                                                                                                                                                                          | _(Optional)_ |
+| [alphabetic?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [amplitude?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [ascent?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [attributeName?](#)                                |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [attributeType?](#)                                |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [autoReverse?](#)                                  |           | [Booleanish](#booleanish) \| undefined                                                                                                                                                                              | _(Optional)_ |
+| [azimuth?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [baseFrequency?](#)                                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [baseProfile?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [bbox?](#)                                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [begin?](#)                                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [bias?](#)                                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [by?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [calcMode?](#)                                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [clip?](#)                                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [clipPathUnits?](#)                                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [color?](#)                                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [contentScriptType?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [contentStyleType?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [crossOrigin?](#)                                  |           | [HTMLCrossOriginAttribute](#htmlcrossoriginattribute)                                                                                                                                                               | _(Optional)_ |
+| [cursor?](#)                                       |           | number \| string                                                                                                                                                                                                    | _(Optional)_ |
+| [cx?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [cy?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [d?](#)                                            |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [decelerate?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [descent?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [diffuseConstant?](#)                              |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [direction?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [display?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [divisor?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [dur?](#)                                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [dx?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [dy?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [elevation?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [end?](#)                                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [exponent?](#)                                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [externalResourcesRequired?](#)                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [fill?](#)                                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [filter?](#)                                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [filterRes?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [filterUnits?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [focusable?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [format?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [fr?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [from?](#)                                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [fx?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [fy?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [g1?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [g2?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [glyphRef?](#)                                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [gradientTransform?](#)                            |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [gradientUnits?](#)                                |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [hanging?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [height?](#)                                       |           | [Size](#size) \| undefined                                                                                                                                                                                          | _(Optional)_ |
+| [href?](#)                                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [id?](#)                                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [ideographic?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [in?](#)                                           |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [in2?](#)                                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [intercept?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k?](#)                                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k1?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k2?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k3?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [k4?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [kernelMatrix?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [kernelUnitLength?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [kerning?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [keyPoints?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [keySplines?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [keyTimes?](#)                                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [lang?](#)                                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [lengthAdjust?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [limitingConeAngle?](#)                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [local?](#)                                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [markerHeight?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [markerUnits?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [markerWidth?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [mask?](#)                                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [maskContentUnits?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [maskUnits?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [mathematical?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [max?](#)                                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [media?](#)                                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [method?](#)                                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [min?](#)                                          |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [mode?](#)                                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [name?](#)                                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [numOctaves?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [offset?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [opacity?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [operator?](#)                                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [order?](#)                                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [orient?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [orientation?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [origin?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [overflow?](#)                                     |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [panose1?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [path?](#)                                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [pathLength?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [patternContentUnits?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [patternTransform?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [patternUnits?](#)                                 |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [points?](#)                                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [pointsAtX?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [pointsAtY?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [pointsAtZ?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [preserveAlpha?](#)                                |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [preserveAspectRatio?](#)                          |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [primitiveUnits?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [r?](#)                                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [radius?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [refX?](#)                                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [refY?](#)                                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [repeatCount?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [repeatDur?](#)                                    |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [requiredextensions?](#)                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [requiredFeatures?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [restart?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [result?](#)                                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [role?](#)                                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [rotate?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [rx?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [ry?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [scale?](#)                                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [seed?](#)                                         |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [slope?](#)                                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [spacing?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [specularConstant?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [specularExponent?](#)                             |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [speed?](#)                                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [spreadMethod?](#)                                 |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [startOffset?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stdDeviation?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stemh?](#)                                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stemv?](#)                                        |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stitchTiles?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [string?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [stroke?](#)                                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [style?](#)                                        |           | [CSSProperties](#cssproperties) \| string \| undefined                                                                                                                                                              | _(Optional)_ |
+| [surfaceScale?](#)                                 |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [systemLanguage?](#)                               |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [tabindex?](#)                                     |           | number \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [tableValues?](#)                                  |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [target?](#)                                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [targetX?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [targetY?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [textLength?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [to?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [transform?](#)                                    |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [type?](#)                                         |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [u1?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [u2?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [unicode?](#)                                      |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [values?](#)                                       |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [version?](#)                                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [viewBox?](#)                                      |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [viewTarget?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [visibility?](#)                                   |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [width?](#)                                        |           | [Size](#size) \| undefined                                                                                                                                                                                          | _(Optional)_ |
+| [widths?](#)                                       |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [x?](#)                                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [x1?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [x2?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [xmlns?](#)                                        |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [y?](#)                                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [y1?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [y2?](#)                                           |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [yChannelSelector?](#)                             |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
+| [z?](#)                                            |           | number \| string \| undefined                                                                                                                                                                                       | _(Optional)_ |
+| [zoomAndPan?](#)                                   |           | string \| undefined                                                                                                                                                                                                 | _(Optional)_ |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## SVGProps
 
 ```typescript
-export interface SVGProps<T extends Element> extends SVGAttributes<T>
+export interface SVGProps<T extends Element> extends SVGAttributes, QwikAttributes<T>
 ```
 
-**Extends:** [SVGAttributes](#svgattributes)&lt;T&gt;
+**Extends:** [SVGAttributes](#svgattributes), QwikAttributes&lt;T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## TableHTMLAttributes
 
 ```typescript
-export interface TableHTMLAttributes<T extends Element> extends HTMLAttributes<T>, TableAttrs
+export interface TableHTMLAttributes<T extends Element> extends Attrs<'table', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, TableAttrs
+**Extends:** Attrs&lt;'table', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -2842,54 +2945,50 @@ export type TaskFn = (ctx: TaskCtx) => ValueOrPromise<void | (() => void)>;
 ## TdHTMLAttributes
 
 ```typescript
-export interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T>, TableCellAttrs
+export interface TdHTMLAttributes<T extends Element> extends Attrs<'td', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, TableCellAttrs
+**Extends:** Attrs&lt;'td', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## TextareaHTMLAttributes
 
 ```typescript
-export interface TextareaHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, TextareaAttrs
+export interface TextareaHTMLAttributes<T extends Element> extends Attrs<'textarea', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, TextareaAttrs
+**Extends:** Attrs&lt;'textarea', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## ThHTMLAttributes
 
 ```typescript
-export interface ThHTMLAttributes<T extends Element> extends TdHTMLAttributes<T>
+export interface ThHTMLAttributes<T extends Element> extends Attrs<'tr', T>
 ```
 
-**Extends:** [TdHTMLAttributes](#tdhtmlattributes)&lt;T&gt;
+**Extends:** Attrs&lt;'tr', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## TimeHTMLAttributes
 
 ```typescript
-export interface TimeHTMLAttributes<T extends Element> extends HTMLAttributes<T>
+export interface TimeHTMLAttributes<T extends Element> extends Attrs<'time', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;
-
-| Property       | Modifiers | Type                | Description  |
-| -------------- | --------- | ------------------- | ------------ |
-| [dateTime?](#) |           | string \| undefined | _(Optional)_ |
+**Extends:** Attrs&lt;'time', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## TitleHTMLAttributes
 
 ```typescript
-export interface TitleHTMLAttributes<T extends Element> extends HTMLAttributes<T, string>
+export interface TitleHTMLAttributes<T extends Element> extends Attrs<'title', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, string&gt;
+**Extends:** Attrs&lt;'title', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -2906,16 +3005,27 @@ The `obs` passed into the `taskFn` is used to mark `state.count` as a property o
 ```tsx
 const Cmp = component$(() => {
   const store = useStore({ count: 0, doubleCount: 0 });
+  const signal = useSignal(0);
   useTask$(({ track }) => {
+    // Any signals or stores accessed inside the task will be tracked
     const count = track(() => store.count);
-    store.doubleCount = 2 * count;
+    // You can also pass a signal to track() directly
+    const signalCount = track(signal);
+    store.doubleCount = count + signalCount;
   });
   return (
     <div>
       <span>
         {store.count} / {store.doubleCount}
       </span>
-      <button onClick$={() => store.count++}>+</button>
+      <button
+        onClick$={() => {
+          store.count++;
+          signal.value++;
+        }}
+      >
+        +
+      </button>
     </div>
   );
 });
@@ -2930,10 +3040,10 @@ export interface Tracker
 ## TrackHTMLAttributes
 
 ```typescript
-export interface TrackHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, TrackAttrs
+export interface TrackHTMLAttributes<T extends Element> extends Attrs<'track', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T, undefined&gt;, TrackAttrs
+**Extends:** Attrs&lt;'track', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -3084,7 +3194,7 @@ Register a listener on the current component's host element.
 Used to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX. Otherwise, it's adding a JSX listener in the `<div>` is a better idea.
 
 ```typescript
-useOn: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void
+useOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-on.ts)
@@ -3096,7 +3206,7 @@ Register a listener on `document`.
 Used to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.
 
 ```typescript
-useOnDocument: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void
+useOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-on.ts)
@@ -3108,7 +3218,7 @@ Register a listener on `window`.
 Used to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.
 
 ```typescript
-useOnWindow: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void
+useOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-on.ts)
@@ -3129,27 +3239,22 @@ Example showing how `useResource` to perform a fetch to request the weather, whe
 
 ```tsx
 const Cmp = component$(() => {
-  const store = useStore({
-    city: "",
-  });
+  const cityS = useSignal("");
 
-  const weatherResource = useResource$<any>(async ({ track, cleanup }) => {
-    const cityName = track(() => store.city);
+  const weatherResource = useResource$(async ({ track, cleanup }) => {
+    const cityName = track(cityS);
     const abortController = new AbortController();
     cleanup(() => abortController.abort("cleanup"));
     const res = await fetch(`http://weatherdata.com?city=${cityName}`, {
       signal: abortController.signal,
     });
-    const data = res.json();
-    return data;
+    const data = await res.json();
+    return data as { temp: number };
   });
 
   return (
     <div>
-      <input
-        name="city"
-        onInput$={(ev: any) => (store.city = ev.target.value)}
-      />
+      <input name="city" bind:value={cityS} />
       <Resource
         value={weatherResource}
         onResolved={(weather) => {
@@ -3184,27 +3289,22 @@ Example showing how `useResource` to perform a fetch to request the weather, whe
 
 ```tsx
 const Cmp = component$(() => {
-  const store = useStore({
-    city: "",
-  });
+  const cityS = useSignal("");
 
-  const weatherResource = useResource$<any>(async ({ track, cleanup }) => {
-    const cityName = track(() => store.city);
+  const weatherResource = useResource$(async ({ track, cleanup }) => {
+    const cityName = track(cityS);
     const abortController = new AbortController();
     cleanup(() => abortController.abort("cleanup"));
     const res = await fetch(`http://weatherdata.com?city=${cityName}`, {
       signal: abortController.signal,
     });
-    const data = res.json();
-    return data;
+    const data = await res.json();
+    return data as { temp: number };
   });
 
   return (
     <div>
-      <input
-        name="city"
-        onInput$={(ev: any) => (store.city = ev.target.value)}
-      />
+      <input name="city" bind:value={cityS} />
       <Resource
         value={weatherResource}
         onResolved={(weather) => {
@@ -3553,10 +3653,10 @@ version: string;
 ## VideoHTMLAttributes
 
 ```typescript
-export interface VideoHTMLAttributes<T extends Element> extends HTMLAttributes<T>, VideoAttrs
+export interface VideoHTMLAttributes<T extends Element> extends Attrs<'video', T>
 ```
 
-**Extends:** [HTMLAttributes](#htmlattributes)&lt;T&gt;, VideoAttrs
+**Extends:** Attrs&lt;'video', T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 

--- a/packages/docs/src/routes/demo/resumability/component.tsx
+++ b/packages/docs/src/routes/demo/resumability/component.tsx
@@ -227,14 +227,14 @@ export function ReadyIcon(props: QwikIntrinsicElements['svg'], key: string) {
       <g
         fill="green"
         stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="4"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
       >
         <path d="M24 4v8"></path>
         <path
           d="m22 22l20 4l-6 4l6 6l-6 6l-6-6l-4 6l-4-20Z"
-          clipRule="evenodd"
+          clip-rule="evenodd"
         ></path>
         <path d="m38.142 9.858l-5.657 5.657M9.858 38.142l5.657-5.657M4 24h8M9.858 9.858l5.657 5.657"></path>
       </g>

--- a/packages/docs/src/routes/demo/state/resource-agify/index.tsx
+++ b/packages/docs/src/routes/demo/state/resource-agify/index.tsx
@@ -27,11 +27,7 @@ export default component$(() => {
       <div>
         <label>
           Enter your name, and I'll guess your age!
-          <input
-            onInput$={(e: Event) =>
-              (name.value = (e.target as HTMLInputElement).value)
-            }
-          />
+          <input onInput$={(ev, el) => (name.value = el.value)} />
         </label>
       </div>
       <Resource

--- a/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
@@ -405,9 +405,7 @@ export default component$(() => {
         <label>
           Enter your name, and I'll guess your age!
           <input
-            onInput$={(e: Event) =>
-              (name.value = (e.target as HTMLInputElement).value)
-            }
+            onInput$={(ev, el) => (name.value = el.value)}
           />
         </label>
       </div>

--- a/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
@@ -120,8 +120,8 @@ export const MyComponent = component$(() => {
   const count = useSignal(0);
 
   // Notice the `$(...)` around the event handler function.
-  const inputHandler = $((event) => {
-    console.log('input', event.target.name, event.target.value);
+  const inputHandler = $((event, elem) => {
+    console.log(event.type, elem.value);
   });
 
   return (
@@ -224,8 +224,8 @@ export function exportedFunction() {
 
 export default component$(() => {
   // The first argument is a function.
-  const valid1 = $((event) => {
-    console.log('input', event.target.name, event.target.value);
+  const valid1 = $((event, elem) => {
+    console.log(event.type, elem.value);
   });
 
   // The first argument is an imported identifier.

--- a/packages/docs/src/routes/examples/apps/reactivity/auto-complete/app.tsx
+++ b/packages/docs/src/routes/examples/apps/reactivity/auto-complete/app.tsx
@@ -46,10 +46,7 @@ export const AutoComplete = component$(() => {
 
   return (
     <div>
-      <input
-        type="text"
-        onInput$={(ev) => (state.searchInput = (ev.target as HTMLInputElement).value)}
-      />
+      <input type="text" onInput$={(ev, el) => (state.searchInput = el.value)} />
       <SuggestionsListComponent state={state}></SuggestionsListComponent>
     </div>
   );

--- a/packages/docs/src/routes/tutorial/hooks/use-task/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-task/problem/app.tsx
@@ -17,10 +17,7 @@ export default component$(() => {
   });
   return (
     <>
-      <input
-        value={store.value}
-        onInput$={(event) => (store.value = (event.target as HTMLInputElement).value)}
-      />
+      <input value={store.value} onInput$={(ev, el) => (store.value = el.value)} />
       <br />
       Current value: {store.value}
       <br />

--- a/packages/docs/src/routes/tutorial/hooks/use-task/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/hooks/use-task/solution/app.tsx
@@ -15,10 +15,7 @@ export default component$(() => {
   });
   return (
     <>
-      <input
-        value={store.value}
-        onInput$={(event) => (store.value = (event.target as HTMLInputElement).value)}
-      />
+      <input value={store.value} onInput$={(ev, el) => (store.value = el.value)} />
       <br />
       Current value: {store.value}
       <br />

--- a/packages/docs/src/routes/tutorial/introduction/listeners/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/introduction/listeners/solution/app.tsx
@@ -11,10 +11,7 @@ export default component$(() => {
       <p>
         <label>
           GitHub username:
-          <input
-            value={github.org}
-            onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
-          />
+          <input value={github.org} onInput$={(ev, el) => (github.org = el.value)} />
         </label>
       </p>
       <section>

--- a/packages/docs/src/routes/tutorial/introduction/resource/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/introduction/resource/problem/app.tsx
@@ -30,10 +30,7 @@ export default component$(() => {
       <p>
         <label>
           GitHub username:
-          <input
-            value={github.org}
-            onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
-          />
+          <input value={github.org} onInput$={(ev, el) => (github.org = el.value)} />
         </label>
       </p>
       <section>

--- a/packages/docs/src/routes/tutorial/introduction/resource/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/introduction/resource/solution/app.tsx
@@ -27,10 +27,7 @@ export default component$(() => {
       <p>
         <label>
           GitHub username:
-          <input
-            value={github.org}
-            onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
-          />
+          <input value={github.org} onInput$={(ev, el) => (github.org = el.value)} />
         </label>
       </p>
       <section>

--- a/packages/docs/src/routes/tutorial/qrl/closures/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/qrl/closures/problem/app.tsx
@@ -7,9 +7,7 @@ export default component$(() => {
       <label>
         Enter your name followed by the enter key:{' '}
         <input
-          // @ts-expect-error we can't infer through the $. Remove this line when solving
-          onInput$={$(async (event) => {
-            const input = event.target as HTMLInputElement;
+          onInput$={$(async (ev, input) => {
             store.name = input.value;
           })}
           onChange$={$(async () => {

--- a/packages/docs/src/routes/tutorial/qrl/closures/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/qrl/closures/solution/app.tsx
@@ -8,8 +8,7 @@ export default component$(() => {
       <label>
         Enter your name followed by the enter key:{' '}
         <input
-          onInput$={(event) => {
-            const input = event.target as HTMLInputElement;
+          onInput$={(event, input) => {
             store.name = input.value;
           }}
           onChange$={() => {

--- a/packages/docs/src/routes/tutorial/reactivity/resource/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/reactivity/resource/problem/app.tsx
@@ -30,10 +30,7 @@ export default component$(() => {
       <p>
         <label>
           GitHub username:
-          <input
-            value={github.org}
-            onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
-          />
+          <input value={github.org} onInput$={(ev, el) => (github.org = el.value)} />
         </label>
       </p>
       <section>

--- a/packages/docs/src/routes/tutorial/reactivity/resource/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/reactivity/resource/solution/app.tsx
@@ -27,10 +27,7 @@ export default component$(() => {
       <p>
         <label>
           GitHub username:
-          <input
-            value={github.org}
-            onInput$={(ev) => (github.org = (ev.target as HTMLInputElement).value)}
-          />
+          <input value={github.org} onInput$={(ev, el) => el.value} />
         </label>
       </p>
       <section>

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -10,16 +10,14 @@ import type { ServerRequestEvent } from '@builder.io/qwik-city/middleware/reques
 // @public
 export const $: <T>(expression: T) => QRL<T>;
 
-// Warning: (ae-forgotten-export) The symbol "AnchorAttrs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "Attrs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<T>, AnchorAttrs {
+export interface AnchorHTMLAttributes<T extends Element> extends Attrs<'a', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "AreaAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface AreaHTMLAttributes<T extends Element> extends HTMLAttributes<T, false>, AreaAttrs {
+export interface AreaHTMLAttributes<T extends Element> extends Attrs<'area', T> {
 }
 
 // @public
@@ -79,61 +77,45 @@ export interface AriaAttributes {
 // @public (undocumented)
 export type AriaRole = 'alert' | 'alertdialog' | 'application' | 'article' | 'banner' | 'button' | 'cell' | 'checkbox' | 'columnheader' | 'combobox' | 'complementary' | 'contentinfo' | 'definition' | 'dialog' | 'directory' | 'document' | 'feed' | 'figure' | 'form' | 'grid' | 'gridcell' | 'group' | 'heading' | 'img' | 'link' | 'list' | 'listbox' | 'listitem' | 'log' | 'main' | 'marquee' | 'math' | 'menu' | 'menubar' | 'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'navigation' | 'none' | 'note' | 'option' | 'presentation' | 'progressbar' | 'radio' | 'radiogroup' | 'region' | 'row' | 'rowgroup' | 'rowheader' | 'scrollbar' | 'search' | 'searchbox' | 'separator' | 'slider' | 'spinbutton' | 'status' | 'switch' | 'tab' | 'table' | 'tablist' | 'tabpanel' | 'term' | 'textbox' | 'timer' | 'toolbar' | 'tooltip' | 'tree' | 'treegrid' | 'treeitem' | (string & {});
 
-// Warning: (ae-forgotten-export) The symbol "AudioAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface AudioHTMLAttributes<T extends Element> extends HTMLAttributes<T>, AudioAttrs {
+export interface AudioHTMLAttributes<T extends Element> extends Attrs<'audio', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "BaseAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface BaseHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, BaseAttrs {
+export interface BaseHTMLAttributes<T extends Element> extends Attrs<'base', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "BlockquoteAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface BlockquoteHTMLAttributes<T extends Element> extends HTMLAttributes<T>, BlockquoteAttrs {
+export interface BlockquoteHTMLAttributes<T extends Element> extends Attrs<'blockquote', T> {
 }
 
 // @public (undocumented)
 export type Booleanish = boolean | `${boolean}`;
 
-// Warning: (ae-forgotten-export) The symbol "ButtonAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ButtonAttrs {
+export interface ButtonHTMLAttributes<T extends Element> extends Attrs<'button', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "CanvasAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface CanvasHTMLAttributes<T extends Element> extends HTMLAttributes<T>, CanvasAttrs {
+export interface CanvasHTMLAttributes<T extends Element> extends Attrs<'canvas', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "BaseClassList" needs to be exported by the entry point index.d.ts
-//
 // @public
-export type ClassList = BaseClassList | BaseClassList[];
+export type ClassList = string | undefined | null | false | Record<string, boolean | string | number | null | undefined> | ClassList[];
 
 // @public (undocumented)
-export interface ColgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    span?: number | undefined;
+export interface ColgroupHTMLAttributes<T extends Element> extends Attrs<'colgroup', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "ColAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface ColHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ColAttrs {
+export interface ColHTMLAttributes<T extends Element> extends Attrs<'col', T> {
 }
 
 // @public
 export const component$: <PROPS extends Record<any, any>>(onMount: (props: PROPS) => JSXNode | null) => Component<PropFunctionProps<PROPS>>;
 
 // @public
-export type Component<PROPS extends Record<any, any>> = FunctionComponent<PublicProps<PROPS>>;
+export type Component<PROPS extends Record<any, any> = Record<string, unknown>> = FunctionComponent<PublicProps<PROPS>>;
 
 // @public (undocumented)
 export interface ComponentBaseProps {
@@ -162,6 +144,14 @@ export interface CorePlatform {
 }
 
 // @public
+export interface CorrectedToggleEvent extends Event {
+    // (undocumented)
+    readonly newState: 'open' | 'closed';
+    // (undocumented)
+    readonly prevState: 'open' | 'closed';
+}
+
+// @public
 export const createContextId: <STATE = unknown>(name: string) => ContextId<STATE>;
 
 // @public (undocumented)
@@ -169,27 +159,19 @@ export interface CSSProperties extends CSS_2.Properties<string | number>, CSS_2.
     [v: `--${string}`]: string | number | undefined;
 }
 
-// Warning: (ae-forgotten-export) The symbol "DataAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface DataHTMLAttributes<T extends Element> extends HTMLAttributes<T>, DataAttrs {
+export interface DataHTMLAttributes<T extends Element> extends Attrs<'data', T> {
 }
 
 // @public (undocumented)
-export interface DelHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    cite?: string | undefined;
-    // (undocumented)
-    dateTime?: string | undefined;
+export interface DelHTMLAttributes<T extends Element> extends Attrs<'del', T> {
 }
 
 // @internal (undocumented)
 export const _deserializeData: (data: string, element?: unknown) => any;
 
 // @public (undocumented)
-export interface DetailsHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    open?: boolean | undefined;
+export interface DetailsHTMLAttributes<T extends Element> extends Attrs<'details', T> {
 }
 
 // @public (undocumented)
@@ -205,29 +187,24 @@ export interface DevJSX {
 }
 
 // @public (undocumented)
-export interface DialogHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    open?: boolean | undefined;
+export interface DialogHTMLAttributes<T extends Element> extends Attrs<'dialog', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "QwikProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "QwikAttributesBase" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "RefAttr" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "QwikEvents" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
-export interface DOMAttributes<T extends Element, Children = JSXChildren> extends QwikProps<T>, QwikEvents<T> {
+// @public
+export interface DOMAttributes<EL extends Element> extends QwikAttributesBase, RefAttr<EL>, QwikEvents<EL> {
     // (undocumented)
-    children?: Children;
-    // (undocumented)
-    key?: string | number | null | undefined;
+    class?: ClassList | Signal<ClassList> | undefined;
 }
 
 // @public (undocumented)
 export type EagernessOptions = 'visible' | 'load' | 'idle';
 
-// Warning: (ae-forgotten-export) The symbol "EmbedAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface EmbedHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, EmbedAttrs {
+export interface EmbedHTMLAttributes<T extends Element> extends Attrs<'embed', T> {
 }
 
 // @public (undocumented)
@@ -242,10 +219,8 @@ export const event$: <T>(first: T) => QRL<T>;
 // @public (undocumented)
 export const eventQrl: <T>(qrl: QRL<T>) => QRL<T>;
 
-// Warning: (ae-forgotten-export) The symbol "FieldSetAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface FieldsetHTMLAttributes<T extends Element> extends HTMLAttributes<T>, FieldSetAttrs {
+export interface FieldsetHTMLAttributes<T extends Element> extends Attrs<'fieldset', T> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "SignalDerived" needs to be exported by the entry point index.d.ts
@@ -253,10 +228,8 @@ export interface FieldsetHTMLAttributes<T extends Element> extends HTMLAttribute
 // @internal (undocumented)
 export const _fnSignal: <T extends (...args: any) => any>(fn: T, args: Parameters<T>, fnStr?: string) => SignalDerived<ReturnType<T>, Parameters<T>>;
 
-// Warning: (ae-forgotten-export) The symbol "FormAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T>, FormAttrs {
+export interface FormHTMLAttributes<T extends Element> extends Attrs<'form', T> {
 }
 
 // @public (undocumented)
@@ -326,7 +299,7 @@ export { h as createElement }
 export { h }
 
 // @public (undocumented)
-export interface HrHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined> {
+export interface HrHTMLAttributes<T extends Element> extends Attrs<'hr', T> {
 }
 
 // @public (undocumented)
@@ -335,11 +308,10 @@ export type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' 
 // @public (undocumented)
 export type HTMLAttributeReferrerPolicy = ReferrerPolicy;
 
-// Warning: (ae-forgotten-export) The symbol "HTMLAttributesBase" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "BadOnes" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "HTMLElementAttrs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export interface HTMLAttributes<E extends Element, Children = JSXChildren> extends HTMLAttributesBase<E, Children>, Partial<Omit<HTMLElement, BadOnes<HTMLElement>>> {
+export interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E> {
 }
 
 // @public (undocumented)
@@ -351,9 +323,7 @@ export const HTMLFragment: FunctionComponent<{
 }>;
 
 // @public (undocumented)
-export interface HtmlHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    manifest?: string | undefined;
+export interface HtmlHTMLAttributes<T extends Element> extends Attrs<'html', T> {
 }
 
 // @public (undocumented)
@@ -365,16 +335,12 @@ export type HTMLInputTypeAttribute = 'button' | 'checkbox' | 'color' | 'date' | 
 // @internal
 export const _hW: () => void;
 
-// Warning: (ae-forgotten-export) The symbol "IframeAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface IframeHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, IframeAttrs {
+export interface IframeHTMLAttributes<T extends Element> extends Attrs<'iframe', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "ImgAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface ImgHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ImgAttrs {
+export interface ImgHTMLAttributes<T extends Element> extends Attrs<'img', T> {
 }
 
 // @internal (undocumented)
@@ -394,34 +360,38 @@ export const inlinedQrl: <T>(symbol: T, symbolName: string, lexicalScopeCapture?
 // @internal (undocumented)
 export const inlinedQrlDEV: <T = any>(symbol: T, symbolName: string, opts: QRLDev, lexicalScopeCapture?: any[]) => QRL<T>;
 
-// Warning: (ae-forgotten-export) The symbol "InputAttrs" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export type InputHTMLAttributes<T extends Element> = Attrs<'input', T, HTMLInputElement>;
+
+// @public (undocumented)
+export interface InsHTMLAttributes<T extends Element> extends Attrs<'ins', T> {
+}
+
+// Warning: (ae-incompatible-release-tags) The symbol "IntrinsicElements" is marked as @public, but its signature references "IntrinsicHTMLElements" which is marked as @internal
+// Warning: (ae-incompatible-release-tags) The symbol "IntrinsicElements" is marked as @public, but its signature references "IntrinsicSVGElements" which is marked as @internal
 //
-// @public (undocumented)
-export interface InputHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, InputAttrs {
-}
-
-// @public (undocumented)
-export interface InsHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    cite?: string | undefined;
-    // (undocumented)
-    dateTime?: string | undefined;
-}
-
 // @public (undocumented)
 export interface IntrinsicElements extends IntrinsicHTMLElements, IntrinsicSVGElements {
 }
 
-// Warning: (ae-forgotten-export) The symbol "QwikHTMLExceptions" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "PlainHTMLElements" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "Augmented" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SpecialAttrs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-missing-underscore) The name "IntrinsicHTMLElements" should be prefixed with an underscore because the declaration is marked as @internal
 //
-// @public (undocumented)
-export interface IntrinsicHTMLElements extends QwikHTMLExceptions, PlainHTMLElements {
-}
+// @internal
+export type IntrinsicHTMLElements = {
+    [key in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[key], SpecialAttrs[key]> & HTMLAttributes<HTMLElementTagNameMap[key]>;
+} & {
+    [unknownTag: string]: {
+        [prop: string]: any;
+    } & HTMLElementAttrs & HTMLAttributes<any>;
+};
 
-// @public (undocumented)
+// Warning: (ae-internal-missing-underscore) The name "IntrinsicSVGElements" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export type IntrinsicSVGElements = {
-    [K in keyof Omit<SVGElementTagNameMap, keyof HTMLElementTagNameMap>]: SVGProps<SVGElementTagNameMap[K]>;
+    [K in keyof Omit<SVGElementTagNameMap, keyof HTMLElementTagNameMap>]: LenientSVGProps<SVGElementTagNameMap[K]>;
 };
 
 // @public
@@ -473,72 +443,54 @@ export const _jsxS: <T extends string>(type: T, mutableProps: Record<any, unknow
 // @public (undocumented)
 export type JSXTagName = keyof HTMLElementTagNameMap | Omit<string, keyof HTMLElementTagNameMap>;
 
-// @public (undocumented)
-export interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    autoFocus?: boolean | undefined;
-    // (undocumented)
-    challenge?: string | undefined;
-    // (undocumented)
-    children?: undefined;
-    // (undocumented)
-    disabled?: boolean | undefined;
-    // (undocumented)
-    form?: string | undefined;
-    // (undocumented)
-    keyParams?: string | undefined;
-    // (undocumented)
-    keyType?: string | undefined;
-    // (undocumented)
-    name?: string | undefined;
+// @public @deprecated (undocumented)
+export interface KeygenHTMLAttributes<T extends Element> extends Attrs<'base', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "LabelAttrs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "LiteralUnion" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "AllEventKeys" needs to be exported by the entry point index.d.ts
 //
+// @public
+export type KnownEventNames = LiteralUnion<AllEventKeys, string>;
+
 // @public (undocumented)
-export interface LabelHTMLAttributes<T extends Element> extends HTMLAttributes<T>, LabelAttrs {
+export interface LabelHTMLAttributes<T extends Element> extends Attrs<'label', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "LiAttrs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-missing-underscore) The name "LenientSVGProps" should be prefixed with an underscore because the declaration is marked as @internal
 //
-// @public (undocumented)
-export interface LiHTMLAttributes<T extends Element> extends HTMLAttributes<T>, LiAttrs {
-}
-
-// Warning: (ae-forgotten-export) The symbol "LinkAttrs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export interface LinkHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, LinkAttrs {
+// @internal (undocumented)
+export interface LenientSVGProps<T extends Element> extends SVGAttributes, DOMAttributes<T> {
 }
 
 // @public (undocumented)
-export interface MapHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    name?: string | undefined;
-}
-
-// Warning: (ae-forgotten-export) The symbol "MediaAttrs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T>, MediaAttrs {
+export interface LiHTMLAttributes<T extends Element> extends Attrs<'li', T> {
 }
 
 // @public (undocumented)
-export interface MenuHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    type?: string | undefined;
+export interface LinkHTMLAttributes<T extends Element> extends Attrs<'link', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "MetaAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface MetaHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, MetaAttrs {
+export interface MapHTMLAttributes<T extends Element> extends Attrs<'map', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "MeterAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T>, MeterAttrs {
+export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T>, Augmented<HTMLMediaElement, {
+    crossOrigin?: HTMLCrossOriginAttribute;
+}> {
+}
+
+// @public (undocumented)
+export interface MenuHTMLAttributes<T extends Element> extends Attrs<'menu', T> {
+}
+
+// @public (undocumented)
+export interface MetaHTMLAttributes<T extends Element> extends Attrs<'meta', T> {
+}
+
+// @public (undocumented)
+export interface MeterHTMLAttributes<T extends Element> extends Attrs<'meter', T> {
 }
 
 // @public @deprecated (undocumented)
@@ -591,16 +543,12 @@ export const noSerialize: <T extends object | undefined>(input: T) => NoSerializ
 // @public (undocumented)
 export type Numberish = number | `${number}`;
 
-// Warning: (ae-forgotten-export) The symbol "ObjectAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ObjectAttrs {
+export interface ObjectHTMLAttributes<T extends Element> extends Attrs<'object', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "OlAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface OlHTMLAttributes<T extends Element> extends HTMLAttributes<T>, OlAttrs {
+export interface OlHTMLAttributes<T extends Element> extends Attrs<'ol', T> {
 }
 
 // @public (undocumented)
@@ -612,27 +560,19 @@ export interface OnVisibleTaskOptions {
 }
 
 // @public (undocumented)
-export interface OptgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    disabled?: boolean | undefined;
-    // (undocumented)
-    label?: string | undefined;
-}
-
-// Warning: (ae-forgotten-export) The symbol "OptionAttrs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export interface OptionHTMLAttributes<T extends Element> extends HTMLAttributes<T, string>, OptionAttrs {
+export interface OptgroupHTMLAttributes<T extends Element> extends Attrs<'optgroup', T> {
 }
 
 // @public (undocumented)
-export interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
+export interface OptionHTMLAttributes<T extends Element> extends Attrs<'option', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "ParamAttrs" needs to be exported by the entry point index.d.ts
-//
+// @public (undocumented)
+export interface OutputHTMLAttributes<T extends Element> extends Attrs<'output', T> {
+}
+
 // @public @deprecated (undocumented)
-export interface ParamHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, ParamAttrs {
+export interface ParamHTMLAttributes<T extends Element> extends Attrs<'base', T, HTMLParamElement> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "QContext" needs to be exported by the entry point index.d.ts
@@ -642,10 +582,8 @@ export interface ParamHTMLAttributes<T extends Element> extends HTMLAttributes<T
 // @internal (undocumented)
 export const _pauseFromContexts: (allContexts: QContext[], containerState: ContainerState, fallbackGetObjId?: GetObjID, textNodes?: Map<string, string>) => Promise<SnapshotResult>;
 
-// Warning: (ae-forgotten-export) The symbol "ProgressAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface ProgressHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ProgressAttrs {
+export interface ProgressHTMLAttributes<T extends Element> extends Attrs<'progress', T> {
 }
 
 // @public (undocumented)
@@ -662,7 +600,7 @@ export type PropFunctionProps<PROPS extends Record<any, any>> = {
 };
 
 // @public
-export type PropsOf<COMP extends Component<any>> = COMP extends Component<infer PROPS> ? NonNullable<PROPS> : never;
+export type PropsOf<COMP> = COMP extends Component<infer PROPS> ? NonNullable<PROPS> : COMP extends FunctionComponent<infer PROPS> ? NonNullable<PublicProps<PROPS>> : COMP extends string ? QwikIntrinsicElements[COMP] : Record<string, unknown>;
 
 // Warning: (ae-forgotten-export) The symbol "TransformProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ComponentChildren" needs to be exported by the entry point index.d.ts
@@ -694,9 +632,7 @@ export const qrl: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: st
 export const qrlDEV: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: string, opts: QRLDev, lexicalScopeCapture?: any[]) => QRL<T>;
 
 // @public (undocumented)
-export interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    cite?: string | undefined;
+export interface QuoteHTMLAttributes<T extends Element> extends Attrs<'q', T> {
 }
 
 // @public @deprecated (undocumented)
@@ -721,11 +657,25 @@ export type QwikDragEvent<T = Element> = NativeDragEvent;
 // @public @deprecated (undocumented)
 export type QwikFocusEvent<T = Element> = NativeFocusEvent;
 
+// Warning: (ae-forgotten-export) The symbol "QwikAttributes" needs to be exported by the entry point index.d.ts
+//
 // @public
-export interface QwikIntrinsicElements extends IntrinsicHTMLElements {
-    // Warning: (ae-forgotten-export) The symbol "QwikCustomHTMLAttributes" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "QwikCustomHTMLElement" needs to be exported by the entry point index.d.ts
-    [key: string]: {} | QwikCustomHTMLAttributes<QwikCustomHTMLElement>;
+export type QwikHTMLElements = {
+    [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> & HTMLElementAttrs & QwikAttributes<HTMLElementTagNameMap[tag]>;
+} & {
+    [unknownTag: string]: {
+        [prop: string]: any;
+    } & HTMLElementAttrs & QwikAttributes<any>;
+};
+
+// @public
+export type QwikIdleEvent = CustomEvent<{}>;
+
+// @public
+export type QwikInitEvent = CustomEvent<{}>;
+
+// @public
+export interface QwikIntrinsicElements extends QwikHTMLElements, QwikSVGElements {
 }
 
 // @public @deprecated (undocumented)
@@ -741,13 +691,17 @@ export namespace QwikJSX {
         // (undocumented)
         children: any;
     }
+    // (undocumented)
+    export type ElementType = string | ((...args: any[]) => JSXNode | null);
     // Warning: (ae-forgotten-export) The symbol "QwikIntrinsicAttributes" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     export interface IntrinsicAttributes extends QwikIntrinsicAttributes {
     }
+    // Warning: (ae-forgotten-export) The symbol "LenientQwikElements" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    export interface IntrinsicElements extends QwikIntrinsicElements {
+    export interface IntrinsicElements extends LenientQwikElements {
     }
 }
 
@@ -762,6 +716,11 @@ export type QwikPointerEvent<T = Element> = NativePointerEvent;
 
 // @public @deprecated (undocumented)
 export type QwikSubmitEvent<T = Element> = Event;
+
+// @public
+export type QwikSVGElements = {
+    [K in keyof Omit<SVGElementTagNameMap, keyof HTMLElementTagNameMap>]: SVGProps<SVGElementTagNameMap[K]>;
+};
 
 // @public
 export type QwikSymbolEvent = CustomEvent<{
@@ -900,16 +859,12 @@ export type ResourceReturn<T> = ResourcePending<T> | ResourceResolved<T> | Resou
 // @internal (undocumented)
 export const _restProps: (props: Record<string, any>, omit: string[]) => Record<string, any>;
 
-// Warning: (ae-forgotten-export) The symbol "ScriptAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ScriptAttrs {
+export interface ScriptHTMLAttributes<T extends Element> extends Attrs<'script', T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "SelectAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<T>, SelectAttrs {
+export interface SelectHTMLAttributes<T extends Element> extends Attrs<'select', T> {
 }
 
 // @internal (undocumented)
@@ -936,9 +891,7 @@ export const Slot: FunctionComponent<{
 }>;
 
 // @public (undocumented)
-export interface SlotHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    name?: string | undefined;
+export interface SlotHTMLAttributes<T extends Element> extends Attrs<'slot', T> {
 }
 
 // @public (undocumented)
@@ -996,10 +949,8 @@ export interface SnapshotState {
     subs: any[];
 }
 
-// Warning: (ae-forgotten-export) The symbol "SourceAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface SourceHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, SourceAttrs {
+export interface SourceHTMLAttributes<T extends Element> extends Attrs<'source', T> {
 }
 
 // @public (undocumented)
@@ -1038,14 +989,12 @@ export type StreamWriter = {
     write: (chunk: string) => void;
 };
 
-// Warning: (ae-forgotten-export) The symbol "StyleAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface StyleHTMLAttributes<T extends Element> extends HTMLAttributes<T, string>, StyleAttrs {
+export interface StyleHTMLAttributes<T extends Element> extends Attrs<'style', T> {
 }
 
 // @public
-export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> {
+export interface SVGAttributes<T extends Element = Element> extends AriaAttributes {
     // (undocumented)
     'accent-height'?: number | string | undefined;
     // (undocumented)
@@ -1193,6 +1142,28 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
     // (undocumented)
     'x-height'?: number | string | undefined;
     // (undocumented)
+    'xlink:actuate'?: string | undefined;
+    // (undocumented)
+    'xlink:arcrole'?: string | undefined;
+    // (undocumented)
+    'xlink:href'?: string | undefined;
+    // (undocumented)
+    'xlink:role'?: string | undefined;
+    // (undocumented)
+    'xlink:show'?: string | undefined;
+    // (undocumented)
+    'xlink:title'?: string | undefined;
+    // (undocumented)
+    'xlink:type'?: string | undefined;
+    // (undocumented)
+    'xml:base'?: string | undefined;
+    // (undocumented)
+    'xml:lang'?: string | undefined;
+    // (undocumented)
+    'xml:space'?: string | undefined;
+    // (undocumented)
+    'xmlns:xlink'?: string | undefined;
+    // (undocumented)
     accumulate?: 'none' | 'sum' | undefined;
     // (undocumented)
     additive?: 'replace' | 'sum' | undefined;
@@ -1226,8 +1197,6 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
     by?: number | string | undefined;
     // (undocumented)
     calcMode?: number | string | undefined;
-    // (undocumented)
-    class?: ClassList | undefined;
     // (undocumented)
     clip?: number | string | undefined;
     // (undocumented)
@@ -1307,7 +1276,7 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
     // (undocumented)
     hanging?: number | string | undefined;
     // (undocumented)
-    height?: Numberish | undefined;
+    height?: Size | undefined;
     // (undocumented)
     href?: string | undefined;
     // (undocumented)
@@ -1519,7 +1488,7 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
     // (undocumented)
     visibility?: number | string | undefined;
     // (undocumented)
-    width?: Numberish | undefined;
+    width?: Size | undefined;
     // (undocumented)
     widths?: number | string | undefined;
     // (undocumented)
@@ -1529,27 +1498,7 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
     // (undocumented)
     x2?: number | string | undefined;
     // (undocumented)
-    xlinkActuate?: string | undefined;
-    // (undocumented)
-    xlinkArcrole?: string | undefined;
-    // (undocumented)
-    xlinkHref?: string | undefined;
-    // (undocumented)
-    xlinkRole?: string | undefined;
-    // (undocumented)
-    xlinkShow?: string | undefined;
-    // (undocumented)
-    xlinkTitle?: string | undefined;
-    // (undocumented)
-    xlinkType?: string | undefined;
-    // (undocumented)
-    xmlBase?: string | undefined;
-    // (undocumented)
-    xmlLang?: string | undefined;
-    // (undocumented)
     xmlns?: string | undefined;
-    // (undocumented)
-    xmlSpace?: string | undefined;
     // (undocumented)
     y?: number | string | undefined;
     // (undocumented)
@@ -1565,13 +1514,11 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
 }
 
 // @public (undocumented)
-export interface SVGProps<T extends Element> extends SVGAttributes<T> {
+export interface SVGProps<T extends Element> extends SVGAttributes, QwikAttributes<T> {
 }
 
-// Warning: (ae-forgotten-export) The symbol "TableAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface TableHTMLAttributes<T extends Element> extends HTMLAttributes<T>, TableAttrs {
+export interface TableHTMLAttributes<T extends Element> extends Attrs<'table', T> {
 }
 
 // @public (undocumented)
@@ -1585,42 +1532,34 @@ export interface TaskCtx {
 // @public (undocumented)
 export type TaskFn = (ctx: TaskCtx) => ValueOrPromise<void | (() => void)>;
 
-// Warning: (ae-forgotten-export) The symbol "TableCellAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T>, TableCellAttrs {
-}
-
-// Warning: (ae-forgotten-export) The symbol "TextareaAttrs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export interface TextareaHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, TextareaAttrs {
+export interface TdHTMLAttributes<T extends Element> extends Attrs<'td', T> {
 }
 
 // @public (undocumented)
-export interface ThHTMLAttributes<T extends Element> extends TdHTMLAttributes<T> {
+export interface TextareaHTMLAttributes<T extends Element> extends Attrs<'textarea', T> {
 }
 
 // @public (undocumented)
-export interface TimeHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-    // (undocumented)
-    dateTime?: string | undefined;
+export interface ThHTMLAttributes<T extends Element> extends Attrs<'tr', T> {
 }
 
 // @public (undocumented)
-export interface TitleHTMLAttributes<T extends Element> extends HTMLAttributes<T, string> {
+export interface TimeHTMLAttributes<T extends Element> extends Attrs<'time', T> {
+}
+
+// @public (undocumented)
+export interface TitleHTMLAttributes<T extends Element> extends Attrs<'title', T> {
 }
 
 // @public
 export interface Tracker {
     <T>(fn: () => T): T;
-    <T extends object>(obj: T): T;
+    <T extends object>(obj: T): T extends Signal<infer U> ? U : T;
 }
 
-// Warning: (ae-forgotten-export) The symbol "TrackAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface TrackHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined>, TrackAttrs {
+export interface TrackHTMLAttributes<T extends Element> extends Attrs<'track', T> {
 }
 
 // @public
@@ -1655,17 +1594,16 @@ export const useId: () => string;
 // @internal
 export const useLexicalScope: <VARS extends any[]>() => VARS;
 
-// Warning: (ae-forgotten-export) The symbol "PascalCaseEventLiteralType" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "EventQRL" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const useOn: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void;
+export const useOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void;
 
 // @public
-export const useOnDocument: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void;
+export const useOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void;
 
 // @public
-export const useOnWindow: <T extends PascalCaseEventLiteralType>(event: T | T[], eventQrl: EventQRL<T>) => void;
+export const useOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => void;
 
 // @public
 export const useResource$: <T>(generatorFn: ResourceFn<T>, opts?: ResourceOptions) => ResourceReturn<T>;
@@ -1743,10 +1681,8 @@ export const _verifySerializable: <T>(value: T, preMessage?: string) => T;
 // @public
 export const version: string;
 
-// Warning: (ae-forgotten-export) The symbol "VideoAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export interface VideoHTMLAttributes<T extends Element> extends HTMLAttributes<T>, VideoAttrs {
+export interface VideoHTMLAttributes<T extends Element> extends Attrs<'video', T> {
 }
 
 // @public (undocumented)

--- a/packages/qwik/src/core/component/component.unit.tsx
+++ b/packages/qwik/src/core/component/component.unit.tsx
@@ -116,28 +116,19 @@ describe('q-component', () => {
     );
   });
 
-  test('types work as expected', () => {
+  test('types work as expected', () => () => {
+    // Let's keep one of these old type exports around for now.
     const Input1 = component$<InputHTMLAttributes<HTMLInputElement>>((props) => {
       return <input {...props} />;
     });
 
-    const Input2 = component$((props: PropFunctionProps<InputHTMLAttributes<HTMLInputElement>>) => {
+    const Input2 = component$((props: PropFunctionProps<PropsOf<'input'>>) => {
       return <input {...props} />;
     });
-
-    const Input3 = component$((props: Partial<InputHTMLAttributes<HTMLInputElement>>) => {
-      return <input {...props} />;
-    });
-
-    const Input4 = component$(
-      (props: Partial<PropFunctionProps<InputHTMLAttributes<HTMLInputElement>>>) => {
-        return <input {...props} />;
-      }
-    );
 
     type Input5Props = {
       type: 'text' | 'number';
-    } & Partial<InputHTMLAttributes<HTMLInputElement>>;
+    } & Partial<PropsOf<'input'>>;
 
     const Input5 = component$<Input5Props>(({ type, ...props }) => {
       return <input type={type} {...props} />;
@@ -158,10 +149,13 @@ describe('q-component', () => {
     component$(() => {
       return (
         <>
-          <Input1 value="1" />
+          <Input1
+            style={{
+              paddingInlineEnd: '10px',
+            }}
+            value="1"
+          />
           <Input2 value="2" />
-          <Input3 value="3" />
-          <Input4 value="4" />
           <Input5 value="5" type="text" />
           <Input6 value="6" type="number" />
         </>

--- a/packages/qwik/src/core/examples.tsx
+++ b/packages/qwik/src/core/examples.tsx
@@ -177,24 +177,22 @@ export const CmpInline = component$(() => {
 () => {
   // <docs anchor="use-resource">
   const Cmp = component$(() => {
-    const store = useStore({
-      city: '',
-    });
+    const cityS = useSignal('');
 
-    const weatherResource = useResource$<any>(async ({ track, cleanup }) => {
-      const cityName = track(() => store.city);
+    const weatherResource = useResource$(async ({ track, cleanup }) => {
+      const cityName = track(cityS);
       const abortController = new AbortController();
       cleanup(() => abortController.abort('cleanup'));
       const res = await fetch(`http://weatherdata.com?city=${cityName}`, {
         signal: abortController.signal,
       });
-      const data = res.json();
-      return data;
+      const data = await res.json();
+      return data as { temp: number };
     });
 
     return (
       <div>
-        <input name="city" onInput$={(ev: any) => (store.city = ev.target.value)} />
+        <input name="city" bind:value={cityS} />
         <Resource
           value={weatherResource}
           onResolved={(weather) => {
@@ -212,16 +210,27 @@ export const CmpInline = component$(() => {
   // <docs anchor="use-task-simple">
   const Cmp = component$(() => {
     const store = useStore({ count: 0, doubleCount: 0 });
+    const signal = useSignal(0);
     useTask$(({ track }) => {
+      // Any signals or stores accessed inside the task will be tracked
       const count = track(() => store.count);
-      store.doubleCount = 2 * count;
+      // You can also pass a signal to track() directly
+      const signalCount = track(signal);
+      store.doubleCount = count + signalCount;
     });
     return (
       <div>
         <span>
           {store.count} / {store.doubleCount}
         </span>
-        <button onClick$={() => store.count++}>+</button>
+        <button
+          onClick$={() => {
+            store.count++;
+            signal.value++;
+          }}
+        >
+          +
+        </button>
       </div>
     );
   });
@@ -466,6 +475,7 @@ function doExtraStuff() {
 
 import { createContextId, useContext, useContextProvider } from './use/use-context';
 import { Resource, useResource$ } from './use/use-resource';
+import { useSignal } from './use/use-signal';
 
 export const greet = () => console.log('greet');
 function topLevelFn() {}

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -60,6 +60,7 @@ export type {
   JSXChildren,
   ComponentBaseProps,
   ClassList,
+  CorrectedToggleEvent,
 } from './render/jsx/types/jsx-qwik-attributes';
 export type { FunctionComponent, JSXNode, DevJSX } from './render/jsx/types/jsx-node';
 export type { QwikDOMAttributes, QwikJSX } from './render/jsx/types/jsx-qwik';
@@ -123,8 +124,11 @@ export { version } from './version';
 // Qwik Events
 //////////////////////////////////////////////////////////////////////////////////////////
 export type {
+  KnownEventNames as KnownEventNames,
   QwikSymbolEvent,
   QwikVisibleEvent,
+  QwikIdleEvent,
+  QwikInitEvent,
   // old
   NativeAnimationEvent,
   NativeClipboardEvent,

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -224,6 +224,7 @@ export type PropFunction<T extends Function = (...args: any) => any> = T extends
  *
  * import { createContextId, useContext, useContextProvider } from './use/use-context';
  * import { Resource, useResource$ } from './use/use-resource';
+ * import { useSignal } from './use/use-signal';
  *
  * export const greet = () => console.log('greet');
  * function topLevelFn() {}

--- a/packages/qwik/src/core/qrl/qrl.unit.ts
+++ b/packages/qwik/src/core/qrl/qrl.unit.ts
@@ -2,7 +2,7 @@ import { parseQRL, serializeQRL } from './qrl';
 import { createQRL } from './qrl-class';
 import { qrl } from './qrl';
 import { describe, test, assert, assertType, expectTypeOf } from 'vitest';
-import type { QRL } from './qrl.public';
+import { $, type QRL } from './qrl.public';
 
 function matchProps(obj: any, properties: Record<string, any>) {
   for (const [key, value] of Object.entries(properties)) {
@@ -20,6 +20,24 @@ describe('types', () => {
     const fakeFn = true as any as QRL<typeof fooFn>;
     expectTypeOf(fakeFn).not.toBeAny();
     assertType<(hi: boolean) => Promise<string>>(fakeFn);
+  });
+  test('inferring', () => () => {
+    const myWrapper = (fn: QRL<(hi: boolean) => string>) => fn(true);
+    const result = myWrapper(
+      $((hi) => {
+        expectTypeOf(hi).toEqualTypeOf<boolean>();
+        return 'hello';
+      })
+    );
+    expectTypeOf(result).toEqualTypeOf<Promise<string>>();
+    const myPropsWrapper = (props: { fn: QRL<(hi: boolean) => string> }) => props.fn(true);
+    const propsResult = myPropsWrapper({
+      fn: $((hi) => {
+        expectTypeOf(hi).toEqualTypeOf<boolean>();
+        return 'hello';
+      }),
+    });
+    expectTypeOf(propsResult).toEqualTypeOf<Promise<string>>();
   });
 });
 

--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -1,6 +1,6 @@
 import * as CSS from 'csstype';
 import type { Signal } from '../../../state/signal';
-import type { DOMAttributes, ClassList, JSXChildren } from './jsx-qwik-attributes';
+import type { DOMAttributes, ClassList, QwikAttributes } from './jsx-qwik-attributes';
 /** @public */
 export type Booleanish = boolean | `${boolean}`;
 /** @public */
@@ -377,29 +377,11 @@ export type AriaRole =
   | 'treeitem'
   | (string & {});
 
-type IfEquals<X, Y, A, B> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
-  ? A
-  : B;
-
-type ReadonlyKeysOf<T> = {
-  [P in keyof T]: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, never, P>;
-}[keyof T];
-
 // All the keys that must be removed
-type BadOnes<T> = Extract<
-  // No functions, readonly or uppercase properties
-  | {
-      [K in keyof T]: T[K] extends (...args: any) => any
-        ? K
-        : K extends string
-          ? K extends Uppercase<K>
-            ? K
-            : never
-          : never;
-    }[keyof T]
-  | ReadonlyKeysOf<T>
+type UnwantedKeys =
   // We have our own
-  | keyof HTMLAttributesBase<any>
+  | keyof HTMLAttributesBase
+  | keyof DOMAttributes<any>
   // We don't support these
   | keyof ARIAMixin
   // We should use onEventName$ instead
@@ -407,17 +389,14 @@ type BadOnes<T> = Extract<
   // deprecated or overridden or can't filter out automatically
   | 'enterKeyHint'
   | 'innerText'
+  | 'innerHTML'
+  | 'outerHTML'
   | 'inputMode'
-  | 'onfullscreenchange'
-  | 'onfullscreenerror'
   | 'outerText'
-  | 'textContent',
-  string
->;
+  | 'nodeValue'
+  | 'textContent';
 
-interface HTMLAttributesBase<E extends Element, Children = JSXChildren>
-  extends AriaAttributes,
-    DOMAttributes<E, Children> {
+interface HTMLAttributesBase extends AriaAttributes {
   /** @deprecated Use `class` instead */
   className?: ClassList | undefined;
   contentEditable?: 'true' | 'false' | 'inherit' | undefined;
@@ -469,29 +448,57 @@ interface HTMLAttributesBase<E extends Element, Children = JSXChildren>
    * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
    */
   is?: string | undefined;
+
+  popover?: 'manual' | 'auto' | undefined;
 }
+
+interface HTMLElementAttrs extends HTMLAttributesBase, FilterBase<HTMLElement> {}
+
 /** @public */
-export interface HTMLAttributes<E extends Element, Children = JSXChildren>
-  extends HTMLAttributesBase<E, Children>,
-    Partial<Omit<HTMLElement, BadOnes<HTMLElement>>> {}
+export interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E> {}
 
 type Prettify<T> = {} & {
   [K in keyof T]: T[K];
 };
 
-/**
- * Filter out "any" value types and non-string keys from an object, currently only for
- * HTMLFormElement
- */
-type FilterAny<T> = {
-  [K in keyof T as any extends T[K] ? never : K extends string ? K : never]: T[K];
-};
-/** Only keep props that are specific to the element */
+type IfEquals<X, Y, A, B> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+  ? A
+  : B;
+type IsReadOnlyKey<T, K extends keyof T> = IfEquals<
+  { [Q in K]: T[K] },
+  { -readonly [Q in K]: T[K] },
+  false,
+  true
+>;
+type IsAcceptableDOMValue<T> = T extends boolean | number | string | null | undefined
+  ? ((...args: any[]) => any) extends T
+    ? false
+    : true
+  : false;
+
+/** Only keep props that are specific to the element and make partial */
 type Filtered<T, A = {}> = {
-  [K in keyof Omit<
-    FilterAny<T>,
-    keyof HTMLAttributes<any> | BadOnes<FilterAny<T>> | keyof A
-  >]?: T[K];
+  [K in keyof Omit<FilterBase<T>, keyof HTMLAttributes<any> | keyof A>]?: T[K];
+};
+type FilterBase<T> = {
+  [K in keyof T as K extends string
+    ? // No uppercase keys
+      K extends Uppercase<K>
+      ? never
+      : // No `any` values
+        any extends T[K]
+        ? never
+        : // Only allow basic types
+          false extends IsAcceptableDOMValue<T[K]>
+          ? never
+          : // No readonly values
+            IsReadOnlyKey<T, K> extends true
+            ? never
+            : K extends UnwantedKeys
+              ? never
+              : // Ok this key is allowed
+                K
+    : never]?: T[K];
 };
 /**
  * Replace given element's props with custom types and return all props specific to the element. Use
@@ -501,157 +508,60 @@ type Filtered<T, A = {}> = {
  */
 type Augmented<E, A = {}> = Prettify<Filtered<E, A> & A>;
 
-// The following interfaces are not very useful, it's better to use QwikIntrinsicElements[tagname]
-/** @public */
-export type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {});
-/** @public */
-export type HTMLAttributeReferrerPolicy = ReferrerPolicy;
+type TableCellSpecialAttrs = {
+  align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
+  height?: Size | undefined;
+  width?: Size | undefined;
+  valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined;
+};
+type MediaSpecialAttrs = {
+  crossOrigin?: HTMLCrossOriginAttribute;
+};
+type PopoverTargetAction = 'hide' | 'show' | 'toggle';
 
-/** @public */
-export interface AnchorHTMLAttributes<T extends Element> extends HTMLAttributes<T>, AnchorAttrs {}
-type AnchorAttrs = Augmented<
-  HTMLAnchorElement,
-  {
+type SpecialAttrs = {
+  a: {
     download?: any;
     target?: HTMLAttributeAnchorTarget | undefined;
     referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-  }
->;
-
-/** @public */
-export interface AreaHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, false>,
-    AreaAttrs {}
-type AreaAttrs = Augmented<
-  HTMLAreaElement,
-  {
+  };
+  area: {
     referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-  }
->;
-
-/** @public */
-export interface MediaHTMLAttributes<T extends Element> extends HTMLAttributes<T>, MediaAttrs {}
-type MediaAttrs = Augmented<
-  HTMLMediaElement,
-  {
-    crossOrigin?: HTMLCrossOriginAttribute;
-  }
->;
-/** @public */
-export interface AudioHTMLAttributes<T extends Element> extends HTMLAttributes<T>, AudioAttrs {}
-type AudioAttrs = Augmented<
-  HTMLAudioElement,
-  {
-    crossOrigin?: HTMLCrossOriginAttribute;
-  }
->;
-/** @public */
-export interface BaseHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    BaseAttrs {}
-type BaseAttrs = Augmented<HTMLBaseElement, {}>;
-
-/** @public */
-export interface BlockquoteHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T>,
-    BlockquoteAttrs {}
-type BlockquoteAttrs = Augmented<HTMLQuoteElement, {}>;
-
-/** @public */
-export interface ButtonHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ButtonAttrs {}
-type ButtonAttrs = Augmented<
-  HTMLButtonElement,
-  {
+    children?: undefined;
+  };
+  audio: MediaSpecialAttrs;
+  base: {
+    children?: undefined;
+  };
+  button: {
     form?: string | undefined;
     value?: string | ReadonlyArray<string> | number | undefined;
-  }
->;
-
-/** @public */
-export interface CanvasHTMLAttributes<T extends Element> extends HTMLAttributes<T>, CanvasAttrs {}
-type CanvasAttrs = Augmented<
-  HTMLCanvasElement,
-  {
+    popovertarget?: string | undefined;
+    popovertargetaction?: PopoverTargetAction | undefined;
+  };
+  canvas: {
     height?: Size | undefined;
     width?: Size | undefined;
-  }
->;
-
-/** @public */
-export interface ColHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    ColAttrs {}
-type ColAttrs = Augmented<
-  HTMLTableColElement,
-  {
+  };
+  col: {
     width?: Size | undefined;
-  }
->;
-
-/** @public */
-export interface ColgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  span?: number | undefined;
-}
-/** @public */
-export interface DataHTMLAttributes<T extends Element> extends HTMLAttributes<T>, DataAttrs {}
-type DataAttrs = Augmented<
-  HTMLDataElement,
-  {
+    children?: undefined;
+  };
+  data: {
     value?: string | ReadonlyArray<string> | number | undefined;
-  }
->;
-
-/** @public */
-export interface DelHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  cite?: string | undefined;
-  dateTime?: string | undefined;
-}
-
-/** @public */
-export interface DetailsHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  open?: boolean | undefined;
-}
-/** @public */
-export interface DialogHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  open?: boolean | undefined;
-}
-/** @public */
-export interface EmbedHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    EmbedAttrs {}
-type EmbedAttrs = Augmented<
-  HTMLEmbedElement,
-  {
+  };
+  embed: {
     height?: Size | undefined;
     width?: Size | undefined;
     children?: undefined;
-  }
->;
-/** @public */
-export interface FieldsetHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T>,
-    FieldSetAttrs {}
-type FieldSetAttrs = Augmented<
-  HTMLFieldSetElement,
-  {
+  };
+  fieldset: {
     form?: string | undefined;
-  }
->;
-/** @public */
-export interface FormHTMLAttributes<T extends Element> extends HTMLAttributes<T>, FormAttrs {}
-type FormAttrs = Augmented<HTMLFormElement, {}>;
-
-/** @public */
-export interface HtmlHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  manifest?: string | undefined;
-}
-/** @public */
-export interface IframeHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    IframeAttrs {}
-type IframeAttrs = Augmented<
-  HTMLIFrameElement,
-  {
+  };
+  hr: {
+    children?: undefined;
+  };
+  iframe: {
     allowTransparency?: boolean | undefined;
     /** @deprecated Deprecated */
     frameBorder?: number | string | undefined;
@@ -661,27 +571,228 @@ type IframeAttrs = Augmented<
     seamless?: boolean | undefined;
     width?: Size | undefined;
     children?: undefined;
-  }
->;
-
-/** @public */
-export interface ImgHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    ImgAttrs {}
-type ImgAttrs = Augmented<
-  HTMLImageElement,
-  {
+  };
+  img: {
     crossOrigin?: HTMLCrossOriginAttribute;
     /** Intrinsic height of the image in pixels. */
     height?: Numberish | undefined;
     referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
     /** Intrinsic width of the image in pixels. */
     width?: Numberish | undefined;
-  }
->;
+    children?: undefined;
+  };
+  input: {
+    autoComplete?:
+      | HTMLInputAutocompleteAttribute
+      | Omit<HTMLInputAutocompleteAttribute, string>
+      | undefined;
+    'bind:checked'?: Signal<boolean | undefined>;
+    'bind:value'?: Signal<string | undefined>;
+    enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
+    height?: Size | undefined;
+    max?: number | string | undefined;
+    maxLength?: number | undefined;
+    min?: number | string | undefined;
+    minLength?: number | undefined;
+    step?: number | string | undefined;
+    type?: HTMLInputTypeAttribute | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined | null | FormDataEntryValue;
+    width?: Size | undefined;
+    children?: undefined;
+  } & (
+    | {
+        type?:
+          | Exclude<HTMLInputTypeAttribute, 'button' | 'reset' | 'submit' | 'checkbox' | 'radio'>
+          | undefined;
+        'bind:checked'?: undefined;
+      }
+    | {
+        type: 'button' | 'reset' | 'submit';
+        'bind:value'?: undefined;
+        'bind:checked'?: undefined;
+        autoComplete?: undefined;
+      }
+    | {
+        type: 'checkbox' | 'radio';
+        'bind:value'?: undefined;
+        autoComplete?: undefined;
+      }
+  ) &
+    (
+      | {
+          type?: Exclude<HTMLInputTypeAttribute, 'button'> | undefined;
+          popovertarget?: undefined;
+          popovertargetaction?: undefined;
+        }
+      | {
+          type: 'button';
+          popovertarget?: string | undefined;
+          popovertargetaction?: PopoverTargetAction | undefined;
+        }
+    );
+  label: {
+    form?: string | undefined;
+    for?: string | undefined;
+    /** @deprecated Use `for` */
+    htmlFor?: string | undefined;
+  };
+  li: {
+    value?: string | ReadonlyArray<string> | number | undefined;
+  };
+  link: {
+    crossOrigin?: HTMLCrossOriginAttribute;
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    sizes?: string | undefined;
+    type?: string | undefined;
+    charSet?: string | undefined;
+    children?: undefined;
+  };
+  meta: {
+    charSet?: string | undefined;
+    children?: undefined;
+  };
+  meter: {
+    form?: string | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+  };
+  object: {
+    classID?: string | undefined;
+    form?: string | undefined;
+    height?: Size | undefined;
+    width?: Size | undefined;
+    wmode?: string | undefined;
+  };
+  ol: {
+    type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined;
+  };
+  optgroup: {
+    disabled?: boolean | undefined;
+    // not sure if correct
+    label?: string | undefined;
+  };
+  option: {
+    value?: string | ReadonlyArray<string> | number | undefined;
+    children?: string;
+  };
+  output: {
+    form?: string | undefined;
+    for?: string | undefined;
+    /** @deprecated Use `for` instead */
+    htmlFor?: string | undefined;
+  };
+  param: {
+    value?: string | ReadonlyArray<string> | number | undefined;
+    children?: undefined;
+  };
+  progress: {
+    max?: number | string | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+  };
+  script: {
+    crossOrigin?: HTMLCrossOriginAttribute;
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+  };
+  select: {
+    form?: string | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+    'bind:value'?: Signal<string | undefined>;
+  };
+  source: {
+    /** Allowed if the parent is a `picture` element */
+    height?: Size | undefined;
+    /** Allowed if the parent is a `picture` element */
+    width?: Size | undefined;
+    children?: undefined;
+  };
+  style: {
+    // not sure if correct
+    scoped?: boolean | undefined;
+    children?: string;
+  };
+  table: {
+    cellPadding?: number | string | undefined;
+    cellSpacing?: number | string | undefined;
+    width?: Size | undefined;
+  };
+  td: TableCellSpecialAttrs;
+  th: TableCellSpecialAttrs;
+  title: {
+    children?: string;
+  };
+  textarea: {
+    enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
+    form?: string | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+    'bind:value'?: Signal<string | undefined>;
+    children?: undefined;
+  };
+  track: {
+    children?: undefined;
+  };
+  video: MediaSpecialAttrs & {
+    height?: Numberish | undefined;
+    width?: Numberish | undefined;
+    disablePictureInPicture?: boolean | undefined;
+    disableRemotePlayback?: boolean | undefined;
+  };
+} & {
+  [key: string]: {};
+};
+
+type Attrs<
+  Name extends keyof HTMLElementTagNameMap,
+  EL extends Element = HTMLElementTagNameMap[Name],
+  AttrEl = HTMLElementTagNameMap[Name],
+> = HTMLAttributes<EL> & Augmented<AttrEl, SpecialAttrs[Name]>;
 
 /** @public */
-export interface HrHTMLAttributes<T extends Element> extends HTMLAttributes<T, undefined> {}
+export type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {});
+/** @public */
+export type HTMLAttributeReferrerPolicy = ReferrerPolicy;
+/** @public */
+export interface AnchorHTMLAttributes<T extends Element> extends Attrs<'a', T> {}
+/** @public */
+export interface AreaHTMLAttributes<T extends Element> extends Attrs<'area', T> {}
+/** @public */
+export interface MediaHTMLAttributes<T extends Element>
+  extends HTMLAttributes<T>,
+    Augmented<HTMLMediaElement, { crossOrigin?: HTMLCrossOriginAttribute }> {}
+/** @public */
+export interface AudioHTMLAttributes<T extends Element> extends Attrs<'audio', T> {}
+/** @public */
+export interface BaseHTMLAttributes<T extends Element> extends Attrs<'base', T> {}
+/** @public */
+export interface BlockquoteHTMLAttributes<T extends Element> extends Attrs<'blockquote', T> {}
+/** @public */
+export interface ButtonHTMLAttributes<T extends Element> extends Attrs<'button', T> {}
+/** @public */
+export interface CanvasHTMLAttributes<T extends Element> extends Attrs<'canvas', T> {}
+/** @public */
+export interface ColHTMLAttributes<T extends Element> extends Attrs<'col', T> {}
+/** @public */
+export interface ColgroupHTMLAttributes<T extends Element> extends Attrs<'colgroup', T> {}
+/** @public */
+export interface DataHTMLAttributes<T extends Element> extends Attrs<'data', T> {}
+/** @public */
+export interface DelHTMLAttributes<T extends Element> extends Attrs<'del', T> {}
+/** @public */
+export interface DetailsHTMLAttributes<T extends Element> extends Attrs<'details', T> {}
+/** @public */
+export interface DialogHTMLAttributes<T extends Element> extends Attrs<'dialog', T> {}
+/** @public */
+export interface EmbedHTMLAttributes<T extends Element> extends Attrs<'embed', T> {}
+/** @public */
+export interface FieldsetHTMLAttributes<T extends Element> extends Attrs<'fieldset', T> {}
+/** @public */
+export interface FormHTMLAttributes<T extends Element> extends Attrs<'form', T> {}
+/** @public */
+export interface HtmlHTMLAttributes<T extends Element> extends Attrs<'html', T> {}
+/** @public */
+export interface IframeHTMLAttributes<T extends Element> extends Attrs<'iframe', T> {}
+/** @public */
+export interface ImgHTMLAttributes<T extends Element> extends Attrs<'img', T> {}
+/** @public */
+export interface HrHTMLAttributes<T extends Element> extends Attrs<'hr', T> {}
 /** @public */
 export type HTMLCrossOriginAttribute = 'anonymous' | 'use-credentials' | '' | undefined;
 /** @public */
@@ -762,283 +873,69 @@ export type HTMLInputAutocompleteAttribute =
   | 'photo';
 
 /** @public */
-export interface InputHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    InputAttrs {}
-type InputAttrs = Augmented<
-  HTMLInputElement,
-  {
-    autoComplete?:
-      | HTMLInputAutocompleteAttribute
-      | Omit<HTMLInputAutocompleteAttribute, string>
-      | undefined;
-    'bind:checked'?: Signal<boolean | undefined>;
-    enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
-    height?: Size | undefined;
-    max?: number | string | undefined;
-    maxLength?: number | undefined;
-    min?: number | string | undefined;
-    minLength?: number | undefined;
-    step?: number | string | undefined;
-    type?: HTMLInputTypeAttribute | undefined;
-    value?: string | ReadonlyArray<string> | number | undefined | null | FormDataEntryValue;
-    'bind:value'?: Signal<string | undefined>;
-    width?: Size | undefined;
-  }
->;
+export type InputHTMLAttributes<T extends Element> = Attrs<'input', T, HTMLInputElement>;
 /** @public */
-export interface InsHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  cite?: string | undefined;
-  dateTime?: string | undefined;
-}
+export interface InsHTMLAttributes<T extends Element> extends Attrs<'ins', T> {}
+/** @public @deprecated in html5 */
+export interface KeygenHTMLAttributes<T extends Element> extends Attrs<'base', T> {}
 /** @public */
-export interface KeygenHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  autoFocus?: boolean | undefined;
-  challenge?: string | undefined;
-  disabled?: boolean | undefined;
-  form?: string | undefined;
-  keyType?: string | undefined;
-  keyParams?: string | undefined;
-  name?: string | undefined;
-  children?: undefined;
-}
+export interface LabelHTMLAttributes<T extends Element> extends Attrs<'label', T> {}
 /** @public */
-export interface LabelHTMLAttributes<T extends Element> extends HTMLAttributes<T>, LabelAttrs {}
-type LabelAttrs = Augmented<
-  HTMLLabelElement,
-  {
-    form?: string | undefined;
-    for?: string | undefined;
-    /** @deprecated Use `for` */
-    htmlFor?: string | undefined;
-  }
->;
+export interface LiHTMLAttributes<T extends Element> extends Attrs<'li', T> {}
 /** @public */
-export interface LiHTMLAttributes<T extends Element> extends HTMLAttributes<T>, LiAttrs {}
-type LiAttrs = Augmented<
-  HTMLLIElement,
-  {
-    value?: string | ReadonlyArray<string> | number | undefined;
-  }
->;
+export interface LinkHTMLAttributes<T extends Element> extends Attrs<'link', T> {}
 /** @public */
-export interface LinkHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    LinkAttrs {}
-type LinkAttrs = Augmented<
-  HTMLLinkElement,
-  {
-    crossOrigin?: HTMLCrossOriginAttribute;
-    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-    sizes?: string | undefined;
-    type?: string | undefined;
-    charSet?: string | undefined;
-  }
->;
+export interface MapHTMLAttributes<T extends Element> extends Attrs<'map', T> {}
 /** @public */
-export interface MapHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  name?: string | undefined;
-}
+export interface MenuHTMLAttributes<T extends Element> extends Attrs<'menu', T> {}
 /** @public */
-export interface MenuHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  type?: string | undefined;
-}
+export interface MetaHTMLAttributes<T extends Element> extends Attrs<'meta', T> {}
 /** @public */
-export interface MetaHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    MetaAttrs {}
-type MetaAttrs = Augmented<
-  HTMLMetaElement,
-  {
-    charSet?: string | undefined;
-  }
->;
+export interface MeterHTMLAttributes<T extends Element> extends Attrs<'meter', T> {}
 /** @public */
-export interface MeterHTMLAttributes<T extends Element> extends HTMLAttributes<T>, MeterAttrs {}
-type MeterAttrs = Augmented<
-  HTMLMeterElement,
-  {
-    form?: string | undefined;
-    value?: string | ReadonlyArray<string> | number | undefined;
-  }
->;
+export interface ObjectHTMLAttributes<T extends Element> extends Attrs<'object', T> {}
 /** @public */
-export interface ObjectHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ObjectAttrs {}
-type ObjectAttrs = Augmented<
-  HTMLObjectElement,
-  {
-    classID?: string | undefined;
-    form?: string | undefined;
-    height?: Size | undefined;
-    width?: Size | undefined;
-    wmode?: string | undefined;
-  }
->;
+export interface OlHTMLAttributes<T extends Element> extends Attrs<'ol', T> {}
 /** @public */
-export interface OlHTMLAttributes<T extends Element> extends HTMLAttributes<T>, OlAttrs {}
-type OlAttrs = Augmented<
-  HTMLOListElement,
-  {
-    type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined;
-  }
->;
+export interface OptgroupHTMLAttributes<T extends Element> extends Attrs<'optgroup', T> {}
 /** @public */
-export interface OptgroupHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  disabled?: boolean | undefined;
-  label?: string | undefined;
-}
+export interface OptionHTMLAttributes<T extends Element> extends Attrs<'option', T> {}
 /** @public */
-export interface OptionHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, string>,
-    OptionAttrs {}
-type OptionAttrs = Augmented<
-  HTMLOptionElement,
-  {
-    value?: string | ReadonlyArray<string> | number | undefined;
-  }
->;
-/** @public */
-export interface OutputHTMLAttributes<T extends Element> extends HTMLAttributes<T> {}
-type OutputAttrs = Augmented<
-  HTMLOutputElement,
-  {
-    form?: string | undefined;
-    for?: string | undefined;
-    /** @deprecated Use `for` instead */
-    htmlFor?: string | undefined;
-  }
->;
+export interface OutputHTMLAttributes<T extends Element> extends Attrs<'output', T> {}
 /** @public @deprecated Old DOM API */
 export interface ParamHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    ParamAttrs {}
-type ParamAttrs = Augmented<
-  HTMLParamElement,
-  {
-    value?: string | ReadonlyArray<string> | number | undefined;
-  }
->;
+  extends Attrs<'base', T, HTMLParamElement> {}
 /** @public */
-export interface ProgressHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T>,
-    ProgressAttrs {}
-type ProgressAttrs = Augmented<
-  HTMLProgressElement,
-  {
-    max?: number | string | undefined;
-    value?: string | ReadonlyArray<string> | number | undefined;
-  }
->;
+export interface ProgressHTMLAttributes<T extends Element> extends Attrs<'progress', T> {}
 /** @public */
-export interface QuoteHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  cite?: string | undefined;
-}
+export interface QuoteHTMLAttributes<T extends Element> extends Attrs<'q', T> {}
 /** @public */
-export interface SlotHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  name?: string | undefined;
-}
+export interface SlotHTMLAttributes<T extends Element> extends Attrs<'slot', T> {}
 /** @public */
-export interface ScriptHTMLAttributes<T extends Element> extends HTMLAttributes<T>, ScriptAttrs {}
-type ScriptAttrs = Augmented<
-  HTMLScriptElement,
-  {
-    crossOrigin?: HTMLCrossOriginAttribute;
-    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-  }
->;
+export interface ScriptHTMLAttributes<T extends Element> extends Attrs<'script', T> {}
 /** @public */
-export interface SelectHTMLAttributes<T extends Element> extends HTMLAttributes<T>, SelectAttrs {}
-type SelectAttrs = Augmented<
-  HTMLSelectElement,
-  {
-    form?: string | undefined;
-    value?: string | ReadonlyArray<string> | number | undefined;
-    'bind:value'?: Signal<string | undefined>;
-  }
->;
+export interface SelectHTMLAttributes<T extends Element> extends Attrs<'select', T> {}
 /** @public */
-export interface SourceHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    SourceAttrs {}
-type SourceAttrs = Augmented<
-  HTMLSourceElement,
-  {
-    height?: Size | undefined;
-    width?: Size | undefined;
-  }
->;
+export interface SourceHTMLAttributes<T extends Element> extends Attrs<'source', T> {}
 /** @public */
-export interface StyleHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, string>,
-    StyleAttrs {}
-type StyleAttrs = Augmented<
-  HTMLStyleElement,
-  {
-    scoped?: boolean | undefined;
-  }
->;
+export interface StyleHTMLAttributes<T extends Element> extends Attrs<'style', T> {}
 /** @public */
-export interface TableHTMLAttributes<T extends Element> extends HTMLAttributes<T>, TableAttrs {}
-type TableAttrs = Augmented<
-  HTMLTableElement,
-  {
-    cellPadding?: number | string | undefined;
-    cellSpacing?: number | string | undefined;
-    width?: Size | undefined;
-  }
->;
+export interface TableHTMLAttributes<T extends Element> extends Attrs<'table', T> {}
 /** @public */
-export interface TdHTMLAttributes<T extends Element> extends HTMLAttributes<T>, TableCellAttrs {}
-type TableCellAttrs = Augmented<
-  HTMLTableCellElement,
-  {
-    align?: 'left' | 'center' | 'right' | 'justify' | 'char' | undefined;
-    height?: Size | undefined;
-    width?: Size | undefined;
-    valign?: 'top' | 'middle' | 'bottom' | 'baseline' | undefined;
-  }
->;
+export interface TdHTMLAttributes<T extends Element> extends Attrs<'td', T> {}
 /** @public */
-export interface TextareaHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    TextareaAttrs {}
-type TextareaAttrs = Augmented<
-  HTMLTextAreaElement,
-  {
-    enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
-    form?: string | undefined;
-    value?: string | ReadonlyArray<string> | number | undefined;
-    'bind:value'?: Signal<string | undefined>;
-  }
->;
+export interface TextareaHTMLAttributes<T extends Element> extends Attrs<'textarea', T> {}
+/** @public */
+export interface ThHTMLAttributes<T extends Element> extends Attrs<'tr', T> {}
+/** @public */
+export interface TimeHTMLAttributes<T extends Element> extends Attrs<'time', T> {}
+/** @public */
+export interface TitleHTMLAttributes<T extends Element> extends Attrs<'title', T> {}
+/** @public */
+export interface TrackHTMLAttributes<T extends Element> extends Attrs<'track', T> {}
+/** @public */
+export interface VideoHTMLAttributes<T extends Element> extends Attrs<'video', T> {}
 
-/** @public */
-export interface ThHTMLAttributes<T extends Element> extends TdHTMLAttributes<T> {}
-
-/** @public */
-export interface TimeHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  dateTime?: string | undefined;
-}
-/** @public */
-export interface TitleHTMLAttributes<T extends Element> extends HTMLAttributes<T, string> {}
-
-/** @public */
-export interface TrackHTMLAttributes<T extends Element>
-  extends HTMLAttributes<T, undefined>,
-    TrackAttrs {}
-type TrackAttrs = Augmented<HTMLTrackElement, {}>;
-/** @public */
-export interface VideoHTMLAttributes<T extends Element> extends HTMLAttributes<T>, VideoAttrs {}
-type VideoAttrs = Augmented<
-  HTMLVideoElement,
-  {
-    crossOrigin?: HTMLCrossOriginAttribute;
-    height?: Numberish | undefined;
-    width?: Numberish | undefined;
-    disablePictureInPicture?: boolean | undefined;
-    disableRemotePlayback?: boolean | undefined;
-  }
->;
 /**
  * @deprecated This is the type for a React Native WebView. It doesn't belong in Qwik (yet?) but
  *   we're keeping it for backwards compatibility.
@@ -1067,12 +964,13 @@ export interface WebViewHTMLAttributes<T extends Element> extends HTMLAttributes
 /**
  * The TS types don't include the SVG attributes so we have to define them ourselves
  *
+ * NOTE: These props are probably not complete
+ *
  * @public
  */
-export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAttributes<T> {
-  class?: ClassList | undefined;
+export interface SVGAttributes<T extends Element = Element> extends AriaAttributes {
   color?: string | undefined;
-  height?: Numberish | undefined;
+  height?: Size | undefined;
   id?: string | undefined;
   lang?: string | undefined;
   max?: number | string | undefined;
@@ -1083,7 +981,7 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
   style?: CSSProperties | string | undefined;
   target?: string | undefined;
   type?: string | undefined;
-  width?: Numberish | undefined;
+  width?: Size | undefined;
 
   role?: string | undefined;
   tabindex?: number | undefined;
@@ -1327,17 +1225,18 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
   x?: number | string | undefined;
   'x-channel-selector'?: string | undefined;
   'x-height'?: number | string | undefined;
-  xlinkActuate?: string | undefined;
-  xlinkArcrole?: string | undefined;
-  xlinkHref?: string | undefined;
-  xlinkRole?: string | undefined;
-  xlinkShow?: string | undefined;
-  xlinkTitle?: string | undefined;
-  xlinkType?: string | undefined;
-  xmlBase?: string | undefined;
-  xmlLang?: string | undefined;
+  'xlink:actuate'?: string | undefined;
+  'xlink:arcrole'?: string | undefined;
+  'xlink:href'?: string | undefined;
+  'xlink:role'?: string | undefined;
+  'xlink:show'?: string | undefined;
+  'xlink:title'?: string | undefined;
+  'xlink:type'?: string | undefined;
+  'xml:base'?: string | undefined;
+  'xml:lang'?: string | undefined;
+  'xml:space'?: string | undefined;
   xmlns?: string | undefined;
-  xmlSpace?: string | undefined;
+  'xmlns:xlink'?: string | undefined;
   y1?: number | string | undefined;
   y2?: number | string | undefined;
   y?: number | string | undefined;
@@ -1346,63 +1245,50 @@ export interface SVGAttributes<T extends Element> extends AriaAttributes, DOMAtt
   zoomAndPan?: string | undefined;
 }
 /** @public */
-export interface SVGProps<T extends Element> extends SVGAttributes<T> {}
+export interface SVGProps<T extends Element> extends SVGAttributes, QwikAttributes<T> {}
+/** @internal */
+export interface LenientSVGProps<T extends Element> extends SVGAttributes, DOMAttributes<T> {}
 /** @public */
 export interface IntrinsicElements extends IntrinsicHTMLElements, IntrinsicSVGElements {}
 
-// HTML tags with special attributes
-interface QwikHTMLExceptions {
-  a: HTMLAttributes<HTMLAnchorElement> & AnchorAttrs;
-  area: HTMLAttributes<HTMLAreaElement, false> & AreaAttrs;
-  audio: HTMLAttributes<HTMLAudioElement> & AudioAttrs;
-  base: HTMLAttributes<HTMLBaseElement, undefined> & BaseAttrs;
-  button: HTMLAttributes<HTMLButtonElement> & ButtonAttrs;
-  canvas: HTMLAttributes<HTMLCanvasElement> & CanvasAttrs;
-  col: HTMLAttributes<HTMLTableColElement, undefined> & ColAttrs;
-  data: HTMLAttributes<HTMLDataElement> & DataAttrs;
-  embed: HTMLAttributes<HTMLEmbedElement, undefined> & EmbedAttrs;
-  fieldset: HTMLAttributes<HTMLFieldSetElement> & FieldSetAttrs;
-  hr: HTMLAttributes<HTMLHRElement, undefined>;
-  iframe: HTMLAttributes<HTMLIFrameElement> & IframeAttrs;
-  img: HTMLAttributes<HTMLImageElement, undefined> & ImgAttrs;
-  input: HTMLAttributes<HTMLInputElement, undefined> & InputAttrs;
-  keygen: KeygenHTMLAttributes<HTMLElement>;
-  label: HTMLAttributes<HTMLLabelElement> & LabelAttrs;
-  li: HTMLAttributes<HTMLLIElement> & LiAttrs;
-  link: HTMLAttributes<HTMLLinkElement, undefined> & LinkAttrs;
-  meta: HTMLAttributes<HTMLMetaElement> & MetaAttrs;
-  meter: HTMLAttributes<HTMLMeterElement> & MeterAttrs;
-  object: HTMLAttributes<HTMLObjectElement> & ObjectAttrs;
-  ol: HTMLAttributes<HTMLOListElement> & OlAttrs;
-  option: HTMLAttributes<HTMLOptionElement, string> & OptionAttrs;
-  output: HTMLAttributes<HTMLOutputElement> & OutputAttrs;
-  progress: HTMLAttributes<HTMLProgressElement> & ProgressAttrs;
-  script: HTMLAttributes<HTMLScriptElement> & ScriptAttrs;
-  select: HTMLAttributes<HTMLSelectElement> & SelectAttrs;
-  source: HTMLAttributes<HTMLSourceElement, undefined> & SourceAttrs;
-  style: HTMLAttributes<HTMLStyleElement, string> & StyleAttrs;
-  table: HTMLAttributes<HTMLTableElement> & TableAttrs;
-  td: HTMLAttributes<HTMLTableCellElement> & TableCellAttrs;
-  textarea: HTMLAttributes<HTMLTextAreaElement, undefined> & TextareaAttrs;
-  th: HTMLAttributes<HTMLTableCellElement> & TableCellAttrs;
-  title: HTMLAttributes<HTMLTitleElement, string>;
-  track: HTMLAttributes<HTMLTrackElement, undefined> & TrackAttrs;
-  video: VideoHTMLAttributes<HTMLVideoElement> & VideoAttrs;
-}
-
-// Automatically converted HTML tag attributes
-type PlainHTMLElements = {
-  [key in keyof Omit<HTMLElementTagNameMap, keyof QwikHTMLExceptions>]: HTMLAttributes<
-    HTMLElementTagNameMap[key]
-  > &
-    Prettify<Filtered<HTMLElementTagNameMap[key], {}>>;
+/**
+ * These are the HTML tags with handlers allowing plain callbacks, to be used for the JSX interface
+ *
+ * @internal
+ */
+export type IntrinsicHTMLElements = {
+  // Generating it this way shows the special props for each element in editor hover
+  [key in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[key], SpecialAttrs[key]> &
+    HTMLAttributes<HTMLElementTagNameMap[key]>;
+} & {
+  /** For unknown tags we allow all props */
+  [unknownTag: string]: { [prop: string]: any } & HTMLElementAttrs & HTMLAttributes<any>;
+};
+/**
+ * These are the SVG tags with handlers allowing plain callbacks, to be used for the JSX interface
+ *
+ * @internal
+ */
+export type IntrinsicSVGElements = {
+  [K in keyof Omit<SVGElementTagNameMap, keyof HTMLElementTagNameMap>]: LenientSVGProps<
+    SVGElementTagNameMap[K]
+  >;
 };
 
-/** @public */
-export interface IntrinsicHTMLElements extends QwikHTMLExceptions, PlainHTMLElements {}
-
-/** @public */
-export type IntrinsicSVGElements = {
+/** The DOM props without plain handlers, for use inside functions @public */
+export type QwikHTMLElements = {
+  [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> &
+    HTMLElementAttrs &
+    QwikAttributes<HTMLElementTagNameMap[tag]>;
+} & {
+  /** For unknown tags we allow all props */
+  [unknownTag: string]: { [prop: string]: any } & HTMLElementAttrs &
+    // We use any instead of Element because this index type needs to be matched by
+    // all the other ones and those are subtypes of Element
+    QwikAttributes<any>;
+};
+/** The SVG props without plain handlers, for use inside functions @public */
+export type QwikSVGElements = {
   [K in keyof Omit<SVGElementTagNameMap, keyof HTMLElementTagNameMap>]: SVGProps<
     SVGElementTagNameMap[K]
   >;

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-elements.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-elements.ts
@@ -1,16 +1,9 @@
-import type { HTMLAttributes, IntrinsicHTMLElements } from './jsx-generated';
-
-/** All unknown attributes are allowed */
-interface QwikCustomHTMLAttributes<T extends Element> extends HTMLAttributes<T> {
-  [key: string]: any;
-}
-
-/**
- * Any custom DOM element.
- *
- * @public
- */
-interface QwikCustomHTMLElement extends Element {}
+import type {
+  IntrinsicHTMLElements,
+  IntrinsicSVGElements,
+  QwikHTMLElements,
+  QwikSVGElements,
+} from './jsx-generated';
 
 /** @public */
 export interface QwikIntrinsicAttributes {
@@ -37,12 +30,14 @@ export interface QwikIntrinsicAttributes {
  * });
  * ```
  *
+ * Note: It is shorter to use `PropsOf<'div'>`
+ *
  * @public
  */
-export interface QwikIntrinsicElements extends IntrinsicHTMLElements {
-  /**
-   * Custom DOM elements can have any name We need to add the empty object to match the type with
-   * the Intrinsic elements
-   */
-  [key: string]: {} | QwikCustomHTMLAttributes<QwikCustomHTMLElement>;
-}
+export interface QwikIntrinsicElements extends QwikHTMLElements, QwikSVGElements {}
+
+/**
+ * These definitions are for the JSX namespace, they allow passing plain event handlers instead of
+ * QRLs
+ */
+export interface LenientQwikElements extends IntrinsicHTMLElements, IntrinsicSVGElements {}

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -1,9 +1,13 @@
-import type { QwikKeysEvents } from './jsx-qwik-attributes';
+import type { AllEventKeys } from './jsx-qwik-attributes';
 
 /** Emitted by qwik-loader when an element becomes visible. Used by `useVisibleTask$` @public */
 export type QwikVisibleEvent = CustomEvent<IntersectionObserverEntry>;
 /** Emitted by qwik-loader when a module was lazily loaded @public */
 export type QwikSymbolEvent = CustomEvent<{ symbol: string; element: Element; reqTime: number }>;
+/** Emitted by qwik-loader on document when the document first becomes interactive @public */
+export type QwikInitEvent = CustomEvent<{}>;
+/** Emitted by qwik-loader on document when the document first becomes idle @public */
+export type QwikIdleEvent = CustomEvent<{}>;
 
 // Utility types for supporting autocompletion in union types
 
@@ -39,11 +43,12 @@ export type LiteralUnion<LiteralType, BaseType extends Primitive> =
   | (BaseType & Record<never, never>);
 
 /**
- * The PascalCaseEventLiteralType combines the QwikKeysEvents type and string type using the
- * LiteralUnion utility type, allowing autocompletion for event names while retaining support for
- * custom event names as strings. Despite the name, the event names are all lowercase :)
+ * The names of events that Qwik knows about. They are all lowercase, but on the JSX side, they are
+ * PascalCase for nicer DX. (`onAuxClick$` vs `onauxclick$`)
+ *
+ * @public
  */
-export type PascalCaseEventLiteralType = LiteralUnion<QwikKeysEvents, string>;
+export type KnownEventNames = LiteralUnion<AllEventKeys, string>;
 
 // Deprecated old types
 export type SyntheticEvent<T = Element, E = Event> = E & { target: EventTarget & T };

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts
@@ -1,17 +1,17 @@
 import type { DOMAttributes } from './jsx-qwik-attributes';
 import type { JSXNode } from './jsx-node';
-import type { QwikIntrinsicAttributes, QwikIntrinsicElements } from './jsx-qwik-elements';
+import type { QwikIntrinsicAttributes, LenientQwikElements } from './jsx-qwik-elements';
 
 /** @public */
 export namespace QwikJSX {
   export interface Element extends JSXNode {}
+  export type ElementType = string | ((...args: any[]) => JSXNode | null);
 
   export interface IntrinsicAttributes extends QwikIntrinsicAttributes {}
   export interface ElementChildrenAttribute {
     children: any;
   }
-  export interface IntrinsicElements extends QwikIntrinsicElements {}
+  export interface IntrinsicElements extends LenientQwikElements {}
 }
-
 /** @public */
 export interface QwikDOMAttributes extends DOMAttributes<Element> {}

--- a/packages/qwik/src/core/render/jsx/types/jsx-types.unit.tsx
+++ b/packages/qwik/src/core/render/jsx/types/jsx-types.unit.tsx
@@ -1,0 +1,120 @@
+import { assertType, describe, expectTypeOf, test } from 'vitest';
+import { $ } from '../../../qrl/qrl.public';
+import type { EventHandler, QRLEventHandlerMulti } from './jsx-qwik-attributes';
+import type { JSXNode } from './jsx-node';
+import type { QwikIntrinsicElements } from './jsx-qwik-elements';
+import type { JSXChildren } from './jsx-qwik-attributes';
+import { component$, type PropsOf } from '../../../component/component.public';
+import type { Size } from './jsx-generated';
+import type { QwikJSX } from './jsx-qwik';
+
+describe('types', () => {
+  // Note, these type checks happen at compile time. We don't need to call anything, so we do ()=>()=>. We just need to
+  // make sure the type check runs.
+  test('basic', () => () => {
+    expectTypeOf(<div />).toEqualTypeOf<JSXNode>();
+    expectTypeOf<QRLEventHandlerMulti<PointerEvent, HTMLDivElement>>().toMatchTypeOf<
+      QwikIntrinsicElements['div']['onAuxClick$']
+    >();
+    expectTypeOf<QwikIntrinsicElements['li']['children']>().toEqualTypeOf<JSXChildren>();
+    expectTypeOf<QwikIntrinsicElements['link']['children']>().toEqualTypeOf<undefined>();
+    expectTypeOf<QwikIntrinsicElements['svg']['width']>().toEqualTypeOf<Size | undefined>();
+  });
+  test('component', () => () => {
+    const Cmp = component$((props: PropsOf<'svg'>) => {
+      const { width = '240', height = '56', onClick$, ...rest } = props;
+      expectTypeOf(onClick$).toEqualTypeOf<QRLEventHandlerMulti<PointerEvent, SVGSVGElement>>();
+      return (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          version="1.1"
+          width={width}
+          height={height}
+          {...rest}
+        />
+      );
+    });
+    expectTypeOf<Parameters<typeof Cmp>[0]['onClick$']>().toMatchTypeOf<
+      EventHandler<PointerEvent, SVGSVGElement> | QRLEventHandlerMulti<PointerEvent, SVGSVGElement>
+    >();
+  });
+  test('unknown string component', () => () => {
+    const t = (
+      <hello-there
+        class="hi"
+        onClick$={(ev, el) => {
+          expectTypeOf(ev).not.toBeAny();
+          expectTypeOf(ev).toEqualTypeOf<PointerEvent>();
+          // Because of interface constraints, this type is "never"
+          // expectTypeOf(el).toEqualTypeOf<Element>();
+        }}
+      />
+    );
+    expectTypeOf(t).toEqualTypeOf<QwikJSX.Element>();
+  });
+  test('inferring', () => () => {
+    // Popover API
+    expectTypeOf<PropsOf<'button'>>().toMatchTypeOf<{
+      popovertarget?: string;
+    }>();
+    expectTypeOf<{
+      popovertarget?: string;
+    }>().not.toMatchTypeOf<PropsOf<'input'>>();
+    expectTypeOf<{
+      type: 'button';
+      popovertarget?: string;
+    }>().toMatchTypeOf<PropsOf<'input'>>();
+    <>
+      <button popovertarget="meep" />
+      <input type="button" popovertarget="meep" />
+      <div popover="manual" id="meep" />
+      <div
+        onToggle$={(ev, el) => {
+          expectTypeOf(ev).not.toBeAny();
+          // It's Event because api extractor doesn't know about ToggleEvent
+          // assertType<ToggleEvent>(ev);
+          expectTypeOf(ev.newState).toBeString();
+        }}
+        onBeforeToggle$={(ev, el) => {
+          expectTypeOf(ev).not.toBeAny();
+          // assertType<ToggleEvent>(ev);
+          expectTypeOf(ev.prevState).toBeString();
+        }}
+        onBlur$={(ev) => {
+          expectTypeOf(ev).not.toBeAny();
+          assertType<FocusEvent>(ev);
+        }}
+        window:onAnimationEnd$={(ev) => {
+          expectTypeOf(ev).not.toBeAny();
+          assertType<AnimationEvent>(ev);
+        }}
+        document:onAbort$={(ev) => {
+          expectTypeOf(ev).not.toBeAny();
+          assertType<UIEvent>(ev);
+        }}
+        // Infer through $
+        onAuxClick$={$((ev) => {
+          expectTypeOf(ev).not.toBeAny();
+          assertType<PointerEvent>(ev);
+        })}
+        // Array of handlers
+        onInput$={[
+          $((ev) => {
+            expectTypeOf(ev).not.toBeAny();
+            assertType<InputEvent>(ev);
+          }),
+          null,
+          undefined,
+          [
+            $(async (ev, el) => {
+              expectTypeOf(ev).not.toBeAny();
+              assertType<InputEvent>(ev);
+              expectTypeOf(el).not.toBeAny();
+              assertType<HTMLDivElement>(el);
+            }),
+          ],
+        ]}
+      />
+    </>;
+  });
+});

--- a/packages/qwik/src/core/use/use-on.ts
+++ b/packages/qwik/src/core/use/use-on.ts
@@ -3,15 +3,15 @@ import type { QRL } from '../qrl/qrl.public';
 import { getContext, HOST_FLAG_NEED_ATTACH_LISTENER } from '../state/context';
 import { type Listener, normalizeOnProp } from '../state/listeners';
 import { useInvokeContext } from './use-core';
-import { type PascalCaseEventLiteralType } from '../render/jsx/types/jsx-qwik-events';
+import { type KnownEventNames } from '../render/jsx/types/jsx-qwik-events';
 import type {
-  BivariantEventHandler,
+  EventHandler,
   EventFromName,
-  QwikKeysEvents,
+  AllEventKeys,
 } from '../render/jsx/types/jsx-qwik-attributes';
 
-export type EventQRL<T extends string = QwikKeysEvents> =
-  | QRL<BivariantEventHandler<EventFromName<T>, Element>>
+export type EventQRL<T extends string = AllEventKeys> =
+  | QRL<EventHandler<EventFromName<T>, Element>>
   | undefined;
 
 // <docs markdown="../readme.md#useOn">
@@ -27,10 +27,7 @@ export type EventQRL<T extends string = QwikKeysEvents> =
  * @see `useOn`, `useOnWindow`, `useOnDocument`.
  */
 // </docs>
-export const useOn = <T extends PascalCaseEventLiteralType>(
-  event: T | T[],
-  eventQrl: EventQRL<T>
-) => {
+export const useOn = <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => {
   _useOn(createEventName(event, undefined), eventQrl);
 };
 
@@ -63,10 +60,7 @@ export const useOn = <T extends PascalCaseEventLiteralType>(
  * ```
  */
 // </docs>
-export const useOnDocument = <T extends PascalCaseEventLiteralType>(
-  event: T | T[],
-  eventQrl: EventQRL<T>
-) => {
+export const useOnDocument = <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => {
   _useOn(createEventName(event, 'document'), eventQrl);
 };
 
@@ -100,15 +94,12 @@ export const useOnDocument = <T extends PascalCaseEventLiteralType>(
  * ```
  */
 // </docs>
-export const useOnWindow = <T extends PascalCaseEventLiteralType>(
-  event: T | T[],
-  eventQrl: EventQRL<T>
-) => {
+export const useOnWindow = <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>) => {
   _useOn(createEventName(event, 'window'), eventQrl);
 };
 
 const createEventName = (
-  event: PascalCaseEventLiteralType | PascalCaseEventLiteralType[],
+  event: KnownEventNames | KnownEventNames[],
   eventType: 'window' | 'document' | undefined
 ) => {
   const formattedEventType = eventType !== undefined ? eventType + ':' : '';

--- a/packages/qwik/src/core/use/use-on.unit.ts
+++ b/packages/qwik/src/core/use/use-on.unit.ts
@@ -60,19 +60,5 @@ describe('types', () => {
         assertType<Event>(ev);
       })
     );
-    <div
-      onBlur$={(ev) => {
-        expectTypeOf(ev).not.toBeAny();
-        assertType<FocusEvent>(ev);
-      }}
-      window:onAnimationEnd$={(ev) => {
-        expectTypeOf(ev).not.toBeAny();
-        assertType<AnimationEvent>(ev);
-      }}
-      document:onAbort$={(ev) => {
-        expectTypeOf(ev).not.toBeAny();
-        assertType<UIEvent>(ev);
-      }}
-    />;
   });
 });

--- a/packages/qwik/src/core/use/use-resource.ts
+++ b/packages/qwik/src/core/use/use-resource.ts
@@ -60,24 +60,22 @@ export interface ResourceOptions {
  *
  * ```tsx
  * const Cmp = component$(() => {
- *   const store = useStore({
- *     city: '',
- *   });
+ *   const cityS = useSignal('');
  *
- *   const weatherResource = useResource$<any>(async ({ track, cleanup }) => {
- *     const cityName = track(() => store.city);
+ *   const weatherResource = useResource$(async ({ track, cleanup }) => {
+ *     const cityName = track(cityS);
  *     const abortController = new AbortController();
  *     cleanup(() => abortController.abort('cleanup'));
  *     const res = await fetch(`http://weatherdata.com?city=${cityName}`, {
  *       signal: abortController.signal,
  *     });
- *     const data = res.json();
- *     return data;
+ *     const data = await res.json();
+ *     return data as { temp: number };
  *   });
  *
  *   return (
  *     <div>
- *       <input name="city" onInput$={(ev: any) => (store.city = ev.target.value)} />
+ *       <input name="city" bind:value={cityS} />
  *       <Resource
  *         value={weatherResource}
  *         onResolved={(weather) => {
@@ -148,24 +146,22 @@ export const useResourceQrl = <T>(
  *
  * ```tsx
  * const Cmp = component$(() => {
- *   const store = useStore({
- *     city: '',
- *   });
+ *   const cityS = useSignal('');
  *
- *   const weatherResource = useResource$<any>(async ({ track, cleanup }) => {
- *     const cityName = track(() => store.city);
+ *   const weatherResource = useResource$(async ({ track, cleanup }) => {
+ *     const cityName = track(cityS);
  *     const abortController = new AbortController();
  *     cleanup(() => abortController.abort('cleanup'));
  *     const res = await fetch(`http://weatherdata.com?city=${cityName}`, {
  *       signal: abortController.signal,
  *     });
- *     const data = res.json();
- *     return data;
+ *     const data = await res.json();
+ *     return data as { temp: number };
  *   });
  *
  *   return (
  *     <div>
- *       <input name="city" onInput$={(ev: any) => (store.city = ev.target.value)} />
+ *       <input name="city" bind:value={cityS} />
  *       <Resource
  *         value={weatherResource}
  *         onResolved={(weather) => {
@@ -220,24 +216,22 @@ export interface ResourceProps<T> {
  *
  * ```tsx
  * const Cmp = component$(() => {
- *   const store = useStore({
- *     city: '',
- *   });
+ *   const cityS = useSignal('');
  *
- *   const weatherResource = useResource$<any>(async ({ track, cleanup }) => {
- *     const cityName = track(() => store.city);
+ *   const weatherResource = useResource$(async ({ track, cleanup }) => {
+ *     const cityName = track(cityS);
  *     const abortController = new AbortController();
  *     cleanup(() => abortController.abort('cleanup'));
  *     const res = await fetch(`http://weatherdata.com?city=${cityName}`, {
  *       signal: abortController.signal,
  *     });
- *     const data = res.json();
- *     return data;
+ *     const data = await res.json();
+ *     return data as { temp: number };
  *   });
  *
  *   return (
  *     <div>
- *       <input name="city" onInput$={(ev: any) => (store.city = ev.target.value)} />
+ *       <input name="city" bind:value={cityS} />
  *       <Resource
  *         value={weatherResource}
  *         onResolved={(weather) => {

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -59,16 +59,27 @@ export const TaskFlagsIsCleanup = 1 << 5;
  * ```tsx
  * const Cmp = component$(() => {
  *   const store = useStore({ count: 0, doubleCount: 0 });
+ *   const signal = useSignal(0);
  *   useTask$(({ track }) => {
+ *     // Any signals or stores accessed inside the task will be tracked
  *     const count = track(() => store.count);
- *     store.doubleCount = 2 * count;
+ *     // You can also pass a signal to track() directly
+ *     const signalCount = track(signal);
+ *     store.doubleCount = count + signalCount;
  *   });
  *   return (
  *     <div>
  *       <span>
  *         {store.count} / {store.doubleCount}
  *       </span>
- *       <button onClick$={() => store.count++}>+</button>
+ *       <button
+ *         onClick$={() => {
+ *           store.count++;
+ *           signal.value++;
+ *         }}
+ *       >
+ *         +
+ *       </button>
  *     </div>
  *   );
  * });
@@ -98,12 +109,15 @@ export interface Tracker {
    * Used to track the whole object. If any property of the passed store changes, the task will be
    * scheduled to run. Also accepts signals.
    *
+   * Note that the change tracking is not deep. If you want to track changes to nested properties,
+   * you need to use `track` on each of them.
+   *
    * ```tsx
-   * track(store);
-   * track(signal);
+   * track(store); // returns store
+   * track(signal); // returns signal.value
    * ```
    */
-  <T extends object>(obj: T): T;
+  <T extends object>(obj: T): T extends Signal<infer U> ? U : T;
 }
 
 /** @public */
@@ -218,9 +232,9 @@ export interface UseTaskOptions {
  *
  * ### Example
  *
- * The `useTask` function is used to observe the `state.count` property. Any changes to the
- * `state.count` cause the `taskFn` to execute which in turn updates the `state.doubleCount` to
- * the double of `state.count`.
+ * The `useTask` function is used to observe the `store.count` property. Any changes to the
+ * `store.count` cause the `taskFn` to execute which in turn updates the `store.doubleCount` to
+ * the double of `store.count`.
  *
  * ```tsx
  * const Cmp = component$(() => {
@@ -343,9 +357,9 @@ export const useComputed$: Computed = implicit$FirstArg(useComputedQrl);
  *
  * ### Example
  *
- * The `useTask` function is used to observe the `state.count` property. Any changes to the
- * `state.count` cause the `taskFn` to execute which in turn updates the `state.doubleCount` to
- * the double of `state.count`.
+ * The `useTask` function is used to observe the `store.count` property. Any changes to the
+ * `store.count` cause the `taskFn` to execute which in turn updates the `store.doubleCount` to
+ * the double of `store.count`.
  *
  * ```tsx
  * const Cmp = component$(() => {

--- a/packages/qwik/src/core/use/use-task.unit.ts
+++ b/packages/qwik/src/core/use/use-task.unit.ts
@@ -1,0 +1,28 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import { component$ } from '../component/component.public';
+import { useResource$ } from './use-resource';
+import { useSignal } from './use-signal';
+import { useStore } from './use-store.public';
+import { useTask$ } from './use-task';
+
+describe('types', () => {
+  test('track', () => () => {
+    component$(() => {
+      const sig = useSignal(1);
+      const store = useStore({ count: 1 });
+      useResource$(({ track }) => {
+        expectTypeOf(track(store)).toEqualTypeOf(store);
+        expectTypeOf(track(sig)).toEqualTypeOf<number>();
+        expectTypeOf(track(() => sig.value)).toEqualTypeOf<number>();
+        expectTypeOf(track(() => store.count)).toEqualTypeOf<number>();
+      });
+      useTask$(({ track }) => {
+        expectTypeOf(track(store)).toEqualTypeOf(store);
+        expectTypeOf(track(sig)).toEqualTypeOf<number>();
+        expectTypeOf(track(() => sig.value)).toEqualTypeOf<number>();
+        expectTypeOf(track(() => store.count)).toEqualTypeOf<number>();
+      });
+      return null;
+    });
+  });
+});

--- a/packages/qwik/src/jsx-runtime/api.md
+++ b/packages/qwik/src/jsx-runtime/api.md
@@ -35,15 +35,17 @@ namespace JSX_2 {
         // (undocumented)
         children: any;
     }
+    // (undocumented)
+    type ElementType = string | ((...args: any[]) => JSXNode | null);
     // Warning: (ae-forgotten-export) The symbol "QwikIntrinsicAttributes" needs to be exported by the entry point jsx-runtime.d.ts
     //
     // (undocumented)
     interface IntrinsicAttributes extends QwikIntrinsicAttributes {
     }
-    // Warning: (ae-forgotten-export) The symbol "QwikIntrinsicElements" needs to be exported by the entry point jsx-runtime.d.ts
+    // Warning: (ae-forgotten-export) The symbol "LenientQwikElements" needs to be exported by the entry point jsx-runtime.d.ts
     //
     // (undocumented)
-    interface IntrinsicElements extends QwikIntrinsicElements {
+    interface IntrinsicElements extends LenientQwikElements {
     }
 }
 export { JSX_2 as JSX }

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -319,9 +319,6 @@ function fixDtsContent(config: BuildConfig, srcPath: string, relativePath?: stri
     dts = dts.replace(/'@builder\.io\/qwik(.*)'/g, `'${relativePath}$1'`);
   }
 
-  // for some reason api-extractor is adding this in  ¯\_(ツ)_/¯
-  dts = dts.replace('{};', '');
-
   // replace QWIK_VERSION with the actual version number, useful for debugging
   return dts.replace(/QWIK_VERSION/g, config.distVersion);
 }

--- a/starters/apps/basic/src/routes/demo/flower/index.tsx
+++ b/starters/apps/basic/src/routes/demo/flower/index.tsx
@@ -36,8 +36,8 @@ export default component$(() => {
         type="range"
         value={state.number}
         max={50}
-        onInput$={(ev) => {
-          state.number = (ev.target as HTMLInputElement).valueAsNumber;
+        onInput$={(ev, el) => {
+          state.number = el.valueAsNumber;
         }}
       />
       <div

--- a/starters/apps/e2e/src/components/attributes/attributes.tsx
+++ b/starters/apps/e2e/src/components/attributes/attributes.tsx
@@ -134,8 +134,8 @@ export const AttributesChild = component$<{ v: number }>(({ v }) => {
               data-stuff={"stuff: " + state.stuff}
               tabIndex={-1}
               title={title.value}
-              onInput$={(ev) => {
-                input.value = (ev.target as any).value;
+              onInput$={(ev, el) => {
+                input.value = el.value;
               }}
             />
             <svg

--- a/starters/apps/e2e/src/components/events/events-client.tsx
+++ b/starters/apps/e2e/src/components/events/events-client.tsx
@@ -14,8 +14,8 @@ export const EventsClient = component$(() => {
           id="input"
           onInput$={
             enabled.value
-              ? $((ev: any) => {
-                  input.value = ev.target.value;
+              ? $((ev, el) => {
+                  input.value = el.value;
                 })
               : undefined
           }

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -12,7 +12,7 @@ import {
   SkipRender,
   SSRRaw,
   HTMLFragment,
-  type QwikIntrinsicElements,
+  type PropsOf,
   Slot,
 } from "@builder.io/qwik";
 import { delay } from "../streaming/demo";
@@ -836,7 +836,7 @@ export const HTMLFragmentTest = component$(() => {
   );
 });
 
-type A = QwikIntrinsicElements["button"];
+type A = PropsOf<"button">;
 
 export interface TestAProps extends A {}
 

--- a/starters/apps/e2e/src/components/resource/weather.tsx
+++ b/starters/apps/e2e/src/components/resource/weather.tsx
@@ -60,7 +60,7 @@ export const Weather = component$(() => {
         name="city"
         autoComplete="off"
         placeholder="City name"
-        onInput$={(ev) => (state.city = (ev.target as any).value)}
+        onInput$={(ev, el) => (state.city = el.value)}
       />
       <WeatherResults2 weather={weather} />
     </div>

--- a/starters/apps/e2e/src/components/signals/signals.tsx
+++ b/starters/apps/e2e/src/components/signals/signals.tsx
@@ -713,9 +713,8 @@ export const Issue2930 = component$(() => {
         style="border: 1px solid black"
         type="text"
         value={group.controls.ctrl.value}
-        onInput$={(e) => {
-          const val = (e.target as HTMLInputElement).value;
-          group.controls.ctrl.value = val;
+        onInput$={(ev, el) => {
+          group.controls.ctrl.value = el.value;
         }}
       />
       <Stringify data={group} />

--- a/starters/apps/starter-partytown-test/src/components/app/app.tsx
+++ b/starters/apps/starter-partytown-test/src/components/app/app.tsx
@@ -76,8 +76,7 @@ export const App = component$(() => {
           Try interacting with this component by changing{" "}
           <input
             value={state.name}
-            onInput$={(event) => {
-              const input = event.target as HTMLInputElement;
+            onInput$={(event, input) => {
               state.name = input.value;
             }}
           ></input>

--- a/starters/features/styled-vanilla-extract/src/routes/styled-flower/index.tsx
+++ b/starters/features/styled-vanilla-extract/src/routes/styled-flower/index.tsx
@@ -25,8 +25,8 @@ export const RangeInput = <Name extends string = "value">({
     {...props}
     type="range"
     value={store[name]}
-    onInput$={(ev) => {
-      store[name] = (ev.target as HTMLInputElement).valueAsNumber;
+    onInput$={(ev, el) => {
+      store[name] = el.valueAsNumber;
     }}
   />
 );


### PR DESCRIPTION
fix(tasks): type of track(Signal)
fix(types): typing intensifies

Type changes only, no real code changes.

- inside functions, handlers are QRLs only
- handler type inferral works through $()
- PropsOf now works on strings and inline components too, e.g. `PropsOf<'div'>`
- also type SVG elements and fix the incorrect SVG examples
- provide JSX.ElementType (supported since TS 5.1)
- examples now use the element argument of onInput$
- some more Qwik events are documented
- improve popover types
- fix api.ts: don't remove `{};` from api docs