### PR TITLE
fix: better deprecation notice on qwikevents

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -1362,7 +1362,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `AnimationEvent`\n> \n\n\n```typescript\nexport type NativeAnimationEvent = AnimationEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `AnimationEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeAnimationEvent = AnimationEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativeanimationevent.md"
     },
@@ -1376,7 +1376,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `ClipboardEvent`\n> \n\n\n```typescript\nexport type NativeClipboardEvent = ClipboardEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `ClipboardEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeClipboardEvent = ClipboardEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativeclipboardevent.md"
     },
@@ -1390,7 +1390,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `CompositionEvent`\n> \n\n\n```typescript\nexport type NativeCompositionEvent = CompositionEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `CompositionEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeCompositionEvent = CompositionEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativecompositionevent.md"
     },
@@ -1404,7 +1404,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `DragEvent`\n> \n\n\n```typescript\nexport type NativeDragEvent = DragEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `DragEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeDragEvent = DragEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativedragevent.md"
     },
@@ -1418,7 +1418,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `FocusEvent`\n> \n\n\n```typescript\nexport type NativeFocusEvent = FocusEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `FocusEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeFocusEvent = FocusEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativefocusevent.md"
     },
@@ -1432,7 +1432,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `KeyboardEvent`\n> \n\n\n```typescript\nexport type NativeKeyboardEvent = KeyboardEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `KeyboardEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeKeyboardEvent = KeyboardEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativekeyboardevent.md"
     },
@@ -1446,7 +1446,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `MouseEvent`\n> \n\n\n```typescript\nexport type NativeMouseEvent = MouseEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `MouseEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeMouseEvent = MouseEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativemouseevent.md"
     },
@@ -1460,7 +1460,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `PointerEvent`\n> \n\n\n```typescript\nexport type NativePointerEvent = PointerEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `PointerEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativePointerEvent = PointerEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativepointerevent.md"
     },
@@ -1474,7 +1474,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `TouchEvent`\n> \n\n\n```typescript\nexport type NativeTouchEvent = TouchEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `TouchEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeTouchEvent = TouchEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativetouchevent.md"
     },
@@ -1488,7 +1488,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `TransitionEvent`\n> \n\n\n```typescript\nexport type NativeTransitionEvent = TransitionEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `TransitionEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeTransitionEvent = TransitionEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativetransitionevent.md"
     },
@@ -1502,7 +1502,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `UIEvent`\n> \n\n\n```typescript\nexport type NativeUIEvent = UIEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `UIEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeUIEvent = UIEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativeuievent.md"
     },
@@ -1516,7 +1516,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `WheelEvent`\n> \n\n\n```typescript\nexport type NativeWheelEvent = WheelEvent;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `WheelEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type NativeWheelEvent = WheelEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.nativewheelevent.md"
     },
@@ -1810,7 +1810,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `AnimationEvent`\n> \n\n\n```typescript\nexport type QwikAnimationEvent<T = Element> = NativeAnimationEvent;\n```\n**References:** [NativeAnimationEvent](#nativeanimationevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `AnimationEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikAnimationEvent<T = Element> = NativeAnimationEvent;\n```\n**References:** [NativeAnimationEvent](#nativeanimationevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikanimationevent.md"
     },
@@ -1824,7 +1824,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `ChangeEvent`\n> \n\n\n```typescript\nexport type QwikChangeEvent<T = Element> = Event;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `Event` and use the second argument to the handler function for the current event target. Also note that in Qwik, onInput$ with the InputEvent is the event that behaves like onChange in React.\n> \n\n\n```typescript\nexport type QwikChangeEvent<T = Element> = Event;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikchangeevent.md"
     },
@@ -1838,7 +1838,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `ClipboardEvent`\n> \n\n\n```typescript\nexport type QwikClipboardEvent<T = Element> = NativeClipboardEvent;\n```\n**References:** [NativeClipboardEvent](#nativeclipboardevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `ClipboardEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikClipboardEvent<T = Element> = NativeClipboardEvent;\n```\n**References:** [NativeClipboardEvent](#nativeclipboardevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikclipboardevent.md"
     },
@@ -1852,7 +1852,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `CompositionEvent`\n> \n\n\n```typescript\nexport type QwikCompositionEvent<T = Element> = NativeCompositionEvent;\n```\n**References:** [NativeCompositionEvent](#nativecompositionevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `CompositionEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikCompositionEvent<T = Element> = NativeCompositionEvent;\n```\n**References:** [NativeCompositionEvent](#nativecompositionevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikcompositionevent.md"
     },
