### PR TITLE
chore(eslint-plugin-qwik): add 'qwik/no-use-visible-task': 'warn' to strict

### DIFF
--- a/packages/eslint-plugin-qwik/index.ts
+++ b/packages/eslint-plugin-qwik/index.ts
@@ -54,6 +54,7 @@ export const configs = {
       'qwik/unused-server': 'error',
       'qwik/jsx-img': 'error',
       'qwik/jsx-a': 'error',
+      'qwik/no-use-visible-task': 'warn',
     },
   },
 };


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

If it's in 'recommended' I think it should be in 'strict'. We shouldn't make it 'error' though, since visible tasks have valid use cases.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
