### PR TITLE
docs: fixed CodeSandbox/CodeFile src paths to match github files

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/algolia-search/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/algolia-search/index.mdx
@@ -6,7 +6,7 @@ updated_at: '2024-01-09T11:00:00Z'
 created_at: '2024-01-09T11:00:00Z'
 ---
 
-import CodeSandbox, {CodeFile} from '../../../../components/code-sandbox/index.tsx';  
+import CodeSandbox from '../../../../components/code-sandbox/index.tsx';
 
 # Algolia Search
 
@@ -34,7 +34,7 @@ Then obviously you can customize and create your graphical interface.
 Many times it makes sense to have a modal where you show the search and the results, such as the search you find in this Qwik documentation.
 You can check what Algolia returns via the [official documentation](https://www.algolia.com/doc/).
 
-<CodeSandbox url="/demo/cookbook/algolia-search/"  style={{ height: '20em' }}>
+<CodeSandbox src="/src/routes/demo/cookbook/algolia-search/"  style={{ height: '20em' }}>
 ```tsx
 import { $, component$, useSignal, useStylesScoped$ } from '@builder.io/qwik';
 
@@ -126,7 +126,7 @@ export default component$(() => {
     .list li .content .text {
       grid-area: text;
       color: black;
-    }    
+    }
   `);
   const termSignal = useSignal('');
   const hitsSig = useSignal<AlgoliaResult['hits']>([]);

--- a/packages/docs/src/routes/docs/cookbook/glob-import/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/glob-import/index.mdx
@@ -50,7 +50,7 @@ The reason for this behavior, is that `import.meta.glob` with `eager.false` brea
 
 As a workaround for now, you can use the build time `isDev` boolean from `"@builder.io/qwik/build"`:
 
-<CodeSandbox url="/demo/cookbook/glob-import/">
+<CodeSandbox src="/src/routes/demo/cookbook/glob-import/">
 ```tsx
 import {
   type Component,

--- a/packages/docs/src/routes/docs/cookbook/mediaController/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/mediaController/index.mdx
@@ -35,7 +35,7 @@ To achieve consistent media playback across various browsers and devices, a holi
 
 Below, you'll find a prototype of an audio and video controller, tailored to provide a consistent user experience across multiple platforms.
 
-<CodeSandbox url="/demo/cookbook/mediaController/"  style={{ height: '700px' }}>
+<CodeSandbox src="/src/routes/demo/cookbook/mediaController/"  style={{ height: '700px' }}>
 </CodeSandbox>
 
 Universal media controller code compatible with iOS devices looks like this:
@@ -81,7 +81,7 @@ export default component$(() => {
         .content {
           width: 60%;
           min-width: 250px;
-        }   
+        }
         button {
           padding: 20px;
           font-weight: bold;

--- a/packages/docs/src/routes/docs/cookbook/portals/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/portals/index.mdx
@@ -52,7 +52,7 @@ It is intentionally opt-in, at some point the CSS Anchor API will provide a nati
 
 > Because these solutions are built on top of the native specs, that also means there's less javascript we need to prefetch, and therefore less work that needs to be done!
 
-Both Qwik UI's popover and modal components can be used regardless of meta-framework or microfrontend, as long as there is support for Qwik. 
+Both Qwik UI's popover and modal components can be used regardless of meta-framework or microfrontend, as long as there is support for Qwik.
 
 ## Custom Portals
 
@@ -66,7 +66,7 @@ The fundamental problems to solve are:
 
 ## Solution
 
-<CodeSandbox url="/demo/cookbook/portal/"  style={{ height: '15em' }}>
+<CodeSandbox src="/src/routes/demo/cookbook/portal/"  style={{ height: '15em' }}>
 </CodeSandbox>
 
 
@@ -80,7 +80,7 @@ Let's break down the solution into steps:
 ### Using the PortalProvider
 
 Let's assume that we already have a `PortalProvider` and let's focus on how it is used first.
-1. We get a hold of the `PortalProvider` API through: 
+1. We get a hold of the `PortalProvider` API through:
    ```tsx
    const portal = useContext(PortalAPI);
    ```

--- a/packages/docs/src/routes/docs/cookbook/re-exporting-loaders/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/re-exporting-loaders/index.mdx
@@ -6,7 +6,7 @@ updated_at: '2023-12-15T11:00:00Z'
 created_at: '2023-12-15T11:00:00Z'
 ---
 
-import CodeSandbox, {CodeFile} from '../../../../components/code-sandbox/index.tsx';  
+import CodeSandbox, {CodeFile} from '../../../../components/code-sandbox/index.tsx';
 
 # Re-exporting loaders
 
@@ -23,13 +23,13 @@ You can define `routeAction$` and `routeLoader$` in your custom path and re-expo
 
 ### Reusable logic example
 
-Let's imagine we have a `routeLoader$` that checks whether our user is logged in or not. 
+Let's imagine we have a `routeLoader$` that checks whether our user is logged in or not.
 It wouldn't make sense to copy and paste the same code into many parts of our code to make it work.
 As per good practices, the ideal method is to centralize the logic.
 Here in this example we declare `routeAction$` and `routeLoader$` in a centralized file so we can then reuse it in our files.
 
 Example with `./shared/loaders.ts`
-<CodeFile url="/demo/cookbook/re-exporting-loaders/shared/loaders.ts" >
+<CodeFile src="/src/routes/demo/cookbook/re-exporting-loaders/shared/loaders.ts" >
 ```tsx
 import { routeAction$, routeLoader$ } from '@builder.io/qwik-city';
 
