### PR TITLE
chore: improve FunctionComponent

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -730,7 +730,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\ntype ElementType = string | ((...args: any[]) => JSXNode | null);\n```\n**References:** [JSXNode](#jsxnode)",
+      "content": "```typescript\ntype ElementType = string | FunctionComponent;\n```\n**References:** [FunctionComponent](#functioncomponent)",
       "mdFile": "qwik.qwikjsx.elementtype.md"
     },
     {
@@ -854,8 +854,8 @@
           "id": "functioncomponent"
         }
       ],
-      "kind": "Interface",
-      "content": "```typescript\nexport interface FunctionComponent<P extends Record<any, any> = Record<any, unknown>> \n```",
+      "kind": "TypeAlias",
+      "content": "Any sync or async function that returns JSXOutput.\n\nNote that this includes QRLs.\n\nThe `key`<!-- -->, `flags` and `dev` parameters are for internal use.\n\n\n```typescript\nexport type FunctionComponent<P extends Record<any, any> = Record<any, any>> = {\n    renderFn(props: P, key: string | null, flags: number, dev?: DevJSX): JSXOutput | Promise<JSXOutput>;\n}['renderFn'];\n```\n**References:** [DevJSX](#devjsx)<!-- -->, [JSXOutput](#jsxoutput)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-node.ts",
       "mdFile": "qwik.functioncomponent.md"
     },
@@ -1208,7 +1208,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "```typescript\njsxDEV: <T extends string | FunctionComponent<Record<any, unknown>>>(type: T, props: T extends FunctionComponent<infer PROPS extends Record<any, any>> ? PROPS : Record<any, unknown>, key: string | number | null | undefined, _isStatic: boolean, opts: JsxDevOpts, _ctx: unknown) => JSXNode<T>\n```",
+      "content": "```typescript\njsxDEV: <T extends string | FunctionComponent>(type: T, props: T extends FunctionComponent<infer PROPS extends Record<any, any>> ? PROPS : Record<any, unknown>, key: string | number | null | undefined, _isStatic: boolean, opts: JsxDevOpts, _ctx: unknown) => JSXNode<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/jsx-runtime.ts",
       "mdFile": "qwik.jsxdev.md"
     },
@@ -1225,6 +1225,20 @@
       "content": "```typescript\nexport interface JSXNode<T = string | FunctionComponent> \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children](#) |  | [JSXChildren](#jsxchildren) \\| null |  |\n|  [dev?](#) |  | [DevJSX](#devjsx) | _(Optional)_ |\n|  [flags](#) |  | number |  |\n|  [immutableProps](#) |  | Record&lt;any, unknown&gt; \\| null |  |\n|  [key](#) |  | string \\| null |  |\n|  [props](#) |  | T extends [FunctionComponent](#functioncomponent)<!-- -->&lt;infer B&gt; ? B : Record&lt;any, unknown&gt; |  |\n|  [type](#) |  | T |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-node.ts",
       "mdFile": "qwik.jsxnode.md"
