### PR TITLE
feat(route-matcher): optional param

### DIFF
--- a/packages/qwik-city/runtime/src/route-matcher.ts
+++ b/packages/qwik-city/runtime/src/route-matcher.ts
@@ -7,10 +7,7 @@ import type { PathParams } from './types';
  * @param path Actual path to match
  * @returns Returns PathParams or null if did not match.
  */
-export function matchRoute(
-  route: string,
-  path: string,
-): PathParams | null {
+export function matchRoute(route: string, path: string): PathParams | null {
   const routeIdx: number = startIdxSkipSlash(route);
   const routeLength = lengthNoTrailingSlash(route);
   const pathIdx: number = startIdxSkipSlash(path);
@@ -24,7 +21,7 @@ function matchRoutePart(
   routeLength: number,
   path: string,
   pathIdx: number,
-  pathLength: number,
+  pathLength: number
 ): PathParams | null {
   let params: PathParams | null = null;
   while (routeIdx < routeLength) {
@@ -82,9 +79,7 @@ function matchRoutePart(
         return null;
       }
       const paramValue = path.substring(paramValueStart, paramValueEnd);
-      if (
-        !isMany && !suffix && !paramValue
-      ) {
+      if (!isMany && !suffix && !paramValue) {
         // empty value is only allowed with rest or suffix (e.g. '/path/[...rest]' or '/path/[param]suffix')
         return null;
       }
@@ -158,7 +153,7 @@ function recursiveScan(
   pathLength: number,
   route: string,
   routeStart: number,
-  routeLength: number,
+  routeLength: number
 ) {
   if (path.charCodeAt(pathStart) === Char.SLASH) {
     pathStart++;
@@ -167,14 +162,7 @@ function recursiveScan(
   const sep = suffix + '/';
   let depthWatchdog = 5;
   while (pathIdx >= pathStart && depthWatchdog--) {
-    const match = matchRoutePart(
-      route,
-      routeStart,
-      routeLength,
-      path,
-      pathIdx,
-      pathLength
-    );
+    const match = matchRoutePart(route, routeStart, routeLength, path, pathIdx, pathLength);
     if (match) {
       let value = path.substring(pathStart, Math.min(pathIdx, pathLength));
       if (value.endsWith(sep)) {

--- a/packages/qwik-city/runtime/src/route-matcher.unit.ts
+++ b/packages/qwik-city/runtime/src/route-matcher.unit.ts
@@ -167,6 +167,11 @@ describe('routeMatcher/#2951', () => {
   test('/[...a]/[...b]/path', () => {
     assert.deepEqual(matchRoute('/[...a]/[...b]/path', '/a/b/c/path'), { a: 'a/b/c', b: '' });
   });
+
+  test('/[optional.]/suffix', () => {
+    assert.deepEqual(matchRoute('/[optional.]/suffix', '/a/suffix'), { optional: 'a' });
+    assert.deepEqual(matchRoute('/[optional.]/suffix', '/suffix'), {});
+  });
 });
 
 describe('routeMatcher/#5080', () => {


### PR DESCRIPTION
# Overview

Adds optional param for route matching

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Draft Sytax: `[param.]`

This is my ever first pull request and I apologize if I messed anything up.

Currently `[...param]` matches zero or more than 1 segments while [param] matches exactly one segment. This might not cover all the use cases. Suppose I am integration i18n into my app and I put all routes under `[...lang]`. Then `/`, `/en-US/`, etc are all valid routes and works perfectly. However, visiting an invalid route will also be rendered by `[...lang]/index.tsx` instead of showing the 404 page.

One of the solution is to use `[lang]` instead of [...lang] and redirect `/` to a default locale but redirecting home page seems a bit sketchy to me (maybe implications towards SEO?).

Second solution is to analyze the path in `[...lang]/index.tsx`, if the first segment is not a supported locale, then throw a redirect or error. I haven't tested this yet but it seems like a workaround instead of a good solution.

 The current draft for the optional param syntax is `[lang.]` and it matches exactly one or zero path segment. With optional param, any invalid route with more than 1 segment will render the 404 page without having to manually check the path.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
