### PR TITLE
docs: Good first issue link doesn't lead you to properly label "COMMUNITY:  good first issue"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ We adopt [trunk-based development](https://trunkbaseddevelopment.com/) therefore
 
 ### Good first issue
 
-The issues marked with [_Good first issue_](https://github.com/BuilderIO/qwik/issues?q=is:open+is:issue+label:%22good+first+issue%22) are a good starting point to familiarize yourself with the project.
+The issues marked with [_Good first issue_](https://github.com/BuilderIO/qwik/issues?q=is%3Aissue+is%3Aopen+label%3A%22COMMUNITY%3A++good+first+issue%22) are a good starting point to familiarize yourself with the project.
 
 Before solving the problem, please check with the maintainers that the issue is still relevant. Feel free to leave a comment on the issue to show your intention to work on it and prevent other people from unintentionally duplicating your effort.
 


### PR DESCRIPTION

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

I would liked to contribute, I was reading the CONTRIBUTING.md file, when clicked on the link for the "good first issue", I haven't seen any. After a deeper investigation I have find out that the correct label is actually: `"COMMUNITY:  good first issue" `

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

## Actual behaviour
<img width="1552" alt="Screenshot 2024-01-17 alle 00 37 34" src="https://github.com/BuilderIO/qwik/assets/12732872/2b4aaad2-5bab-4e79-bb1a-7a23885c2d3b">

## Expected behaviour
<img width="1552" alt="Screenshot 2024-01-17 alle 00 37 40" src="https://github.com/BuilderIO/qwik/assets/12732872/51dbcd18-18d6-4169-84bd-bb075ad0e48d">


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
