### PR TITLE
chore: allow any undici version

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "terser": "^5.26.0",
     "tsm": "^2.3.0",
     "typescript": "5.3.3",
-    "undici": "^6.3.0",
+    "undici": "*",
     "vfile": "^6.0.1",
     "vite": "^5.0.11",
     "vite-imagetools": "^6.2.9",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -44,7 +44,7 @@
     "tailwindcss": "3.3.3",
     "tsm": "^2.3.0",
     "typescript": "5.3.3",
-    "undici": "^6.3.0",
+    "undici": "*",
     "valibot": "^0.17.1",
     "vite": "^5.0.11",
     "vite-plugin-inspect": "^0.7.42",

--- a/packages/insights/package.json
+++ b/packages/insights/package.json
@@ -34,7 +34,7 @@
     "prettier-plugin-tailwindcss": "^0.5.4",
     "tailwindcss": "3.3.3",
     "typescript": "5.3.3",
-    "undici": "^6.3.0",
+    "undici": "*",
     "vite": "^5.0.11",
     "vite-tsconfig-paths": "^4.2.3",
     "vitest": "^1.1.3"

--- a/packages/qwik-city/package.json
+++ b/packages/qwik-city/package.json
@@ -8,7 +8,7 @@
     "@types/mdx": "^2.0.8",
     "source-map": "0.7.4",
     "svgo": "^3.2.0",
-    "undici": "^6.3.0",
+    "undici": "*",
     "vfile": "^6.0.1",
     "vite": "^5.0.11",
     "vite-imagetools": "^6.2.9",

--- a/packages/qwik-labs/package.json
+++ b/packages/qwik-labs/package.json
@@ -13,7 +13,7 @@
     "np": "^8.0.4",
     "prettier": "^3.1.1",
     "typescript": "5.3.3",
-    "undici": "^6.3.0",
+    "undici": "*",
     "vite": "^5.0.11"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,7 @@ importers:
         specifier: 5.3.3
         version: 5.3.3
       undici:
-        specifier: ^6.3.0
+        specifier: '*'
         version: 6.3.0
       vfile:
         specifier: ^6.0.1
@@ -358,7 +358,7 @@ importers:
         specifier: 5.3.3
         version: 5.3.3
       undici:
-        specifier: ^6.3.0
+        specifier: '*'
         version: 6.3.0
       valibot:
         specifier: ^0.17.1
@@ -492,7 +492,7 @@ importers:
         specifier: 5.3.3
         version: 5.3.3
       undici:
-        specifier: ^6.3.0
+        specifier: '*'
         version: 6.3.0
       vite:
         specifier: ^5.0.11
@@ -556,7 +556,7 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
       undici:
-        specifier: ^6.3.0
+        specifier: '*'
         version: 6.3.0
       vfile:
         specifier: ^6.0.1
@@ -688,7 +688,7 @@ importers:
         specifier: 5.3.3
         version: 5.3.3
       undici:
-        specifier: ^6.3.0
+        specifier: '*'
         version: 6.3.0
       vite:
         specifier: ^5.0.11


### PR DESCRIPTION
we don't need a specific version, and in the next major release we'll remove it