### PR TITLE
docs(showcase): add Blueagle's Profolio & Blog

### DIFF
--- a/packages/docs/scripts/pages.json
+++ b/packages/docs/scripts/pages.json
@@ -1,5 +1,9 @@
 [
   {
+    "href": "https://blueagle.top/",
+    "tags": "portfolio,site,blog"
+  },
+  {
     "href": "https://quotemingle.com/",
     "tags": "site"
   },


### PR DESCRIPTION
# Overview

The PR adds Blueagle's Profolio & Blog to the sites showcase in the documentation website.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

The PR adds Blueagle's Profolio & Blog to the sites showcase in the documentation website.

# Use cases and why

No specific use case. Only documentation update.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
