### PR TITLE
fix(tailwind starter): switch from cjs to esm to support vite 5

### DIFF
--- a/starters/features/tailwind/tailwind.config.js
+++ b/starters/features/tailwind/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
When adding the tailwind integration with `1.3.1`, we get the following error:

```
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Failed to load PostCSS config: Failed to load PostCSS config (searchPath: /Volumes/Primary/Code/eatess/cruncho-landing): [ReferenceError] module is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '/Volumes/Primary/Code/eatess/cruncho-landing/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
ReferenceError: module is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '/Volumes/Primary/Code/eatess/cruncho-landing/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```

This is vite 5 telling us we are using CJS, and we should either have it as an es module, or rename the file to `.cjs` so that CJS continues to work.

https://vitejs.dev/guide/migration.html#deprecate-cjs-node-api

It seems that ESM works fine here, so I've made a tiny PR so that this behavior is fixed.

Related:
https://discord.com/channels/842438759945601056/1188215300236251279/1188268842682699846
https://discord.com/channels/842438759945601056/1187876025913327756/1187876025913327756

