### PR TITLE
fix(types): JSX.Element is JSXOutput

### DIFF
--- a/packages/docs/src/components/builder-content/index.tsx
+++ b/packages/docs/src/components/builder-content/index.tsx
@@ -119,10 +119,14 @@ export async function getBuilderContent({
     qwikUrl.searchParams.set('cachebust', 'true');
   }
 
-  const response = await fetch(qwikUrl.href);
-  if (response.ok) {
-    const content: BuilderContent = JSON.parse(await response.text());
-    return content;
+  try {
+    const response = await fetch(qwikUrl.href);
+    if (response.ok) {
+      const content: BuilderContent = JSON.parse(await response.text());
+      return content;
+    }
+  } catch (err) {
+    console.error(err);
   }
-  throw new Error(`Unable to load Builder content from ${qwikUrl.toString()}`);
+  return { html: `<div>Unable to load Builder content from ${qwikUrl.toString()}</div>` };
 }

--- a/packages/docs/src/repl/monaco.tsx
+++ b/packages/docs/src/repl/monaco.tsx
@@ -226,12 +226,6 @@ const loadDeps = async (qwikVersion: string) => {
       pkgPath: '/server.d.ts',
       path: '/node_modules/@types/builder.io__qwik/server.d.ts',
     },
-    {
-      pkgName: '@builder.io/qwik',
-      pkgVersion: qwikVersion,
-      pkgPath: '/build/index.d.ts',
-      path: '/node_modules/@types/builder.io__qwik/build/index.d.ts',
-    },
   ];
 
   const cache = await caches.open('QwikReplResults');

--- a/packages/docs/src/repl/repl-version.ts
+++ b/packages/docs/src/repl/repl-version.ts
@@ -90,7 +90,7 @@ export const getReplVersion = async (version: string | undefined) => {
       return 0;
     });
 
-    if (!version || !npmData.versions.includes(version)) {
+    if (!version) {
       version = versions[0];
     }
   }

--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -253,7 +253,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "```typescript\nForm: <O, I>({ action, spaReset, reloadDocument, onSubmit$, ...rest }: FormProps<O, I>, key: string | null) => QwikJSX.Element\n```",
+      "content": "```typescript\nForm: <O, I>({ action, spaReset, reloadDocument, onSubmit$, ...rest }: FormProps<O, I>, key: string | null) => import(\"@builder.io/qwik\").JSXOutput\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/form-component.tsx",
       "mdFile": "qwik-city.form.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -364,7 +364,7 @@ export type FailReturn<T> = T & Failed;
 Form: <O, I>(
   { action, spaReset, reloadDocument, onSubmit$, ...rest }: FormProps<O, I>,
   key: string | null,
-) => QwikJSX.Element;
+) => import("@builder.io/qwik").JSXOutput;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/form-component.tsx)

--- a/packages/docs/src/routes/api/qwik-testing/api.json
+++ b/packages/docs/src/routes/api/qwik-testing/api.json
@@ -12,7 +12,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "CreatePlatform and CreateDocument\n\n\n```typescript\ncreateDOM: ({ html }?: {\n    html?: string | undefined;\n}) => Promise<{\n    render: (jsxElement: JSXNode) => Promise<import(\"@builder.io/qwik\").RenderResult>;\n    screen: HTMLElement;\n    userEvent: (queryOrElement: string | Element | keyof HTMLElementTagNameMap | null, eventNameCamel: string | keyof WindowEventMap, eventPayload?: any) => Promise<void>;\n}>\n```",
+      "content": "CreatePlatform and CreateDocument\n\n\n```typescript\ncreateDOM: ({ html }?: {\n    html?: string | undefined;\n}) => Promise<{\n    render: (jsxElement: JSXOutput) => Promise<import(\"@builder.io/qwik\").RenderResult>;\n    screen: HTMLElement;\n    userEvent: (queryOrElement: string | Element | keyof HTMLElementTagNameMap | null, eventNameCamel: string | keyof WindowEventMap, eventPayload?: any) => Promise<void>;\n}>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/testing/library.ts",
       "mdFile": "qwik.createdom.md"
     }

--- a/packages/docs/src/routes/api/qwik-testing/index.md
+++ b/packages/docs/src/routes/api/qwik-testing/index.md
@@ -12,7 +12,7 @@ CreatePlatform and CreateDocument
 createDOM: ({ html }?: { html?: string | undefined }) =>
   Promise<{
     render: (
-      jsxElement: JSXNode,
+      jsxElement: JSXOutput,
     ) => Promise<import("@builder.io/qwik").RenderResult>;
     screen: HTMLElement;
     userEvent: (

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -676,45 +676,37 @@
     },
     {
       "name": "Element",
-      "id": "h-jsx-element",
+      "id": "qwikjsx-element",
       "hierarchy": [
         {
-          "name": "h",
-          "id": "h-jsx-element"
-        },
-        {
-          "name": "JSX",
-          "id": "h-jsx-element"
+          "name": "QwikJSX",
+          "id": "qwikjsx-element"
         },
         {
           "name": "Element",
-          "id": "h-jsx-element"
+          "id": "qwikjsx-element"
         }
       ],
-      "kind": "Interface",
-      "content": "```typescript\ninterface Element extends QwikJSX.Element \n```\n**Extends:** [QwikJSX.Element](#)",
-      "mdFile": "qwik.h.jsx.element.md"
+      "kind": "TypeAlias",
+      "content": "```typescript\ntype Element = JSXOutput;\n```\n**References:** [JSXOutput](#jsxoutput)",
+      "mdFile": "qwik.qwikjsx.element.md"
     },
     {
       "name": "ElementChildrenAttribute",
-      "id": "h-jsx-elementchildrenattribute",
+      "id": "qwikjsx-elementchildrenattribute",
       "hierarchy": [
         {
-          "name": "h",
-          "id": "h-jsx-elementchildrenattribute"
-        },
-        {
-          "name": "JSX",
-          "id": "h-jsx-elementchildrenattribute"
+          "name": "QwikJSX",
+          "id": "qwikjsx-elementchildrenattribute"
         },
         {
           "name": "ElementChildrenAttribute",
-          "id": "h-jsx-elementchildrenattribute"
+          "id": "qwikjsx-elementchildrenattribute"
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\ninterface ElementChildrenAttribute \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children?](#) |  | any | _(Optional)_ |",
-      "mdFile": "qwik.h.jsx.elementchildrenattribute.md"
+      "content": "```typescript\ninterface ElementChildrenAttribute \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [children](#) |  | any |  |",
+      "mdFile": "qwik.qwikjsx.elementchildrenattribute.md"
     },
     {
       "name": "ElementType",
@@ -883,7 +875,7 @@
         }
       ],
       "kind": "Function",
-      "content": "```typescript\nexport declare namespace h \n```\n\n\n|  Function | Description |\n|  --- | --- |\n|  [h(type)](#) |  |\n|  [h(type, data)](#) |  |\n|  [h(type, text)](#) |  |\n|  [h(type, children)](#) |  |\n|  [h(type, data, text)](#) |  |\n|  [h(type, data, children)](#) |  |\n|  [h(sel, data, children)](#) |  |\n\n\n|  Namespace | Description |\n|  --- | --- |\n|  [JSX](#h-jsx) |  |",
+      "content": "```typescript\nexport declare namespace h \n```\n\n\n|  Function | Description |\n|  --- | --- |\n|  [h(type)](#) |  |\n|  [h(type, data)](#) |  |\n|  [h(type, text)](#) |  |\n|  [h(type, children)](#) |  |\n|  [h(type, data, text)](#) |  |\n|  [h(type, data, children)](#) |  |\n|  [h(sel, data, children)](#) |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/factory.ts",
       "mdFile": "qwik.h.md"
     },
@@ -897,7 +889,7 @@
         }
       ],
       "kind": "Namespace",
