### PR TITLE
fix(jsx-qwik-attributes): enable qrlEventHanlerMulti to accept Function types

### DIFF
--- a/packages/qwik/src/core/component/component.unit.tsx
+++ b/packages/qwik/src/core/component/component.unit.tsx
@@ -2,12 +2,11 @@ import { createDOM } from '../../testing/library';
 import { expectDOM } from '../../testing/expect-dom';
 import { inlinedQrl } from '../qrl/qrl';
 import { useStylesQrl } from '../use/use-styles';
-import { type PropsOf, component$, type PropFunctionProps } from './component.public';
+import { type PropsOf, component$ } from './component.public';
 import { useStore } from '../use/use-store.public';
 import { useLexicalScope } from '../use/use-lexical-scope.public';
 import { describe, test } from 'vitest';
 import type { InputHTMLAttributes } from '../render/jsx/types/jsx-generated';
-import type { QwikIntrinsicElements } from '../render/jsx/types/jsx-qwik-elements';
 
 describe('q-component', () => {
   /**
@@ -115,49 +114,50 @@ describe('q-component', () => {
     `
     );
   });
-
   test('types work as expected', () => () => {
     // Let's keep one of these old type exports around for now.
-    const Input1 = component$<InputHTMLAttributes<HTMLInputElement>>((props) => {
+    const OldInput = component$<InputHTMLAttributes<HTMLInputElement>>((props) => {
       return <input {...props} />;
     });
 
-    const Input2 = component$((props: PropFunctionProps<PropsOf<'input'>>) => {
+    const BasicInput = component$((props: PropsOf<'input'>) => {
       return <input {...props} />;
     });
 
-    type Input5Props = {
+    type PartialInputProps = {
       type: 'text' | 'number';
     } & Partial<PropsOf<'input'>>;
 
-    const Input5 = component$<Input5Props>(({ type, ...props }) => {
+    const PartialInput = component$<PartialInputProps>(({ type, ...props }) => {
       return <input type={type} {...props} />;
     });
 
-    type Input6Props = {
-      type: 'text' | 'number';
-    } & QwikIntrinsicElements['input'];
-
-    const Input6 = component$<Input6Props>(({ type, ...props }) => {
-      return (
-        <div>
-          <input type={type} {...props} />
-        </div>
-      );
+    const Checkbox = component$<PropsOf<'input'>>(({ ...props }) => {
+      return <input type="checkbox" {...props} />;
     });
+
+    type PropFunctionButtonProps = {
+      onTestFunction$: (a: 2) => number;
+    } & PropsOf<'button'>;
+
+    const PropFunctionButton = component$<PropFunctionButtonProps>(
+      ({ onTestFunction$, ...props }) => {
+        return (
+          <div>
+            <button onClick$={() => onTestFunction$(2)} {...props} />
+          </div>
+        );
+      }
+    );
 
     component$(() => {
       return (
         <>
-          <Input1
-            style={{
-              paddingInlineEnd: '10px',
-            }}
-            value="1"
-          />
-          <Input2 value="2" />
-          <Input5 value="5" type="text" />
-          <Input6 value="6" type="number" />
+          <OldInput value="1" />
+          <BasicInput value="2" />
+          <PartialInput value="3" type="text" />
+          <Checkbox value="4" />
+          <PropFunctionButton onTestFunction$={(a) => a + 1} />
         </>
       );
     });

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -163,9 +163,12 @@ export type EventHandler<EV = Event, EL = Element> = {
 
 export type QRLEventHandlerMulti<EV extends Event, EL> =
   | QRL<EventHandler<EV, EL>>
-  | undefined
-  | null
-  | QRLEventHandlerMulti<EV, EL>[];
+  | QRLEventHandlerMulti<EV, EL>[]
+  | SingleOrArray<Function>
+  | SingleOrArray<undefined>
+  | null;
+
+type SingleOrArray<T> = T | (SingleOrArray<T> | undefined | null)[];
 
 type QwikCustomEvents<EL> = {
   [key: `${'document:' | 'window:' | ''}on${string}$`]: QRLEventHandlerMulti<Event, EL>;


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

With the new type changes introduced in 1.3.1, some types aren't passing.

Getting lots of

>    Property 'onSelectedIndexChange$' is incompatible with index signature.
      Type '(index: number) => void' is not assignable to type '((event: Event, element: HTMLDivElement) => any) | QRL<(event: Event, element: HTMLDivElement) => any> | QRLEventHandlerMulti<Event, HTMLDivElement>[] | ((event: Event, element: unknown) => any) | null | undefined'.
 > Type '(index: number) => void' is not assignable to type '(event: Event, element: HTMLDivElement) => any'.
        >  Types of parameters 'index' and 'event' are incompatible.
          >  Type 'Event' is not assignable to type 'number'.ts
            
types of errors in qwik-ui when trying to access a prop function parameter in a component prop (see newly added test).

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