@@ -47,7 +47,7 @@ export const useCommonRouteLoader = routeLoader$(async () => {
 
 Now you can use your common `routeAction$` and `routeLoader$` in paths like this one `./src/routes/index.tsx`.
 
-<CodeFile url="/demo/cookbook/re-exporting-loaders/" >
+<CodeFile src="/src/routes/demo/cookbook/re-exporting-loaders/" >
 ```tsx
 import { component$ } from '@builder.io/qwik';
 import { Form } from '@builder.io/qwik-city';
@@ -81,7 +81,7 @@ export default component$(() => {
 ```
 </CodeFile>
 
-<CodeSandbox url="/demo/cookbook/re-exporting-loaders/"  style={{ height: '15em' }} />
+<CodeSandbox src="/src/routes/demo/cookbook/re-exporting-loaders/"  style={{ height: '15em' }} />
 
 ### Third-party libraries example
 
@@ -92,7 +92,7 @@ Here, if this library needs `routeAction$` or `routeLoader$` we must re-export t
 
 #### Here is our code:
 
-<CodeSandbox url="/demo/cookbook/re-exporting-loaders/third-party/index.tsx"  style={{ height: '20em' }}>
+<CodeSandbox src="/src/routes/demo/cookbook/re-exporting-loaders/third-party/index.tsx"  style={{ height: '20em' }}>
 ```tsx
 import { component$ } from '@builder.io/qwik';
 import { ThirdPartyPaymentComponent } from './third-party-library';
@@ -112,7 +112,7 @@ export default component$(() => {
 
 #### Here is the library code:
 
-<CodeFile url="/demo/cookbook/re-exporting-loaders/third-party/third-party-library.tsx" >
+<CodeFile src="/src/routes/demo/cookbook/re-exporting-loaders/third-party/third-party-library.tsx" >
 ```tsx
 import { component$ } from '@builder.io/qwik';
 import { routeLoader$ } from '@builder.io/qwik-city';

--- a/packages/docs/src/routes/docs/cookbook/sync-events/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/sync-events/index.mdx
@@ -28,7 +28,7 @@ In this example, we have a behavior where we want to prevent the default behavio
 3. `data-should-prevent-default`: an attribute on the element that is used to pass state into the `sync$()` function.
 
 
-<CodeSandbox url="/demo/cookbook/sync-event/"  style={{ height: '15em' }}>
+<CodeSandbox src="/src/routes/demo/cookbook/sync-event/"  style={{ height: '15em' }}>
 </CodeSandbox>
 
 

--- a/packages/docs/src/routes/docs/integrations/react/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/react/index.mdx
@@ -77,7 +77,7 @@ The above command will perform the following:
       return {
         ...,
         plugins: [
-          ..., 
+          ...,
           // The important part
           qwikReact()
         ],
@@ -92,7 +92,7 @@ The above command will perform the following:
 >   - `@mui/material 5.11.9`
 >   - `@mui/x-data-grid 5.17.24`
 > - `src/route`:
->   - `/src/routes/react`: New public route showcasing react integration 
+>   - `/src/routes/react`: New public route showcasing react integration
 >   - `/src/integrations/react`: Here's where the react component lives
 >
 > We will ignore these in this guide and instead take you through the process from the beginning.
@@ -102,7 +102,7 @@ The above command will perform the following:
 
 Let's start with a simple example. We will create a simple React component and then wrap it in a Qwik component. We will then use the Qwik component in a Qwik route.
 
-<CodeSandbox url="/src/routes/demo/react/hello-world/" tabs={["react.tsx","index.tsx"]} style={{ height: '6em' }}>
+<CodeSandbox src="/src/routes/demo/react/hello-world/" tabs={["react.tsx","index.tsx"]} style={{ height: '6em' }}>
 <div  q:slot="0">
 <CodeFile src="/src/routes/demo/react/hello-world/react.tsx">
 ```tsx /qwikify$/ /QGreetings/
@@ -148,7 +148,7 @@ React and Qwik components can not be mixed in the same file, if you check your p
 
 The above example shows how to SSR static React content on the server. The benefit is that that component will never re-render in the browser and therefore its code never downloads to the client. But what if the component needs to be interactive, and therefore we need to download its behavior in the browser? Let's start with building a simple counter example in React.
 
-<CodeSandbox url="/src/routes/demo/react/counter-simple/" tabs={["react.tsx","index.tsx"]} style={{ height: '6em' }}>
+<CodeSandbox src="/src/routes/demo/react/counter-simple/" tabs={["react.tsx","index.tsx"]} style={{ height: '6em' }}>
 <div  q:slot="0">
 <CodeFile src="/src/routes/demo/react/counter-simple/react.tsx">
 ```tsx /qwikify$/ /QGreetings/
@@ -191,7 +191,7 @@ export default component$(() => {
 
 Notice that clicking on the `Count` button does nothing. This is because the React has not been downloaded and therefore the component was not hydrated. We need to tell Qwik to download the React component and hydrate it, but we need to specify the condition under which we want to do that. Doing it eagerly would lose all of the benefits of turning the React application into islands. In this case, we want to download the component when the user hovers over the button, we do so by adding `{: eagerness: 'hover' }` to `qwikify$()`.
 
-<CodeSandbox url="/src/routes/demo/react/counter-simple-hover/" console={true}
+<CodeSandbox src="/src/routes/demo/react/counter-simple-hover/" console={true}
              tabs={["react.tsx","index.tsx"]} style={{ height: '20em' }}>
 <div  q:slot="0">
 <CodeFile src="/src/routes/demo/react/counter-simple-hover/react.tsx">
@@ -246,7 +246,7 @@ By giving the `eagerness` property to `qwikify$()`, we are allowing you to fine-
 In the previous example, we had a single island that we delay-hydrated. But once you have multiple islands, there will be a need to communicate between them. This example shows how to do inter-island communication with Qwik.
 
 
-<CodeSandbox url="/src/routes/demo/react/counter-two-islands/" console={true}
+<CodeSandbox src="/src/routes/demo/react/counter-two-islands/" console={true}
              tabs={["react.tsx","index.tsx"]} style={{ height: '20em' }}>
 <div  q:slot="0">
 <CodeFile src="/src/routes/demo/react/counter-two-islands/react.tsx">
@@ -317,7 +317,7 @@ Also notice that `console.log('Qwik Render');` never executes in the browser.
 
 In the previous example, we had two islands. The `QButton` had to be eagerly hydrated so that React can set up the `onClick` event handler. This is a bit wasteful because the `QButton` island will never need to be re-rendered as its output is static. Clicking on the `QButton` will not cause the `QButton` island to re-render. In such a case, we can ask Qwik to register the `click` listener instead of hydrating the whole component in React just to attach a listener. This is done by using the `host:` prefix in the event name.
 
-<CodeSandbox url="/src/routes/demo/react/counter-two-islands-host/" console={true}
+<CodeSandbox src="/src/routes/demo/react/counter-two-islands-host/" console={true}
              tabs={["index.tsx","react.tsx"]} style={{ height: '20em' }}>
 <div  q:slot="0">
 <CodeFile src="/src/routes/demo/react/counter-two-islands-host/index.tsx">
@@ -376,7 +376,7 @@ Now hovering over the button will not do anything (no React hydration). Clicking
 
 A common use case is to pass content children to components. This works with Qwik React as well. In the React component just declare `children` in your props and use them as expected (See `react.tsx`).
 
-<CodeSandbox url="/src/routes/demo/react/children/" console={true}
+<CodeSandbox src="/src/routes/demo/react/children/" console={true}
              tabs={["index.tsx","react.tsx"]} style={{ height: '20em' }}>
 <div  q:slot="0">
 <CodeFile src="/src/routes/demo/react/children/index.tsx">
@@ -437,10 +437,10 @@ Notice that the `QFrame` island is never hydrated because it has no `eagerness` 
 
 ## 6. Using React libraries
 
-Finally, it is possible to use React libraries in your Qwik application. In this example [Material UI](https://mui.com/) and [Emotion](https://emotion.sh/docs/introduction) are used to render this React example. 
+Finally, it is possible to use React libraries in your Qwik application. In this example [Material UI](https://mui.com/) and [Emotion](https://emotion.sh/docs/introduction) are used to render this React example.
 
 
-<CodeSandbox url="/src/routes/demo/react/mui/"
+<CodeSandbox src="/src/routes/demo/react/mui/"
              tabs={["react.tsx", "index.tsx"]} style={{ height: '8em' }}>
 <div  q:slot="0">
 <CodeFile src="/src/routes/demo/react/mui/react.tsx">
@@ -508,7 +508,7 @@ export default component$(() => {
 </div>
 </CodeSandbox>
 
-The React example is hydrated on hover and works as you would expect. 
+The React example is hydrated on hover and works as you would expect.
 
 # Rules
 
@@ -558,7 +558,7 @@ The `qwikify$(ReactCmp, options?): QwikCmp` allows to implement partial hydratio
 
 Notice that by default no React code will run in the browser, meaning that React component will NOT be interactive by default, for example, in the following example, we _qwikify_ the [Slider](https://mui.com/material-ui/react-slider/) component from MUI, but it will not be interactive (it is missing an `eagerness` property to tell Qwik when the React component should be hydrated in the browser.)
 
-<CodeSandbox url="/src/routes/demo/react/slider/" console={true}
+<CodeSandbox src="/src/routes/demo/react/slider/" console={true}
              tabs={["react.tsx","index.tsx"]} style={{ height: '20em' }}>
 <div  q:slot="0">
 <CodeFile src="/src/routes/demo/react/slider/react.tsx">


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

While I was wandering through the docs, I have noticed that some documentation cookbooks examples have broken urls.


https://github.com/BuilderIO/qwik/assets/12732872/d4eedcbf-ac13-4269-a7d7-981cbcfa3e15


# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

## Actual behaviour
Some broken urls for documentations examples

## Expected behaviour
No broken urls for documentations examples

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
