### PR TITLE
fix(tailwind): fix prettier config type

### DIFF
--- a/starters/features/tailwind/.prettierrc.js
+++ b/starters/features/tailwind/.prettierrc.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
   plugins: ['prettier-plugin-tailwindcss'],
 }


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

When trying to format files using prettier it fails because the qwik project by default has `type: module` defined in the package.json file

Thanks to @dmitry-stepanenko for helping me find the issue

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