@@ -1880,7 +1880,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `DragEvent`\n> \n\n\n```typescript\nexport type QwikDragEvent<T = Element> = NativeDragEvent;\n```\n**References:** [NativeDragEvent](#nativedragevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `DragEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikDragEvent<T = Element> = NativeDragEvent;\n```\n**References:** [NativeDragEvent](#nativedragevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikdragevent.md"
     },
@@ -1894,7 +1894,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `FocusEvent`\n> \n\n\n```typescript\nexport type QwikFocusEvent<T = Element> = NativeFocusEvent;\n```\n**References:** [NativeFocusEvent](#nativefocusevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `FocusEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikFocusEvent<T = Element> = NativeFocusEvent;\n```\n**References:** [NativeFocusEvent](#nativefocusevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikfocusevent.md"
     },
@@ -1964,7 +1964,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `InvalidEvent`\n> \n\n\n```typescript\nexport type QwikInvalidEvent<T = Element> = Event;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `Event` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikInvalidEvent<T = Element> = Event;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikinvalidevent.md"
     },
@@ -1992,7 +1992,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `KeyboardEvent`\n> \n\n\n```typescript\nexport type QwikKeyboardEvent<T = Element> = NativeKeyboardEvent;\n```\n**References:** [NativeKeyboardEvent](#nativekeyboardevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `KeyboardEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikKeyboardEvent<T = Element> = NativeKeyboardEvent;\n```\n**References:** [NativeKeyboardEvent](#nativekeyboardevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikkeyboardevent.md"
     },
@@ -2006,7 +2006,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `MouseEvent`\n> \n\n\n```typescript\nexport type QwikMouseEvent<T = Element, E = NativeMouseEvent> = E;\n```\n**References:** [NativeMouseEvent](#nativemouseevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `MouseEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikMouseEvent<T = Element, E = NativeMouseEvent> = E;\n```\n**References:** [NativeMouseEvent](#nativemouseevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikmouseevent.md"
     },
@@ -2020,7 +2020,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `PointerEvent`\n> \n\n\n```typescript\nexport type QwikPointerEvent<T = Element> = NativePointerEvent;\n```\n**References:** [NativePointerEvent](#nativepointerevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `PointerEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikPointerEvent<T = Element> = NativePointerEvent;\n```\n**References:** [NativePointerEvent](#nativepointerevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikpointerevent.md"
     },
@@ -2034,7 +2034,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `SubmitEvent`\n> \n\n\n```typescript\nexport type QwikSubmitEvent<T = Element> = Event;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `SubmitEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikSubmitEvent<T = Element> = SubmitEvent;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwiksubmitevent.md"
     },
@@ -2076,7 +2076,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `TouchEvent`\n> \n\n\n```typescript\nexport type QwikTouchEvent<T = Element> = NativeTouchEvent;\n```\n**References:** [NativeTouchEvent](#nativetouchevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `TouchEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikTouchEvent<T = Element> = NativeTouchEvent;\n```\n**References:** [NativeTouchEvent](#nativetouchevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwiktouchevent.md"
     },
@@ -2090,7 +2090,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `TransitionEvent`\n> \n\n\n```typescript\nexport type QwikTransitionEvent<T = Element> = NativeTransitionEvent;\n```\n**References:** [NativeTransitionEvent](#nativetransitionevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `TransitionEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikTransitionEvent<T = Element> = NativeTransitionEvent;\n```\n**References:** [NativeTransitionEvent](#nativetransitionevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwiktransitionevent.md"
     },
@@ -2104,7 +2104,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `UIEvent`\n> \n\n\n```typescript\nexport type QwikUIEvent<T = Element> = NativeUIEvent;\n```\n**References:** [NativeUIEvent](#nativeuievent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `UIEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikUIEvent<T = Element> = NativeUIEvent;\n```\n**References:** [NativeUIEvent](#nativeuievent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikuievent.md"
     },
@@ -2132,7 +2132,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "> Warning: This API is now obsolete.\n> \n> Use `WheelEvent`\n> \n\n\n```typescript\nexport type QwikWheelEvent<T = Element> = NativeWheelEvent;\n```\n**References:** [NativeWheelEvent](#nativewheelevent)",
+      "content": "> Warning: This API is now obsolete.\n> \n> Use `WheelEvent` and use the second argument to the handler function for the current event target\n> \n\n\n```typescript\nexport type QwikWheelEvent<T = Element> = NativeWheelEvent;\n```\n**References:** [NativeWheelEvent](#nativewheelevent)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts",
       "mdFile": "qwik.qwikwheelevent.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -1381,7 +1381,7 @@ export interface MeterHTMLAttributes<T extends Element> extends Attrs<'meter', T
 
 > Warning: This API is now obsolete.
 >
-> Use `AnimationEvent`
+> Use `AnimationEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeAnimationEvent = AnimationEvent;
@@ -1393,7 +1393,7 @@ export type NativeAnimationEvent = AnimationEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `ClipboardEvent`
+> Use `ClipboardEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeClipboardEvent = ClipboardEvent;
@@ -1405,7 +1405,7 @@ export type NativeClipboardEvent = ClipboardEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `CompositionEvent`
+> Use `CompositionEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeCompositionEvent = CompositionEvent;
@@ -1417,7 +1417,7 @@ export type NativeCompositionEvent = CompositionEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `DragEvent`
+> Use `DragEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeDragEvent = DragEvent;
@@ -1429,7 +1429,7 @@ export type NativeDragEvent = DragEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `FocusEvent`
+> Use `FocusEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeFocusEvent = FocusEvent;
@@ -1441,7 +1441,7 @@ export type NativeFocusEvent = FocusEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `KeyboardEvent`
+> Use `KeyboardEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeKeyboardEvent = KeyboardEvent;
@@ -1453,7 +1453,7 @@ export type NativeKeyboardEvent = KeyboardEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `MouseEvent`
+> Use `MouseEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeMouseEvent = MouseEvent;
@@ -1465,7 +1465,7 @@ export type NativeMouseEvent = MouseEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `PointerEvent`
+> Use `PointerEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativePointerEvent = PointerEvent;
@@ -1477,7 +1477,7 @@ export type NativePointerEvent = PointerEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `TouchEvent`
+> Use `TouchEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeTouchEvent = TouchEvent;
@@ -1489,7 +1489,7 @@ export type NativeTouchEvent = TouchEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `TransitionEvent`
+> Use `TransitionEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeTransitionEvent = TransitionEvent;
@@ -1501,7 +1501,7 @@ export type NativeTransitionEvent = TransitionEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `UIEvent`
+> Use `UIEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeUIEvent = UIEvent;
@@ -1513,7 +1513,7 @@ export type NativeUIEvent = UIEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `WheelEvent`
+> Use `WheelEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type NativeWheelEvent = WheelEvent;
@@ -1783,7 +1783,7 @@ export interface QuoteHTMLAttributes<T extends Element> extends Attrs<'q', T>
 
 > Warning: This API is now obsolete.
 >
-> Use `AnimationEvent`
+> Use `AnimationEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikAnimationEvent<T = Element> = NativeAnimationEvent;
@@ -1797,7 +1797,7 @@ export type QwikAnimationEvent<T = Element> = NativeAnimationEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `ChangeEvent`
+> Use `Event` and use the second argument to the handler function for the current event target. Also note that in Qwik, onInput$ with the InputEvent is the event that behaves like onChange in React.
 
 ```typescript
 export type QwikChangeEvent<T = Element> = Event;
@@ -1809,7 +1809,7 @@ export type QwikChangeEvent<T = Element> = Event;
 
 > Warning: This API is now obsolete.
 >
-> Use `ClipboardEvent`
+> Use `ClipboardEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikClipboardEvent<T = Element> = NativeClipboardEvent;
@@ -1823,7 +1823,7 @@ export type QwikClipboardEvent<T = Element> = NativeClipboardEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `CompositionEvent`
+> Use `CompositionEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikCompositionEvent<T = Element> = NativeCompositionEvent;
@@ -1847,7 +1847,7 @@ export interface QwikDOMAttributes extends DOMAttributes<Element>
 
 > Warning: This API is now obsolete.
 >
-> Use `DragEvent`
+> Use `DragEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikDragEvent<T = Element> = NativeDragEvent;
@@ -1861,7 +1861,7 @@ export type QwikDragEvent<T = Element> = NativeDragEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `FocusEvent`
+> Use `FocusEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikFocusEvent<T = Element> = NativeFocusEvent;
@@ -1947,7 +1947,7 @@ export interface QwikIntrinsicElements extends QwikHTMLElements, QwikSVGElements
 
 > Warning: This API is now obsolete.
 >
-> Use `InvalidEvent`
+> Use `Event` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikInvalidEvent<T = Element> = Event;
@@ -1978,7 +1978,7 @@ export declare namespace QwikJSX
 
 > Warning: This API is now obsolete.
 >
-> Use `KeyboardEvent`
+> Use `KeyboardEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikKeyboardEvent<T = Element> = NativeKeyboardEvent;
@@ -1992,7 +1992,7 @@ export type QwikKeyboardEvent<T = Element> = NativeKeyboardEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `MouseEvent`
+> Use `MouseEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikMouseEvent<T = Element, E = NativeMouseEvent> = E;
@@ -2006,7 +2006,7 @@ export type QwikMouseEvent<T = Element, E = NativeMouseEvent> = E;
 
 > Warning: This API is now obsolete.
 >
-> Use `PointerEvent`
+> Use `PointerEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikPointerEvent<T = Element> = NativePointerEvent;
@@ -2020,10 +2020,10 @@ export type QwikPointerEvent<T = Element> = NativePointerEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `SubmitEvent`
+> Use `SubmitEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
-export type QwikSubmitEvent<T = Element> = Event;
+export type QwikSubmitEvent<T = Element> = SubmitEvent;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts)
@@ -2063,7 +2063,7 @@ export type QwikSymbolEvent = CustomEvent<{
 
 > Warning: This API is now obsolete.
 >
-> Use `TouchEvent`
+> Use `TouchEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikTouchEvent<T = Element> = NativeTouchEvent;
@@ -2077,7 +2077,7 @@ export type QwikTouchEvent<T = Element> = NativeTouchEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `TransitionEvent`
+> Use `TransitionEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikTransitionEvent<T = Element> = NativeTransitionEvent;
@@ -2091,7 +2091,7 @@ export type QwikTransitionEvent<T = Element> = NativeTransitionEvent;
 
 > Warning: This API is now obsolete.
 >
-> Use `UIEvent`
+> Use `UIEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikUIEvent<T = Element> = NativeUIEvent;
@@ -2115,7 +2115,7 @@ export type QwikVisibleEvent = CustomEvent<IntersectionObserverEntry>;
 
 > Warning: This API is now obsolete.
 >
