### PR TITLE
chore: Remove duplicated dist directory from .prettierignore

### DIFF
--- a/packages/docs/.prettierignore
+++ b/packages/docs/.prettierignore
@@ -19,7 +19,6 @@ server
 .cache
 .vscode
 .rollup.cache
-dist
 tsconfig.tsbuildinfo
 src/pages/**/*.mdx
 src/**/*.gen.*

--- a/starters/apps/base/.prettierignore
+++ b/starters/apps/base/.prettierignore
@@ -26,7 +26,6 @@ build
 .cache
 .vscode
 .rollup.cache
-dist
 tsconfig.tsbuildinfo
 vite.config.ts
 *.spec.tsx


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

Removing dist directoring duplicated value

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
