### PR TITLE
refactor(qwik): add `__qwik_serializable__` brand to types

### DIFF
--- a/packages/eslint-plugin-qwik/tests/valid-lexical-scope/valid-component-prop-function.tsx
+++ b/packages/eslint-plugin-qwik/tests/valid-lexical-scope/valid-component-prop-function.tsx
@@ -1,0 +1,11 @@
+import { component$, type PropFunction } from '@builder.io/qwik';
+
+export default component$<{ onClick$: PropFunction<() => void> }>(({ onClick$ }) => {
+  return (
+    <button
+      onClick$={() => {
+        onClick$();
+      }}
+    />
+  );
+});

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -614,6 +614,7 @@ export type PublicProps<PROPS extends Record<any, any>> = TransformProps<PROPS> 
 //
 // @public
 export type QRL<TYPE = unknown> = {
+    __qwik_serializable__: any;
     __brand__QRL__: TYPE;
     resolve(): Promise<TYPE>;
     resolved: undefined | TYPE;

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -134,6 +134,8 @@ export type QrlReturn<T> = T extends (...args: any) => infer R ? Awaited<R> : un
  */
 // </docs>
 export type QRL<TYPE = unknown> = {
+  // Special type brand to let eslint that the Type is serializable
+  __qwik_serializable__: [TYPE];
   __brand__QRL__: TYPE;
 
   /** Resolve the QRL and return the actual value. */
@@ -159,9 +161,11 @@ type BivariantQrlFn<ARGS extends any[], RETURN> = {
 }['bivarianceHack'];
 
 /** @public */
-export type PropFnInterface<ARGS extends any[], RET> = {
+export declare interface PropFnInterface<ARGS extends any[], RET> {
+  // Special type brand to let eslint that the Type is serializable
+  __qwik_serializable__: [ARGS, RET];
   (...args: ARGS): Promise<RET>;
-};
+}
 
 let runtimeSymbolId = 0;
 

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -135,7 +135,7 @@ export type QrlReturn<T> = T extends (...args: any) => infer R ? Awaited<R> : un
 // </docs>
 export type QRL<TYPE = unknown> = {
   // Special type brand to let eslint that the Type is serializable
-  __qwik_serializable__: [TYPE];
+  __qwik_serializable__: any;
   __brand__QRL__: TYPE;
 
   /** Resolve the QRL and return the actual value. */
@@ -161,11 +161,9 @@ type BivariantQrlFn<ARGS extends any[], RETURN> = {
 }['bivarianceHack'];
 
 /** @public */
-export declare interface PropFnInterface<ARGS extends any[], RET> {
-  // Special type brand to let eslint that the Type is serializable
-  __qwik_serializable__: [ARGS, RET];
+export type PropFnInterface<ARGS extends any[], RET> = {
   (...args: ARGS): Promise<RET>;
-}
+};
 
 let runtimeSymbolId = 0;
 

--- a/packages/qwik/src/core/render/jsx/types/jsx-node.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-node.ts
@@ -2,7 +2,6 @@ import type { JSXChildren } from './jsx-qwik-attributes';
 
 /** @public */
 export interface FunctionComponent<P extends Record<any, any> = Record<any, unknown>> {
-  __qwik_serializable__: [P];
   (props: P, key: string | null, flags: number, dev?: DevJSX): JSXNode | null;
 }
 /** @public */

--- a/packages/qwik/src/core/render/jsx/types/jsx-node.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-node.ts
@@ -2,6 +2,7 @@ import type { JSXChildren } from './jsx-qwik-attributes';
 
 /** @public */
 export interface FunctionComponent<P extends Record<any, any> = Record<any, unknown>> {
+  __qwik_serializable__: [P];
   (props: P, key: string | null, flags: number, dev?: DevJSX): JSXNode | null;
 }
 /** @public */


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
