### PR TITLE
docs(usevisibletask$): reduce eslint noUseVisibleTask message + transfer to docs

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
@@ -26,7 +26,8 @@ contributors:
   - mrhoodz
   - eecopa
   - drumnistnakano
-updated_at: '2023-10-03T18:53:59Z'
+  - maiieul
+updated_at: '2023-12-14T18:38:38Z'
 created_at: '2023-03-20T23:45:13Z'
 ---
 
@@ -393,9 +394,9 @@ bundled with the parent component.
 
 ### Events
 
-- [`useOn()`](../events/index.mdx) - appends a listener to the current component programmatically
-- [`useOnWindow()`](../events/index.mdx) - appends a listener to the window object programmatically
-- [`useOnDocument()`](../events/index.mdx) - appends a listener to the document object programmatically
+- [`useOn()`](../events/index.mdx#useonwindowdocument-hook) - appends a listener to the current component programmatically
+- [`useOnWindow()`](../events/index.mdx#useonwindowdocument-hook) - appends a listener to the window object programmatically
+- [`useOnDocument()`](../events/index.mdx#useonwindowdocument-hook) - appends a listener to the document object programmatically
 
 ### Tasks/Lifecycle
 

--- a/packages/docs/src/routes/docs/(qwikcity)/guides/best-practices/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/best-practices/index.mdx
@@ -19,7 +19,8 @@ contributors:
   - anartzdev
   - adamdbradley
   - hamatoyogi
-updated_at: '2023-07-05T18:56:52Z'
+  - maiieul
+updated_at: '2023-12-14T18:38:38Z'
 created_at: '2023-03-30T17:37:51Z'
 ---
 
@@ -62,7 +63,21 @@ export default component$(() => {
 });
 ```
 
-## Avoid registering DOM events in `useVisibleTask$()`
+## Use `useVisibleTask$()` as a last resort
+
+Although convenient, `useVisibleTask$()` runs code eagerly and blocks the main thread. This prevents the user from interacting until the task is finished. By consequence, it is best to not think about it as the main client-side task API, but as an escape hatch.
+
+When in doubt, instead of "useVisibleTask$()" use:
+- `useTask$` -> perform code execution in SSR mode.
+- `useOn()` -> listen to events on the root element of `the current component`.
+- `useOnWindow()` -> listen to events on the `window` object.
+- `useOnDocument()` -> listen to events on the `document` object.
+
+Sometimes though, it is the only way to achieve the result.
+
+In that case, you can add `// eslint-disable-next-line qwik/no-use-visible-task` to the line before "useVisibleTask$" to remove the warning.
+
+### Register DOM events with `useOn()`, `useOnWindow()`, or `useOnDocument()`
 
 Qwik allows to register event listeners in a declarative way, using the `useOn()` or using JSX.
 
@@ -97,12 +112,6 @@ useOnDocument(
   })
 );
 ```
-
-When in doubt, instead of `useVisibleTask$()` use:
-- `useOn()`: listen to events on the root element of `the current component`.
-- `useOnWindow()`: listen to events on the `window` object.
-- `useOnDocument()`: listen to events on the `document` object.
-
 
 ## Avoid accessing the location from the `window` object
 

--- a/packages/docs/src/routes/docs/(qwikcity)/guides/best-practices/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/best-practices/index.mdx
@@ -65,10 +65,10 @@ export default component$(() => {
 
 ## Use `useVisibleTask$()` as a last resort
 
-Although convenient, `useVisibleTask$()` runs code eagerly and blocks the main thread. This prevents the user from interacting until the task is finished. By consequence, it is best to not think about it as the main client-side task API, but as an escape hatch.
+Although convenient, `useVisibleTask$()` runs code eagerly and blocks the main thread, preventing user interaction until the task is finished. You can think of it as an escape hatch.
 
 When in doubt, instead of "useVisibleTask$()" use:
-- `useTask$` -> perform code execution in SSR mode.
+- `useTask$()` -> perform code execution in SSR mode.
 - `useOn()` -> listen to events on the root element of `the current component`.
 - `useOnWindow()` -> listen to events on the `window` object.
 - `useOnDocument()` -> listen to events on the `document` object.
@@ -81,7 +81,7 @@ In that case, you can add `// eslint-disable-next-line qwik/no-use-visible-task`
 
 Qwik allows to register event listeners in a declarative way, using the `useOn()` or using JSX.
 
-When using `useVisibleTask` to programmatically register events, we are downloading and executing JavaScript eagerly, even if the event is not triggered.
+When using `useVisibleTask$()` to programmatically register events, we are downloading and executing JavaScript eagerly, even if the event is not triggered.
 
 ```tsx title="Suboptimal implementation"
 // Don't do this!

--- a/packages/eslint-plugin-qwik/src/noUseVisibleTask.ts
+++ b/packages/eslint-plugin-qwik/src/noUseVisibleTask.ts
@@ -9,8 +9,7 @@ export const noUseVisibleTask: Rule.RuleModule = {
       url: 'https://qwik.builder.io/docs/guides/best-practices/#use-usevisibletask-as-a-last-resort',
     },
     messages: {
-      noUseVisibleTask:
-        'useVisibleTask$ runs eagerly and blocks the main thread. It should be used as a last resort.',
+      noUseVisibleTask: `useVisibleTask$() runs eagerly and blocks the main thread, preventing user interaction until the task is finished. Consider using useTask$(), useOn(), useOnDocument(), or useOnWindow() instead. If you have to use a useVisibleTask$(), you can disable the warning with a '// eslint-disable-next-line qwik/no-use-visible-task' comment.`,
     },
   },
   create(context) {

--- a/packages/eslint-plugin-qwik/src/noUseVisibleTask.ts
+++ b/packages/eslint-plugin-qwik/src/noUseVisibleTask.ts
@@ -6,25 +6,11 @@ export const noUseVisibleTask: Rule.RuleModule = {
     docs: {
       description: 'Detect useVisibleTask$() functions.',
       recommended: true,
-      url: 'https://qwik.builder.io/docs/guides/best-practices/#avoid-registering-dom-events-in-usevisibletask',
+      url: 'https://qwik.builder.io/docs/guides/best-practices/#use-usevisibletask-as-a-last-resort',
     },
     messages: {
-      noUseVisibleTask: `Qwik tries very hard to defer client code execution for as long as possible.
-This is done to give the end-user the best possible user experience.
-Running code eagerly blocks the main thread, which prevents the user from interacting until the task is finished.
-"useVisibleTask$" is provided as an escape hatch.
-
-When in doubt, instead of "useVisibleTask$()" use:
-- useTask$ -> perform code execution in SSR mode.
-- useOn() -> listen to events on the root element of the current component.
-- useOnWindow() -> listen to events on the window object.
-- useOnDocument() -> listen to events on the document object.
-
-Sometimes it is the only way to achieve the result.
-In that case, add:
-// eslint-disable-next-line qwik/no-use-visible-task
-to the line before "useVisibleTask$" to acknowledge you understand.
-`,
+      noUseVisibleTask:
+        'useVisibleTask$ runs eagerly and blocks the main thread. It should be used as a last resort.',
     },
   },
   create(context) {


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Reduced the eslint warning message for noUseVisibleTask as this warning can add up a lot of noise when it comes many times at once (especially codebases that are transitioning to 1.3).

Most other warnings are rather small, so I made it consistent with the other warnings.

I added the corresponding documentation. On their IDE, users can click on the qwik/no-use-visible-task link when hovering the warning. On the console, the warning redirects to where this happens in the IDE.

I believe this would result in less frustration, especially since useVisibleTask$ is sometimes unavoidable.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