-      "content": "```typescript\nexport declare namespace h \n```\n\n\n|  Function | Description |\n|  --- | --- |\n|  [h(type)](#) |  |\n|  [h(type, data)](#) |  |\n|  [h(type, text)](#) |  |\n|  [h(type, children)](#) |  |\n|  [h(type, data, text)](#) |  |\n|  [h(type, data, children)](#) |  |\n|  [h(sel, data, children)](#) |  |\n\n\n|  Namespace | Description |\n|  --- | --- |\n|  [JSX](#h-jsx) |  |",
+      "content": "```typescript\nexport declare namespace h \n```\n\n\n|  Function | Description |\n|  --- | --- |\n|  [h(type)](#) |  |\n|  [h(type, data)](#) |  |\n|  [h(type, text)](#) |  |\n|  [h(type, children)](#) |  |\n|  [h(type, data, text)](#) |  |\n|  [h(type, data, children)](#) |  |\n|  [h(sel, data, children)](#) |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/factory.ts",
       "mdFile": "qwik.h.md"
     },
@@ -1113,45 +1105,34 @@
     },
     {
       "name": "IntrinsicAttributes",
-      "id": "h-jsx-intrinsicattributes",
+      "id": "qwikjsx-intrinsicattributes",
       "hierarchy": [
         {
-          "name": "h",
-          "id": "h-jsx-intrinsicattributes"
-        },
-        {
-          "name": "JSX",
-          "id": "h-jsx-intrinsicattributes"
+          "name": "QwikJSX",
+          "id": "qwikjsx-intrinsicattributes"
         },
         {
           "name": "IntrinsicAttributes",
-          "id": "h-jsx-intrinsicattributes"
+          "id": "qwikjsx-intrinsicattributes"
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\ninterface IntrinsicAttributes extends QwikJSX.IntrinsicAttributes \n```\n**Extends:** [QwikJSX.IntrinsicAttributes](#)",
-      "mdFile": "qwik.h.jsx.intrinsicattributes.md"
+      "content": "```typescript\ninterface IntrinsicAttributes extends QwikIntrinsicAttributes \n```\n**Extends:** QwikIntrinsicAttributes",
+      "mdFile": "qwik.qwikjsx.intrinsicattributes.md"
     },
     {
       "name": "IntrinsicElements",
-      "id": "h-jsx-intrinsicelements",
+      "id": "intrinsicelements",
       "hierarchy": [
         {
-          "name": "h",
-          "id": "h-jsx-intrinsicelements"
-        },
-        {
-          "name": "JSX",
-          "id": "h-jsx-intrinsicelements"
-        },
-        {
           "name": "IntrinsicElements",
-          "id": "h-jsx-intrinsicelements"
+          "id": "intrinsicelements"
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\ninterface IntrinsicElements extends QwikJSX.IntrinsicElements \n```\n**Extends:** [QwikJSX.IntrinsicElements](#)",
-      "mdFile": "qwik.h.jsx.intrinsicelements.md"
+      "content": "```typescript\nexport interface IntrinsicElements extends IntrinsicHTMLElements, IntrinsicSVGElements \n```\n**Extends:** IntrinsicHTMLElements, IntrinsicSVGElements",
+      "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts",
+      "mdFile": "qwik.intrinsicelements.md"
     },
     {
       "name": "isSignal",
@@ -1180,23 +1161,6 @@
       "content": "```typescript\njsx: <T extends string | FunctionComponent<any>>(type: T, props: T extends FunctionComponent<infer PROPS extends Record<any, any>> ? PROPS : Record<any, unknown>, key?: string | number | null) => JSXNode<T>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/jsx-runtime.ts",
       "mdFile": "qwik.jsx.md"
-    },
-    {
-      "name": "JSX",
-      "id": "h-jsx",
-      "hierarchy": [
-        {
-          "name": "h",
-          "id": "h-jsx"
-        },
-        {
-          "name": "JSX",
-          "id": "h-jsx"
-        }
-      ],
-      "kind": "Namespace",
-      "content": "```typescript\nnamespace JSX \n```\n\n\n|  Interface | Description |\n|  --- | --- |\n|  [Element](#h-jsx-element) |  |\n|  [ElementChildrenAttribute](#h-jsx-elementchildrenattribute) |  |\n|  [IntrinsicAttributes](#h-jsx-intrinsicattributes) |  |\n|  [IntrinsicElements](#h-jsx-intrinsicelements) |  |",
-      "mdFile": "qwik.h.jsx.md"
     },
     {
       "name": "JSXChildren",
@@ -2090,7 +2054,7 @@
         }
       ],
       "kind": "Namespace",
-      "content": "```typescript\nexport declare namespace QwikJSX \n```\n\n\n|  Interface | Description |\n|  --- | --- |\n|  [Element](#) |  |\n|  [ElementChildrenAttribute](#) |  |\n|  [IntrinsicAttributes](#) |  |\n|  [IntrinsicElements](#) |  |\n\n\n|  Type Alias | Description |\n|  --- | --- |\n|  [ElementType](#qwikjsx-elementtype) |  |",
+      "content": "```typescript\nexport declare namespace QwikJSX \n```\n\n\n|  Interface | Description |\n|  --- | --- |\n|  [ElementChildrenAttribute](#qwikjsx-elementchildrenattribute) |  |\n|  [IntrinsicAttributes](#qwikjsx-intrinsicattributes) |  |\n|  [IntrinsicElements](#) |  |\n\n\n|  Type Alias | Description |\n|  --- | --- |\n|  [Element](#qwikjsx-element) |  |\n|  [ElementType](#qwikjsx-elementtype) |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts",
       "mdFile": "qwik.qwikjsx.md"
     },
@@ -2272,7 +2236,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "Render JSX.\n\nUse this method to render JSX. This function does reconciling which means it always tries to reuse what is already in the DOM (rather then destroy and recreate content.) It returns a cleanup function you could use for cleaning up subscriptions.\n\n\n```typescript\nrender: (parent: Element | Document, jsxNode: JSXNode | FunctionComponent<any>, opts?: RenderOptions) => Promise<RenderResult>\n```",
+      "content": "Render JSX.\n\nUse this method to render JSX. This function does reconciling which means it always tries to reuse what is already in the DOM (rather then destroy and recreate content.) It returns a cleanup function you could use for cleaning up subscriptions.\n\n\n```typescript\nrender: (parent: Element | Document, jsxOutput: JSXOutput | FunctionComponent<any>, opts?: RenderOptions) => Promise<RenderResult>\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/dom/render.public.ts",
       "mdFile": "qwik.render.md"
     },
@@ -2342,7 +2306,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "This method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- 'pending' - the data is not yet available. - 'resolved' - the data is available. - 'rejected' - the data is not available due to an error or timeout.\n\n\\#\\#\\# Example\n\nExample showing how `useResource` to perform a fetch to request the weather, whenever the input city name changes.\n\n```tsx\nconst Cmp = component$(() => {\n  const cityS = useSignal('');\n\n  const weatherResource = useResource$(async ({ track, cleanup }) => {\n    const cityName = track(cityS);\n    const abortController = new AbortController();\n    cleanup(() => abortController.abort('cleanup'));\n    const res = await fetch(`http://weatherdata.com?city=${cityName}`, {\n      signal: abortController.signal,\n    });\n    const data = await res.json();\n    return data as { temp: number };\n  });\n\n  return (\n    <div>\n      <input name=\"city\" bind:value={cityS} />\n      <Resource\n        value={weatherResource}\n        onResolved={(weather) => {\n          return <div>Temperature: {weather.temp}</div>;\n        }}\n      />\n    </div>\n  );\n});\n```\n\n\n```typescript\nResource: <T>(props: ResourceProps<T>) => JSXNode\n```",
+      "content": "This method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- 'pending' - the data is not yet available. - 'resolved' - the data is available. - 'rejected' - the data is not available due to an error or timeout.\n\n\\#\\#\\# Example\n\nExample showing how `useResource` to perform a fetch to request the weather, whenever the input city name changes.\n\n```tsx\nconst Cmp = component$(() => {\n  const cityS = useSignal('');\n\n  const weatherResource = useResource$(async ({ track, cleanup }) => {\n    const cityName = track(cityS);\n    const abortController = new AbortController();\n    cleanup(() => abortController.abort('cleanup'));\n    const res = await fetch(`http://weatherdata.com?city=${cityName}`, {\n      signal: abortController.signal,\n    });\n    const data = await res.json();\n    return data as { temp: number };\n  });\n\n  return (\n    <div>\n      <input name=\"city\" bind:value={cityS} />\n      <Resource\n        value={weatherResource}\n        onResolved={(weather) => {\n          return <div>Temperature: {weather.temp}</div>;\n        }}\n      />\n    </div>\n  );\n});\n```\n\n\n```typescript\nResource: <T>(props: ResourceProps<T>) => JSXOutput\n```",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts",
       "mdFile": "qwik.resource.md"
     },
