### PR TITLE
docs: add Storybook Examples

### DIFF
--- a/packages/docs/src/routes/docs/integrations/storybook/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/storybook/index.mdx
@@ -6,7 +6,8 @@ contributors:
   - igorbabko
   - Benny-Nottonson
   - mrhoodz
-updated_at: '2023-10-03T18:53:23Z'
+  - thenhawke
+updated_at: '2024-01-15T18:53:23Z'
 created_at: '2023-04-25T19:05:53Z'
 ---
 
@@ -31,3 +32,81 @@ Now you can serve the Storybook dashboard:
 ```shell
 npm run storybook
 ```
+
+## Examples
+
+### Simple component
+
+The following demonstrates a simple story that uses a qwik component:
+
+```tsx title="src/components/button.tsx"
+import { component$ } from "@builder.io/qwik";
+
+export interface ButtonProps {
+  label: string;
+}
+
+export const Button = component$<ButtonProps>(({label}) => {
+  return (
+    <button>
+      {label}
+    </button>
+  );
+});
+```
+
+```tsx title="src/components/button.stories.tsx"
+import type { Meta, StoryObj } from "storybook-framework-qwik";
+import {Button, type ButtonProps} from "./button";
+
+const meta: Meta<ButtonProps>  = {
+  component: Button,
+};
+
+export default meta;
+type Story = StoryObj<ButtonProps>; 
+
+export const Primary: Story = {
+  args: {
+    label: "Hello World", 
+  }
+};
+```
+
+### Component That Uses QwikCity
+
+When using Qwikcity, you must pass a context to the story by using the [`<QwikCityMockProvider>`](https://qwik.builder.io/docs/api/#qwikcitymockprovider):
+
+```tsx title="src/components/with-link.tsx"
+import { component$ } from "@builder.io/qwik";
+import { Link } from "@builder.io/qwik-city";
+
+export const WithLink = component$(() => {
+  return (
+    <Link href="https://google.com">Google Link</Link>
+  );
+});
+```
+
+```tsx title="src/components/with-link.stories.tsx"
+import type { Meta, StoryObj } from "storybook-framework-qwik";
+import { QwikCityMockProvider } from "@builder.io/qwik-city";
+
+import { WithLink } from "./with-link";
+
+const meta: Meta = {
+  component: WithLink,
+};
+
+type Story = StoryObj;
+export default meta;
+
+export const Primary: Story = {
+  render: () =>
+    <QwikCityMockProvider>
+      <WithLink />
+    </QwikCityMockProvider>
+};
+```
+
+For more information please refer to the [storybook documentation.](https://storybook.js.org/docs)


### PR DESCRIPTION
Added a few examples to the Storybook documentation. Included an example of using <QwikCityMockProvider> as this is required when using QwikCity.

re #5684

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Requested in #5684 to make it a little more clear that when using QwikCity in Storybook the \<QwikCityMockProvider\> must be used. Also included a simple component story for clarity. 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation