### PR TITLE
docs: fix entry file name

### DIFF
--- a/packages/docs/src/routes/docs/deployments/node/index.mdx
+++ b/packages/docs/src/routes/docs/deployments/node/index.mdx
@@ -78,7 +78,7 @@ By default, all Qwik City applications are protected against [CSRF attacks](http
 
 This protection is enabled by default and it's the reason why you need to set the `ORIGIN` environment variable when deploying your application for production.
 
-If you want to disable CSRF protection, you can set `checkOrigin: false` in the `createQwikCity()` options in `src/entry.preview.tsx`:
+If you want to disable CSRF protection, you can set `checkOrigin: false` in the `createQwikCity()` options in `src/entry.preview.tsx` or `src/entry.[server].tsx`:
 
 ```tsx {6} /checkOrigin/ title="entry.preview.tsx"
 // ...

--- a/packages/docs/src/routes/docs/deployments/node/index.mdx
+++ b/packages/docs/src/routes/docs/deployments/node/index.mdx
@@ -78,9 +78,9 @@ By default, all Qwik City applications are protected against [CSRF attacks](http
 
 This protection is enabled by default and it's the reason why you need to set the `ORIGIN` environment variable when deploying your application for production.
 
-If you want to disable CSRF protection, you can set `checkOrigin: false` in the `createQwikCity()` options in `src/entry.express.tsx`:
+If you want to disable CSRF protection, you can set `checkOrigin: false` in the `createQwikCity()` options in `src/entry.preview.tsx`:
 
-```tsx {6} /checkOrigin/ title="entry.express.tsx"
+```tsx {6} /checkOrigin/ title="entry.preview.tsx"
 // ...
 const { router, notFound, staticFile } = createQwikCity({
   render,


### PR DESCRIPTION
# Overview

Simple change to the docs based on behavior I found in the CLI

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Docs currently mention that `createQwikCity` exists in `/src/entry.[server].tsx`, but actual behavior is in `/src/entry.preview.tsx`

I'm not sure about some of the other references in the rest of the page.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