-> Use `WheelEvent`
+> Use `WheelEvent` and use the second argument to the handler function for the current event target
 
 ```typescript
 export type QwikWheelEvent<T = Element> = NativeWheelEvent;

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -715,7 +715,7 @@ export type QwikMouseEvent<T = Element, E = NativeMouseEvent> = E;
 export type QwikPointerEvent<T = Element> = NativePointerEvent;
 
 // @public @deprecated (undocumented)
-export type QwikSubmitEvent<T = Element> = Event;
+export type QwikSubmitEvent<T = Element> = SubmitEvent;
 
 // @public
 export type QwikSVGElements = {

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts
@@ -52,57 +52,57 @@ export type KnownEventNames = LiteralUnion<AllEventKeys, string>;
 
 // Deprecated old types
 export type SyntheticEvent<T = Element, E = Event> = E & { target: EventTarget & T };
-/** @public @deprecated Use `AnimationEvent` */
+/** @public @deprecated Use `AnimationEvent` and use the second argument to the handler function for the current event target */
 export type NativeAnimationEvent = AnimationEvent;
-/** @public @deprecated Use `ClipboardEvent` */
+/** @public @deprecated Use `ClipboardEvent` and use the second argument to the handler function for the current event target */
 export type NativeClipboardEvent = ClipboardEvent;
-/** @public @deprecated Use `CompositionEvent` */
+/** @public @deprecated Use `CompositionEvent` and use the second argument to the handler function for the current event target */
 export type NativeCompositionEvent = CompositionEvent;
-/** @public @deprecated Use `DragEvent` */
+/** @public @deprecated Use `DragEvent` and use the second argument to the handler function for the current event target */
 export type NativeDragEvent = DragEvent;
-/** @public @deprecated Use `FocusEvent` */
+/** @public @deprecated Use `FocusEvent` and use the second argument to the handler function for the current event target */
 export type NativeFocusEvent = FocusEvent;
-/** @public @deprecated Use `KeyboardEvent` */
+/** @public @deprecated Use `KeyboardEvent` and use the second argument to the handler function for the current event target */
 export type NativeKeyboardEvent = KeyboardEvent;
-/** @public @deprecated Use `MouseEvent` */
+/** @public @deprecated Use `MouseEvent` and use the second argument to the handler function for the current event target */
 export type NativeMouseEvent = MouseEvent;
-/** @public @deprecated Use `TouchEvent` */
+/** @public @deprecated Use `TouchEvent` and use the second argument to the handler function for the current event target */
 export type NativeTouchEvent = TouchEvent;
-/** @public @deprecated Use `PointerEvent` */
+/** @public @deprecated Use `PointerEvent` and use the second argument to the handler function for the current event target */
 export type NativePointerEvent = PointerEvent;
-/** @public @deprecated Use `TransitionEvent` */
+/** @public @deprecated Use `TransitionEvent` and use the second argument to the handler function for the current event target */
 export type NativeTransitionEvent = TransitionEvent;
-/** @public @deprecated Use `UIEvent` */
+/** @public @deprecated Use `UIEvent` and use the second argument to the handler function for the current event target */
 export type NativeUIEvent = UIEvent;
-/** @public @deprecated Use `WheelEvent` */
+/** @public @deprecated Use `WheelEvent` and use the second argument to the handler function for the current event target */
 export type NativeWheelEvent = WheelEvent;
-/** @public @deprecated Use `AnimationEvent` */
+/** @public @deprecated Use `AnimationEvent` and use the second argument to the handler function for the current event target */
 export type QwikAnimationEvent<T = Element> = NativeAnimationEvent;
-/** @public @deprecated Use `ClipboardEvent` */
+/** @public @deprecated Use `ClipboardEvent` and use the second argument to the handler function for the current event target */
 export type QwikClipboardEvent<T = Element> = NativeClipboardEvent;
-/** @public @deprecated Use `CompositionEvent` */
+/** @public @deprecated Use `CompositionEvent` and use the second argument to the handler function for the current event target */
 export type QwikCompositionEvent<T = Element> = NativeCompositionEvent;
-/** @public @deprecated Use `DragEvent` */
+/** @public @deprecated Use `DragEvent` and use the second argument to the handler function for the current event target */
 export type QwikDragEvent<T = Element> = NativeDragEvent;
-/** @public @deprecated Use `PointerEvent` */
+/** @public @deprecated Use `PointerEvent` and use the second argument to the handler function for the current event target */
 export type QwikPointerEvent<T = Element> = NativePointerEvent;
-/** @public @deprecated Use `FocusEvent` */
+/** @public @deprecated Use `FocusEvent` and use the second argument to the handler function for the current event target */
 export type QwikFocusEvent<T = Element> = NativeFocusEvent;
-/** @public @deprecated Use `SubmitEvent` */
-export type QwikSubmitEvent<T = Element> = Event;
-/** @public @deprecated Use `InvalidEvent` */
+/** @public @deprecated Use `SubmitEvent` and use the second argument to the handler function for the current event target */
+export type QwikSubmitEvent<T = Element> = SubmitEvent;
+/** @public @deprecated Use `Event` and use the second argument to the handler function for the current event target */
 export type QwikInvalidEvent<T = Element> = Event;
-/** @public @deprecated Use `ChangeEvent` */
+/** @public @deprecated Use `Event` and use the second argument to the handler function for the current event target. Also note that in Qwik, onInput$ with the InputEvent is the event that behaves like onChange in React. */
 export type QwikChangeEvent<T = Element> = Event;
-/** @public @deprecated Use `KeyboardEvent` */
+/** @public @deprecated Use `KeyboardEvent` and use the second argument to the handler function for the current event target */
 export type QwikKeyboardEvent<T = Element> = NativeKeyboardEvent;
-/** @public @deprecated Use `MouseEvent` */
+/** @public @deprecated Use `MouseEvent` and use the second argument to the handler function for the current event target */
 export type QwikMouseEvent<T = Element, E = NativeMouseEvent> = E;
-/** @public @deprecated Use `TouchEvent` */
+/** @public @deprecated Use `TouchEvent` and use the second argument to the handler function for the current event target */
 export type QwikTouchEvent<T = Element> = NativeTouchEvent;
-/** @public @deprecated Use `UIEvent` */
+/** @public @deprecated Use `UIEvent` and use the second argument to the handler function for the current event target */
 export type QwikUIEvent<T = Element> = NativeUIEvent;
-/** @public @deprecated Use `WheelEvent` */
+/** @public @deprecated Use `WheelEvent` and use the second argument to the handler function for the current event target */
 export type QwikWheelEvent<T = Element> = NativeWheelEvent;
-/** @public @deprecated Use `TransitionEvent` */
+/** @public @deprecated Use `TransitionEvent` and use the second argument to the handler function for the current event target */
 export type QwikTransitionEvent<T = Element> = NativeTransitionEvent;


### PR DESCRIPTION
Not all replacement events were correct. Also, the event.target is the starting target and not the current target, so the old events had incorrect types on the target when bubbling.
