### PR TITLE
fix: polymorphic component types

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "yarn": "please-use-pnpm",
     "pnpm": ">=8.6.12"
   },
-  "packageManager": "pnpm@8.11.0",
+  "packageManager": "pnpm@8.14.0",
   "pnpm": {
     "overrides": {
       "vfile": "6.0.1",
@@ -125,8 +125,8 @@
     "build.cli.prod": "tsm scripts/index.ts --cli",
     "build.core": "tsm scripts/index.ts --tsc --build --qwikcity --platform-binding-wasm-copy",
     "build.eslint": "tsm scripts/index.ts --eslint",
-    "build.full": "tsm scripts/index.ts --tsc --build --supabaseauthhelpers --api --eslint --qwikcity --qwikworker --qwiklabs --qwikreact --qwikauth --cli --platform-binding --wasm",
-    "build.local": "tsm scripts/index.ts --tsc --build --supabaseauthhelpers --api --eslint --qwikcity --qwikworker --qwiklabs --qwikreact --qwikauth --cli --platform-binding-wasm-copy",
+    "build.full": "tsm scripts/index.ts --tsc --tsc-docs --build --supabaseauthhelpers --api --eslint --qwikcity --qwikworker --qwiklabs --qwikreact --qwikauth --cli --platform-binding --wasm",
+    "build.local": "tsm scripts/index.ts --tsc --tsc-docs --build --supabaseauthhelpers --api --eslint --qwikcity --qwikworker --qwiklabs --qwikreact --qwikauth --cli --platform-binding-wasm-copy",
     "build.only_javascript": "tsm scripts/index.ts --tsc --build --api",
     "build.platform": "tsm scripts/index.ts --platform-binding",
     "build.platform.copy": "tsm scripts/index.ts --platform-binding-wasm-copy",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,7 +11,7 @@
     "@builder.io/qwik": "workspace:*",
     "@builder.io/qwik-city": "workspace:*",
     "@builder.io/qwik-labs": "workspace:*",
-    "@builder.io/qwik-react": "0.5.0",
+    "@builder.io/qwik-react": "workspace:*",
     "@builder.io/sdk-qwik": "^0.6.2",
     "@docsearch/css": "^3.5.2",
     "@emotion/react": "^11.11.1",
@@ -58,12 +58,7 @@
   },
   "homepage": "https://qwik.builder.io/",
   "license": "MIT",
-  "packageManager": "pnpm@8.6.12",
-  "pnpm": {
-    "overrides": {
-      "@supabase/realtime-js": "2.8.4"
-    }
-  },
+  "packageManager": "pnpm@8.14.0",
   "private": true,
   "scripts": {
     "build": "node ./node_modules/@builder.io/qwik/qwik.cjs build",

--- a/packages/docs/src/components/docsearch/search-box.tsx
+++ b/packages/docs/src/components/docsearch/search-box.tsx
@@ -1,10 +1,4 @@
-import {
-  component$,
-  useVisibleTask$,
-  useContext,
-  type Signal,
-  type PropFunction,
-} from '@builder.io/qwik';
+import { component$, useVisibleTask$, useContext, type Signal, type QRL } from '@builder.io/qwik';
 
 import { MAX_QUERY_SIZE } from './constants';
 import { SearchContext } from './context';
@@ -23,7 +17,7 @@ interface SearchBoxProps {
   state: DocSearchState;
   autoFocus: boolean;
   inputRef: Signal<HTMLInputElement | null>;
-  onClose$: PropFunction<() => void>;
+  onClose$: QRL<() => void>;
 }
 
 export const SearchBox = component$((props: SearchBoxProps) => {

--- a/packages/docs/src/repl/editor.tsx
+++ b/packages/docs/src/repl/editor.tsx
@@ -1,7 +1,7 @@
 import {
   component$,
   type NoSerialize,
-  type PropFunction,
+  type QRL,
   useVisibleTask$,
   useContext,
   useSignal,
@@ -78,7 +78,7 @@ export interface EditorProps {
   input: ReplAppInput;
   ariaLabel: string;
   lineNumbers: 'on' | 'off';
-  onChange$: PropFunction<(path: string, code: string) => void>;
+  onChange$: QRL<(path: string, code: string) => void>;
   wordWrap: 'on' | 'off';
   store: ReplStore;
 }

--- a/packages/docs/src/repl/repl-input-panel.tsx
+++ b/packages/docs/src/repl/repl-input-panel.tsx
@@ -1,4 +1,4 @@
-import type { PropFunction } from '@builder.io/qwik';
+import type { QRL } from '@builder.io/qwik';
 import { Editor } from './editor';
 import { ReplCommands } from './repl-commands';
 import { ReplTabButton } from './repl-tab-button';
@@ -65,8 +65,8 @@ const formatFilePath = (path: string) => {
 interface ReplInputPanelProps {
   input: ReplAppInput;
   store: ReplStore;
-  onInputChange$: PropFunction<(path: string, code: string) => void>;
-  onInputDelete$: PropFunction<(path: string) => void>;
+  onInputChange$: QRL<(path: string, code: string) => void>;
+  onInputDelete$: QRL<(path: string) => void>;
   enableDownload?: boolean;
   enableCopyToPlayground?: boolean;
   enableInputDelete?: boolean;

--- a/packages/docs/src/repl/repl-tab-button.tsx
+++ b/packages/docs/src/repl/repl-tab-button.tsx
@@ -1,7 +1,7 @@
-import type { PropFunction } from '@builder.io/qwik';
+import type { PropsOf, Component } from '@builder.io/qwik';
 import { CloseIcon } from '../components/svgs/close-icon';
 
-export const ReplTabButton = (props: ReplTabButtonProps) => {
+export const ReplTabButton: Component<ReplTabButtonProps> = (props) => {
   return (
     <div
       key={props.text}
@@ -32,8 +32,8 @@ export const ReplTabButton = (props: ReplTabButtonProps) => {
 interface ReplTabButtonProps {
   text: string;
   isActive: boolean;
-  onClick$: PropFunction<() => void>;
-  onClose$?: PropFunction<() => void>;
+  onClick$: PropsOf<'button'>['onClick$'];
+  onClose$?: PropsOf<'button'>['onClick$'];
   cssClass?: Record<string, boolean>;
   enableInputDelete?: boolean;
 }

--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -365,7 +365,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "```typescript\nLink: import(\"@builder.io/qwik\").Component<import(\"@builder.io/qwik\").PropFunctionProps<LinkProps>>\n```",
+      "content": "```typescript\nLink: import(\"@builder.io/qwik\").Component<LinkProps>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/link-component.tsx",
       "mdFile": "qwik-city.link.md"
     },
@@ -491,7 +491,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "```typescript\nQwikCityMockProvider: import(\"@builder.io/qwik\").Component<import(\"@builder.io/qwik\").PropFunctionProps<QwikCityMockProps>>\n```",
+      "content": "```typescript\nQwikCityMockProvider: import(\"@builder.io/qwik\").Component<QwikCityMockProps>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/qwik-city-component.tsx",
       "mdFile": "qwik-city.qwikcitymockprovider.md"
     },
@@ -533,7 +533,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "```typescript\nQwikCityProvider: import(\"@builder.io/qwik\").Component<import(\"@builder.io/qwik\").PropFunctionProps<QwikCityProps>>\n```",
+      "content": "```typescript\nQwikCityProvider: import(\"@builder.io/qwik\").Component<QwikCityProps>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/qwik-city-component.tsx",
       "mdFile": "qwik-city.qwikcityprovider.md"
     },
@@ -659,7 +659,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "```typescript\nRouterOutlet: import(\"@builder.io/qwik\").Component<import(\"@builder.io/qwik\").PropFunctionProps<Record<any, any>>>\n```",
+      "content": "```typescript\nRouterOutlet: import(\"@builder.io/qwik\").Component<Record<any, any>>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/router-outlet-component.tsx",
       "mdFile": "qwik-city.routeroutlet.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -460,9 +460,7 @@ export type JSONValue =
 ## Link
 
 ```typescript
-Link: import("@builder.io/qwik").Component<
-  import("@builder.io/qwik").PropFunctionProps<LinkProps>
->;
+Link: import("@builder.io/qwik").Component<LinkProps>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/link-component.tsx)
@@ -566,9 +564,7 @@ export interface QwikCityMockProps
 ## QwikCityMockProvider
 
 ```typescript
-QwikCityMockProvider: import("@builder.io/qwik").Component<
-  import("@builder.io/qwik").PropFunctionProps<QwikCityMockProps>
->;
+QwikCityMockProvider: import("@builder.io/qwik").Component<QwikCityMockProps>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/qwik-city-component.tsx)
@@ -605,9 +601,7 @@ export interface QwikCityProps
 ## QwikCityProvider
 
 ```typescript
-QwikCityProvider: import("@builder.io/qwik").Component<
-  import("@builder.io/qwik").PropFunctionProps<QwikCityProps>
->;
+QwikCityProvider: import("@builder.io/qwik").Component<QwikCityProps>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/qwik-city-component.tsx)
@@ -711,9 +705,7 @@ export type RouteNavigate = QRL<
 ## RouterOutlet
 
 ```typescript
-RouterOutlet: import("@builder.io/qwik").Component<
-  import("@builder.io/qwik").PropFunctionProps<Record<any, any>>
->;
+RouterOutlet: import("@builder.io/qwik").Component<Record<any, any>>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/router-outlet-component.tsx)

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -474,7 +474,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "Declare a Qwik component that can be used to create UI.\n\nUse `component$` to declare a Qwik component. A Qwik component is a special kind of component that allows the Qwik framework to lazy load and execute the component independently of other Qwik components as well as lazy load the component's life-cycle hooks and event handlers.\n\nSide note: You can also declare regular (standard JSX) components that will have standard synchronous behavior.\n\nQwik component is a facade that describes how the component should be used without forcing the implementation of the component to be eagerly loaded. A minimum Qwik definition consists of:\n\n\\#\\#\\# Example\n\nAn example showing how to create a counter component:\n\n```tsx\nexport interface CounterProps {\n  initialValue?: number;\n  step?: number;\n}\nexport const Counter = component$((props: CounterProps) => {\n  const state = useStore({ count: props.initialValue || 0 });\n  return (\n    <div>\n      <span>{state.count}</span>\n      <button onClick$={() => (state.count += props.step || 1)}>+</button>\n    </div>\n  );\n});\n```\n- `component$` is how a component gets declared. - `{ value?: number; step?: number }` declares the public (props) interface of the component. - `{ count: number }` declares the private (state) interface of the component.\n\nThe above can then be used like so:\n\n```tsx\nexport const OtherComponent = component$(() => {\n  return <Counter initialValue={100} />;\n});\n```\nSee also: `component`<!-- -->, `useCleanup`<!-- -->, `onResume`<!-- -->, `onPause`<!-- -->, `useOn`<!-- -->, `useOnDocument`<!-- -->, `useOnWindow`<!-- -->, `useStyles`\n\n\n```typescript\ncomponent$: <PROPS extends Record<any, any>>(onMount: (props: PROPS) => JSXNode | null) => Component<PropFunctionProps<PROPS>>\n```",
+      "content": "Declare a Qwik component that can be used to create UI.\n\nUse `component$` to declare a Qwik component. A Qwik component is a special kind of component that allows the Qwik framework to lazy load and execute the component independently of other Qwik components as well as lazy load the component's life-cycle hooks and event handlers.\n\nSide note: You can also declare regular (standard JSX) components that will have standard synchronous behavior.\n\nQwik component is a facade that describes how the component should be used without forcing the implementation of the component to be eagerly loaded. A minimum Qwik definition consists of:\n\n\\#\\#\\# Example\n\nAn example showing how to create a counter component:\n\n```tsx\nexport interface CounterProps {\n  initialValue?: number;\n  step?: number;\n}\nexport const Counter = component$((props: CounterProps) => {\n  const state = useStore({ count: props.initialValue || 0 });\n  return (\n    <div>\n      <span>{state.count}</span>\n      <button onClick$={() => (state.count += props.step || 1)}>+</button>\n    </div>\n  );\n});\n```\n- `component$` is how a component gets declared. - `{ value?: number; step?: number }` declares the public (props) interface of the component. - `{ count: number }` declares the private (state) interface of the component.\n\nThe above can then be used like so:\n\n```tsx\nexport const OtherComponent = component$(() => {\n  return <Counter initialValue={100} />;\n});\n```\nSee also: `component`<!-- -->, `useCleanup`<!-- -->, `onResume`<!-- -->, `onPause`<!-- -->, `useOn`<!-- -->, `useOnDocument`<!-- -->, `useOnWindow`<!-- -->, `useStyles`\n\n\n```typescript\ncomponent$: <PROPS extends Record<any, any>>(onMount: (props: PROPS) => JSXNode | null) => Component<PROPS>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.component_.md"
     },
@@ -774,6 +774,20 @@
       "content": "```typescript\nevent$: <T>(first: T) => QRL<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts",
       "mdFile": "qwik.event_.md"
+    },
+    {
+      "name": "EventHandler",
+      "id": "eventhandler",
+      "hierarchy": [
+        {
+          "name": "EventHandler",
+          "id": "eventhandler"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "A DOM event handler\n\n\n```typescript\nexport type EventHandler<EV = Event, EL = Element> = {\n    bivarianceHack(event: EV, element: EL): any;\n}['bivarianceHack'];\n```",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts",
+      "mdFile": "qwik.eventhandler.md"
     },
     {
       "name": "eventQrl",
@@ -1782,7 +1796,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "Infers `Props` from the component.\n\n```typescript\nexport const OtherComponent = component$(() => {\n  return $(() => <Counter value={100} />);\n});\n```\n\n\n```typescript\nexport type PropsOf<COMP> = COMP extends Component<infer PROPS> ? NonNullable<PROPS> : COMP extends FunctionComponent<infer PROPS> ? NonNullable<PublicProps<PROPS>> : COMP extends string ? QwikIntrinsicElements[COMP] : Record<string, unknown>;\n```\n**References:** [Component](#component)<!-- -->, [FunctionComponent](#functioncomponent)<!-- -->, [PublicProps](#publicprops)<!-- -->, [QwikIntrinsicElements](#qwikintrinsicelements)",
+      "content": "Infers `Props` from the component.\n\n```typescript\nexport const OtherComponent = component$(() => {\n  return $(() => <Counter value={100} />);\n});\n```\n\n\n```typescript\nexport type PropsOf<COMP> = COMP extends Component<infer PROPS> ? NonNullable<PROPS> : COMP extends FunctionComponent<infer PROPS> ? NonNullable<PublicProps<PROPS>> : COMP extends keyof QwikIntrinsicElements ? QwikIntrinsicElements[COMP] : COMP extends string ? QwikIntrinsicElements['span'] : Record<string, unknown>;\n```\n**References:** [Component](#component)<!-- -->, [FunctionComponent](#functioncomponent)<!-- -->, [PublicProps](#publicprops)<!-- -->, [QwikIntrinsicElements](#qwikintrinsicelements)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.propsof.md"
     },
@@ -1796,7 +1810,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "Extends the defined component PROPS, adding the default ones (children and q:slot)..\n\n\n```typescript\nexport type PublicProps<PROPS extends Record<any, any>> = TransformProps<PROPS> & ComponentBaseProps & ComponentChildren<PROPS>;\n```\n**References:** [ComponentBaseProps](#componentbaseprops)",
+      "content": "Extends the defined component PROPS, adding the default ones (children and q:slot) and allowing plain functions to QRL arguments.\n\n\n```typescript\nexport type PublicProps<PROPS extends Record<any, any>> = Omit<PROPS, `${string}$`> & _Only$<PROPS> & ComponentBaseProps & ComponentChildren<PROPS>;\n```\n**References:** [ComponentBaseProps](#componentbaseprops)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.publicprops.md"
     },
@@ -1827,6 +1841,20 @@
       "content": "Used by Qwik Optimizer to point to lazy-loaded resources.\n\nThis function should be used by the Qwik Optimizer only. The function should not be directly referred to in the source code of the application.\n\n\n```typescript\nqrl: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: string, lexicalScopeCapture?: any[], stackOffset?: number) => QRL<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts",
       "mdFile": "qwik.qrl.md"
+    },
+    {
+      "name": "QRLEventHandlerMulti",
+      "id": "qrleventhandlermulti",
+      "hierarchy": [
+        {
+          "name": "QRLEventHandlerMulti",
+          "id": "qrleventhandlermulti"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.\n> \n\nAn event handler for Qwik events, can be a handler QRL or an array of handler QRLs.\n\n\n```typescript\nexport type QRLEventHandlerMulti<EV extends Event, EL> = QRL<EventHandler<EV, EL>> | undefined | null | QRLEventHandlerMulti<EV, EL>[];\n```\n**References:** [QRL](#qrl)<!-- -->, [EventHandler](#eventhandler)<!-- -->, [QRLEventHandlerMulti](#qrleventhandlermulti)",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts",
+      "mdFile": "qwik.qrleventhandlermulti.md"
     },
     {
       "name": "QuoteHTMLAttributes",
@@ -1950,7 +1978,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "The DOM props without plain handlers, for use inside functions\n\n\n```typescript\nexport type QwikHTMLElements = {\n    [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> & HTMLElementAttrs & QwikAttributes<HTMLElementTagNameMap[tag]>;\n} & {\n    [unknownTag: string]: {\n        [prop: string]: any;\n    } & HTMLElementAttrs & QwikAttributes<any>;\n};\n```",
+      "content": "The DOM props without plain handlers, for use inside functions\n\n\n```typescript\nexport type QwikHTMLElements = {\n    [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> & HTMLElementAttrs & QwikAttributes<HTMLElementTagNameMap[tag]>;\n};\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.qwikhtmlelements.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -458,7 +458,7 @@ See also: `component`, `useCleanup`, `onResume`, `onPause`, `useOn`, `useOnDocum
 ```typescript
 component$: <PROPS extends Record<any, any>>(
   onMount: (props: PROPS) => JSXNode | null,
-) => Component<PropFunctionProps<PROPS>>;
+) => Component<PROPS>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts)
@@ -816,6 +816,18 @@ event$: <T>(first: T) => QRL<T>;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts)
+
+## EventHandler
+
+A DOM event handler
+
+```typescript
+export type EventHandler<EV = Event, EL = Element> = {
+  bivarianceHack(event: EV, element: EL): any;
+}["bivarianceHack"];
+```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
 
 ## eventQrl
 
@@ -1766,9 +1778,11 @@ export type PropsOf<COMP> = COMP extends Component<infer PROPS>
   ? NonNullable<PROPS>
   : COMP extends FunctionComponent<infer PROPS>
     ? NonNullable<PublicProps<PROPS>>
-    : COMP extends string
+    : COMP extends keyof QwikIntrinsicElements
       ? QwikIntrinsicElements[COMP]
-      : Record<string, unknown>;
+      : COMP extends string
+        ? QwikIntrinsicElements["span"]
+        : Record<string, unknown>;
 ```
 
 **References:** [Component](#component), [FunctionComponent](#functioncomponent), [PublicProps](#publicprops), [QwikIntrinsicElements](#qwikintrinsicelements)
@@ -1777,11 +1791,16 @@ export type PropsOf<COMP> = COMP extends Component<infer PROPS>
 
 ## PublicProps
 
-Extends the defined component PROPS, adding the default ones (children and q:slot)..
+Extends the defined component PROPS, adding the default ones (children and q:slot) and allowing plain functions to QRL arguments.
 
 ```typescript
-export type PublicProps<PROPS extends Record<any, any>> =
-  TransformProps<PROPS> & ComponentBaseProps & ComponentChildren<PROPS>;
+export type PublicProps<PROPS extends Record<any, any>> = Omit<
+  PROPS,
+  `${string}$`
+> &
+  _Only$<PROPS> &
+  ComponentBaseProps &
+  ComponentChildren<PROPS>;
 ```
 
 **References:** [ComponentBaseProps](#componentbaseprops)
@@ -1821,6 +1840,24 @@ qrl: <T = any>(
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts)
+
+## QRLEventHandlerMulti
+
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+
+An event handler for Qwik events, can be a handler QRL or an array of handler QRLs.
+
+```typescript
+export type QRLEventHandlerMulti<EV extends Event, EL> =
+  | QRL<EventHandler<EV, EL>>
+  | undefined
+  | null
+  | QRLEventHandlerMulti<EV, EL>[];
+```
+
+**References:** [QRL](#qrl), [EventHandler](#eventhandler), [QRLEventHandlerMulti](#qrleventhandlermulti)
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
 
 ## QuoteHTMLAttributes
 
@@ -1936,11 +1973,6 @@ export type QwikHTMLElements = {
   > &
     HTMLElementAttrs &
     QwikAttributes<HTMLElementTagNameMap[tag]>;
-} & {
-  [unknownTag: string]: {
-    [prop: string]: any;
-  } & HTMLElementAttrs &
-    QwikAttributes<any>;
 };
 ```
 

--- a/packages/docs/src/routes/demo/resumability/component.tsx
+++ b/packages/docs/src/routes/demo/resumability/component.tsx
@@ -1,5 +1,5 @@
 import {
-  type QwikIntrinsicElements,
+  type PropsOf,
   component$,
   useStylesScoped$,
   Slot,
@@ -214,7 +214,7 @@ export const UnderstandingResumability = component$(() => {
   );
 });
 
-export function ReadyIcon(props: QwikIntrinsicElements['svg'], key: string) {
+export function ReadyIcon(props: PropsOf<'svg'>, key: string) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/docs/src/routes/docs/(qwik)/components/events/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/events/index.mdx
@@ -292,9 +292,9 @@ export const Button = component$<ButtonProps>(({ onTripleClick$ }) => {
 ```
 </CodeSandbox>
 
-⚠️ When using type annotations, we need to wrap the event type with `PropFunction` in order to tell TypeScript that the function can't be called synchronously.
+⚠️ When using type annotations, we need to wrap the event type with `QRL` in order to tell TypeScript that the function can't be called synchronously.
 ```tsx
-component$(({ onTripleClick$ } : { onTripleClick$?: PropFunction<() => void> }) => {
+component$(({ onTripleClick$ } : { onTripleClick$?: QRL<() => void> }) => {
   ...
 });
 ```

--- a/packages/docs/src/routes/docs/integrations/icons/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/icons/index.mdx
@@ -69,9 +69,9 @@ Icones is powered by [iconify](https://iconify.design/) which allows to easy add
 Click the `Qwik` button to copy the icon code to your clipboard, then paste it into your project.
 
 ```tsx
-import type { QwikIntrinsicElements } from '@builder.io/qwik'
+import type { PropsOf } from '@builder.io/qwik'
 
-export function OcticonAlertFill12(props: QwikIntrinsicElements['svg'], key: string) {
+export function OcticonAlertFill12(props: PropsOf<'svg'>, key: string) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 12 12" {...props} key={key}><path fill="#888888" d="M4.855.708c.5-.896 1.79-.896 2.29 0l4.675 8.351a1.312 1.312 0 0 1-1.146 1.954H1.33A1.313 1.313 0 0 1 .183 9.058ZM7 7V3H5v4Zm-1 3a1 1 0 1 0 0-2a1 1 0 0 0 0 2Z"></path></svg>
   )

--- a/packages/docs/src/routes/tutorial/props/closures/index.mdx
+++ b/packages/docs/src/routes/tutorial/props/closures/index.mdx
@@ -32,12 +32,12 @@ Most of the time we use the first form as it allows us to inline our callbacks d
 A component can declare a callback in its props by:
 
 - Property that ends in `$` (as in `goodbye$`)
-- The type of the property is `PropFunction<T>` where `T` is the lazy reference type that the QRL points to (function signature).
+- The type of the property is `QRL<T>` where `T` is the lazy reference type that the QRL points to (function signature).
 
 ```tsx
 interface MyComponentProps {
-  goodbye$: PropFunction<() => void>;
-  hello$: PropFunction<() => void>;
+  goodbye$: QRL<() => void>;
+  hello$: QRL<() => void>;
 }
 
 export const MyComponent = component$((props: MyComponentProps) => { ... });

--- a/packages/docs/src/routes/tutorial/props/closures/problem/app.tsx
+++ b/packages/docs/src/routes/tutorial/props/closures/problem/app.tsx
@@ -1,4 +1,4 @@
-import { component$, $, type PropFunction } from '@builder.io/qwik';
+import { component$, $, type QRL } from '@builder.io/qwik';
 
 export default component$(() => {
   const goodbye$ = $(() => alert('Good Bye!'));
@@ -10,8 +10,8 @@ export default component$(() => {
 });
 
 interface MyComponentProps {
-  goodbye$: PropFunction<() => void>;
-  hello$: PropFunction<(name: string) => void>;
+  goodbye$: QRL<() => void>;
+  hello$: QRL<(name: string) => void>;
 }
 export const MyComponent = component$((props: MyComponentProps) => {
   return (

--- a/packages/docs/src/routes/tutorial/props/closures/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/props/closures/solution/app.tsx
@@ -1,4 +1,4 @@
-import { component$, $, type PropFunction } from '@builder.io/qwik';
+import { component$, $, type QRL } from '@builder.io/qwik';
 
 export default component$(() => {
   const goodbye$ = $(() => alert('Good Bye!'));
@@ -10,8 +10,8 @@ export default component$(() => {
 });
 
 interface MyComponentProps {
-  goodbye$: PropFunction<() => void>;
-  hello$: PropFunction<(name: string) => void>;
+  goodbye$: QRL<() => void>;
+  hello$: QRL<(name: string) => void>;
 }
 export const MyComponent = component$((props: MyComponentProps) => {
   return (

--- a/packages/eslint-plugin-qwik/src/validLexicalScope.ts
+++ b/packages/eslint-plugin-qwik/src/validLexicalScope.ts
@@ -183,7 +183,7 @@ export const validLexicalScope = createRule({
                       node: firstArg.expression,
                       data: {
                         varName: firstArg.expression.name,
-                        solution: `Fix the type of ${firstArg.expression.name} to be PropFunction`,
+                        solution: `Fix the type of ${firstArg.expression.name} to be QRL`,
                       },
                     });
                   }

--- a/packages/eslint-plugin-qwik/tests/valid-lexical-scope/valid-component-prop-function.tsx
+++ b/packages/eslint-plugin-qwik/tests/valid-lexical-scope/valid-component-prop-function.tsx
@@ -1,6 +1,6 @@
-import { component$, type PropFunction } from '@builder.io/qwik';
+import { component$, type QRL } from '@builder.io/qwik';
 
-export default component$<{ onClick$: PropFunction<() => void> }>(({ onClick$ }) => {
+export default component$<{ onClick$: QRL<() => void> }>(({ onClick$ }) => {
   return (
     <button
       onClick$={() => {

--- a/packages/eslint-plugin-qwik/tests/valid-lexical-scope/valid-component-props.tsx
+++ b/packages/eslint-plugin-qwik/tests/valid-lexical-scope/valid-component-props.tsx
@@ -1,17 +1,9 @@
-import { component$ } from '@builder.io/qwik';
-
-export interface PropFnInterface<ARGS extends any[], RET> {
-  (...args: ARGS): Promise<RET>;
-}
-
-export type PropFunction<T extends Function> = T extends (...args: infer ARGS) => infer RET
-  ? PropFnInterface<ARGS, RET>
-  : never;
+import { type QRL, component$ } from '@builder.io/qwik';
 
 export interface Props {
-  method$: PropFunction<() => void>;
-  method1$: PropFunction<() => void>;
-  method2$: PropFunction<() => void> | null;
+  method$: QRL<() => void>;
+  method1$: QRL<() => void>;
+  method2$: QRL<() => void> | null;
   method3$: any;
 }
 

--- a/packages/insights/src/components/icons/copy.tsx
+++ b/packages/insights/src/components/icons/copy.tsx
@@ -1,8 +1,8 @@
-import { component$, useSignal, type PropFunction, useStylesScoped$ } from '@builder.io/qwik';
+import { component$, useSignal, type QRL, useStylesScoped$ } from '@builder.io/qwik';
 
 interface CopyIconProps {
   class?: string;
-  onClick$: PropFunction<() => void>;
+  onClick$: QRL<() => void>;
 }
 
 export const CopyIcon = component$<CopyIconProps>(({ onClick$, ...props }) => {

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -11,7 +11,6 @@ import { CookieValue } from '@builder.io/qwik-city/middleware/request-handler';
 import { DeferReturn } from '@builder.io/qwik-city/middleware/request-handler';
 import type { EnvGetter } from '@builder.io/qwik-city/middleware/request-handler';
 import { JSXNode } from '@builder.io/qwik';
-import { PropFunctionProps } from '@builder.io/qwik';
 import { QRL } from '@builder.io/qwik';
 import { QwikIntrinsicElements } from '@builder.io/qwik';
 import { QwikJSX } from '@builder.io/qwik';
@@ -255,7 +254,7 @@ export type JSONValue = string | number | boolean | {
 } | Array<JSONValue>;
 
 // @public (undocumented)
-export const Link: Component<PropFunctionProps<LinkProps>>;
+export const Link: Component<LinkProps>;
 
 // Warning: (ae-forgotten-export) The symbol "AnchorAttributes" needs to be exported by the entry point index.d.ts
 //
@@ -317,7 +316,7 @@ export interface QwikCityMockProps {
 }
 
 // @public (undocumented)
-export const QwikCityMockProvider: Component<PropFunctionProps<QwikCityMockProps>>;
+export const QwikCityMockProvider: Component<QwikCityMockProps>;
 
 // @public (undocumented)
 export interface QwikCityPlan {
@@ -341,7 +340,7 @@ export interface QwikCityProps {
 }
 
 // @public (undocumented)
-export const QwikCityProvider: Component<PropFunctionProps<QwikCityProps>>;
+export const QwikCityProvider: Component<QwikCityProps>;
 
 export { RequestEvent }
 
@@ -405,7 +404,7 @@ export type RouteNavigate = QRL<(path?: string, options?: {
 } | boolean) => Promise<void>>;
 
 // @public (undocumented)
-export const RouterOutlet: Component<PropFunctionProps<Record<any, any>>>;
+export const RouterOutlet: Component<Record<any, any>>;
 
 // @public (undocumented)
 export const server$: <T extends ServerFunction>(first: T) => ServerQRL<T>;

--- a/packages/qwik-city/runtime/src/error-boundary.tsx
+++ b/packages/qwik-city/runtime/src/error-boundary.tsx
@@ -1,9 +1,9 @@
-import { component$, useErrorBoundary, Slot, type PropFunction } from '@builder.io/qwik';
+import { component$, useErrorBoundary, Slot, type QRL } from '@builder.io/qwik';
 
 /** @public */
 export interface ErrorBoundaryProps {
   children: any;
-  fallback$: PropFunction<(ev: any) => any>;
+  fallback$: QRL<(ev: any) => any>;
 }
 
 /** @public */

--- a/packages/qwik-react/package.json
+++ b/packages/qwik-react/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "main": "./lib/index.qwik.mjs",
   "peerDependencies": {
-    "@builder.io/qwik": "1.2.6",
+    "@builder.io/qwik": "^1.3.2",
     "@types/react": "18.2.17",
     "@types/react-dom": "18.2.7",
     "react": "18.2.0",

--- a/packages/qwik-react/src/react/qwikify.tsx
+++ b/packages/qwik-react/src/react/qwikify.tsx
@@ -14,14 +14,14 @@ import {
 
 import { isBrowser, isServer } from '@builder.io/qwik/build';
 import type { Root } from 'react-dom/client';
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent as ReactFC } from 'react';
 import * as client from './client';
 import { renderFromServer } from './server-render';
 import { getHostProps, main, mainExactProps, useWakeupSignal } from './slot';
 import type { Internal, QwikifyOptions, QwikifyProps } from './types';
 
-export function qwikifyQrl<PROPS extends {}>(
-  reactCmp$: QRL<FunctionComponent<PROPS & { children?: any }>>,
+export function qwikifyQrl<PROPS extends Record<any, any>>(
+  reactCmp$: QRL<ReactFC<PROPS & { children?: any }>>,
   opts?: QwikifyOptions
 ) {
   return component$((props: QwikifyProps<PROPS>) => {

--- a/packages/qwik-react/src/react/types.ts
+++ b/packages/qwik-react/src/react/types.ts
@@ -1,10 +1,10 @@
-import type { PropFunction, Signal } from '@builder.io/qwik';
-import type { FunctionComponent } from 'react';
+import type { QRL, Signal } from '@builder.io/qwik';
+import type { FunctionComponent as ReactFC } from 'react';
 import type { Root } from 'react-dom/client';
 
 export interface Internal<PROPS> {
   root: Root | undefined;
-  cmp: FunctionComponent<PROPS>;
+  cmp: ReactFC<PROPS>;
 }
 
 export interface QwikifyBase {
@@ -65,44 +65,34 @@ export interface QwikifyBase {
    * Adds a `click` event listener to the host element, this event will be dispatched even if the
    * react component is not hydrated.
    */
-  'host:onClick$'?: PropFunction<(ev: Event) => void>;
+  'host:onClick$'?: QRL<(ev: Event) => void>;
 
   /**
    * Adds a `blur` event listener to the host element, this event will be dispatched even if the
    * react component is not hydrated.
    */
-  'host:onBlur$'?: PropFunction<(ev: Event) => void>;
+  'host:onBlur$'?: QRL<(ev: Event) => void>;
 
   /**
    * Adds a `focus` event listener to the host element, this event will be dispatched even if the
    * react component is not hydrated.
    */
-  'host:onFocus$'?: PropFunction<(ev: Event) => void>;
+  'host:onFocus$'?: QRL<(ev: Event) => void>;
 
   /**
    * Adds a `mouseover` event listener to the host element, this event will be dispatched even if
    * the react component is not hydrated.
    */
-  'host:onMouseOver$'?: PropFunction<(ev: Event) => void>;
+  'host:onMouseOver$'?: QRL<(ev: Event) => void>;
 
   children?: any;
 }
 
-export type TransformProps<PROPS extends {}> = {
-  [K in keyof PROPS as TransformKey<K>]: TransformProp<K, PROPS[K]>;
+export type TransformProps<PROPS extends Record<any, any>> = {
+  [K in keyof PROPS as K extends `on${string}` ? `${K}$` : K]: PROPS[K];
 };
 
-export type TransformKey<K extends string | number | symbol> = K extends `on${string}`
-  ? `${K}$`
-  : K;
-
-export type TransformProp<K extends string | number | symbol, V> = K extends `on${string}`
-  ? V extends Function
-    ? PropFunction<V>
-    : never
-  : V;
-
-export type QwikifyProps<PROPS extends {}> = TransformProps<PROPS> & QwikifyBase;
+export type QwikifyProps<PROPS extends Record<any, any>> = TransformProps<PROPS> & QwikifyBase;
 
 export interface QwikifyOptions {
   tagName?: string;

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -10,6 +10,9 @@ import { JSXNode as JSXNode_2 } from '@builder.io/qwik/jsx-runtime';
 // @public
 export const $: <T>(expression: T) => QRL<T>;
 
+// @internal (undocumented)
+export type _AllowPlainQrl<Q> = QRLEventHandlerMulti<any, any> extends Q ? Q extends QRLEventHandlerMulti<infer EV, infer EL> ? Q | (EL extends Element ? EventHandler<EV, EL> : never) : Q : Q extends QRL<infer U> ? Q | U : NonNullable<Q> extends never ? Q : QRL<Q> | Q;
+
 // Warning: (ae-forgotten-export) The symbol "Attrs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -112,7 +115,7 @@ export interface ColHTMLAttributes<T extends Element> extends Attrs<'col', T> {
 }
 
 // @public
-export const component$: <PROPS extends Record<any, any>>(onMount: (props: PROPS) => JSXNode | null) => Component<PropFunctionProps<PROPS>>;
+export const component$: <PROPS extends Record<any, any>>(onMount: (props: PROPS) => JSXNode | null) => Component<PROPS>;
 
 // @public
 export type Component<PROPS extends Record<any, any> = Record<string, unknown>> = FunctionComponent<PublicProps<PROPS>>;
@@ -215,6 +218,11 @@ export interface ErrorBoundaryStore {
 
 // @public (undocumented)
 export const event$: <T>(first: T) => QRL<T>;
+
+// @public
+export type EventHandler<EV = Event, EL = Element> = {
+    bivarianceHack(event: EV, element: EL): any;
+}['bivarianceHack'];
 
 // @public (undocumented)
 export const eventQrl: <T>(qrl: QRL<T>) => QRL<T>;
@@ -551,6 +559,11 @@ export interface ObjectHTMLAttributes<T extends Element> extends Attrs<'object',
 export interface OlHTMLAttributes<T extends Element> extends Attrs<'ol', T> {
 }
 
+// @internal (undocumented)
+export type _Only$<P> = {
+    [K in keyof P as K extends `${string}$` ? K : never]: _AllowPlainQrl<P[K]>;
+};
+
 // @public (undocumented)
 export type OnRenderFn<PROPS extends Record<any, any>> = (props: PROPS) => JSXNode | null;
 
@@ -616,13 +629,13 @@ export type PropFunctionProps<PROPS extends Record<any, any>> = {
 };
 
 // @public
-export type PropsOf<COMP> = COMP extends Component<infer PROPS> ? NonNullable<PROPS> : COMP extends FunctionComponent<infer PROPS> ? NonNullable<PublicProps<PROPS>> : COMP extends string ? QwikIntrinsicElements[COMP] : Record<string, unknown>;
+export type PropsOf<COMP> = COMP extends Component<infer PROPS> ? NonNullable<PROPS> : COMP extends FunctionComponent<infer PROPS> ? NonNullable<PublicProps<PROPS>> : COMP extends keyof QwikIntrinsicElements ? QwikIntrinsicElements[COMP] : COMP extends string ? QwikIntrinsicElements['span'] : Record<string, unknown>;
 
-// Warning: (ae-forgotten-export) The symbol "TransformProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ComponentChildren" needs to be exported by the entry point index.d.ts
+// Warning: (ae-incompatible-release-tags) The symbol "PublicProps" is marked as @public, but its signature references "_Only$" which is marked as @internal
 //
 // @public
-export type PublicProps<PROPS extends Record<any, any>> = TransformProps<PROPS> & ComponentBaseProps & ComponentChildren<PROPS>;
+export type PublicProps<PROPS extends Record<any, any>> = Omit<PROPS, `${string}$`> & _Only$<PROPS> & ComponentBaseProps & ComponentChildren<PROPS>;
 
 // Warning: (ae-forgotten-export) The symbol "BivariantQrlFn" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "QrlArgs" needs to be exported by the entry point index.d.ts
@@ -647,6 +660,9 @@ export const qrl: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: st
 //
 // @internal (undocumented)
 export const qrlDEV: <T = any>(chunkOrFn: string | (() => Promise<any>), symbol: string, opts: QRLDev, lexicalScopeCapture?: any[]) => QRL<T>;
+
+// @beta
+export type QRLEventHandlerMulti<EV extends Event, EL> = QRL<EventHandler<EV, EL>> | undefined | null | QRLEventHandlerMulti<EV, EL>[];
 
 // Warning: (ae-forgotten-export) The symbol "SyncQRL" needs to be exported by the entry point index.d.ts
 //
@@ -684,10 +700,6 @@ export type QwikFocusEvent<T = Element> = NativeFocusEvent;
 // @public
 export type QwikHTMLElements = {
     [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> & HTMLElementAttrs & QwikAttributes<HTMLElementTagNameMap[tag]>;
-} & {
-    [unknownTag: string]: {
-        [prop: string]: any;
-    } & HTMLElementAttrs & QwikAttributes<any>;
 };
 
 // @public

--- a/packages/qwik/src/core/component/component.unit.tsx
+++ b/packages/qwik/src/core/component/component.unit.tsx
@@ -5,9 +5,10 @@ import { useStylesQrl } from '../use/use-styles';
 import { type PropsOf, component$, type PropFunctionProps } from './component.public';
 import { useStore } from '../use/use-store.public';
 import { useLexicalScope } from '../use/use-lexical-scope.public';
-import { describe, test } from 'vitest';
+import { describe, test, expectTypeOf } from 'vitest';
 import type { InputHTMLAttributes } from '../render/jsx/types/jsx-generated';
 import type { QwikIntrinsicElements } from '../render/jsx/types/jsx-qwik-elements';
+import type { PropFunction, QRL } from '../qrl/qrl.public';
 
 describe('q-component', () => {
   /**
@@ -161,6 +162,73 @@ describe('q-component', () => {
         </>
       );
     });
+  });
+
+  test('custom function types should work', () => () => {
+    type TestProps = PropsOf<'h1'> & {
+      plain$?: () => void;
+      qrl$?: QRL<() => void>;
+    };
+    const Test1 = component$<TestProps>(({ plain$, qrl$, ...props }) => {
+      return (
+        <>
+          <h1 onClick$={plain$} onDblClick$={qrl$} {...props}>
+            Hi 👋
+          </h1>
+        </>
+      );
+    });
+    expectTypeOf<TestProps['plain$']>().toMatchTypeOf<Parameters<typeof Test1>[0]['plain$']>();
+    expectTypeOf<TestProps['qrl$']>().toMatchTypeOf<Parameters<typeof Test1>[0]['qrl$']>();
+    expectTypeOf<Parameters<typeof Test1>[0]['plain$']>().toEqualTypeOf<
+      (() => void) | QRL<() => void> | undefined
+    >();
+    expectTypeOf<Parameters<typeof Test1>[0]['qrl$']>().toEqualTypeOf<
+      (() => void) | QRL<() => void> | undefined
+    >();
+
+    const Test2 = component$(({ plain$, qrl$, ...props }: TestProps) => {
+      return (
+        <>
+          <h1 onClick$={plain$} onDblClick$={qrl$} {...props}>
+            Hi 👋
+          </h1>
+        </>
+      );
+    });
+    expectTypeOf<TestProps['plain$']>().toMatchTypeOf<Parameters<typeof Test2>[0]['plain$']>();
+    expectTypeOf<TestProps['qrl$']>().toMatchTypeOf<Parameters<typeof Test2>[0]['qrl$']>();
+    expectTypeOf<Parameters<typeof Test2>[0]['plain$']>().toEqualTypeOf<
+      (() => void) | QRL<() => void> | undefined
+    >();
+    expectTypeOf<Parameters<typeof Test2>[0]['qrl$']>().toEqualTypeOf<
+      (() => void) | QRL<() => void> | undefined
+    >();
+    component$(() => {
+      return (
+        <>
+          <Test1 />
+          <Test2 />
+        </>
+      );
+    });
+  });
+
+  test('PropFunction should work', () => () => {
+    type TestProps = PropsOf<'h1'> & {
+      test$?: PropFunction<() => void>;
+    };
+    const Test1 = component$<TestProps>(({ test$, ...props }) => {
+      return (
+        <>
+          <h1 onClick$={test$} {...props}>
+            Hi 👋
+          </h1>
+        </>
+      );
+    });
+    expectTypeOf<TestProps['test$']>().toMatchTypeOf<Parameters<typeof Test1>[0]['test$']>();
+    expectTypeOf<QRL<() => void>>().toMatchTypeOf<Parameters<typeof Test1>[0]['test$']>();
   });
 });
 

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -9,6 +9,8 @@ export type {
   Component,
   PublicProps,
   PropFunctionProps,
+  _AllowPlainQrl,
+  _Only$,
 } from './component/component.public';
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -61,10 +63,13 @@ export type {
   ComponentBaseProps,
   ClassList,
   CorrectedToggleEvent,
+  EventHandler,
+  QRLEventHandlerMulti,
 } from './render/jsx/types/jsx-qwik-attributes';
 export type { FunctionComponent, JSXNode, DevJSX } from './render/jsx/types/jsx-node';
 export type { QwikDOMAttributes, QwikJSX } from './render/jsx/types/jsx-qwik';
 export type { QwikIntrinsicElements } from './render/jsx/types/jsx-qwik-elements';
+export type { QwikHTMLElements, QwikSVGElements } from './render/jsx/types/jsx-generated';
 export { render } from './render/dom/render.public';
 export type { RenderSSROptions, StreamWriter } from './render/ssr/render-ssr';
 export type { RenderOptions, RenderResult } from './render/dom/render.public';

--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -1275,19 +1275,21 @@ export type IntrinsicSVGElements = {
   >;
 };
 
-/** The DOM props without plain handlers, for use inside functions @public */
+/**
+ * The DOM props without plain handlers, for use inside functions
+ *
+ * @public
+ */
 export type QwikHTMLElements = {
   [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> &
     HTMLElementAttrs &
     QwikAttributes<HTMLElementTagNameMap[tag]>;
-} & {
-  /** For unknown tags we allow all props */
-  [unknownTag: string]: { [prop: string]: any } & HTMLElementAttrs &
-    // We use any instead of Element because this index type needs to be matched by
-    // all the other ones and those are subtypes of Element
-    QwikAttributes<any>;
 };
-/** The SVG props without plain handlers, for use inside functions @public */
+/**
+ * The SVG props without plain handlers, for use inside functions
+ *
+ * @public
+ */
 export type QwikSVGElements = {
   [K in keyof Omit<SVGElementTagNameMap, keyof HTMLElementTagNameMap>]: SVGProps<
     SVGElementTagNameMap[K]

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -155,12 +155,21 @@ export type ClassList =
   | Record<string, boolean | string | number | null | undefined>
   | ClassList[];
 
-/** A DOM event handler */
+/**
+ * A DOM event handler
+ *
+ * @public
+ */
 export type EventHandler<EV = Event, EL = Element> = {
   // https://stackoverflow.com/questions/52667959/what-is-the-purpose-of-bivariancehack-in-typescript-types/52668133#52668133
   bivarianceHack(event: EV, element: EL): any;
 }['bivarianceHack'];
 
+/**
+ * An event handler for Qwik events, can be a handler QRL or an array of handler QRLs.
+ *
+ * @beta
+ */
 export type QRLEventHandlerMulti<EV extends Event, EL> =
   | QRL<EventHandler<EV, EL>>
   | undefined

--- a/packages/qwik/src/server/server-modules.d.ts
+++ b/packages/qwik/src/server/server-modules.d.ts
@@ -1,4 +1,41 @@
 declare module '@qwik-client-manifest' {
-  const manifest: import('./index').QwikManifest;
+  const manifest: import('.').QwikManifest;
   export { manifest };
+}
+// MD
+declare module '*.md' {
+  const node: import('.').FunctionComponent;
+  export const frontmatter: Record<string, any>;
+  export default node;
+}
+// MDX
+declare module '*.mdx' {
+  const node: import('.').FunctionComponent;
+  export const frontmatter: Record<string, any>;
+  export default node;
+}
+// SVG ?jsx
+declare module '*.svg?jsx' {
+  const Cmp: import('.').FunctionComponent<import('.').QwikIntrinsicElements['svg']>;
+  export default Cmp;
+}
+// Image ?jsx
+declare module '*?jsx' {
+  const Cmp: import('.').FunctionComponent<
+    Omit<import('.').QwikIntrinsicElements['img'], 'src' | 'width' | 'height' | 'srcSet'>
+  >;
+  export default Cmp;
+  export const width: number;
+  export const height: number;
+  export const srcSet: string;
+}
+// Image &jsx
+declare module '*&jsx' {
+  const Cmp: import('.').FunctionComponent<
+    Omit<import('.').QwikIntrinsicElements['img'], 'src' | 'width' | 'height' | 'srcSet'>
+  >;
+  export default Cmp;
+  export const width: number;
+  export const height: number;
+  export const srcSet: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,8 +259,8 @@ importers:
         specifier: workspace:*
         version: link:../qwik-labs
       '@builder.io/qwik-react':
-        specifier: 0.5.0
-        version: 0.5.0(@builder.io/qwik@packages+qwik)(@types/react-dom@18.2.13)(@types/react@18.2.28)(react-dom@18.2.0)(react@18.2.0)
+        specifier: workspace:*
+        version: link:../qwik-react
       '@builder.io/sdk-qwik':
         specifier: ^0.6.2
         version: 0.6.2(@builder.io/qwik@packages+qwik)(undici@5.26.0)
@@ -1084,23 +1084,6 @@ packages:
     transitivePeerDependencies:
       - rollup
       - supports-color
-    dev: true
-
-  /@builder.io/qwik-react@0.5.0(@builder.io/qwik@packages+qwik)(@types/react-dom@18.2.13)(@types/react@18.2.28)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-JdJWQWOJGv7ddQqEZwzR8wPh0IoCQZwD9qo75+reiQaLp6eH+Pjsm/kn1LaMQt6u72pCCNjnj5kEn/bnbfnIjQ==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@builder.io/qwik': '>=0.22.0'
-      '@types/react': '>=18.0.1'
-      '@types/react-dom': '>=18.0.0'
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-    dependencies:
-      '@builder.io/qwik': link:packages/qwik
-      '@types/react': 18.2.28
-      '@types/react-dom': 18.2.13
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
   /@builder.io/qwik@1.2.13(undici@5.26.0):

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -26,6 +26,7 @@ import { submoduleQwikPrefetch } from './submodule-qwikprefetch';
 import { submoduleServer } from './submodule-server';
 import { submoduleTesting } from './submodule-testing';
 import { tsc } from './tsc';
+import { tscDocs } from './tsc-docs';
 import { validateBuild } from './validate-build';
 import { buildQwikAuth } from './qwik-auth';
 import { buildSupabaseAuthHelpers } from './supabase-auth-helpers';
@@ -125,6 +126,10 @@ export async function build(config: BuildConfig) {
 
     if (config.supabaseauthhelpers) {
       await buildSupabaseAuthHelpers(config);
+    }
+
+    if (config.tscDocs) {
+      await tscDocs(config);
     }
 
     if (config.api) {

--- a/scripts/tsc-docs.ts
+++ b/scripts/tsc-docs.ts
@@ -1,0 +1,13 @@
+import { execa } from 'execa';
+import { type BuildConfig, panic } from './util';
+
+// Run tsc for docs separately because it requires e.g. qwik-react types to be built first
+// plus it takes some time to run and we don't need to run it during core dev.
+export async function tscDocs(config: BuildConfig) {
+  const result = await execa('tsc', ['-p', 'tsconfig-docs.json'], {
+    stdout: 'inherit',
+  });
+  if (result.failed) {
+    panic(`tsc -p tsconfig-docs.json failed`);
+  }
+}

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -66,6 +66,7 @@ export interface BuildConfig {
   devRelease?: boolean;
   setDistTag?: string;
   tsc?: boolean;
+  tscDocs?: boolean;
   validate?: boolean;
   wasm?: boolean;
   watch?: boolean;
@@ -92,6 +93,7 @@ export function loadConfig(args: string[] = []) {
   config.distQwikCityPkgDir = join(config.packagesDir, 'qwik-city', 'lib');
   config.distBindingsDir = join(config.distQwikPkgDir, 'bindings');
   config.tscDir = join(config.tmpDir, 'tsc-out');
+  config.tscDocs = (config as any)['tsc-docs'];
   config.dtsDir = join(config.tmpDir, 'dts-out');
   config.esmNode = parseInt(process.version.slice(1).split('.')[0], 10) >= 14;
   config.platformBinding = (config as any)['platform-binding'];

--- a/starters/apps/e2e/src/components/events/events.tsx
+++ b/starters/apps/e2e/src/components/events/events.tsx
@@ -1,7 +1,7 @@
 import {
   component$,
   useStore,
-  type PropFunction,
+  type QRL,
   useSignal,
   useOnWindow,
   $,
@@ -58,8 +58,8 @@ export const Events = component$(() => {
 });
 
 interface ButtonProps {
-  onTransparentClick$?: PropFunction<(ev: Event) => any>;
-  onWrappedClick$?: PropFunction<(nu: number) => void>;
+  onTransparentClick$?: QRL<(ev: Event) => any>;
+  onWrappedClick$?: QRL<(nu: number) => void>;
 }
 
 export const Buttons = component$((props: ButtonProps) => {

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -1,7 +1,6 @@
 import {
   component$,
   type JSXNode,
-  type PropFunction,
   useSignal,
   useStore,
   useStylesScoped$,
@@ -14,6 +13,7 @@ import {
   HTMLFragment,
   type PropsOf,
   Slot,
+  type QRL,
 } from "@builder.io/qwik";
 import { delay } from "../streaming/demo";
 import { isServer } from "@builder.io/qwik/build";
@@ -373,7 +373,7 @@ export const Issue2889 = component$(() => {
 type Product = string;
 
 export type ProductRelationProps = {
-  render$: PropFunction<(products: Product[]) => JSXNode>;
+  render$: QRL<(products: Product[]) => JSXNode>;
 };
 
 export const ProductRelations = component$((props: ProductRelationProps) => {

--- a/tsconfig-docs.json
+++ b/tsconfig-docs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["packages/docs"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -90,7 +90,6 @@
   },
   "include": [
     "packages/create-qwik",
-    "packages/docs",
     "packages/qwik/src",
     "packages/qwik-city",
     "packages/qwik-auth",


### PR DESCRIPTION
This simplifies the types so typescript can infer across props for polymorphic components, and also changes the component props derivation so only props ending in $ get special QRL treatment.

No actual code changes.