### PR TITLE
feat(labs): Support base prefix in untypedAppUrl

### DIFF
--- a/packages/qwik-labs/src/qwik-types/public-api.ts
+++ b/packages/qwik-labs/src/qwik-types/public-api.ts
@@ -17,8 +17,8 @@ export const untypedAppUrl = function appUrl(
       path.splice(i, 1);
     }
   }
-  if (import.meta.env.BASE_URL) {
-    let baseURL = import.meta.env.BASE_URL;
+  let baseURL = import.meta.env.BASE_URL;
+  if (baseURL) {
     if (!baseURL.endsWith('/')) {
       baseURL += '/';
     }

--- a/packages/qwik-labs/src/qwik-types/public-api.ts
+++ b/packages/qwik-labs/src/qwik-types/public-api.ts
@@ -17,7 +17,15 @@ export const untypedAppUrl = function appUrl(
       path.splice(i, 1);
     }
   }
-  return path.join('/');
+  if (import.meta.env.BASE_URL) {
+    let baseURL = import.meta.env.BASE_URL;
+    if (!baseURL.endsWith('/')) {
+      baseURL += '/';
+    }
+    return baseURL + path.join('/');
+  } else {
+    return path.join('/');
+  }
 };
 
 /**


### PR DESCRIPTION

# Overview
https://github.com/BuilderIO/qwik/issues/5417
 support the base in [untypedAppUrl](https://github.com/BuilderIO/qwik/blob/eaf939fda440f5bf75e8bf16d0b4df176001a56f/packages/qwik-labs/src/qwik-types/public-api.ts#L2).
<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.


_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

If a base URL is specified in the base field of vite.config, the return value of untypedAppUrl is prefixed with the base URL.

If baseURL is not set, no prefix is given to the path returned.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