+    },
+    {
+      "name": "JSXOutput",
+      "id": "jsxoutput",
+      "hierarchy": [
+        {
+          "name": "JSXOutput",
+          "id": "jsxoutput"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "Any valid output for a component\n\n\n```typescript\nexport type JSXOutput = JSXNode | string | number | boolean | null | undefined | JSXOutput[];\n```\n**References:** [JSXNode](#jsxnode)<!-- -->, [JSXOutput](#jsxoutput)",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-node.ts",
+      "mdFile": "qwik.jsxoutput.md"
     },
     {
       "name": "JSXTagName",
@@ -1796,7 +1810,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "Infers `Props` from the component.\n\n```typescript\nexport const OtherComponent = component$(() => {\n  return $(() => <Counter value={100} />);\n});\n```\n\n\n```typescript\nexport type PropsOf<COMP> = COMP extends FunctionComponent<infer PROPS> ? NonNullable<PROPS> : COMP extends keyof QwikIntrinsicElements ? QwikIntrinsicElements[COMP] : COMP extends string ? QwikIntrinsicElements['span'] : Record<string, unknown>;\n```\n**References:** [FunctionComponent](#functioncomponent)<!-- -->, [QwikIntrinsicElements](#qwikintrinsicelements)",
+      "content": "Infers `Props` from the component or tag.\n\n\n```typescript\nexport type PropsOf<COMP> = COMP extends string ? COMP extends keyof QwikIntrinsicElements ? QwikIntrinsicElements[COMP] : QwikIntrinsicElements['span'] : NonNullable<COMP> extends never ? never : COMP extends FunctionComponent<infer PROPS> ? NonNullable<PROPS> : Record<string, unknown>;\n```\n**References:** [QwikIntrinsicElements](#qwikintrinsicelements)<!-- -->, [FunctionComponent](#functioncomponent)\n\n\n\n```tsx\nconst Desc = component$(({desc, ...props}: { desc: string } & PropsOf<'div'>) => {\n return <div {...props}>{desc}</div>;\n});\n\nconst TitleBox = component$(({title, ...props}: { title: string } & PropsOf<Box>) => {\n  return <Box {...props}><h1>{title}</h1></Box>;\n});\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/component/component.public.ts",
       "mdFile": "qwik.propsof.md"
     },

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -246,11 +246,10 @@ export const Fragment: FunctionComponent<{
     key?: string | number | null;
 }>;
 
-// @public (undocumented)
-export interface FunctionComponent<P extends Record<any, any> = Record<any, unknown>> {
-    // (undocumented)
-    (props: P, key: string | null, flags: number, dev?: DevJSX): JSXNode | null;
-}
+// @public
+export type FunctionComponent<P extends Record<any, any> = Record<any, any>> = {
+    renderFn(props: P, key: string | null, flags: number, dev?: DevJSX): JSXOutput | Promise<JSXOutput>;
+}['renderFn'];
 
 // @internal (undocumented)
 export const _getContextElement: () => unknown;
@@ -416,13 +415,13 @@ export const _jsxBranch: <T>(input?: T | undefined) => T | undefined;
 // Warning: (ae-forgotten-export) The symbol "JsxDevOpts" needs to be exported by the entry point index.d.ts
 //
 // @internal
-export const _jsxC: <T extends string | FunctionComponent<Record<any, unknown>>>(type: T, mutableProps: (T extends FunctionComponent<infer PROPS extends Record<any, any>> ? PROPS : Record<any, unknown>) | null, flags: number, key: string | number | null, dev?: JsxDevOpts) => JSXNode<T>;
+export const _jsxC: <T extends string | FunctionComponent>(type: T, mutableProps: (T extends FunctionComponent<infer PROPS extends Record<any, any>> ? PROPS : Record<any, unknown>) | null, flags: number, key: string | number | null, dev?: JsxDevOpts) => JSXNode<T>;
 
 // @public (undocumented)
 export type JSXChildren = string | number | boolean | null | undefined | Function | RegExp | JSXChildren[] | Promise<JSXChildren> | Signal<JSXChildren> | JSXNode;
 
 // @public (undocumented)
-export const jsxDEV: <T extends string | FunctionComponent<Record<any, unknown>>>(type: T, props: T extends FunctionComponent<infer PROPS extends Record<any, any>> ? PROPS : Record<any, unknown>, key: string | number | null | undefined, _isStatic: boolean, opts: JsxDevOpts, _ctx: unknown) => JSXNode<T>;
+export const jsxDEV: <T extends string | FunctionComponent>(type: T, props: T extends FunctionComponent<infer PROPS extends Record<any, any>> ? PROPS : Record<any, unknown>, key: string | number | null | undefined, _isStatic: boolean, opts: JsxDevOpts, _ctx: unknown) => JSXNode<T>;
 
 // @public (undocumented)
 export interface JSXNode<T = string | FunctionComponent> {
@@ -441,6 +440,9 @@ export interface JSXNode<T = string | FunctionComponent> {
     // (undocumented)
     type: T;
 }
+
+// @public
+export type JSXOutput = JSXNode | string | number | boolean | null | undefined | JSXOutput[];
 
 // @internal
 export const _jsxQ: <T extends string>(type: T, mutableProps: Record<any, unknown> | null, immutableProps: Record<any, unknown> | null, children: JSXChildren | null, flags: number, key: string | number | null, dev?: DevJSX) => JSXNode<T>;
@@ -629,7 +631,7 @@ export type PropFunctionProps<PROPS extends Record<any, any>> = {
 };
 
 // @public
-export type PropsOf<COMP> = COMP extends FunctionComponent<infer PROPS> ? NonNullable<PROPS> : COMP extends keyof QwikIntrinsicElements ? QwikIntrinsicElements[COMP] : COMP extends string ? QwikIntrinsicElements['span'] : Record<string, unknown>;
+export type PropsOf<COMP> = COMP extends string ? COMP extends keyof QwikIntrinsicElements ? QwikIntrinsicElements[COMP] : QwikIntrinsicElements['span'] : NonNullable<COMP> extends never ? never : COMP extends FunctionComponent<infer PROPS> ? NonNullable<PROPS> : Record<string, unknown>;
 
 // Warning: (ae-forgotten-export) The symbol "ComponentChildren" needs to be exported by the entry point index.d.ts
 // Warning: (ae-incompatible-release-tags) The symbol "PublicProps" is marked as @public, but its signature references "_Only$" which is marked as @internal
@@ -726,7 +728,7 @@ export namespace QwikJSX {
         children: any;
     }
     // (undocumented)
-    export type ElementType = string | ((...args: any[]) => JSXNode | null);
+    export type ElementType = string | FunctionComponent;
     // Warning: (ae-forgotten-export) The symbol "QwikIntrinsicAttributes" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/qwik/src/core/component/component.public.ts
+++ b/packages/qwik/src/core/component/component.public.ts
@@ -17,24 +17,32 @@ import { assertNumber } from '../error/assert';
 import type { QwikIntrinsicElements } from '../render/jsx/types/jsx-qwik-elements';
 
 /**
- * Infers `Props` from the component.
+ * Infers `Props` from the component or tag.
  *
- * ```typescript
- * export const OtherComponent = component$(() => {
- *   return $(() => <Counter value={100} />);
+ * @example
+ *
+ * ```tsx
+ * const Desc = component$(({desc, ...props}: { desc: string } & PropsOf<'div'>) => {
+ *  return <div {...props}>{desc}</div>;
+ * });
+ *
+ * const TitleBox = component$(({title, ...props}: { title: string } & PropsOf<Box>) => {
+ *   return <Box {...props}><h1>{title}</h1></Box>;
  * });
  * ```
  *
  * @public
  */
 // </docs>
-export type PropsOf<COMP> = COMP extends FunctionComponent<infer PROPS>
-  ? NonNullable<PROPS>
-  : COMP extends keyof QwikIntrinsicElements
+export type PropsOf<COMP> = COMP extends string
+  ? COMP extends keyof QwikIntrinsicElements
     ? QwikIntrinsicElements[COMP]
-    : COMP extends string
-      ? // `<span/>` has no special attributes
-        QwikIntrinsicElements['span']
+    : // `<span/>` has no special attributes
+      QwikIntrinsicElements['span']
+  : NonNullable<COMP> extends never
+    ? never
+    : COMP extends FunctionComponent<infer PROPS>
+      ? NonNullable<PROPS>
       : Record<string, unknown>;
 
 /**

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -66,7 +66,7 @@ export type {
   EventHandler,
   QRLEventHandlerMulti,
 } from './render/jsx/types/jsx-qwik-attributes';
-export type { FunctionComponent, JSXNode, DevJSX } from './render/jsx/types/jsx-node';
+export type { JSXOutput, FunctionComponent, JSXNode, DevJSX } from './render/jsx/types/jsx-node';
 export type { QwikDOMAttributes, QwikJSX } from './render/jsx/types/jsx-qwik';
 export type { QwikIntrinsicElements } from './render/jsx/types/jsx-qwik-elements';
 export type { QwikHTMLElements, QwikSVGElements } from './render/jsx/types/jsx-generated';

--- a/packages/qwik/src/core/render/dom/render-dom.ts
+++ b/packages/qwik/src/core/render/dom/render-dom.ts
@@ -170,7 +170,6 @@ export const processData = (
     newNode.$signal$ = node;
     return newNode;
   } else if (isArray(node)) {
-    // PERF(misko): possible place to make it faster by not creating promises unnecessarily
     const output = promiseAll(node.flatMap((n) => processData(n, invocationContext)));
     return maybeThen(output, (array) => array.flat(100).filter(isNotNullable));
   } else if (isPromise(node)) {

--- a/packages/qwik/src/core/render/jsx/types/jsx-node.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-node.ts
@@ -1,9 +1,31 @@
 import type { JSXChildren } from './jsx-qwik-attributes';
 
-/** @public */
-export interface FunctionComponent<P extends Record<any, any> = Record<any, unknown>> {
-  (props: P, key: string | null, flags: number, dev?: DevJSX): JSXNode | null;
-}
+/**
+ * Any valid output for a component
+ *
+ * @public
+ */
+export type JSXOutput = JSXNode | string | number | boolean | null | undefined | JSXOutput[];
+
+/**
+ * Any sync or async function that returns JSXOutput.
+ *
+ * Note that this includes QRLs.
+ *
+ * The `key`, `flags` and `dev` parameters are for internal use.
+ *
+ * @public
+ */
+// Normally we'd default to Record<any, unknown> but that causes problems with matching event$ index
+export type FunctionComponent<P extends Record<any, any> = Record<any, any>> = {
+  renderFn(
+    props: P,
+    key: string | null,
+    flags: number,
+    dev?: DevJSX
+  ): JSXOutput | Promise<JSXOutput>;
+}['renderFn'];
+
 /** @public */
 export interface DevJSX {
   fileName: string;

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts
@@ -1,11 +1,11 @@
 import type { DOMAttributes } from './jsx-qwik-attributes';
-import type { JSXNode } from './jsx-node';
+import type { FunctionComponent, JSXNode } from './jsx-node';
 import type { QwikIntrinsicAttributes, LenientQwikElements } from './jsx-qwik-elements';
 
 /** @public */
 export namespace QwikJSX {
   export interface Element extends JSXNode {}
-  export type ElementType = string | ((...args: any[]) => JSXNode | null);
+  export type ElementType = string | FunctionComponent;
 
   export interface IntrinsicAttributes extends QwikIntrinsicAttributes {}
   export interface ElementChildrenAttribute {

--- a/packages/qwik/src/core/render/jsx/types/jsx-types.unit.tsx
+++ b/packages/qwik/src/core/render/jsx/types/jsx-types.unit.tsx
@@ -4,8 +4,8 @@ import type { EventHandler, QRLEventHandlerMulti } from './jsx-qwik-attributes';
 import type { FunctionComponent, JSXNode } from './jsx-node';
 import type { QwikIntrinsicElements } from './jsx-qwik-elements';
 import type { JSXChildren } from './jsx-qwik-attributes';
-import { component$, type PropsOf } from '../../../component/component.public';
-import type { Size } from './jsx-generated';
+import { component$, type PropsOf, type PublicProps } from '../../../component/component.public';
+import type { QwikHTMLElements, QwikSVGElements, Size } from './jsx-generated';
 import type { QwikJSX } from './jsx-qwik';
 
 describe('types', () => {
@@ -20,6 +20,7 @@ describe('types', () => {
     expectTypeOf<QwikIntrinsicElements['link']['children']>().toEqualTypeOf<undefined>();
     expectTypeOf<QwikIntrinsicElements['svg']['width']>().toEqualTypeOf<Size | undefined>();
   });
+
   test('component', () => () => {
     const Cmp = component$((props: PropsOf<'svg'>) => {
       const { width = '240', height = '56', onClick$, ...rest } = props;
@@ -38,6 +39,7 @@ describe('types', () => {
       EventHandler<PointerEvent, SVGSVGElement> | QRLEventHandlerMulti<PointerEvent, SVGSVGElement>
     >();
   });
+
   test('unknown string component', () => () => {
     const t = (
       <hello-there
@@ -52,6 +54,7 @@ describe('types', () => {
     );
     expectTypeOf(t).toEqualTypeOf<QwikJSX.Element>();
   });
+
   test('inferring', () => () => {
     // Popover API
     expectTypeOf<PropsOf<'button'>>().toMatchTypeOf<{
@@ -117,6 +120,7 @@ describe('types', () => {
       />
     </>;
   });
+
   test('polymorphic component', () => () => {
     const Poly = component$(
       <C extends string | FunctionComponent>({
@@ -164,7 +168,62 @@ describe('types', () => {
         >
           Bar
         </Poly>
+        <Poly as={Poly} />
+        <Poly
+          as={$((p: { name: string }) => (
+            <span>Hi {p.name}</span>
+          ))}
+          name="meep"
+        />
       </>
     );
+  });
+
+  test('FunctionComponent', () => () => {
+    const Cmp = component$((props: { foo: string }) => null);
+    expectTypeOf(Cmp).toMatchTypeOf<FunctionComponent<{ foo: string }>>();
+    expectTypeOf<FunctionComponent<{ foo: string }>>().toMatchTypeOf(Cmp);
+
+    expectTypeOf((p: { hi: number }) => <span>{p.hi}</span>).toMatchTypeOf<FunctionComponent>();
+    expectTypeOf((p: { hi: number }) => <span>{p.hi}</span>).toMatchTypeOf<
+      FunctionComponent<{ hi: number }>
+    >();
+    expectTypeOf((p: { hi: number }) => <span>{p.hi}</span>).not.toMatchTypeOf<
+      FunctionComponent<{ hi: string }>
+    >();
+    expectTypeOf((p: { hi: number }) => <span>{p.hi}</span>).not.toMatchTypeOf<
+      FunctionComponent<{ meep: string }>
+    >();
+    expectTypeOf((p: { hi: number }) => `${p.hi}`).toMatchTypeOf<
+      FunctionComponent<{ hi: number }>
+    >();
+    expectTypeOf((p: { hi: number }) => p.hi).toMatchTypeOf<FunctionComponent<{ hi: number }>>();
+    expectTypeOf((p: { hi?: number | boolean | null }) => p.hi).toMatchTypeOf<
+      FunctionComponent<{ hi: number }>
+    >();
+    expectTypeOf(() => null).toMatchTypeOf<FunctionComponent<{ hi: number }>>();
+
+    expectTypeOf(() => new Date()).not.toMatchTypeOf<FunctionComponent>();
+    expectTypeOf((p: string) => null).not.toMatchTypeOf<FunctionComponent>();
+  });
+
+  test('PropsOf', () => () => {
+    expectTypeOf<PropsOf<'div'>>().toEqualTypeOf<QwikHTMLElements['div']>();
+    expectTypeOf<PropsOf<'div'>>().not.toEqualTypeOf<QwikIntrinsicElements['li']>();
+    expectTypeOf<PropsOf<'path'>>().toEqualTypeOf<QwikSVGElements['path']>();
+    expectTypeOf<PropsOf<'not-exist'>>().toEqualTypeOf<QwikHTMLElements['span']>();
+
+    const Fn = (props: { foo: string }) => <div />;
+    expectTypeOf<PropsOf<typeof Fn>>().toEqualTypeOf<{ foo: string }>();
+
+    const Fn$ = $(Fn);
+    expectTypeOf<PropsOf<typeof Fn$>>().toEqualTypeOf<{ foo: string }>();
+
+    const Cmp = component$(Fn);
+    expectTypeOf<PropsOf<typeof Cmp>>().toEqualTypeOf<PublicProps<{ foo: string }>>();
+
+    expectTypeOf<PropsOf<typeof Fn$ | null>>().toEqualTypeOf<{ foo: string }>();
+
+    expectTypeOf<PropsOf<17>>().toEqualTypeOf<Record<any, unknown>>();
   });
 });

--- a/packages/qwik/src/jsx-runtime/api.md
+++ b/packages/qwik/src/jsx-runtime/api.md
@@ -12,13 +12,10 @@ export const Fragment: FunctionComponent<{
     key?: string | number | null;
 }>;
 
-// @public (undocumented)
-export interface FunctionComponent<P extends Record<any, any> = Record<any, unknown>> {
-    // Warning: (ae-forgotten-export) The symbol "DevJSX" needs to be exported by the entry point jsx-runtime.d.ts
-    //
-    // (undocumented)
-    (props: P, key: string | null, flags: number, dev?: DevJSX): JSXNode | null;
-}
+// @public
+export type FunctionComponent<P extends Record<any, any> = Record<any, unknown>> = {
+    renderFn(props: P, key: string | null, flags: number, dev?: DevJSX): JSXOutput | Promise<JSXOutput>;
+}['renderFn'];
 
 // @public (undocumented)
 const jsx: <T extends string | FunctionComponent<any>>(type: T, props: T extends FunctionComponent<infer PROPS extends Record<any, any>> ? PROPS : Record<any, unknown>, key?: string | number | null) => JSXNode<T>;
@@ -36,7 +33,7 @@ namespace JSX_2 {
         children: any;
     }
     // (undocumented)
-    type ElementType = string | ((...args: any[]) => JSXNode | null);
+    type ElementType = string | FunctionComponent;
     // Warning: (ae-forgotten-export) The symbol "QwikIntrinsicAttributes" needs to be exported by the entry point jsx-runtime.d.ts
     //
     // (undocumented)
@@ -74,6 +71,11 @@ export interface JSXNode<T = string | FunctionComponent> {
     // (undocumented)
     type: T;
 }
+
+// Warnings were encountered during analysis:
+//
+// /home/wmertens/Projects/qwik/dist-dev/dts-out/packages/qwik/src/core/render/jsx/types/jsx-node.d.ts:18:5 - (ae-forgotten-export) The symbol "DevJSX" needs to be exported by the entry point jsx-runtime.d.ts
+// /home/wmertens/Projects/qwik/dist-dev/dts-out/packages/qwik/src/core/render/jsx/types/jsx-node.d.ts:18:5 - (ae-forgotten-export) The symbol "JSXOutput" needs to be exported by the entry point jsx-runtime.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -20,11 +20,11 @@ export async function apiExtractor(config: BuildConfig) {
     join(config.distQwikPkgDir, 'core.d.ts'),
     '.'
   );
-  createTypesApi(
-    config,
-    join(config.srcQwikDir, 'jsx-runtime'),
+  // Special case for jsx-runtime:
+  // It only re-exports JSX. Don't duplicate the types
+  writeFileSync(
     join(config.distQwikPkgDir, 'jsx-runtime.d.ts'),
-    '.'
+    `export {QwikJSX as JSX} from './core.d.ts'\n`
   );
   createTypesApi(
     config,


### PR DESCRIPTION
FunctionComponent now handles QRLs, PropsOf is more robust, and the JSX namespace doesn't duplicate all the types any more.