### PR TITLE
fix: improve escapeText and unescapeText replace to prevent XSS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,6 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
-
     {
       "type": "node",
       "name": "docs dev.debug",

--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -309,7 +309,7 @@ const reviveNestedObjects = (obj: unknown, getObject: GetObject, parser: Parser)
 };
 
 const unescapeText = (str: string) => {
-  return str.replace(/\\x3C(\/?script)/g, '<$1');
+  return str.replace(/\\x3C(\/?script)/gi, '<$1');
 };
 
 export const getQwikInlinedFuncs = (containerEl: Element): Function[] => {

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -37,7 +37,7 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
       while (script) {
         if (script.tagName === 'SCRIPT' && getAttribute(script, 'type') === 'qwik/json') {
           (containerEl as QContainerElement)['_qwikjson_'] = JSON.parse(
-            script.textContent!.replace(/\\x3C(\/?script)/g, '<$1')
+            script.textContent!.replace(/\\x3C(\/?script)/gi, '<$1')
           );
           break;
         }

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -318,7 +318,7 @@ export function resolveManifest(
 }
 
 const escapeText = (str: string) => {
-  return str.replace(/<(\/?script)/g, '\\x3C$1');
+  return str.replace(/<(\/?script)/gi, '\\x3C$1');
 };
 
 function collectRenderSymbols(renderSymbols: string[], elements: QContext[]) {


### PR DESCRIPTION
# Overview

It's a follow up PR for https://github.com/BuilderIO/qwik/pull/5689 to prevent XSS injection on server side as well.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Improves `escapeText` and `unescapeText` replace to prevent `XSS`.

# Use cases and why

## Before

![Screenshot 2024-01-11 at 10 10 45](https://github.com/BuilderIO/qwik/assets/4927804/f1dd5462-ab4a-4a64-9274-918f73b9fe39)

## After

![Screenshot 2024-01-11 at 10 15 36](https://github.com/BuilderIO/qwik/assets/4927804/73f35cc6-e95d-45a2-a737-6a0d05a3fc35)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
