### PR TITLE
chore(starters): add type module to package.json 

### DIFF
--- a/starters/apps/base/package.json
+++ b/starters/apps/base/package.json
@@ -36,5 +36,6 @@
   "engines": {
     "node": ">=16.8.0 <18.0.0 || >=18.11"
   },
-  "private": true
+  "private": true,
+  "type": "module"
 }


### PR DESCRIPTION
# Overview
Fix the following warning after vite was upgraded to v5.x in qwik v.1.3.0:
![image](https://github.com/BuilderIO/qwik/assets/8364345/8b9a4d63-3cd0-44b8-84d7-032409223e9c)

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description
Adding `type: module` to the `package.json` of the base app starter.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
