### PR TITLE
feat(util): add a utility function for combining RequestHandlers

### DIFF
--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -59,6 +59,20 @@
       "mdFile": "qwik-city.actionstore.md"
     },
     {
+      "name": "combineRequestHandlers",
+      "id": "combinerequesthandlers",
+      "hierarchy": [
+        {
+          "name": "combineRequestHandlers",
+          "id": "combinerequesthandlers"
+        }
+      ],
+      "kind": "Variable",
+      "content": "Combines multiple request handlers into a single request handler.\n\nThe handlers will be called in order:\n\n1. Handler1 before next() 2. Handler2 before next() 3. Handler3 before next() 4. Next() 5. Handler3 after next() 6. Handler2 after next() 7. Handler1 after next()\n\n\n```typescript\ncombineRequestHandlers: (...handlers: RequestHandler[]) => RequestHandler\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/combine-request-handlers.ts",
+      "mdFile": "qwik-city.combinerequesthandlers.md"
+    },
+    {
       "name": "ContentHeading",
       "id": "contentheading",
       "hierarchy": [

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -172,6 +172,20 @@ export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/types.ts)
 
+## combineRequestHandlers
+
+Combines multiple request handlers into a single request handler.
+
+The handlers will be called in order:
+
+1. Handler1 before next() 2. Handler2 before next() 3. Handler3 before next() 4. Next() 5. Handler3 after next() 6. Handler2 after next() 7. Handler1 after next()
+
+```typescript
+combineRequestHandlers: (...handlers: RequestHandler[]) => RequestHandler;
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/combine-request-handlers.ts)
+
 ## ContentHeading
 
 ```typescript

--- a/packages/docs/src/routes/docs/(qwikcity)/middleware/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/middleware/index.mdx
@@ -11,7 +11,7 @@ contributors:
   - mrhoodz
   - harishkrishnan24
   - erikras
-updated_at: '2023-09-18T19:04:44Z'
+updated_at: '2023-12-11T09:55:00Z'
 created_at: '2023-06-13T06:46:09Z'
 ---
 

--- a/packages/docs/src/routes/docs/(qwikcity)/middleware/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/middleware/index.mdx
@@ -10,6 +10,7 @@ contributors:
   - gparlakov
   - mrhoodz
   - harishkrishnan24
+  - erikras
 updated_at: '2023-09-18T19:04:44Z'
 created_at: '2023-06-13T06:46:09Z'
 ---
@@ -51,6 +52,14 @@ export const onDelete: RequestHandler = async (requestEvent) => { ... }
 
 Each middleware function is passed a [`RequestEvent`](#requestevent) object which allows the middleware to control the response.
 
+If you want to combine multiple `RequestHandler`s together, there is a utility function called `combineRequestHandlers()` that will allow you to chain mulitple `RequestHandler`s together.
+```typescript
+import type { RequestHandler } from '@builder.io/qwik-city';
+import { combineRequestHandlers } from "@builder.io/qwik-city";
+
+export const onRequest: RequestHandler = combineRequestHandlers(handler1, handler2, handler3);
+```
+They will be called in the order they are given, so `handler2` can depend on something `handler1` has placed into the `sharedMap`, for example.
 
 ## Order of invocation
 

--- a/packages/docs/src/routes/docs/(qwikcity)/middleware/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/middleware/index.mdx
@@ -59,7 +59,7 @@ import { combineRequestHandlers } from "@builder.io/qwik-city";
 
 export const onRequest: RequestHandler = combineRequestHandlers(handler1, handler2, handler3);
 ```
-They will be called in the order they are given, so `handler2` can depend on something `handler1` has placed into the `sharedMap`, for example.
+They will be called in the order they are given, so `handler2` can depend on something `handler1` has placed into the `sharedMap`. For example, if you have one middleware to connect to a database, and another to load the current user record, the latter depends on the former, so they must be called in order.
 
 ## Order of invocation
 

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -70,6 +70,11 @@ export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {
     readonly submit: QRL<OPTIONAL extends true ? (form?: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>> : (form: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>>>;
 };
 
+// Warning: (ae-forgotten-export) The symbol "RequestHandler_2" needs to be exported by the entry point index.d.ts
+//
+// @public
+export const combineRequestHandlers: (...handlers: RequestHandler_2[]) => RequestHandler_2;
+
 // @public (undocumented)
 export interface ContentHeading {
     // (undocumented)

--- a/packages/qwik-city/runtime/src/combine-request-handlers.ts
+++ b/packages/qwik-city/runtime/src/combine-request-handlers.ts
@@ -1,0 +1,29 @@
+import type { RequestHandler } from '../../middleware/request-handler/types';
+
+/**
+ * Combines multiple request handlers into a single request handler.
+ *
+ * The handlers will be called in order:
+ *
+ * 1. Handler1 before next()
+ * 2. Handler2 before next()
+ * 3. Handler3 before next()
+ * 4. Next()
+ * 5. Handler3 after next()
+ * 6. Handler2 after next()
+ * 7. Handler1 after next()
+ */
+export const combineRequestHandlers =
+  (...handlers: RequestHandler[]): RequestHandler =>
+  async (originalContext) => {
+    let lastNext = originalContext.next;
+    for (let i = handlers.length - 1; i >= 0; i--) {
+      const currentHandler = handlers[i];
+      const nextInChain = lastNext;
+      lastNext = async () => {
+        await currentHandler({ ...originalContext, next: nextInChain });
+      };
+    }
+
+    await lastNext();
+  };

--- a/packages/qwik-city/runtime/src/combine-request-handlers.ts
+++ b/packages/qwik-city/runtime/src/combine-request-handlers.ts
@@ -12,6 +12,8 @@ import type { RequestHandler } from '../../middleware/request-handler/types';
  * 5. Handler3 after next()
  * 6. Handler2 after next()
  * 7. Handler1 after next()
+ * 
+ * @public
  */
 export const combineRequestHandlers =
   (...handlers: RequestHandler[]): RequestHandler =>

--- a/packages/qwik-city/runtime/src/combine-request-handlers.ts
+++ b/packages/qwik-city/runtime/src/combine-request-handlers.ts
@@ -12,7 +12,7 @@ import type { RequestHandler } from '../../middleware/request-handler/types';
  * 5. Handler3 after next()
  * 6. Handler2 after next()
  * 7. Handler1 after next()
- * 
+ *
  * @public
  */
 export const combineRequestHandlers =

--- a/packages/qwik-city/runtime/src/combine-request-handlers.unit.ts
+++ b/packages/qwik-city/runtime/src/combine-request-handlers.unit.ts
@@ -1,0 +1,147 @@
+import type { RequestHandler } from '@builder.io/qwik-city';
+import { describe, expect, it, vi } from 'vitest';
+import { combineRequestHandlers } from './combine-request-handlers';
+
+describe('combineRequestHandlers', () => {
+  // Correct order
+  it('should execute code before and after next() in the correct order', async () => {
+    const executionOrder: string[] = [];
+
+    const handler1: RequestHandler = vi.fn(async (context) => {
+      executionOrder.push('pre1');
+      await context.next();
+      executionOrder.push('post1');
+    });
+    const handler2: RequestHandler = vi.fn(async (context) => {
+      executionOrder.push('pre2');
+      await context.next();
+      executionOrder.push('post2');
+    });
+    const handler3: RequestHandler = vi.fn(async (context) => {
+      executionOrder.push('pre3');
+      await context.next();
+      executionOrder.push('post3');
+    });
+
+    const next = vi.fn(async () => {
+      executionOrder.push('originalNext');
+    });
+    const context = { next } as any as Parameters<RequestHandler>[0];
+
+    const combined = combineRequestHandlers(handler1, handler2, handler3);
+    await combined(context);
+
+    expect(executionOrder).toEqual([
+      'pre1',
+      'pre2',
+      'pre3',
+      'originalNext',
+      'post3',
+      'post2',
+      'post1',
+    ]);
+  });
+
+  // No Handlers
+  it('should call original next when no handlers are provided', async () => {
+    const next = vi.fn();
+    const context = { next } as any as Parameters<RequestHandler>[0];
+
+    const combined = combineRequestHandlers();
+    await combined(context);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  // Single Handler
+  it('should handle a single handler correctly', async () => {
+    const handler: RequestHandler = vi.fn(async (context) => {
+      await context.next();
+    });
+
+    const next = vi.fn();
+    const context = { next } as any as Parameters<RequestHandler>[0];
+
+    const combined = combineRequestHandlers(handler);
+    await combined(context);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  // Handler Throws Error
+  it('should propagate errors from handlers', async () => {
+    const erroringHandler: RequestHandler = vi.fn(async () => {
+      throw new Error('Test error');
+    });
+
+    const next = vi.fn();
+    const context = { next } as any as Parameters<RequestHandler>[0];
+
+    const combined = combineRequestHandlers(erroringHandler);
+
+    await expect(combined(context)).rejects.toThrow('Test error');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // Handler Does Not Call `next()`
+  it('should not call subsequent handlers if a handler does not call next', async () => {
+    const handler1: RequestHandler = vi.fn(async () => {
+      /* not calling next */
+    });
+    const handler2: RequestHandler = vi.fn(async (context) => {
+      await context.next();
+    });
+
+    const next = vi.fn();
+    const context = { next } as any as Parameters<RequestHandler>[0];
+
+    const combined = combineRequestHandlers(handler1, handler2);
+    await combined(context);
+
+    expect(handler1).toHaveBeenCalledOnce();
+    expect(handler2).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // Asynchronous Handlers
+  it('should handle asynchronous handlers correctly', async () => {
+    const handler: RequestHandler = vi.fn(async (context) => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await context.next();
+    });
+
+    const next = vi.fn();
+    const context = { next } as any as Parameters<RequestHandler>[0];
+
+    const combined = combineRequestHandlers(handler);
+    await combined(context);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  // Context Modification
+  it('should pass modified context to subsequent handlers', async () => {
+    const handler1: RequestHandler = vi.fn(async (context) => {
+      context.sharedMap.set('modified', true);
+      await context.next();
+    });
+    const handler2: RequestHandler = vi.fn(async (context) => {
+      expect(context.sharedMap.get('modified')).toBe(true);
+      await context.next();
+    });
+
+    const next = vi.fn();
+    const context = {
+      next,
+      sharedMap: new Map(),
+    } as any as Parameters<RequestHandler>[0];
+
+    const combined = combineRequestHandlers(handler1, handler2);
+    await combined(context);
+
+    expect(handler1).toHaveBeenCalledOnce();
+    expect(handler2).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/qwik-city/runtime/src/index.ts
+++ b/packages/qwik-city/runtime/src/index.ts
@@ -51,6 +51,7 @@ export {
 } from './qwik-city-component';
 export { type LinkProps, Link } from './link-component';
 export { ServiceWorkerRegister } from './sw-component';
+export { combineRequestHandlers } from './combine-request-handlers';
 export { useDocumentHead, useLocation, useContent, useNavigate } from './use-functions';
 export { routeAction$, routeActionQrl } from './server-functions';
 export { globalAction$, globalActionQrl } from './server-functions';


### PR DESCRIPTION
# Overview

`combineRequestHandlers()` takes any number of `RequestHandler`s and combines them such that they will run in the correct order.

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

When making endpoints with Qwik City, I found myself writing several different middlewares, e.g. to create a database connection, to create a Stripe object, to instantiate a Slackbot, and I found it frustrating that you can only export a single `onRequest` value.

So I came up with a way to combine multiple `RequestHandler` functions whilst maintaining the order that they are called.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. If you have one middleware to connect to a database, and another to load the current user record, the latter depends on the former, so they must be called in order.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Added new tests to cover the fix / functionality
