### PR TITLE
fix: `server$` and AbortSignal types

### DIFF
--- a/packages/qwik-city/runtime/src/server-functions.unit.ts
+++ b/packages/qwik-city/runtime/src/server-functions.unit.ts
@@ -12,6 +12,15 @@ describe('types', () => {
     expectTypeOf(foo).returns.not.toMatchTypeOf<(meep: boolean) => Promise<string>>();
   });
 
+  test('matching with args', () => () => {
+    const foo = () => server$((name: string) => 'hello ' + name);
+
+    expectTypeOf(foo).not.toBeAny();
+    expectTypeOf(foo).returns.toMatchTypeOf<(name: string) => Promise<string>>();
+    expectTypeOf(foo).returns.toMatchTypeOf<(sig: AbortSignal, name: string) => Promise<string>>();
+    expectTypeOf(foo).returns.not.toMatchTypeOf<(meep: boolean) => Promise<string>>();
+  });
+
   test('inferring', () => () => {
     const callIt = () =>
       server$(function () {

--- a/packages/qwik-city/runtime/src/types.ts
+++ b/packages/qwik-city/runtime/src/types.ts
@@ -796,5 +796,6 @@ export type ServerFunction = {
  * abort the fetch when fired.
  */
 export type ServerQRL<T extends ServerFunction> = QRL<
-  (...args: [abort: AbortSignal, ...Parameters<T>] | Parameters<T>) => ReturnType<T>
+  | ((abort: AbortSignal, ...args: Parameters<T>) => ReturnType<T>)
+  | ((...args: Parameters<T>) => ReturnType<T>)
 >;

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -609,21 +609,18 @@ export type PropsOf<COMP> = COMP extends Component<infer PROPS> ? NonNullable<PR
 // @public
 export type PublicProps<PROPS extends Record<any, any>> = TransformProps<PROPS> & ComponentBaseProps & ComponentChildren<PROPS>;
 
-// Warning: (ae-forgotten-export) The symbol "BivariantQrlFn" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "QrlArgs" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "QrlReturn" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type QRL<TYPE = unknown> = {
     __qwik_serializable__?: any;
     __brand__QRL__: TYPE;
+    (...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never): Promise<TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never>;
     resolve(): Promise<TYPE>;
     resolved: undefined | TYPE;
     getCaptured(): unknown[] | null;
     getSymbol(): string;
     getHash(): string;
     dev: QRLDev | null;
-} & BivariantQrlFn<QrlArgs<TYPE>, QrlReturn<TYPE>>;
+};
 
 // @public
 export const qrl: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: string, lexicalScopeCapture?: any[], stackOffset?: number) => QRL<T>;

--- a/packages/qwik/src/core/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/qrl/qrl-class.ts
@@ -73,7 +73,7 @@ export const createQRL = <TYPE>(
     const fn = invokeFn.call(this, tryGetInvokeContext());
     const result = await fn(...args);
     return result;
-  } as QRLInternal<TYPE>;
+  } as any as QRLInternal<TYPE>;
 
   const setContainer = (el: Element | undefined) => {
     if (!_containerEl) {

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -138,6 +138,16 @@ export type QRL<TYPE = unknown> = {
   __qwik_serializable__?: any;
   __brand__QRL__: TYPE;
 
+  /**
+   * Resolve the QRL of closure and invoke it.
+   *
+   * @param args - Closure arguments.
+   * @returns A promise of the return value of the closure.
+   */
+  (
+    ...args: TYPE extends (...args: infer ARGS) => any ? ARGS : never
+  ): Promise<TYPE extends (...args: any[]) => infer RETURN ? Awaited<RETURN> : never>;
+
   /** Resolve the QRL and return the actual value. */
   resolve(): Promise<TYPE>;
   /** The resolved value, once `resolve()` returns. */
@@ -147,18 +157,7 @@ export type QRL<TYPE = unknown> = {
   getSymbol(): string;
   getHash(): string;
   dev: QRLDev | null;
-} & BivariantQrlFn<QrlArgs<TYPE>, QrlReturn<TYPE>>;
-
-// https://stackoverflow.com/questions/52667959/what-is-the-purpose-of-bivariancehack-in-typescript-types/52668133#52668133
-type BivariantQrlFn<ARGS extends any[], RETURN> = {
-  /**
-   * Resolve the QRL of closure and invoke it.
-   *
-   * @param args - Closure arguments.
-   * @returns A promise of the return value of the closure.
-   */
-  bivarianceHack(...args: ARGS): Promise<RETURN>;
-}['bivarianceHack'];
+};
 
 /** @public */
 export type PropFnInterface<ARGS extends any[], RET> = {


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
