### PR TITLE
fix(jsx-qwik-attributes): fix ts error TS4023

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -953,7 +953,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E> \n```\n**Extends:** HTMLElementAttrs, [DOMAttributes](#domattributes)<!-- -->&lt;E&gt;",
+      "content": "```typescript\nexport interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E> \n```\n**Extends:** [HTMLElementAttrs](#htmlelementattrs)<!-- -->, [DOMAttributes](#domattributes)<!-- -->&lt;E&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.htmlattributes.md"
     },
@@ -970,6 +970,20 @@
       "content": "```typescript\nexport type HTMLCrossOriginAttribute = 'anonymous' | 'use-credentials' | '' | undefined;\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.htmlcrossoriginattribute.md"
+    },
+    {
+      "name": "HTMLElementAttrs",
+      "id": "htmlelementattrs",
+      "hierarchy": [
+        {
+          "name": "HTMLElementAttrs",
+          "id": "htmlelementattrs"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface HTMLElementAttrs extends HTMLAttributesBase, FilterBase<HTMLElement> \n```\n**Extends:** HTMLAttributesBase, FilterBase&lt;HTMLElement&gt;",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.htmlelementattrs.md"
     },
     {
       "name": "HTMLFragment",
@@ -1899,6 +1913,20 @@
       "mdFile": "qwik.qwikanimationevent.md"
     },
     {
+      "name": "QwikAttributes",
+      "id": "qwikattributes",
+      "hierarchy": [
+        {
+          "name": "QwikAttributes",
+          "id": "qwikattributes"
+        }
+      ],
+      "kind": "Interface",
+      "content": "The Qwik DOM attributes without plain handlers, for use as function parameters\n\n\n```typescript\nexport interface QwikAttributes<EL extends Element> extends QwikAttributesBase, RefAttr<EL>, QwikEvents<EL, false> \n```\n**Extends:** QwikAttributesBase, RefAttr&lt;EL&gt;, QwikEvents&lt;EL, false&gt;\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [class?](#) |  | [ClassList](#classlist) \\| undefined | _(Optional)_ |",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts",
+      "mdFile": "qwik.qwikattributes.md"
+    },
+    {
       "name": "QwikChangeEvent",
       "id": "qwikchangeevent",
       "hierarchy": [
@@ -1992,7 +2020,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "The DOM props without plain handlers, for use inside functions\n\n\n```typescript\nexport type QwikHTMLElements = {\n    [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> & HTMLElementAttrs & QwikAttributes<HTMLElementTagNameMap[tag]>;\n};\n```",
+      "content": "The DOM props without plain handlers, for use inside functions\n\n\n```typescript\nexport type QwikHTMLElements = {\n    [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> & HTMLElementAttrs & QwikAttributes<HTMLElementTagNameMap[tag]>;\n};\n```\n**References:** [HTMLElementAttrs](#htmlelementattrs)<!-- -->, [QwikAttributes](#qwikattributes)",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.qwikhtmlelements.md"
     },
@@ -2776,7 +2804,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface SVGProps<T extends Element> extends SVGAttributes, QwikAttributes<T> \n```\n**Extends:** [SVGAttributes](#svgattributes)<!-- -->, QwikAttributes&lt;T&gt;",
+      "content": "```typescript\nexport interface SVGProps<T extends Element> extends SVGAttributes, QwikAttributes<T> \n```\n**Extends:** [SVGAttributes](#svgattributes)<!-- -->, [QwikAttributes](#qwikattributes)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
       "mdFile": "qwik.svgprops.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -982,7 +982,7 @@ export type HTMLAttributeReferrerPolicy = ReferrerPolicy;
 export interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E>
 ```
 
-**Extends:** HTMLElementAttrs, [DOMAttributes](#domattributes)&lt;E&gt;
+**Extends:** [HTMLElementAttrs](#htmlelementattrs), [DOMAttributes](#domattributes)&lt;E&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -995,6 +995,16 @@ export type HTMLCrossOriginAttribute =
   | ""
   | undefined;
 ```
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
+
+## HTMLElementAttrs
+
+```typescript
+export interface HTMLElementAttrs extends HTMLAttributesBase, FilterBase<HTMLElement>
+```
+
+**Extends:** HTMLAttributesBase, FilterBase&lt;HTMLElement&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -1935,6 +1945,22 @@ export type QwikAnimationEvent<T = Element> = NativeAnimationEvent;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-events.ts)
 
+## QwikAttributes
+
+The Qwik DOM attributes without plain handlers, for use as function parameters
+
+```typescript
+export interface QwikAttributes<EL extends Element> extends QwikAttributesBase, RefAttr<EL>, QwikEvents<EL, false>
+```
+
+**Extends:** QwikAttributesBase, RefAttr&lt;EL&gt;, QwikEvents&lt;EL, false&gt;
+
+| Property    | Modifiers | Type                                 | Description  |
+| ----------- | --------- | ------------------------------------ | ------------ |
+| [class?](#) |           | [ClassList](#classlist) \| undefined | _(Optional)_ |
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
+
 ## QwikChangeEvent
 
 > Warning: This API is now obsolete.
@@ -2027,6 +2053,8 @@ export type QwikHTMLElements = {
     QwikAttributes<HTMLElementTagNameMap[tag]>;
 };
 ```
+
+**References:** [HTMLElementAttrs](#htmlelementattrs), [QwikAttributes](#qwikattributes)
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
@@ -3039,7 +3067,7 @@ export interface SVGAttributes<T extends Element = Element> extends AriaAttribut
 export interface SVGProps<T extends Element> extends SVGAttributes, QwikAttributes<T>
 ```
 
-**Extends:** [SVGAttributes](#svgattributes), QwikAttributes&lt;T&gt;
+**Extends:** [SVGAttributes](#svgattributes), [QwikAttributes](#qwikattributes)&lt;T&gt;
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -315,14 +315,19 @@ export type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' 
 // @public (undocumented)
 export type HTMLAttributeReferrerPolicy = ReferrerPolicy;
 
-// Warning: (ae-forgotten-export) The symbol "HTMLElementAttrs" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E> {
 }
 
 // @public (undocumented)
 export type HTMLCrossOriginAttribute = 'anonymous' | 'use-credentials' | '' | undefined;
+
+// Warning: (ae-forgotten-export) The symbol "HTMLAttributesBase" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "FilterBase" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface HTMLElementAttrs extends HTMLAttributesBase, FilterBase<HTMLElement> {
+}
 
 // @public (undocumented)
 export const HTMLFragment: FunctionComponent<{
@@ -681,6 +686,12 @@ export interface QuoteHTMLAttributes<T extends Element> extends Attrs<'q', T> {
 // @public @deprecated (undocumented)
 export type QwikAnimationEvent<T = Element> = NativeAnimationEvent;
 
+// @public
+export interface QwikAttributes<EL extends Element> extends QwikAttributesBase, RefAttr<EL>, QwikEvents<EL, false> {
+    // (undocumented)
+    class?: ClassList | undefined;
+}
+
 // @public @deprecated (undocumented)
 export type QwikChangeEvent<T = Element> = Event;
 
@@ -700,8 +711,6 @@ export type QwikDragEvent<T = Element> = NativeDragEvent;
 // @public @deprecated (undocumented)
 export type QwikFocusEvent<T = Element> = NativeFocusEvent;
 
-// Warning: (ae-forgotten-export) The symbol "QwikAttributes" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type QwikHTMLElements = {
     [tag in keyof HTMLElementTagNameMap]: Augmented<HTMLElementTagNameMap[tag], SpecialAttrs[tag]> & HTMLElementAttrs & QwikAttributes<HTMLElementTagNameMap[tag]>;

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -58,6 +58,7 @@ export { Fragment, HTMLFragment, RenderOnce, jsx, jsxDEV, jsxs } from './render/
 export type * from './render/jsx/types/jsx-generated';
 export type {
   DOMAttributes,
+  QwikAttributes,
   JSXTagName,
   JSXChildren,
   ComponentBaseProps,

--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -452,7 +452,8 @@ interface HTMLAttributesBase extends AriaAttributes {
   popover?: 'manual' | 'auto' | undefined;
 }
 
-interface HTMLElementAttrs extends HTMLAttributesBase, FilterBase<HTMLElement> {}
+/** @public */
+export interface HTMLElementAttrs extends HTMLAttributesBase, FilterBase<HTMLElement> {}
 
 /** @public */
 export interface HTMLAttributes<E extends Element> extends HTMLElementAttrs, DOMAttributes<E> {}

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -260,7 +260,7 @@ export interface DOMAttributes<EL extends Element>
   class?: ClassList | Signal<ClassList> | undefined;
 }
 
-/** The Qwik DOM attributes without plain handlers, for use as function parameters */
+/** The Qwik DOM attributes without plain handlers, for use as function parameters @public */
 export interface QwikAttributes<EL extends Element>
   extends QwikAttributesBase,
     RefAttr<EL>,


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Since v1.3.2 some components using `PropsOf<>` or `QwikIntrinsicElements[]` got the following error:

> error TS4023: Exported variable 'ModalHeader' has or is using name 'HTMLElementAttrs' from external module "/Users/maieul/dev/qwik-ui/node_modules/.pnpm/@builder.io+qwik@1.3.5_@types+node@20.11.4_sass@1.69.7_undici@5.28.2/node_modules/@builder.io/qwik/core" but cannot be named.

The solution is to `export` and `@public` the erroring types. 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
