### PR TITLE
feat: add `skipConfirmation` to cli add command

### DIFF
--- a/packages/qwik/src/cli/add/run-add-interactive.ts
+++ b/packages/qwik/src/cli/add/run-add-interactive.ts
@@ -1,14 +1,14 @@
-import type { IntegrationData, UpdateAppResult } from '../types';
-import { bgBlue, bgMagenta, blue, bold, cyan, magenta } from 'kleur/colors';
-import { bye, getPackageManager, note, panic, printHeader } from '../utils/utils';
 import { intro, isCancel, log, outro, select, spinner } from '@clack/prompts';
+import { bgBlue, bgMagenta, blue, bold, cyan, magenta } from 'kleur/colors';
+import type { IntegrationData, UpdateAppResult } from '../types';
 import { loadIntegrations, sortIntegrationsAndReturnAsClackOptions } from '../utils/integrations';
+import { bye, getPackageManager, note, panic, printHeader } from '../utils/utils';
 
 /* eslint-disable no-console */
-import type { AppCommand } from '../utils/app-command';
-import { logNextStep } from '../utils/log';
 import { relative } from 'node:path';
+import type { AppCommand } from '../utils/app-command';
 import { runInPkg } from '../utils/install-deps';
+import { logNextStep } from '../utils/log';
 import { updateApp } from './update-app';
 
 export async function runAddInteractive(app: AppCommand, id: string | undefined) {
@@ -69,7 +69,9 @@ export async function runAddInteractive(app: AppCommand, id: string | undefined)
     installDeps: runInstall,
   });
 
-  await logUpdateAppResult(pkgManager, result);
+  if (app.getArg('skipConfirmation') !== 'true') {
+    await logUpdateAppResult(pkgManager, result);
+  }
   await result.commit(true);
   const postInstall = result.integration.pkgJson.__qwik__?.postInstall;
   if (postInstall) {


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

The ability to add `--skipConfirmation=true` to the `add` command in qwik cli.

# Use cases and why

It's good for other CLI tools that reuses the `qwik add` command to install integrations (like the qwik-ui cli for example)



# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
