### PR TITLE
docs: create NavLink cookbook example

### DIFF
--- a/packages/docs/src/routes/demo/cookbook/nav-link/example/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/nav-link/example/index.tsx
@@ -1,0 +1,24 @@
+import { component$ } from '@builder.io/qwik';
+import { NavLink } from '..';
+
+export default component$(() => {
+  return (
+    <>
+      Links
+      <div>
+        <NavLink href="/docs" activeClass="active" pendingClass="pending">
+          Docs
+        </NavLink>
+      </div>
+      <div>
+        <NavLink
+          href="/docs/cookbook/nav-link/"
+          activeClass="active"
+          pendingClass="pending"
+        >
+          NavLink
+        </NavLink>
+      </div>
+    </>
+  );
+});

--- a/packages/docs/src/routes/demo/cookbook/nav-link/example/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/nav-link/example/index.tsx
@@ -6,17 +6,16 @@ export default component$(() => {
     <>
       Links
       <div>
-        <NavLink href="/docs" activeClass="active" pendingClass="pending">
-          Docs
+        <NavLink href="/docs" activeClass="text-green-600">
+          /docs
         </NavLink>
       </div>
       <div>
         <NavLink
-          href="/docs/cookbook/nav-link/"
-          activeClass="active"
-          pendingClass="pending"
+          href="/demo/cookbook/nav-link/example/"
+          activeClass="text-green-600"
         >
-          NavLink
+          /demo/cookbook/nav-link/example/
         </NavLink>
       </div>
     </>

--- a/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
@@ -1,5 +1,5 @@
 import type { QwikIntrinsicElements } from '@builder.io/qwik';
-import { Slot, component$ } from '@builder.io/qwik';
+import { Slot, component$, useComputed$ } from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
 
 type NavLinkProps = QwikIntrinsicElements['a'] & {
@@ -12,23 +12,23 @@ export const NavLink = component$(
     const location = useLocation();
     const toPathname = props.href ?? '';
     const locationPathname = location.url.pathname;
+    const isPenddingSig = useComputed$(() => location.isNavigating);
 
     const endSlashPosition =
       toPathname !== '/' && toPathname.endsWith('/')
         ? toPathname.length - 1
         : toPathname.length;
-    const check_isActive =
+    const isActive =
       locationPathname === toPathname ||
       (locationPathname.endsWith(toPathname) &&
         locationPathname.charAt(endSlashPosition) === '/');
-    const check_isPendding = location.isNavigating;
 
     return (
       <a
         class={`
-          ${props.class}  
-          ${check_isActive ? activeClass : ''}
-          ${check_isPendding && check_isActive ? pendingClass : ''}
+          ${props.class || ''}  
+          ${isActive ? activeClass : ''}
+          ${isPenddingSig.value && isActive ? pendingClass : ''}
         `}
         {...props}
       >

--- a/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
@@ -1,40 +1,3 @@
----
-title: Cookbook | Navbar link
-contributors:
-  - Adbib
----
-
-import { CodeFile } from '../../../../components/code-sandbox/index.tsx';
-
-# NavLink Component
-
-If you want to add `active` and `pending` states to your links you can use this solution.
-The NavLink component enhances `<a>` element by adding:
-
-- **Active Status**: Apply a class when the link href matches the current URL pathname.
-- **Pending Status**: Apply a class during navigation when linking to the target location.
-
-This allows styling the active and pending states for navigation.
-
-## Usage
-
-You can use NavLink with the addition of `isActive` and `isPending` props:
-
-```tsx
-<NavLink href="/" isActive="active" isPending="pending">
-  Home
-</NavLink>
-```
-
-## How it Works 
-
-Under the hood, NavLink uses the `useLocation` hook to get navigation status.
-It checks if the link href matches the current URL pathname to set isActive. 
-It uses `isNavigating` to determine pending status when navigating to the link.
-This allows NavLink to know the active and pending state automatically based on navigation.
-
-<CodeFile>
-```tsx
 import type { QwikIntrinsicElements } from '@builder.io/qwik';
 import { Slot, component$ } from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
@@ -74,5 +37,3 @@ export const NavLink = component$(
     );
   }
 );
-```
-</CodeFile>

--- a/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
@@ -1,6 +1,6 @@
 import type { QwikIntrinsicElements } from '@builder.io/qwik';
-import { Slot, component$, useComputed$,Link } from '@builder.io/qwik';
-import { useLocation } from '@builder.io/qwik-city';
+import { Slot, component$, useComputed$ } from '@builder.io/qwik';
+import { useLocation,Link } from '@builder.io/qwik-city';
 
 type NavLinkProps = QwikIntrinsicElements['a'] & {
   activeClass?: string;

--- a/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
@@ -1,5 +1,5 @@
 import type { QwikIntrinsicElements } from '@builder.io/qwik';
-import { Slot, component$, useComputed$ } from '@builder.io/qwik';
+import { Slot, component$, useComputed$,Link } from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
 
 type NavLinkProps = QwikIntrinsicElements['a'] & {
@@ -14,17 +14,22 @@ export const NavLink = component$(
     const locationPathname = location.url.pathname;
     const isPenddingSig = useComputed$(() => location.isNavigating);
 
+     const startSlashPosition =
+       toPathname !== "/" && toPathname.startsWith("/")
+         ? toPathname.length - 1
+         : toPathname.length;
     const endSlashPosition =
       toPathname !== '/' && toPathname.endsWith('/')
         ? toPathname.length - 1
         : toPathname.length;
     const isActive =
-      locationPathname === toPathname ||
-      (locationPathname.endsWith(toPathname) &&
-        locationPathname.charAt(endSlashPosition) === '/');
+       locationPathname === toPathname ||
+       (locationPathname.endsWith(toPathname) &&
+         (locationPathname.charAt(endSlashPosition) === "/" ||
+           locationPathname.charAt(startSlashPosition) === "/"));
 
     return (
-      <a
+      <Link
         class={`
           ${props.class || ''}  
           ${isActive ? activeClass : ''}
@@ -33,7 +38,7 @@ export const NavLink = component$(
         {...props}
       >
         <Slot />
-      </a>
+      </Link>
     );
   }
 );

--- a/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
@@ -1,40 +1,31 @@
-import type { QwikIntrinsicElements } from '@builder.io/qwik';
-import { Slot, component$, useComputed$ } from '@builder.io/qwik';
-import { useLocation,Link } from '@builder.io/qwik-city';
+import { Slot, component$ } from '@builder.io/qwik';
+import { Link, useLocation, type LinkProps } from '@builder.io/qwik-city';
 
-type NavLinkProps = QwikIntrinsicElements['a'] & {
-  activeClass?: string;
-  pendingClass?: string;
-};
+type NavLinkProps = LinkProps & { activeClass?: string };
 
 export const NavLink = component$(
-  ({ activeClass, pendingClass, ...props }: NavLinkProps) => {
+  ({ activeClass, ...props }: NavLinkProps) => {
     const location = useLocation();
     const toPathname = props.href ?? '';
     const locationPathname = location.url.pathname;
-    const isPenddingSig = useComputed$(() => location.isNavigating);
 
-     const startSlashPosition =
-       toPathname !== "/" && toPathname.startsWith("/")
-         ? toPathname.length - 1
-         : toPathname.length;
+    const startSlashPosition =
+      toPathname !== '/' && toPathname.startsWith('/')
+        ? toPathname.length - 1
+        : toPathname.length;
     const endSlashPosition =
       toPathname !== '/' && toPathname.endsWith('/')
         ? toPathname.length - 1
         : toPathname.length;
     const isActive =
-       locationPathname === toPathname ||
-       (locationPathname.endsWith(toPathname) &&
-         (locationPathname.charAt(endSlashPosition) === "/" ||
-           locationPathname.charAt(startSlashPosition) === "/"));
+      locationPathname === toPathname ||
+      (locationPathname.endsWith(toPathname) &&
+        (locationPathname.charAt(endSlashPosition) === '/' ||
+          locationPathname.charAt(startSlashPosition) === '/'));
 
     return (
       <Link
-        class={`
-          ${props.class || ''}  
-          ${isActive ? activeClass : ''}
-          ${isPenddingSig.value && isActive ? pendingClass : ''}
-        `}
+        class={`${props.class || ''} ${isActive ? activeClass : ''}`}
         {...props}
       >
         <Slot />

--- a/packages/docs/src/routes/docs/cookbook/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/index.mdx
@@ -7,6 +7,7 @@ contributors:
   - Craiqser
   - Inaam-Ur-Rehman
   - maiieul
+  - Adbib
 updated_at: '2023-10-10T19:26:56Z'
 created_at: '2023-08-14T18:24:46Z'
 ---
@@ -20,3 +21,4 @@ Examples:
 - [Media Controller with iOS Support](./mediaController/)
 - [Glob Import with `import.meta.glob`](./glob-import/)
 - [Theme Managment](./theme-management/)
+- [NavLink](./nav-link/)

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -50,6 +50,10 @@ export const NavLink = component$(
     const toPathname = props.href ?? '';
     const locationPathname = location.url.pathname;
 
+    const startSlashPosition =
+      toPathname !== "/" && toPathname.startsWith("/")
+        ? toPathname.length - 1
+        : toPathname.length;
     const endSlashPosition =
       toPathname !== '/' && toPathname.endsWith('/')
         ? toPathname.length - 1
@@ -57,7 +61,8 @@ export const NavLink = component$(
     const check_isActive =
       locationPathname === toPathname ||
       (locationPathname.endsWith(toPathname) &&
-        locationPathname.charAt(endSlashPosition) === '/');
+        (locationPathname.charAt(endSlashPosition) === "/" ||
+          locationPathname.charAt(startSlashPosition) === "/"));
     const check_isPendding = location.isNavigating;
 
     return (

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -8,7 +8,7 @@ import CodeSandbox from '../../../../components/code-sandbox/index.tsx';
 
 # NavLink Component
 
-When building navigation in Qwik, you may want to know when a link is active or pending navigation. The standard <a> and <Link> components don't provide this. 
+When building navigation in Qwik, you may want to know when a link is active or pending navigation. The standard a and Link components don't provide this. 
 The NavLink component enhances navigation links by adding:
 
 - **Active Status** - Apply a class when the link matches the current location.

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -75,3 +75,4 @@ export const NavLink = component$(
 );
 
 ```
+</CodeSandbox>

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -8,39 +8,36 @@ import CodeSandbox, { CodeFile } from '../../../../components/code-sandbox/index
 
 # NavLink Component
 
-If you want to add `active` and `pending` states to your links you can use this solution.
-The NavLink component enhances `<a>` element by adding:
+If you want to add `active` state to your links you can use this solution.
+The NavLink component enhances Qwik `<Link>` component by adding:
 
 - **Active Status**: Apply a class when the link href matches the current URL pathname.
-- **Pending Status**: Apply a class during navigation when linking to the target location.
 
-This allows styling the active and pending states for navigation.
+This allows styling the active state for navigation.
 
 ## How it Works 
 
 Under the hood, NavLink uses the `useLocation` hook to get navigation status.
 It checks if the link href matches the current URL pathname to set activeClass. 
-It uses `isNavigating` to determine pending status when navigating to the link.
-This allows NavLink to know the active and pending state automatically based on navigation.
+This allows NavLink to know the active state automatically based on navigation.
 
 <CodeFile src="/src/routes/demo/cookbook/nav-link/index.tsx">
 ```tsx
-import type { QwikIntrinsicElements } from '@builder.io/qwik';
-import { Slot, component$, useComputed$ } from '@builder.io/qwik';
-import { useLocation } from '@builder.io/qwik-city';
+import { Slot, component$ } from '@builder.io/qwik';
+import { Link, useLocation, type LinkProps } from '@builder.io/qwik-city';
 
-type NavLinkProps = QwikIntrinsicElements['a'] & {
-  activeClass?: string;
-  pendingClass?: string;
-};
+type NavLinkProps = LinkProps & { activeClass?: string };
 
 export const NavLink = component$(
-  ({ activeClass, pendingClass, ...props }: NavLinkProps) => {
+  ({ activeClass, ...props }: NavLinkProps) => {
     const location = useLocation();
     const toPathname = props.href ?? '';
     const locationPathname = location.url.pathname;
-    const isPenddingSig = useComputed$(() => location.isNavigating);
 
+    const startSlashPosition =
+      toPathname !== '/' && toPathname.startsWith('/')
+        ? toPathname.length - 1
+        : toPathname.length;
     const endSlashPosition =
       toPathname !== '/' && toPathname.endsWith('/')
         ? toPathname.length - 1
@@ -48,19 +45,16 @@ export const NavLink = component$(
     const isActive =
       locationPathname === toPathname ||
       (locationPathname.endsWith(toPathname) &&
-        locationPathname.charAt(endSlashPosition) === '/');
+        (locationPathname.charAt(endSlashPosition) === '/' ||
+          locationPathname.charAt(startSlashPosition) === '/'));
 
     return (
-      <a
-        class={`
-          ${props.class}  
-          ${isActive ? activeClass : ''}
-          ${isPenddingSig.value && isActive ? pendingClass : ''}
-        `}
+      <Link
+        class={`${props.class || ''} ${isActive ? activeClass : ''}`}
         {...props}
       >
         <Slot />
-      </a>
+      </Link>
     );
   }
 );
@@ -70,7 +64,7 @@ export const NavLink = component$(
 
 ## Usage
 
-You can use NavLink with the addition of `activeClass` and `pendingClass` props:
+You can use NavLink with the addition of `activeClass` props:
 
 <CodeSandbox src="/src/routes/demo/cookbook/nav-link/example/index.tsx" style={{ height: '10em' }}>
 ```tsx
@@ -82,17 +76,16 @@ export default component$(() => {
     <>
       Links
       <div>
-        <NavLink href="/docs" activeClass="active" pendingClass="pending">
-          Docs
+        <NavLink href="/docs" activeClass="text-green-600">
+          /docs
         </NavLink>
       </div>
       <div>
         <NavLink
-          href="/docs/cookbook/nav-link/"
-          activeClass="active"
-          pendingClass="pending"
+          href="/demo/cookbook/nav-link/example/"
+          activeClass="text-green-600"
         >
-          NavLink
+          /demo/cookbook/nav-link/example/
         </NavLink>
       </div>
     </>

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -4,7 +4,7 @@ contributors:
   - Adbib
 ---
 
-import { CodeFile } from '../../../../components/code-sandbox/index.tsx';
+import CodeSandbox, { CodeFile } from '../../../../components/code-sandbox/index.tsx';
 
 # NavLink Component
 
@@ -16,27 +16,17 @@ The NavLink component enhances `<a>` element by adding:
 
 This allows styling the active and pending states for navigation.
 
-## Usage
-
-You can use NavLink with the addition of `isActive` and `isPending` props:
-
-```tsx
-<NavLink href="/" isActive="active" isPending="pending">
-  Home
-</NavLink>
-```
-
 ## How it Works 
 
 Under the hood, NavLink uses the `useLocation` hook to get navigation status.
-It checks if the link href matches the current URL pathname to set isActive. 
+It checks if the link href matches the current URL pathname to set activeClass. 
 It uses `isNavigating` to determine pending status when navigating to the link.
 This allows NavLink to know the active and pending state automatically based on navigation.
 
-<CodeFile>
+<CodeFile src="/src/routes/demo/cookbook/nav-link/index.tsx">
 ```tsx
 import type { QwikIntrinsicElements } from '@builder.io/qwik';
-import { Slot, component$ } from '@builder.io/qwik';
+import { Slot, component$, useComputed$ } from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
 
 type NavLinkProps = QwikIntrinsicElements['a'] & {
@@ -49,28 +39,23 @@ export const NavLink = component$(
     const location = useLocation();
     const toPathname = props.href ?? '';
     const locationPathname = location.url.pathname;
+    const isPenddingSig = useComputed$(() => location.isNavigating);
 
-    const startSlashPosition =
-      toPathname !== "/" && toPathname.startsWith("/")
-        ? toPathname.length - 1
-        : toPathname.length;
     const endSlashPosition =
       toPathname !== '/' && toPathname.endsWith('/')
         ? toPathname.length - 1
         : toPathname.length;
-    const check_isActive =
+    const isActive =
       locationPathname === toPathname ||
       (locationPathname.endsWith(toPathname) &&
-        (locationPathname.charAt(endSlashPosition) === "/" ||
-          locationPathname.charAt(startSlashPosition) === "/"));
-    const check_isPendding = location.isNavigating;
+        locationPathname.charAt(endSlashPosition) === '/');
 
     return (
       <a
         class={`
           ${props.class}  
-          ${check_isActive ? activeClass : ''}
-          ${check_isPendding && check_isActive ? pendingClass : ''}
+          ${isActive ? activeClass : ''}
+          ${isPenddingSig.value && isActive ? pendingClass : ''}
         `}
         {...props}
       >
@@ -81,3 +66,37 @@ export const NavLink = component$(
 );
 ```
 </CodeFile>
+
+
+## Usage
+
+You can use NavLink with the addition of `activeClass` and `pendingClass` props:
+
+<CodeSandbox src="/src/routes/demo/cookbook/nav-link/example/index.tsx" style={{ height: '10em' }}>
+```tsx
+import { component$ } from '@builder.io/qwik';
+import { NavLink } from '..';
+
+export default component$(() => {
+  return (
+    <>
+      Links
+      <div>
+        <NavLink href="/docs" activeClass="active" pendingClass="pending">
+          Docs
+        </NavLink>
+      </div>
+      <div>
+        <NavLink
+          href="/docs/cookbook/nav-link/"
+          activeClass="active"
+          pendingClass="pending"
+        >
+          NavLink
+        </NavLink>
+      </div>
+    </>
+  );
+});
+```
+</CodeSandbox>

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -1,0 +1,67 @@
+# NavLink Component
+
+When building navigation in Qwik, you may want to know when a link is active or pending navigation. The standard <a> and <Link> components don't provide this. 
+The NavLink component enhances navigation links by adding:
+
+- **Active Status** - Apply a class when the link matches the current location.
+- **Pending Status** - Apply a class during navigation when linking to the target location.
+
+This allows styling the active and pending states for navigation.
+
+## Usage
+
+Using NavLink is the same as Link, with the addition of `isActive` and `isPending` props:
+
+```jsx
+<NavLink href="/" isActive="active" isPending="pending">
+  Home
+</NavLink>
+```
+
+## How NavLink Works 
+
+Under the hood, NavLink uses the useLocation hook to get navigation status. It checks if the link href matches the current URL pathname to set isActive. It uses isNavigating to determine pending status when navigating to the link.
+
+This allows NavLink to know the active and pending state automatically based on navigation.
+
+```tsx
+import { Slot, component$ } from "@builder.io/qwik";
+import { type LinkProps, useLocation } from "@builder.io/qwik-city";
+
+interface NavLinkProps extends LinkProps {
+  isActive?: string;
+  isPending?: string;
+}
+
+export const NavLink = component$(
+  ({ isActive, isPending, ...props }: NavLinkProps) => {
+    const location = useLocation();
+    const toPathname = props.href ?? "";
+    const locationPathname = location.url.pathname;
+
+    const endSlashPosition =
+      toPathname !== "/" && toPathname.endsWith("/")
+        ? toPathname.length - 1
+        : toPathname.length;
+    const check_isActive =
+      locationPathname === toPathname ||
+      (locationPathname.endsWith(toPathname) &&
+        locationPathname.charAt(endSlashPosition) === "/");
+    const check_isPendding = location.isNavigating;
+
+    return (
+      <a
+        class={`
+          ${props.class}  
+          ${check_isActive ? isActive : ""}
+          ${check_isPendding && check_isActive ? isPending : ""}
+        `}
+        {...props}
+      >
+        <Slot />
+      </a>
+    );
+  },
+);
+
+```

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -1,3 +1,11 @@
+---
+title: Cookbook | Navbar link
+contributors:
+  - Adbib
+---
+
+import CodeSandbox from '../../../../components/code-sandbox/index.tsx';
+
 # NavLink Component
 
 When building navigation in Qwik, you may want to know when a link is active or pending navigation. The standard <a> and <Link> components don't provide this. 
@@ -23,6 +31,8 @@ Using NavLink is the same as Link, with the addition of `isActive` and `isPendin
 Under the hood, NavLink uses the useLocation hook to get navigation status. It checks if the link href matches the current URL pathname to set isActive. It uses isNavigating to determine pending status when navigating to the link.
 
 This allows NavLink to know the active and pending state automatically based on navigation.
+
+<CodeSandbox url="/demo/cookbook/navbar/">
 
 ```tsx
 import { Slot, component$ } from "@builder.io/qwik";

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -42,6 +42,7 @@
 - [Media Controller](/docs/cookbook/mediaController/index.mdx)
 - [Portal](/docs/cookbook/portal/index.mdx)
 - [Sync events w state](/docs/cookbook/sync-events/index.mdx)
+- [Navbar Link](/docs/cookbook/navbar/index.mdx)
 
 ## Integrations
 

--- a/packages/docs/src/routes/docs/menu.md
+++ b/packages/docs/src/routes/docs/menu.md
@@ -42,7 +42,7 @@
 - [Media Controller](/docs/cookbook/mediaController/index.mdx)
 - [Portal](/docs/cookbook/portal/index.mdx)
 - [Sync events w state](/docs/cookbook/sync-events/index.mdx)
-- [Navbar Link](/docs/cookbook/navbar/index.mdx)
+- [NavLink](/docs/cookbook/nav-link/index.mdx)
 
 ## Integrations
 


### PR DESCRIPTION
The NavLink component enhances navigation by getting isPending and isActive status to styling your links

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description
When building navigation in Qwik, you may want to know when a link is active or pending navigation. The standard <a> and <Link> components don't provide this.

The NavLink component enhances navigation links by adding:
- **Active Status** - Apply a class when the link matches the current location. 
- **Pending Status** - Apply a class during navigation when linking to the target location.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. navbar
- 2. sidebar

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
