### PR TITLE
fix(qwik-city): Scroll Position doesn't reset to 0 when it was triggered by an Action.

### DIFF
--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -300,9 +300,13 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
           }
 
           if (
-            navigation.scroll &&
-            (!navigation.forceReload || !isSamePath(trackUrl, prevUrl)) &&
-            (navType === 'link' || navType === 'popstate')
+            (
+              navigation.scroll &&
+              (!navigation.forceReload || !isSamePath(trackUrl, prevUrl)) &&
+              (navType === 'link' || navType === 'popstate')
+            ) ||
+            // Action might have responded with a redirect.
+            (navType === 'form' && !isSamePath(trackUrl, prevUrl))
           ) {
             // Mark next DOM render to scroll.
             document.__q_scroll_restore__ = () =>

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -300,11 +300,9 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
           }
 
           if (
-            (
-              navigation.scroll &&
+            (navigation.scroll &&
               (!navigation.forceReload || !isSamePath(trackUrl, prevUrl)) &&
-              (navType === 'link' || navType === 'popstate')
-            ) ||
+              (navType === 'link' || navType === 'popstate')) ||
             // Action might have responded with a redirect.
             (navType === 'form' && !isSamePath(trackUrl, prevUrl))
           ) {

--- a/packages/qwik-city/runtime/src/scroll-restoration.ts
+++ b/packages/qwik-city/runtime/src/scroll-restoration.ts
@@ -9,7 +9,7 @@ export const restoreScroll = (
 ) => {
   if (type === 'popstate' && scrollState) {
     window.scrollTo(scrollState.x, scrollState.y);
-  } else if (type === 'link') {
+  } else if (type === 'link' || type === 'form') {
     if (!hashScroll(toUrl, fromUrl)) {
       window.scrollTo(0, 0);
     }


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Fixes: https://github.com/BuilderIO/qwik/issues/5537

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Restore the scroll position to 0 if the navigation caused by an action (navType=from) and the URL has changed, that means action triggered a redirect.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
