### PR TITLE
fix(ssr): slot subscribers

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -2160,7 +2160,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type ReadonlySignal<T = any> = Readonly<Signal<T>>;\n```\n**References:** [Signal](#signal)",
+      "content": "```typescript\nexport type ReadonlySignal<T = unknown> = Readonly<Signal<T>>;\n```\n**References:** [Signal](#signal)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/state/signal.ts",
       "mdFile": "qwik.readonlysignal.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -2144,7 +2144,7 @@ export type QwikWheelEvent<T = Element> = NativeWheelEvent;
 ## ReadonlySignal
 
 ```typescript
-export type ReadonlySignal<T = any> = Readonly<Signal<T>>;
+export type ReadonlySignal<T = unknown> = Readonly<Signal<T>>;
 ```
 
 **References:** [Signal](#signal)

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -578,7 +578,7 @@ export interface ParamHTMLAttributes<T extends Element> extends Attrs<'base', T,
 // Warning: (ae-forgotten-export) The symbol "ContainerState" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "GetObjID" needs to be exported by the entry point index.d.ts
 //
-// @internal (undocumented)
+// @internal
 export const _pauseFromContexts: (allContexts: QContext[], containerState: ContainerState, fallbackGetObjId?: GetObjID, textNodes?: Map<string, string>) => Promise<SnapshotResult>;
 
 // @public (undocumented)
@@ -751,7 +751,7 @@ export type QwikVisibleEvent = CustomEvent<IntersectionObserverEntry>;
 export type QwikWheelEvent<T = Element> = NativeWheelEvent;
 
 // @public (undocumented)
-export type ReadonlySignal<T = any> = Readonly<Signal<T>>;
+export type ReadonlySignal<T = unknown> = Readonly<Signal<T>>;
 
 // @internal (undocumented)
 export const _regSymbol: (symbol: any, hash: string) => any;

--- a/packages/qwik/src/core/container/pause.ts
+++ b/packages/qwik/src/core/container/pause.ts
@@ -37,6 +37,7 @@ import {
   isConnected,
   serializeSubscription,
   type Subscriptions,
+  type SubscriberSignal,
 } from '../state/common';
 import { QObjectImmutable, QObjectRecursive } from '../state/constants';
 import { HOST_FLAG_DYNAMIC, tryGetContext, type QContext } from '../state/context';
@@ -137,6 +138,7 @@ export const _serializeData = async (data: any, pureQRL?: boolean) => {
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!
 // (edit ../readme.md#pauseContainer instead)
 // </docs>
+/** This pauses a running container in the browser. It is not used for SSR */
 export const pauseContainer = async (
   elmOrDoc: Element | Document,
   defaultParentJSON?: Element
@@ -202,7 +204,11 @@ export const pauseContainer = async (
   return data;
 };
 
-/** @internal */
+/**
+ * Grab all state needed to resume the container later.
+ *
+ * @internal
+ */
 export const _pauseFromContexts = async (
   allContexts: QContext[],
   containerState: ContainerState,
@@ -215,6 +221,7 @@ export const _pauseFromContexts = async (
   });
   let hasListeners = false;
 
+  // Collect resources
   // TODO: optimize
   for (const ctx of allContexts) {
     if (ctx.$tasks$) {
@@ -239,6 +246,8 @@ Task Symbol: ${task.$qrl$.$symbol$}
     }
   }
 
+  // Find all listeners. They are the "entries" for resuming the container.
+  // Any lexical scope they reference must be serialized.
   for (const ctx of allContexts) {
     const el = ctx.$element$;
     const ctxListeners = ctx.li;
@@ -248,10 +257,15 @@ Task Symbol: ${task.$qrl$.$symbol$}
         const captured = qrl.$captureRef$;
         if (captured) {
           for (const obj of captured) {
+            /**
+             * Collect the lexical scope used by the listener. This also collects all the
+             * subscribers of any reactive state in scope, since the listener might change that
+             * state
+             */
             collectValue(obj, collector, true);
           }
         }
-        collector.$qrls$.push(qrl as QRL);
+        collector.$qrls$.push(qrl);
         hasListeners = true;
       }
     }
@@ -595,9 +609,11 @@ export interface Collector {
   $promises$: Promise<any>[];
 }
 
+// Collect props proxy objects
 const collectProps = (elCtx: QContext, collector: Collector) => {
-  const parentCtx = elCtx.$parentCtx$;
+  const parentCtx = elCtx.$realParentCtx$ || elCtx.$parentCtx$;
   const props = elCtx.$props$;
+  // Collect only if the parent (which changes the props) is part of the listener graph
   if (parentCtx && props && !isEmptyObj(props) && collector.$elements$.includes(parentCtx)) {
     const subs = getSubscriptionManager(props)?.$subs$;
     const el = elCtx.$element$ as VirtualElement;
@@ -650,13 +666,13 @@ const collectDeferElement = (el: VirtualElement, collector: Collector) => {
     return;
   }
   collector.$elements$.push(ctx);
-  collector.$prefetch$++;
   if (ctx.$flags$ & HOST_FLAG_DYNAMIC) {
+    collector.$prefetch$++;
     collectElementData(ctx, collector, true);
+    collector.$prefetch$--;
   } else {
     collector.$deferElements$.push(ctx);
   }
-  collector.$prefetch$--;
 };
 
 const collectElement = (el: QwikElement, collector: Collector) => {
@@ -721,6 +737,7 @@ export const escapeText = (str: string) => {
   return str.replace(/<(\/?script)/g, '\\x3C$1');
 };
 
+// Collect all the subscribers of this manager
 export const collectSubscriptions = (
   manager: LocalSubscriptionManager,
   collector: Collector,
@@ -736,15 +753,15 @@ export const collectSubscriptions = (
 
   const subs = manager.$subs$;
   assertDefined(subs, 'subs must be defined');
-  for (const key of subs) {
-    const type = key[0];
+  for (const sub of subs) {
+    const type = sub[0];
     if (type > 0) {
-      collectValue(key[2], collector, leaks);
+      collectValue((sub as SubscriberSignal)[2], collector, leaks);
     }
     if (leaks === true) {
-      const host = key[1];
+      const host = sub[1];
       if (isNode(host) && isVirtualElement(host)) {
-        if (type === 0) {
+        if (sub[0] === 0) {
           collectDeferElement(host, collector);
         }
       } else {
@@ -785,26 +802,27 @@ const getPromiseValue = (promise: Promise<any>): PromiseValue | undefined => {
   return (promise as any)[PROMISE_VALUE];
 };
 
-export const collectValue = (obj: any, collector: Collector, leaks: boolean | QwikElement) => {
-  if (obj !== null) {
+export const collectValue = (obj: unknown, collector: Collector, leaks: boolean | QwikElement) => {
+  if (obj != null) {
     const objType = typeof obj;
     switch (objType) {
       case 'function':
       case 'object': {
-        const seen = collector.$seen$;
-        if (seen.has(obj)) {
+        if (collector.$seen$.has(obj)) {
           return;
         }
-        seen.add(obj);
+        collector.$seen$.add(obj);
         if (fastSkipSerialize(obj)) {
           collector.$objSet$.add(undefined);
           collector.$noSerialize$.push(obj);
           return;
         }
 
+        /** The possibly proxied `obj` */
         const input = obj;
         const target = getProxyTarget(obj);
         if (target) {
+          // `obj` is now the non-proxied object
           obj = target;
           // NOTE: You may be tempted to add the `target` to the `seen` set,
           // but that would not work as it is possible for the `target` object
@@ -841,20 +859,15 @@ export const collectValue = (obj: any, collector: Collector, leaks: boolean | Qw
           }
           if (isArray(obj)) {
             for (let i = 0; i < obj.length; i++) {
-              collectValue(input[i], collector, leaks);
+              collectValue((input as typeof obj)[i], collector, leaks);
             }
           } else if (isSerializableObject(obj)) {
             for (const key in obj) {
-              collectValue(input[key], collector, leaks);
+              collectValue((input as typeof obj)[key], collector, leaks);
             }
           }
         }
         break;
-      }
-      case 'string': {
-        if (collector.$seen$.has(obj)) {
-          return;
-        }
       }
     }
   }

--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -290,7 +290,7 @@ const reviveSubscriptions = (
   }
 };
 
-const reviveNestedObjects = (obj: any, getObject: GetObject, parser: Parser) => {
+const reviveNestedObjects = (obj: unknown, getObject: GetObject, parser: Parser) => {
   if (parser.fill(obj, getObject)) {
     return;
   }
@@ -298,11 +298,11 @@ const reviveNestedObjects = (obj: any, getObject: GetObject, parser: Parser) => 
   if (obj && typeof obj == 'object') {
     if (isArray(obj)) {
       for (let i = 0; i < obj.length; i++) {
-        obj[i] = getObject(obj[i]);
+        obj[i] = getObject(obj[i] as string);
       }
     } else if (isSerializableObject(obj)) {
       for (const key in obj) {
-        obj[key] = getObject(obj[key]);
+        obj[key] = getObject(obj[key] as string);
       }
     }
   }

--- a/packages/qwik/src/core/render/dom/notify-render.ts
+++ b/packages/qwik/src/core/render/dom/notify-render.ts
@@ -243,12 +243,12 @@ export const postRendering = async (containerState: ContainerState, rCtx: Render
   }
 };
 
+const isTask = (task: SubscriberEffect) => (task.$flags$ & TaskFlagsIsTask) !== 0;
+const isResourceTask = (task: SubscriberEffect) => (task.$flags$ & TaskFlagsIsResource) !== 0;
 const executeTasksBefore = async (containerState: ContainerState, rCtx: RenderContext) => {
   const containerEl = containerState.$containerEl$;
   const resourcesPromises: ValueOrPromise<SubscriberEffect>[] = [];
   const taskPromises: ValueOrPromise<SubscriberEffect>[] = [];
-  const isTask = (task: SubscriberEffect) => (task.$flags$ & TaskFlagsIsTask) !== 0;
-  const isResourceTask = (task: SubscriberEffect) => (task.$flags$ & TaskFlagsIsResource) !== 0;
 
   containerState.$taskNext$.forEach((task) => {
     if (isTask(task)) {
@@ -290,7 +290,10 @@ const executeTasksBefore = async (containerState: ContainerState, rCtx: RenderCo
   if (resourcesPromises.length > 0) {
     const resources = await Promise.all(resourcesPromises);
     sortTasks(resources);
-    resources.forEach((task) => runSubscriber(task, containerState, rCtx));
+    // no await so these run concurrently with the rendering
+    for (const task of resources) {
+      runSubscriber(task, containerState, rCtx);
+    }
   }
 };
 

--- a/packages/qwik/src/core/render/execute-component.ts
+++ b/packages/qwik/src/core/render/execute-component.ts
@@ -42,7 +42,7 @@ export const executeComponent = (
   // Set component context
   const newCtx = pushRenderContext(rCtx);
   newCtx.$cmpCtx$ = elCtx;
-  newCtx.$slotCtx$ = null;
+  newCtx.$slotCtx$ = undefined;
 
   // Invoke render hook
   iCtx.$subscriber$ = [0, hostElement];
@@ -98,7 +98,7 @@ export const createRenderContext = (
       $visited$: [],
     },
     $cmpCtx$: null,
-    $slotCtx$: null,
+    $slotCtx$: undefined,
   };
   seal(ctx);
   seal(ctx.$static$);

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -168,7 +168,10 @@ export type QRLEventHandlerMulti<EV extends Event, EL> =
   | QRLEventHandlerMulti<EV, EL>[];
 
 type QwikCustomEvents<EL> = {
-  [key: `${'document:' | 'window:' | ''}on${string}$`]: QRLEventHandlerMulti<Event, EL>;
+  /**
+   * We don't add custom events here because often people will add props to DOM props that look like
+   * custom events but are not
+   */
 };
 type QwikCustomEventsPlain<EL> = {
   /** The handler */

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -374,6 +374,7 @@ const renderNodeElementSync = (
   stream.write(`</${tagName}>`);
 };
 
+/** Render a component$ */
 const renderSSRComponent = (
   rCtx: RenderContext,
   ssrCtx: SSRContext,
@@ -795,7 +796,12 @@ This goes against the HTML spec: https://html.spec.whatwg.org/multipage/dom.html
 
   if (tagName === Virtual) {
     const elCtx = createMockQContext(111);
-    elCtx.$parentCtx$ = rCtx.$slotCtx$ || rCtx.$cmpCtx$;
+    if (rCtx.$slotCtx$) {
+      elCtx.$parentCtx$ = rCtx.$slotCtx$;
+      elCtx.$realParentCtx$ = rCtx.$cmpCtx$!;
+    } else {
+      elCtx.$parentCtx$ = rCtx.$cmpCtx$;
+    }
     if (hostCtx && hostCtx.$flags$ & HOST_FLAG_DYNAMIC) {
       addDynamicSlot(hostCtx, elCtx);
     }

--- a/packages/qwik/src/core/render/types.ts
+++ b/packages/qwik/src/core/render/types.ts
@@ -14,7 +14,7 @@ export interface RenderContext {
   /** Current Qwik component */
   $cmpCtx$: QContext | null;
   /** Current Slot parent */
-  $slotCtx$: QContext | null;
+  $slotCtx$: QContext | undefined;
 }
 
 export interface RenderStaticContext {

--- a/packages/qwik/src/core/state/common.ts
+++ b/packages/qwik/src/core/state/common.ts
@@ -103,21 +103,21 @@ const _verifySerializable = <T>(value: T, seen: Set<any>, ctx: string, preMessag
   }
   return value;
 };
-const noSerializeSet = /*#__PURE__*/ new WeakSet<any>();
-const weakSerializeSet = /*#__PURE__*/ new WeakSet<any>();
+const noSerializeSet = /*#__PURE__*/ new WeakSet<object>();
+const weakSerializeSet = /*#__PURE__*/ new WeakSet<object>();
 
-export const shouldSerialize = (obj: any): boolean => {
+export const shouldSerialize = (obj: unknown): boolean => {
   if (isObject(obj) || isFunction(obj)) {
     return !noSerializeSet.has(obj);
   }
   return true;
 };
 
-export const fastSkipSerialize = (obj: any): boolean => {
+export const fastSkipSerialize = (obj: object): boolean => {
   return noSerializeSet.has(obj);
 };
 
-export const fastWeakSerialize = (obj: any): boolean => {
+export const fastWeakSerialize = (obj: object): boolean => {
   return weakSerializeSet.has(obj);
 };
 

--- a/packages/qwik/src/core/state/context.ts
+++ b/packages/qwik/src/core/state/context.ts
@@ -38,6 +38,7 @@ export interface QContext {
   $props$: Record<string, any> | null;
   /** The QRL if this is `component$`-wrapped component. */
   $componentQrl$: QRLInternal<OnRenderFn<any>> | null;
+  /** The event handlers for this element */
   li: Listener[];
   /** Sequential data store for hooks, managed by useSequentialScope. */
   $seq$: any[] | null;
@@ -54,6 +55,11 @@ export interface QContext {
    * the owner virtual component, and for a virtual component it's the wrapping virtual component.
    */
   $parentCtx$: QContext | null | undefined;
+  /**
+   * During SSR, separately store the actual parent of slotted components to correctly pause
+   * subscriptions
+   */
+  $realParentCtx$: QContext | undefined;
 }
 
 export const tryGetContext = (element: QwikElement): QContext | undefined => {
@@ -156,6 +162,7 @@ export const createContext = (element: Element | VirtualElement): QContext => {
     $contexts$: null,
     $dynamicSlots$: null,
     $parentCtx$: undefined,
+    $realParentCtx$: undefined,
   } as QContext;
   seal(ctx);
   (element as any)[Q_CTX] = ctx;

--- a/packages/qwik/src/core/state/listeners.ts
+++ b/packages/qwik/src/core/state/listeners.ts
@@ -11,6 +11,7 @@ import type { PossibleEvents } from '../use/use-core';
 
 const ON_PROP_REGEX = /^(on|window:|document:)/;
 
+/** A QRL that will be called when the event occurs */
 export type Listener = [
   eventName: string,
   qrl: QRLInternal<(event: PossibleEvents, elem?: Element) => any>,

--- a/packages/qwik/src/core/state/signal.ts
+++ b/packages/qwik/src/core/state/signal.ts
@@ -21,7 +21,7 @@ export interface Signal<T = any> {
 }
 
 /** @public */
-export type ReadonlySignal<T = any> = Readonly<Signal<T>>;
+export type ReadonlySignal<T = unknown> = Readonly<Signal<T>>;
 
 /** @public */
 export type ValueOrSignal<T> = T | Signal<T>;

--- a/packages/qwik/src/core/use/use-context.ts
+++ b/packages/qwik/src/core/use/use-context.ts
@@ -335,6 +335,7 @@ const getParentProvider = (ctx: QContext, containerState: ContainerState): QCont
   // `null` means there's no parent, `undefined` means we don't know yet.
   if (ctx.$parentCtx$ === undefined) {
     // Not fully resumed container, find context from DOM
+    // We cannot recover $realParentCtx$ from this but that's fine because we don't need to pause on the client
     ctx.$parentCtx$ = findParentCtx(ctx.$element$, containerState);
   }
   /**

--- a/packages/qwik/src/core/use/use-resource.ts
+++ b/packages/qwik/src/core/use/use-resource.ts
@@ -322,7 +322,7 @@ export const getInternalResource = <T>(resource: ResourceReturn<T>): ResourceRet
 };
 
 export const isResourceReturn = (obj: any): obj is ResourceReturn<unknown> => {
-  return isObject(obj) && obj.__brand === 'resource';
+  return isObject(obj) && (obj as any).__brand === 'resource';
 };
 
 export const serializeResource = (

--- a/packages/qwik/src/core/util/element.ts
+++ b/packages/qwik/src/core/util/element.ts
@@ -5,25 +5,25 @@ export const isNode = (value: any): value is Node => {
 };
 
 export const isDocument = (value: Node): value is Document => {
-  return value.nodeType === 9;
+  return (value as any).nodeType === 9;
 };
 
-export const isElement = (value: Node | VirtualElement): value is Element => {
-  return value.nodeType === 1;
+export const isElement = (value: object): value is Element => {
+  return (value as any).nodeType === 1;
 };
 
-export const isQwikElement = (value: Node | VirtualElement): value is QwikElement => {
-  const nodeType = value.nodeType;
+export const isQwikElement = (value: object): value is QwikElement => {
+  const nodeType = (value as any).nodeType;
   return nodeType === 1 || nodeType === 111;
 };
 
-export const isNodeElement = (value: any): value is QwikElement => {
-  const nodeType = value.nodeType;
+export const isNodeElement = (value: object): value is QwikElement => {
+  const nodeType = (value as any).nodeType;
   return nodeType === 1 || nodeType === 111 || nodeType === 3;
 };
 
-export const isVirtualElement = (value: Node | VirtualElement): value is VirtualElement => {
-  return value.nodeType === 111;
+export const isVirtualElement = (value: object): value is VirtualElement => {
+  return (value as any).nodeType === 111;
 };
 
 export const isVirtualElementOpenComment = (value: Node | VirtualElement): value is Comment => {
@@ -31,9 +31,9 @@ export const isVirtualElementOpenComment = (value: Node | VirtualElement): value
 };
 
 export const isText = (value: Node | QwikElement): value is Text => {
-  return value.nodeType === 3;
+  return (value as any).nodeType === 3;
 };
 
 export const isComment = (value: Node | QwikElement): value is Comment => {
-  return value.nodeType === 8;
+  return (value as any).nodeType === 8;
 };

--- a/packages/qwik/src/core/util/types.ts
+++ b/packages/qwik/src/core/util/types.ts
@@ -1,26 +1,26 @@
 /** @private */
-export const isHtmlElement = (node: any): node is Element => {
-  return node ? node.nodeType === 1 : false;
+export const isHtmlElement = (node: unknown): node is Element => {
+  return node ? (node as Node).nodeType === 1 : false;
 };
 
-export const isSerializableObject = (v: any) => {
+export const isSerializableObject = (v: unknown): v is Record<string, unknown> => {
   const proto = Object.getPrototypeOf(v);
   return proto === Object.prototype || proto === null;
 };
 
-export const isObject = (v: any): v is any => {
-  return v && typeof v === 'object';
+export const isObject = (v: unknown): v is object => {
+  return !!v && typeof v === 'object';
 };
 
-export const isArray = (v: any): v is any[] => {
+export const isArray = (v: unknown): v is unknown[] => {
   return Array.isArray(v);
 };
 
-export const isString = (v: any): v is string => {
+export const isString = (v: unknown): v is string => {
   return typeof v === 'string';
 };
 
-export const isFunction = <T extends (...args: any) => any>(v: any): v is T => {
+export const isFunction = <T extends (...args: any) => any>(v: unknown): v is T => {
   return typeof v === 'function';
 };
 

--- a/starters/apps/e2e/src/components/slot/slot.tsx
+++ b/starters/apps/e2e/src/components/slot/slot.tsx
@@ -1,5 +1,6 @@
 import {
   component$,
+  $,
   useStore,
   Slot,
   useContext,
@@ -66,6 +67,7 @@ export const SlotParent = component$(() => {
           </Issue4283>
           <Issue4658 />
           <Issue5270 />
+          <Issue5506 />
         </>
       )}
       <div>
@@ -531,5 +533,51 @@ export const Issue5270 = component$(() => {
     <ProviderParent>
       <ContextChild />
     </ProviderParent>
+  );
+});
+
+export const Toggle5506 = component$<any>((props) => {
+  return (
+    <>
+      <label>
+        <input
+          {...props}
+          type="checkbox"
+          // ensure it gets checked state only from props
+          preventdefault:click
+        />
+        toggle me
+      </label>
+    </>
+  );
+});
+
+export const SlotParent5506 = component$(() => <Slot />);
+
+// This breaks signal propagation, if you put this expression directly in the JSX prop it works
+function coerceBoolean(value: string) {
+  return value === "true";
+}
+
+export const Issue5506 = component$(() => {
+  const sig = useSignal("true");
+  const render = useSignal(0);
+  const onClick$ = $(() => {
+    const newValue = sig.value === "true" ? "false" : "true";
+    sig.value = newValue;
+  });
+
+  return (
+    <div id="issue-5506-div">
+      <SlotParent5506 id="3456" key={render.value}>
+        <Toggle5506
+          id="input-5506"
+          checked={coerceBoolean(sig.value)}
+          onClick$={onClick$}
+        />
+        <br />
+        <button onClick$={() => render.value++}>Rerender on client</button>
+      </SlotParent5506>
+    </div>
   );
 });

--- a/starters/e2e/e2e.slot.spec.ts
+++ b/starters/e2e/e2e.slot.spec.ts
@@ -338,6 +338,13 @@ test.describe("slot", () => {
     await expect(div).toHaveText("Ctx: hello");
   });
 
+  test("issue 5506", async ({ page }) => {
+    const input = page.locator("#input-5506");
+    await expect(input).toBeChecked();
+    await input.click();
+    await expect(input).not.toBeChecked();
+  });
+
   test.beforeEach(async ({ page }) => {
     await page.goto("/e2e/slot");
     page.on("pageerror", (err) => expect(err).toEqual(undefined));


### PR DESCRIPTION
Fixes #5506 

By removing the `slotParent` in #5263, the container pause couldn't correctly determine the listener activation graph, so some subscriptions were left out.

This PR ensures that slot contexts are considered for subscriptions by storing the original parent for slotted components.

Also includes some internal type improvements and comments. Please don't squash when merging.