### PR TITLE
docs: change placement of {...props}  and add section

### DIFF
--- a/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/nav-link/index.tsx
@@ -25,8 +25,8 @@ export const NavLink = component$(
 
     return (
       <Link
-        class={`${props.class || ''} ${isActive ? activeClass : ''}`}
         {...props}
+        class={`${props.class || ''} ${isActive ? activeClass : ''}`}
       >
         <Slot />
       </Link>

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -50,8 +50,9 @@ export const NavLink = component$(
 
     return (
       <Link
+{...props}
         class={`${props.class || ''} ${isActive ? activeClass : ''}`}
-        {...props}
+        
       >
         <Slot />
       </Link>
@@ -93,3 +94,7 @@ export default component$(() => {
 });
 ```
 </CodeSandbox>
+
+## Tailwind 
+If you are using TailwinCss make sure to edit your tailwind config file, and add `important=true` to your export, then add `!` before the CSS classes you're using `activeClass="!text-green-600"` to make them important when the like is active.
+

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -50,7 +50,7 @@ export const NavLink = component$(
 
     return (
       <Link
-{...props}
+        {...props}
         class={`${props.class || ''} ${isActive ? activeClass : ''}`}
         
       >


### PR DESCRIPTION
change placement of {...props} to not overwrite class when active with default classes  also, add a section to make Navlink work when you're adding class and activeClass at the same time

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
