### PR TITLE
fix(optimizer): use correct prop in omit

### DIFF
--- a/packages/qwik/src/optimizer/core/src/props_destructuring.rs
+++ b/packages/qwik/src/optimizer/core/src/props_destructuring.rs
@@ -342,7 +342,7 @@ fn transform_pat(
                                 });
                                 local.push((
                                     id!(ident.id),
-                                    ident.sym.clone(),
+                                    key.sym.clone(),
                                     ast::Expr::Bin(ast::BinExpr {
                                         span: DUMMY_SP,
                                         op: ast::BinaryOp::NullishCoalescing,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_props_optimization.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_props_optimization.snap
@@ -62,7 +62,7 @@ export const Works = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl((props)
         "some",
         "hello",
         "stuff",
-        "hey2"
+        "stuffDefault"
     ]);
     console.log(props.stuff, props.some ?? 3);
     useTaskQrl(/*#__PURE__*/ inlinedQrl(({ track  })=>{


### PR DESCRIPTION
it was converting `{foo: bar = 123, ...rest}` into `rest = omit(props, ['bar'])` instead of `rest = omit(props, ['foo'])`