### PR TITLE
docs: Update build command in Static Site Generation (SSG) Overview docs

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
@@ -57,7 +57,7 @@ Your build files will be generated into the `dist` folder.
 You can build your static site using:
 
 ```shell
-npm run build
+npm run build.server
 ```
 
 ### SSG Config


### PR DESCRIPTION
# Overview

 The current command for building static site is
```
npm run build
```

It should be 
```
npm run build.server
```

Right?


# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Updated index.md file for the SSG docs

# Use cases and why

 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