@@ -2412,7 +2376,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ResourceProps<T> \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [onPending?](#) |  | () =&gt; [JSXNode](#jsxnode) | _(Optional)_ |\n|  [onRejected?](#) |  | (reason: Error) =&gt; [JSXNode](#jsxnode) | _(Optional)_ |\n|  [onResolved](#) |  | (value: T) =&gt; [JSXNode](#jsxnode) |  |\n|  [value](#) | <code>readonly</code> | [ResourceReturn](#resourcereturn)<!-- -->&lt;T&gt; \\| [Signal](#signal)<!-- -->&lt;Promise&lt;T&gt; \\| T&gt; \\| Promise&lt;T&gt; |  |",
+      "content": "```typescript\nexport interface ResourceProps<T> \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [onPending?](#) |  | () =&gt; [JSXOutput](#jsxoutput) | _(Optional)_ |\n|  [onRejected?](#) |  | (reason: Error) =&gt; [JSXOutput](#jsxoutput) | _(Optional)_ |\n|  [onResolved](#) |  | (value: T) =&gt; [JSXOutput](#jsxoutput) |  |\n|  [value](#) | <code>readonly</code> | [ResourceReturn](#resourcereturn)<!-- -->&lt;T&gt; \\| [Signal](#signal)<!-- -->&lt;Promise&lt;T&gt; \\| T&gt; \\| Promise&lt;T&gt; |  |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts",
       "mdFile": "qwik.resourceprops.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -760,10 +760,10 @@ export type EagernessOptions = "visible" | "load" | "idle";
 ## Element
 
 ```typescript
-interface Element extends QwikJSX.Element
+type Element = JSXOutput;
 ```
 
-**Extends:** [QwikJSX.Element](#)
+**References:** [JSXOutput](#jsxoutput)
 
 ## ElementChildrenAttribute
 
@@ -771,9 +771,9 @@ interface Element extends QwikJSX.Element
 interface ElementChildrenAttribute
 ```
 
-| Property       | Modifiers | Type | Description  |
-| -------------- | --------- | ---- | ------------ |
-| [children?](#) |           | any  | _(Optional)_ |
+| Property      | Modifiers | Type | Description |
+| ------------- | --------- | ---- | ----------- |
+| [children](#) |           | any  |             |
 
 ## ElementType
 
@@ -917,10 +917,6 @@ export declare namespace h
 | [h(type, data, children)](#) |             |
 | [h(sel, data, children)](#)  |             |
 
-| Namespace     | Description |
-| ------------- | ----------- |
-| [JSX](#h-jsx) |             |
-
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/factory.ts)
 
 ## h
@@ -938,10 +934,6 @@ export declare namespace h
 | [h(type, data, text)](#)     |             |
 | [h(type, data, children)](#) |             |
 | [h(sel, data, children)](#)  |             |
-
-| Namespace     | Description |
-| ------------- | ----------- |
-| [JSX](#h-jsx) |             |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/factory.ts)
 
@@ -1201,18 +1193,20 @@ export interface InsHTMLAttributes<T extends Element> extends Attrs<'ins', T>
 ## IntrinsicAttributes
 
 ```typescript
-interface IntrinsicAttributes extends QwikJSX.IntrinsicAttributes
+interface IntrinsicAttributes extends QwikIntrinsicAttributes
 ```
 
-**Extends:** [QwikJSX.IntrinsicAttributes](#)
+**Extends:** QwikIntrinsicAttributes
 
 ## IntrinsicElements
 
 ```typescript
-interface IntrinsicElements extends QwikJSX.IntrinsicElements
+export interface IntrinsicElements extends IntrinsicHTMLElements, IntrinsicSVGElements
 ```
 
-**Extends:** [QwikJSX.IntrinsicElements](#)
+**Extends:** IntrinsicHTMLElements, IntrinsicSVGElements
+
+[Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-generated.ts)
 
 ## isSignal
 
@@ -1237,19 +1231,6 @@ jsx: <T extends string | FunctionComponent<any>>(
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/jsx-runtime.ts)
-
-## JSX
-
-```typescript
-namespace JSX
-```
-
-| Interface                                                   | Description |
-| ----------------------------------------------------------- | ----------- |
-| [Element](#h-jsx-element)                                   |             |
-| [ElementChildrenAttribute](#h-jsx-elementchildrenattribute) |             |
-| [IntrinsicAttributes](#h-jsx-intrinsicattributes)           |             |
-| [IntrinsicElements](#h-jsx-intrinsicelements)               |             |
 
 ## JSXChildren
 
@@ -2126,15 +2107,15 @@ export type QwikInvalidEvent<T = Element> = Event;
 export declare namespace QwikJSX
 ```
 
-| Interface                     | Description |
-| ----------------------------- | ----------- |
-| [Element](#)                  |             |
-| [ElementChildrenAttribute](#) |             |
-| [IntrinsicAttributes](#)      |             |
-| [IntrinsicElements](#)        |             |
+| Interface                                                     | Description |
+| ------------------------------------------------------------- | ----------- |
+| [ElementChildrenAttribute](#qwikjsx-elementchildrenattribute) |             |
+| [IntrinsicAttributes](#qwikjsx-intrinsicattributes)           |             |
+| [IntrinsicElements](#)                                        |             |
 
 | Type Alias                          | Description |
 | ----------------------------------- | ----------- |
+| [Element](#qwikjsx-element)         |             |
 | [ElementType](#qwikjsx-elementtype) |             |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts)
@@ -2309,7 +2290,7 @@ Use this method to render JSX. This function does reconciling which means it alw
 ```typescript
 render: (
   parent: Element | Document,
-  jsxNode: JSXNode | FunctionComponent<any>,
+  jsxOutput: JSXOutput | FunctionComponent<any>,
   opts?: RenderOptions,
 ) => Promise<RenderResult>;
 ```
@@ -2414,7 +2395,7 @@ const Cmp = component$(() => {
 ```
 
 ```typescript
-Resource: <T>(props: ResourceProps<T>) => JSXNode;
+Resource: <T>(props: ResourceProps<T>) => JSXOutput;
 ```
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts)
@@ -2482,9 +2463,9 @@ export interface ResourceProps<T>
 
 | Property         | Modifiers             | Type                                                                                                             | Description  |
 | ---------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------ |
-| [onPending?](#)  |                       | () =&gt; [JSXNode](#jsxnode)                                                                                     | _(Optional)_ |
-| [onRejected?](#) |                       | (reason: Error) =&gt; [JSXNode](#jsxnode)                                                                        | _(Optional)_ |
-| [onResolved](#)  |                       | (value: T) =&gt; [JSXNode](#jsxnode)                                                                             |              |
+| [onPending?](#)  |                       | () =&gt; [JSXOutput](#jsxoutput)                                                                                 | _(Optional)_ |
+| [onRejected?](#) |                       | (reason: Error) =&gt; [JSXOutput](#jsxoutput)                                                                    | _(Optional)_ |
+| [onResolved](#)  |                       | (value: T) =&gt; [JSXOutput](#jsxoutput)                                                                         |              |
 | [value](#)       | <code>readonly</code> | [ResourceReturn](#resourcereturn)&lt;T&gt; \| [Signal](#signal)&lt;Promise&lt;T&gt; \| T&gt; \| Promise&lt;T&gt; |              |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts)

--- a/packages/docs/src/routes/demo/cookbook/portal/portal-provider.tsx
+++ b/packages/docs/src/routes/demo/cookbook/portal/portal-provider.tsx
@@ -10,8 +10,8 @@ import {
   type ContextId,
   type QRL,
   type Signal,
+  type JSXOutput,
 } from '@builder.io/qwik';
-import { type JSXNode } from '@builder.io/qwik/jsx-runtime';
 import CSS from './portal-provider.css?inline';
 
 // Define public API for opening up Portals
@@ -24,7 +24,7 @@ export const PortalAPI = createContextId<
    * @returns A function used for closing the portal.
    */
   QRL<
-    (name: string, jsx: JSXNode, contexts?: ContextPair<any>[]) => () => void
+    (name: string, jsx: JSXOutput, contexts?: ContextPair<any>[]) => () => void
   >
 >('PortalProviderAPI');
 
@@ -39,7 +39,7 @@ const PortalsContextId = createContextId<Signal<Portal[]>>('Portals');
 
 interface Portal {
   name: string;
-  jsx: JSXNode;
+  jsx: JSXOutput;
   close: QRL<() => void>;
   contexts: Array<ContextPair<any>>;
 }
@@ -51,7 +51,7 @@ export const PortalProvider = component$(() => {
   // Provide the public API for the PopupManager for other components.
   useContextProvider(
     PortalAPI,
-    $((name: string, jsx: JSXNode, contexts?: ContextPair<any>[]) => {
+    $((name: string, jsx: JSXOutput, contexts?: ContextPair<any>[]) => {
       const portal: Portal = {
         name,
         jsx,
@@ -94,7 +94,7 @@ export const Portal = component$<{ name: string }>(({ name }) => {
 });
 
 export const WrapJsxInContext = component$<{
-  jsx: JSXNode;
+  jsx: JSXOutput;
   contexts: Array<ContextPair<any>>;
 }>(({ jsx, contexts }) => {
   contexts.forEach(({ id, value }) => {

--- a/packages/docs/src/routes/demo/resumability/index.tsx
+++ b/packages/docs/src/routes/demo/resumability/index.tsx
@@ -4,8 +4,8 @@ import {
   noSerialize,
   useContext,
   useStore,
-  type JSXNode,
   type NoSerialize,
+  type JSXOutput,
 } from '@builder.io/qwik';
 import {
   Portal,
@@ -46,7 +46,7 @@ export const HoverProvider = component$(() => {
           target.dispatchEvent(
             new CustomEvent('hover', {
               bubbles: true,
-              detail: async (jsx: JSXNode) => {
+              detail: async (jsx: JSXOutput) => {
                 if (state.close) return;
                 state.currentTarget = e.target as HTMLElement;
                 state.close = noSerialize(await portal('popup', jsx));
@@ -83,4 +83,4 @@ function isPortal(element: HTMLElement) {
   return element.closest('[data-portal]') != null;
 }
 
-export type HoverEvent = CustomEvent<(jsx: JSXNode) => void>;
+export type HoverEvent = CustomEvent<(jsx: JSXOutput) => void>;

--- a/packages/docs/src/routes/examples/[...id]/examples.css
+++ b/packages/docs/src/routes/examples/[...id]/examples.css
@@ -11,10 +11,10 @@
   grid-template-rows: 100%;
   grid-template-columns: 100vw 100vw;
   grid-template-areas: 'example-content-panel example-repl-panel';
-  height: calc(100% - var(--header-height));
+  height: 100%;
+  height: calc(100% - var(--header-height) - var(--panel-toggle-height));
   transform: translate3d(0, 0, 0);
   transition: transform 500ms;
-  height: 100%;
 }
 
 .examples-panel-input {
@@ -35,7 +35,6 @@
   border-width: 1px;
   border-top-style: solid;
   border-top-left-radius: 5px;
-  overflow: hidden;
 }
 
 .examples .repl {
@@ -43,7 +42,7 @@
   grid-template-rows: auto;
   grid-template-columns: 100vw 100vw 100vw;
   grid-template-areas: 'repl-input-panel repl-output-panel repl-detail-panel';
-  height: calc(100vh - var(--header-height));
+  height: 100%;
 }
 
 @media (min-width: 768px) {

--- a/packages/docs/src/routes/playground/playground.css
+++ b/packages/docs/src/routes/playground/playground.css
@@ -1,6 +1,7 @@
 .playground {
   width: 100%;
   height: cal(100vh - var(--header-height));
+  height: cal(100dvh - var(--header-height));
 
   --playground-header-height: 0px;
 }
@@ -14,6 +15,7 @@
     'repl-input-panel repl-detail-panel';
   top: calc(var(--header-height) + var(--playground-header-height));
   height: calc(100vh - var(--header-height) - var(--panel-toggle-height));
+  height: calc(100dvh - var(--header-height) - var(--panel-toggle-height));
 }
 
 .playground .repl-col-resize-bar {
@@ -56,6 +58,9 @@
 }
 
 @media (max-width: 768px) {
+  body {
+    overflow-x: hidden;
+  }
   .playground .repl {
     width: 300vw;
     grid-template-rows: 100%;

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -11,6 +11,7 @@ import { CookieValue } from '@builder.io/qwik-city/middleware/request-handler';
 import { DeferReturn } from '@builder.io/qwik-city/middleware/request-handler';
 import type { EnvGetter } from '@builder.io/qwik-city/middleware/request-handler';
 import { JSXNode } from '@builder.io/qwik';
+import { JSXOutput } from '@builder.io/qwik';
 import { QRL } from '@builder.io/qwik';
 import { QwikIntrinsicElements } from '@builder.io/qwik';
 import { QwikJSX } from '@builder.io/qwik';
@@ -211,7 +212,7 @@ export type FailOfRest<REST extends readonly DataValidator[]> = REST extends rea
 export type FailReturn<T> = T & Failed;
 
 // @public (undocumented)
-export const Form: <O, I>({ action, spaReset, reloadDocument, onSubmit$, ...rest }: FormProps<O, I>, key: string | null) => QwikJSX.Element;
+export const Form: <O, I>({ action, spaReset, reloadDocument, onSubmit$, ...rest }: FormProps<O, I>, key: string | null) => JSXOutput;
 
 // @public (undocumented)
 export interface FormProps<O, I> extends Omit<QwikJSX.IntrinsicElements['form'], 'action' | 'method'> {

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -284,23 +284,7 @@ namespace h {
     function h(type: any, data: any, children: Array<JSXNode<any> | undefined | null>): JSXNode<any>;
     // (undocumented)
     function h(sel: any, data: any | null, children: JSXNode<any>): JSXNode<any>;
-    // (undocumented)
-    namespace JSX {
-        // (undocumented)
-        interface Element extends QwikJSX.Element {
-        }
-        // (undocumented)
-        interface ElementChildrenAttribute {
-            // (undocumented)
-            children?: any;
-        }
-        // (undocumented)
-        interface IntrinsicAttributes extends QwikJSX.IntrinsicAttributes {
-        }
-        // (undocumented)
-        interface IntrinsicElements extends QwikJSX.IntrinsicElements {
-        }
-    }
+        { JSX };
 }
 export { h as createElement }
 export { h }
@@ -732,8 +716,7 @@ export type QwikInvalidEvent<T = Element> = Event;
 // @public (undocumented)
 export namespace QwikJSX {
     // (undocumented)
-    export interface Element extends JSXNode {
-    }
+    export type Element = JSXOutput;
     // (undocumented)
     export interface ElementChildrenAttribute {
         // (undocumented)
@@ -799,7 +782,7 @@ export type ReadonlySignal<T = unknown> = Readonly<Signal<T>>;
 export const _regSymbol: (symbol: any, hash: string) => any;
 
 // @public
-export const render: (parent: Element | Document, jsxNode: JSXNode | FunctionComponent<any>, opts?: RenderOptions) => Promise<RenderResult>;
+export const render: (parent: Element | Document, jsxOutput: JSXOutput | FunctionComponent<any>, opts?: RenderOptions) => Promise<RenderResult>;
 
 // @public (undocumented)
 export const RenderOnce: FunctionComponent<{
@@ -820,7 +803,7 @@ export interface RenderResult {
 }
 
 // @internal (undocumented)
-export const _renderSSR: (node: JSXNode, opts: RenderSSROptions) => Promise<void>;
+export const _renderSSR: (node: JSXOutput, opts: RenderSSROptions) => Promise<void>;
 
 // @public (undocumented)
 export interface RenderSSROptions {
@@ -843,7 +826,7 @@ export interface RenderSSROptions {
 }
 
 // @public
-export const Resource: <T>(props: ResourceProps<T>) => JSXNode;
+export const Resource: <T>(props: ResourceProps<T>) => JSXOutput;
 
 // @public (undocumented)
 export interface ResourceCtx<T> {
@@ -876,11 +859,11 @@ export interface ResourcePending<T> {
 // @public (undocumented)
 export interface ResourceProps<T> {
     // (undocumented)
-    onPending?: () => JSXNode;
+    onPending?: () => JSXOutput;
     // (undocumented)
-    onRejected?: (reason: Error) => JSXNode;
+    onRejected?: (reason: Error) => JSXOutput;
     // (undocumented)
-    onResolved: (value: T) => JSXNode;
+    onResolved: (value: T) => JSXOutput;
     // (undocumented)
     readonly value: ResourceReturn<T> | Signal<Promise<T> | T> | Promise<T>;
 }

--- a/packages/qwik/src/core/container/render.unit.tsx
+++ b/packages/qwik/src/core/container/render.unit.tsx
@@ -1,20 +1,20 @@
 import { assert, suite, test } from 'vitest';
-import type { JSXNode } from '../../jsx-runtime';
 import { renderToString } from '../../server/render';
 import { createDocument } from '../../testing/document';
 import { createDOM } from '../../testing/library';
 import { component$ } from '../component/component.public';
 import { _fnSignal } from '../internal';
 import { useSignal } from '../use/use-signal';
+import type { JSXOutput } from '../render/jsx/types/jsx-node';
 
 suite('jsx signals', () => {
   const RenderJSX = component$(() => {
-    const jsx = useSignal<string | JSXNode>(<span>SSR</span>);
+    const jsx = useSignal<string | JSXOutput>(<span>SSR</span>);
     return (
       <>
         <button
           class="set-jsx"
-          onJsx$={(e: CustomEvent<JSXNode | string>) => (jsx.value = e.detail)}
+          onJsx$={(e: CustomEvent<JSXOutput | string>) => (jsx.value = e.detail)}
         />
         <div class="jsx">{jsx.value}</div>
         <div class="jsx-signal">{_fnSignal((p0) => p0.value, [jsx], 'p0.value')}</div>

--- a/packages/qwik/src/core/render/dom/render.public.ts
+++ b/packages/qwik/src/core/render/dom/render.public.ts
@@ -1,6 +1,6 @@
 import { isDocument } from '../../util/element';
-import { isJSXNode, jsx } from '../jsx/jsx-runtime';
-import type { JSXNode, FunctionComponent } from '../jsx/types/jsx-node';
+import { jsx } from '../jsx/jsx-runtime';
+import type { JSXOutput, FunctionComponent } from '../jsx/types/jsx-node';
 import { cleanupTree, domToVnode, smartUpdateChildren } from './visitor';
 import { getDocument } from '../../util/dom';
 import { qDev } from '../../util/qdev';
@@ -40,18 +40,18 @@ export interface RenderResult {
  *
  * @param parent - Element which will act as a parent to `jsxNode`. When possible the rendering will
  *   try to reuse existing nodes.
- * @param jsxNode - JSX to render
+ * @param jsxOutput - JSX to render
  * @returns An object containing a cleanup function.
  * @public
  */
 export const render = async (
   parent: Element | Document,
-  jsxNode: JSXNode | FunctionComponent<any>,
+  jsxOutput: JSXOutput | FunctionComponent<any>,
   opts?: RenderOptions
 ): Promise<RenderResult> => {
-  // If input is not JSX, convert it
-  if (!isJSXNode(jsxNode)) {
-    jsxNode = jsx(jsxNode, null);
+  // If input is a component, convert it
+  if (typeof jsxOutput === 'function') {
+    jsxOutput = jsx(jsxOutput, null);
   }
   const doc = getDocument(parent);
   const containerEl = getElement(parent);
@@ -73,7 +73,7 @@ export const render = async (
   const rCtx = createRenderContext(doc, containerState);
   containerState.$hostsRendering$ = new Set();
   containerState.$styleMoved$ = true;
-  await renderRoot(rCtx, containerEl, jsxNode, doc, containerState, containerEl);
+  await renderRoot(rCtx, containerEl, jsxOutput, doc, containerState, containerEl);
 
   await postRendering(containerState, rCtx);
 
@@ -87,7 +87,7 @@ export const render = async (
 const renderRoot = async (
   rCtx: RenderContext,
   parent: Element,
-  jsxNode: JSXNode<unknown> | FunctionComponent<any>,
+  jsxOutput: JSXOutput,
   doc: Document,
   containerState: ContainerState,
   containerEl: Element
@@ -95,7 +95,7 @@ const renderRoot = async (
   const staticCtx = rCtx.$static$;
 
   try {
-    const processedNodes = await processData(jsxNode);
+    const processedNodes = await processData(jsxOutput);
     // const rootJsx = getVdom(parent);
     const rootJsx = domToVnode(parent);
     await smartUpdateChildren(rCtx, rootJsx, wrapJSX(parent, processedNodes), 0);

--- a/packages/qwik/src/core/render/jsx/factory.ts
+++ b/packages/qwik/src/core/render/jsx/factory.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import { jsx } from './jsx-runtime';
-import type { QwikJSX } from './types/jsx-qwik';
+import type { QwikJSX as JSX } from './types/jsx-qwik';
 import type { FunctionComponent, JSXNode } from './types/jsx-node';
 import { isArray } from '../../util/types';
 
@@ -60,12 +60,5 @@ export declare namespace h {
   ): JSXNode<any>;
   export function h(sel: any, data: any | null, children: JSXNode<any>): JSXNode<any>;
 
-  export namespace JSX {
-    export interface Element extends QwikJSX.Element {}
-    export interface IntrinsicAttributes extends QwikJSX.IntrinsicAttributes {}
-    export interface IntrinsicElements extends QwikJSX.IntrinsicElements {}
-    export interface ElementChildrenAttribute {
-      children?: any;
-    }
-  }
+  export { JSX };
 }

--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik.ts
@@ -1,10 +1,10 @@
 import type { DOMAttributes } from './jsx-qwik-attributes';
-import type { FunctionComponent, JSXNode } from './jsx-node';
+import type { FunctionComponent, JSXOutput } from './jsx-node';
 import type { QwikIntrinsicAttributes, LenientQwikElements } from './jsx-qwik-elements';
 
 /** @public */
 export namespace QwikJSX {
-  export interface Element extends JSXNode {}
+  export type Element = JSXOutput;
   export type ElementType = string | FunctionComponent<Record<any, any>>;
 
   export interface IntrinsicAttributes extends QwikIntrinsicAttributes {}

--- a/packages/qwik/src/core/render/jsx/types/jsx-types.unit.tsx
+++ b/packages/qwik/src/core/render/jsx/types/jsx-types.unit.tsx
@@ -1,7 +1,7 @@
 import { assertType, describe, expectTypeOf, test } from 'vitest';
 import { $ } from '../../../qrl/qrl.public';
 import type { EventHandler, QRLEventHandlerMulti } from './jsx-qwik-attributes';
-import type { FunctionComponent, JSXNode } from './jsx-node';
+import type { FunctionComponent, JSXOutput } from './jsx-node';
 import type { QwikIntrinsicElements } from './jsx-qwik-elements';
 import type { JSXChildren } from './jsx-qwik-attributes';
 import { component$, type PropsOf, type PublicProps } from '../../../component/component.public';
@@ -12,7 +12,7 @@ describe('types', () => {
   // Note, these type checks happen at compile time. We don't need to call anything, so we do ()=>()=>. We just need to
   // make sure the type check runs.
   test('basic', () => () => {
-    expectTypeOf(<div />).toEqualTypeOf<JSXNode>();
+    expectTypeOf(<div />).toEqualTypeOf<JSXOutput>();
     expectTypeOf<QRLEventHandlerMulti<PointerEvent, HTMLDivElement>>().toMatchTypeOf<
       QwikIntrinsicElements['div']['onAuxClick$']
     >();

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -2,7 +2,7 @@ import { isPromise, maybeThen } from '../../util/promises';
 import { type InvokeContext, newInvokeContext, invoke, trackSignal } from '../../use/use-core';
 import { Virtual, _jsxC, _jsxQ, createJSXError, isJSXNode } from '../jsx/jsx-runtime';
 import { isArray, isFunction, isString, type ValueOrPromise } from '../../util/types';
-import type { FunctionComponent, JSXNode } from '../jsx/types/jsx-node';
+import type { FunctionComponent, JSXNode, JSXOutput } from '../jsx/types/jsx-node';
 import {
   createRenderContext,
   executeComponent,
@@ -114,7 +114,7 @@ const createDocument = () => {
 };
 
 /** @internal */
-export const _renderSSR = async (node: JSXNode, opts: RenderSSROptions) => {
+export const _renderSSR = async (node: JSXOutput, opts: RenderSSROptions) => {
   const root = opts.containerTagName;
   const containerEl = createMockQContext(1).$element$;
   const containerState = createContainerState(containerEl as Element, opts.base ?? '/');
@@ -170,7 +170,7 @@ export const _renderSSR = async (node: JSXNode, opts: RenderSSROptions) => {
     containerState.$serverData$ = opts.serverData;
   }
 
-  node = _jsxQ(
+  const rootNode = _jsxQ(
     root,
     null,
     containerAttributes,
@@ -180,7 +180,7 @@ export const _renderSSR = async (node: JSXNode, opts: RenderSSROptions) => {
   );
   containerState.$hostsRendering$ = new Set();
   await Promise.resolve().then(() =>
-    renderRoot(node, rCtx, ssrCtx, opts.stream, containerState, opts)
+    renderRoot(rootNode, rCtx, ssrCtx, opts.stream, containerState, opts)
   );
 };
 

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -1,4 +1,3 @@
-import type { JSXNode } from '@builder.io/qwik/jsx-runtime';
 import { format } from 'prettier';
 
 import type { StreamWriter } from '../../../server/types';
@@ -18,6 +17,7 @@ import { _renderSSR, type RenderSSROptions } from './render-ssr';
 import { useStore } from '../../use/use-store.public';
 import { useSignal } from '../../use/use-signal';
 import { expect, test, vi } from 'vitest';
+import type { JSXOutput } from '../jsx/types/jsx-node';
 
 test('render attributes', async () => {
   await testSSR(
@@ -1839,7 +1839,7 @@ export const HtmlContext = component$(() => {
 });
 
 async function testSSR(
-  node: JSXNode,
+  node: JSXOutput,
   expected: string | string[],
   opts?: Partial<RenderSSROptions>
 ) {

--- a/packages/qwik/src/core/use/use-resource.ts
+++ b/packages/qwik/src/core/use/use-resource.ts
@@ -11,7 +11,6 @@ import {
   type ResourceReturnInternal,
 } from './use-task';
 import { Fragment, jsx } from '../render/jsx/jsx-runtime';
-import type { JSXNode } from '../render/jsx/types/jsx-node';
 import { isServerPlatform } from '../platform/platform';
 import { untrack, useBindInvokeContext } from './use-core';
 
@@ -22,6 +21,7 @@ import { getProxyTarget } from '../state/common';
 import { isSignal, type Signal } from '../state/signal';
 import { isObject } from '../util/types';
 import { isPromise } from '../util/promises';
+import type { JSXOutput } from '../render/jsx/types/jsx-node';
 
 /**
  * Options to pass to `useResource$()`
@@ -188,9 +188,9 @@ export const useResource$ = <T>(
 /** @public */
 export interface ResourceProps<T> {
   readonly value: ResourceReturn<T> | Signal<Promise<T> | T> | Promise<T>;
-  onResolved: (value: T) => JSXNode;
-  onPending?: () => JSXNode;
-  onRejected?: (reason: Error) => JSXNode;
+  onResolved: (value: T) => JSXOutput;
+  onPending?: () => JSXOutput;
+  onRejected?: (reason: Error) => JSXOutput;
 }
 
 // <docs markdown="../readme.md#useResource">
@@ -248,7 +248,7 @@ export interface ResourceProps<T> {
  * @see ResourceReturn
  */
 // </docs>
-export const Resource = <T>(props: ResourceProps<T>): JSXNode => {
+export const Resource = <T>(props: ResourceProps<T>): JSXOutput => {
   const isBrowser = !isServerPlatform();
   const resource = props.value as ResourceReturnInternal<T> | Promise<T> | Signal<T>;
   let promise: Promise<T> | undefined;

--- a/packages/qwik/src/testing/api.md
+++ b/packages/qwik/src/testing/api.md
@@ -4,14 +4,14 @@
 
 ```ts
 
-import type { JSXNode } from '@builder.io/qwik/jsx-runtime';
+import type { JSXOutput } from '@builder.io/qwik';
 import { RenderResult } from '@builder.io/qwik';
 
 // @public
 export const createDOM: ({ html }?: {
     html?: string | undefined;
 }) => Promise<{
-    render: (jsxElement: JSXNode) => Promise<RenderResult>;
+    render: (jsxElement: JSXOutput) => Promise<RenderResult>;
     screen: HTMLElement;
     userEvent: (queryOrElement: string | Element | keyof HTMLElementTagNameMap | null, eventNameCamel: string | keyof WindowEventMap, eventPayload?: any) => Promise<void>;
 }>;

--- a/packages/qwik/src/testing/library.ts
+++ b/packages/qwik/src/testing/library.ts
@@ -1,6 +1,6 @@
-import type { JSXNode } from '@builder.io/qwik/jsx-runtime';
 import { ElementFixture, trigger } from './element-fixture';
 import { setTestPlatform } from './platform';
+import type { JSXOutput } from '@builder.io/qwik';
 
 /**
  * CreatePlatform and CreateDocument
@@ -12,7 +12,7 @@ export const createDOM = async function ({ html }: { html?: string } = {}) {
   setTestPlatform(qwik.setPlatform);
   const host = new ElementFixture({ html }).host;
   return {
-    render: function (jsxElement: JSXNode) {
+    render: function (jsxElement: JSXOutput) {
       return qwik.render(host, jsxElement);
     },
     screen: host,

--- a/starters/apps/e2e/src/components/render/render.tsx
+++ b/starters/apps/e2e/src/components/render/render.tsx
@@ -1,6 +1,5 @@
 import {
   component$,
-  type JSXNode,
   useSignal,
   useStore,
   useStylesScoped$,
@@ -14,6 +13,7 @@ import {
   type PropsOf,
   Slot,
   type QRL,
+  type JSXOutput,
 } from "@builder.io/qwik";
 import { delay } from "../streaming/demo";
 import { isServer } from "@builder.io/qwik/build";
@@ -373,7 +373,7 @@ export const Issue2889 = component$(() => {
 type Product = string;
 
 export type ProductRelationProps = {
-  render$: QRL<(products: Product[]) => JSXNode>;
+  render$: QRL<(products: Product[]) => JSXOutput>;
 };
 
 export const ProductRelations = component$((props: ProductRelationProps) => {


### PR DESCRIPTION
- correct JSX.Element so it accepts JSXOutput
- also correct render functions
- bonus repl fixes on mobile

slightly breaking, so should probably be released as at least minor.