### PR TITLE
fix(cli): Update jokes.json

### DIFF
--- a/packages/create-qwik/src/helpers/jokes.json
+++ b/packages/create-qwik/src/helpers/jokes.json
@@ -34,7 +34,6 @@
   ["What did the fish say when it hit the wall?", "Dam."],
   ["Want to hear a joke about a piece of paper?", "Never mind...it's tearable"],
   ["What did the big flower say to the littler flower?", "Hi, bud!"],
-  ["What has ears but cannot hear?", "A field of corn."],
   ["What's the best thing about elevator jokes?", "They work on so many levels."],
   ["Why can't your nose be  inches long?", "Because then it'd be a foot!"],
   ["Why does Superman get invited to dinners?", "Because he is a Supperhero."],


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I ran `npm create qwik` and got greeted with this:
<img width="324" alt="What has ears but cannot hear? A field of corn." src="https://github.com/BuilderIO/qwik/assets/9084735/8e7284e8-44a6-4817-86ff-5f8e45e71692">


Not sure where y'all are sourcing your jokes from, but you might want to do a review. For now, I'm just removing this one.

# Use cases and why

Because it's not funny, it's abhorrent.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
