### PR TITLE
docs: fix typos for nav link cookbook 

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -96,5 +96,5 @@ export default component$(() => {
 </CodeSandbox>
 
 ## Tailwind 
-If you are using TailwindCss make sure to edit your tailwind config file, and add `important=true` to your export, then add `!` before the CSS classes you're using `activeClass="!text-green-600"` to make them important when the link is active.
+If you are using Tailwind CSS make sure to edit your tailwind config file, and add `important=true` to your export, then add `!` before the CSS classes you're using `activeClass="!text-green-600"` to make them important when the link is active.
 

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -96,5 +96,5 @@ export default component$(() => {
 </CodeSandbox>
 
 ## Tailwind 
-If you are using TailwinCss make sure to edit your tailwind config file, and add `important=true` to your export, then add `!` before the CSS classes you're using `activeClass="!text-green-600"` to make them important when the like is active.
+If you are using TailwindCss make sure to edit your tailwind config file, and add `important=true` to your export, then add `!` before the CSS classes you're using `activeClass="!text-green-600"` to make them important when the link is active.
 


### PR DESCRIPTION
# Overview


# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Fix typos for TailwinCss --> TailwindCss and like--> link in end section of docs

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
