### PR TITLE
fix: Bun integration env.get is undefined

### DIFF
--- a/packages/qwik-city/middleware/bun/index.ts
+++ b/packages/qwik-city/middleware/bun/index.ts
@@ -75,7 +75,11 @@ export function createQwikCity(opts: QwikCityBunOptions) {
         mode: 'server',
         locale: undefined,
         url,
-        env: Bun.env,
+        env: {
+          get(key) {
+            return Bun.env[key];
+          },
+        },
         request,
         getWritableStream: (status, headers, cookies, resolve) => {
           const { readable, writable } = new TransformStream<Uint8Array>();


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Fixes this error when using `req.env` with Bun (e.g. for qwik-auth):

```
TypeError: req.env.get is not a function. (In 'req.env.get("AUTH_SECRET")', 'req.env.get' is undefined)
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
