### PR TITLE
docs: improve getting started steps

### DIFF
--- a/starters/apps/basic/src/components/starter/next-steps/next-steps.tsx
+++ b/starters/apps/basic/src/components/starter/next-steps/next-steps.tsx
@@ -4,11 +4,11 @@ import styles from "./next-steps.module.css";
 export const GETTING_STARTED_STEPS = [
   {
     message:
-      "Press and hold the <b>ALT</b> key to activate 'Click-to-Source' mode",
+      "Press and hold the <b>ALT/Option</b> key to activate 'Click-to-Source' mode",
   },
   {
     message:
-      "Select the title of this page while keeping the <b>ALT</b> key pressed",
+      "Select the title of this page while keeping the <b>ALT/Option</b> key pressed",
     hint: 'Edit the title and save the changes. If your editor does not open, have a look at <a href="https://github.com/yyx990803/launch-editor#supported-editors" target="_blank">this page</a> to set the correct <code>LAUNCH_EDITOR</code> value.',
   },
   {


### PR DESCRIPTION
Added ALT/Option for clearer instruction for the Mac users

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

The onboarding is awsome! 
I just added a little help for the Mac users

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. When a Mac user sees `ALT`, they might not know that it referes to the Option key.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
