### PR TITLE
feat(qwik-react): directive aliases for Astro and other package conflicts

### DIFF
--- a/packages/qwik-react/package.json
+++ b/packages/qwik-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@builder.io/qwik-react",
   "description": "QwikReact allows adding React components into existing Qwik application",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "bugs": "https://github.com/BuilderIO/qwik/issues",
   "devDependencies": {
     "@builder.io/qwik": "workspace:*",

--- a/packages/qwik-react/src/react/slot.ts
+++ b/packages/qwik-react/src/react/slot.ts
@@ -71,11 +71,7 @@ export class SlotElement extends Component {
 export const getReactProps = (props: Record<string, any>): Record<string, any> => {
   const obj: Record<string, any> = {};
   Object.keys(props).forEach((key) => {
-    if (
-      !key.startsWith('client:') &&
-      !key.startsWith('qwik:') &&
-      !key.startsWith(HOST_PREFIX)
-    ) {
+    if (!key.startsWith('client:') && !key.startsWith('qwik:') && !key.startsWith(HOST_PREFIX)) {
       const normalizedKey = key.endsWith('$') ? key.slice(0, -1) : key;
       obj[normalizedKey] = props[key];
     }
@@ -104,14 +100,12 @@ export const useWakeupSignal = (props: QwikifyProps<{}>, opts: QwikifyOptions = 
   const clientVisible =
     props['client:visible'] || props['qwik:visible'] || opts?.eagerness === 'visible';
 
-  const clientIdle =
-    props['client:idle'] || props['qwik:idle'] || opts?.eagerness === 'idle';
+  const clientIdle = props['client:idle'] || props['qwik:idle'] || opts?.eagerness === 'idle';
 
   const clientLoad =
     props['client:load'] || props['qwik:load'] || clientOnly || opts?.eagerness === 'load';
 
-  const clientHover =
-    props['client:hover'] || props['qwik:hover'] || opts?.eagerness === 'hover';
+  const clientHover = props['client:hover'] || props['qwik:hover'] || opts?.eagerness === 'hover';
 
   const clientEvent = props['client:event'] || props['qwik:event'];
 

--- a/packages/qwik-react/src/react/slot.ts
+++ b/packages/qwik-react/src/react/slot.ts
@@ -73,7 +73,7 @@ export const getReactProps = (props: Record<string, any>): Record<string, any> =
   Object.keys(props).forEach((key) => {
     if (
       !key.startsWith('client:') &&
-      !key.startsWith('qwik-client:') &&
+      !key.startsWith('qwik:') &&
       !key.startsWith(HOST_PREFIX)
     ) {
       const normalizedKey = key.endsWith('$') ? key.slice(0, -1) : key;
@@ -96,24 +96,24 @@ export const getHostProps = (props: Record<string, any>): Record<string, any> =>
 export const useWakeupSignal = (props: QwikifyProps<{}>, opts: QwikifyOptions = {}) => {
   const signal = useSignal(false);
   const activate = $(() => (signal.value = true));
-  const clientOnly = !!(props['client:only'] || props['qwik-client:only'] || opts?.clientOnly);
+  const clientOnly = !!(props['client:only'] || props['qwik:only'] || opts?.clientOnly);
 
   /*
-    qwik-client:* is an alias so that it can be used in meta-frameworks that also use client:* directives.
+    qwik:* is an alias so that it can be used in meta-frameworks that also use client:* directives.
   */
   const clientVisible =
-    props['client:visible'] || props['qwik-client:visible'] || opts?.eagerness === 'visible';
+    props['client:visible'] || props['qwik:visible'] || opts?.eagerness === 'visible';
 
   const clientIdle =
-    props['client:idle'] || props['qwik-client:idle'] || opts?.eagerness === 'idle';
+    props['client:idle'] || props['qwik:idle'] || opts?.eagerness === 'idle';
 
   const clientLoad =
-    props['client:load'] || props['qwik-client:load'] || clientOnly || opts?.eagerness === 'load';
+    props['client:load'] || props['qwik:load'] || clientOnly || opts?.eagerness === 'load';
 
   const clientHover =
-    props['client:hover'] || props['qwik-client:hover'] || opts?.eagerness === 'hover';
+    props['client:hover'] || props['qwik:hover'] || opts?.eagerness === 'hover';
 
-  const clientEvent = props['client:event'] || props['qwik-client:event'];
+  const clientEvent = props['client:event'] || props['qwik:event'];
 
   if (isServer) {
     if (clientVisible) {

--- a/packages/qwik-react/src/react/types.ts
+++ b/packages/qwik-react/src/react/types.ts
@@ -14,7 +14,7 @@ export interface QwikifyBase {
    * **Use case:** Immediately-visible UI elements that need to be interactive as soon as possible.
    */
   'client:load'?: boolean;
-  'qwik-client:load'?: boolean;
+  'qwik:load'?: boolean;
 
   /**
    * The component eagerly hydrates when the browser first become idle, ie, when everything
@@ -23,7 +23,7 @@ export interface QwikifyBase {
    * **Use case:** Lower-priority UI elements that don’t need to be immediately interactive.
    */
   'client:idle'?: boolean;
-  'qwik-client:idle'?: boolean;
+  'qwik:idle'?: boolean;
 
   /**
    * The component eagerly hydrates when it becomes visible in the viewport.
@@ -33,7 +33,7 @@ export interface QwikifyBase {
    * saw the element.
    */
   'client:visible'?: boolean;
-  'qwik-client:visible'?: boolean;
+  'qwik:visible'?: boolean;
 
   /**
    * The component eagerly hydrates when the mouse is over the component.
@@ -42,11 +42,11 @@ export interface QwikifyBase {
    * run in desktop.
    */
   'client:hover'?: boolean;
-  'qwik-client:hover'?: boolean;
+  'qwik:hover'?: boolean;
 
   /** When `true`, the component will not run in SSR, only in the browser. */
   'client:only'?: boolean;
-  'qwik-client:only'?: boolean;
+  'qwik:only'?: boolean;
 
   /**
    * This is an advanced API that allows to hydrate the component whenever the passed signal becomes
@@ -55,11 +55,11 @@ export interface QwikifyBase {
    * This effectively allows you to implement custom strategies for hydration.
    */
   'client:signal'?: Signal<boolean>;
-  'qwik-client:signal'?: Signal<boolean>;
+  'qwik:signal'?: Signal<boolean>;
 
   /** The component eagerly hydrates when specified DOM events are dispatched. */
   'client:event'?: string | string[];
-  'qwik-client:event'?: string | string[];
+  'qwik:event'?: string | string[];
 
   /**
    * Adds a `click` event listener to the host element, this event will be dispatched even if the

--- a/packages/qwik-react/src/react/types.ts
+++ b/packages/qwik-react/src/react/types.ts
@@ -14,6 +14,7 @@ export interface QwikifyBase {
    * **Use case:** Immediately-visible UI elements that need to be interactive as soon as possible.
    */
   'client:load'?: boolean;
+  'qwik-client:load'?: boolean;
 
   /**
    * The component eagerly hydrates when the browser first become idle, ie, when everything
@@ -22,6 +23,7 @@ export interface QwikifyBase {
    * **Use case:** Lower-priority UI elements that don’t need to be immediately interactive.
    */
   'client:idle'?: boolean;
+  'qwik-client:idle'?: boolean;
 
   /**
    * The component eagerly hydrates when it becomes visible in the viewport.
@@ -31,6 +33,7 @@ export interface QwikifyBase {
    * saw the element.
    */
   'client:visible'?: boolean;
+  'qwik-client:visible'?: boolean;
 
   /**
    * The component eagerly hydrates when the mouse is over the component.
@@ -39,9 +42,11 @@ export interface QwikifyBase {
    * run in desktop.
    */
   'client:hover'?: boolean;
+  'qwik-client:hover'?: boolean;
 
   /** When `true`, the component will not run in SSR, only in the browser. */
   'client:only'?: boolean;
+  'qwik-client:only'?: boolean;
 
   /**
    * This is an advanced API that allows to hydrate the component whenever the passed signal becomes
@@ -50,9 +55,11 @@ export interface QwikifyBase {
    * This effectively allows you to implement custom strategies for hydration.
    */
   'client:signal'?: Signal<boolean>;
+  'qwik-client:signal'?: Signal<boolean>;
 
   /** The component eagerly hydrates when specified DOM events are dispatched. */
   'client:event'?: string | string[];
+  'qwik-client:event'?: string | string[];
 
   /**
    * Adds a `click` event listener to the host element, this event will be dispatched even if the


### PR DESCRIPTION
This PR adds aliases for the directives so that they can be used in `.astro` files.

But, it can also be used in other places where packages might have `client:*` directives that conflict.