### PR TITLE
fix: improve escapeText replace

### DIFF
--- a/packages/qwik/src/core/container/pause.ts
+++ b/packages/qwik/src/core/container/pause.ts
@@ -734,7 +734,7 @@ const collectContext = (elCtx: QContext | null | undefined, collector: Collector
 };
 
 export const escapeText = (str: string) => {
-  return str.replace(/<(\/?script)/g, '\\x3C$1');
+  return str.replace(/<(\/?script)/gi, '\\x3C$1');
 };
 
 // Collect all the subscribers of this manager


### PR DESCRIPTION
# Overview

Prevents XSS by escaping all scripts in `qwik/json` before inserting into DOM.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Previous implementation of "escapeText" function was case sensitive so it was possible to inject XSS via URL when using different cases for script tag (e.g. "scRipt"). The new implementation takes case of case sensitiveness so it prevents XSS injection.

# Use cases and why

## Before - XSS is present

![Screenshot 2024-01-11 at 10 10 45](https://github.com/BuilderIO/qwik/assets/4927804/a9db46c9-8f92-4710-a45c-e31442c59477)

## After - XSS has been fixed

![Screenshot 2024-01-11 at 10 15 36](https://github.com/BuilderIO/qwik/assets/4927804/a6cbc4f8-7159-496d-a68c-4d7acc321eeb)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
