### PR TITLE
docs: Fixed various typos (or misspelled words) in documentation files

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
@@ -28,6 +28,7 @@ contributors:
   - drumnistnakano
   - maiieul
   - wmertens
+  - aendel
 updated_at: '2023-12-14T18:38:38Z'
 created_at: '2023-03-20T23:45:13Z'
 ---
@@ -109,7 +110,7 @@ export default component$(() => {
 
 ## Props
 
-Props are used to pass data from the parent into the component. Props are accesible via the `props` argument to the component$ function.
+Props are used to pass data from the parent into the component. Props are accessible via the `props` argument to the component$ function.
 
 In this example a component `Item` declares optional `name`, `quantity`, `description`, and `price`.
 

--- a/packages/docs/src/routes/docs/(qwik)/components/rendering/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/rendering/index.mdx
@@ -17,6 +17,7 @@ contributors:
   - mrhoodz
   - thejackshelton
   - Balastrong
+  - aendel
 updated_at: '2023-09-19T17:37:26Z'
 created_at: '2023-03-20T23:45:13Z'
 ---
@@ -38,7 +39,7 @@ Qwik presents a few differences from other JSX frameworks:
 - Components can use the `useSignal` hook to create reactive state.
 - Event handlers are declared with the `$` suffix.
 - For `<input>`, the `onChange` event is called `onInput$` in Qwik.
-- HTML attributes are prefered. `class` instead of `className`. `for` instead of `htmlFor`.
+- HTML attributes are preferred. `class` instead of `className`. `for` instead of `htmlFor`.
 
 ```tsx /component$/#a /onClick$/#b /class/#c
 import { component$, useSignal } from '@builder.io/qwik';

--- a/packages/docs/src/routes/docs/(qwik)/components/tasks/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/tasks/index.mdx
@@ -17,6 +17,7 @@ contributors:
   - ehrencrona
   - julianobrasil
   - adamdbradley
+  - aendel
 updated_at: '2023-10-18T07:33:22Z'
 created_at: '2023-03-31T02:40:50Z'
 ---
@@ -327,11 +328,11 @@ Sometimes a task needs to run only on the browser and after rendering, in that c
 > ```tsx
 > import { component$, useSignal, useTask$ } from '@builder.io/qwik';
 > import { isServer } from '@builder.io/qwik/build';
-> 
+>
 > export default component$(() => {
 >   const text = useSignal('Initial text');
 >   const isBold = useSignal(false);
-> 
+>
 >   useTask$(({ track }) => {
 >     track(() => text.value);
 >     if (isServer) {
@@ -340,7 +341,7 @@ Sometimes a task needs to run only on the browser and after rendering, in that c
 >     isBold.value = true;
 >     delay(1000).then(() => (isBold.value = false));
 >   });
-> 
+>
 >   return (
 >     <section>
 >       <label>
@@ -352,7 +353,7 @@ Sometimes a task needs to run only on the browser and after rendering, in that c
 >     </section>
 >   );
 > });
-> 
+>
 > const delay = (time: number) => new Promise((res) => setTimeout(res, time));
 > ```
 > </CodeSandbox>

--- a/packages/docs/src/routes/docs/(qwikcity)/advanced/complex-forms/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/advanced/complex-forms/index.mdx
@@ -4,6 +4,7 @@ description: Learn how to create complex forms with arrays and objects.
 contributors:
   - ulic75
   - hamatoyogi
+  - aendel
 updated_at: '2023-08-21T21:04:20Z'
 created_at: '2023-08-21T21:04:20Z'
 ---
@@ -18,7 +19,7 @@ Complex forms would typically contain data in a structure that is more than just
 
 ### Objects
 
-Nested items can be created by seperating the items with `.` (dot) in the name. For example, `person.name` would be converted to `{ person: { name: 'sam' } }`.
+Nested items can be created by separating the items with `.` (dot) in the name. For example, `person.name` would be converted to `{ person: { name: 'sam' } }`.
 
 ### Arrays
 
@@ -50,7 +51,7 @@ The key to creating a complex form is in the naming of the inputs. Below would b
 
 #### Output object
 
-The after submiting the form the data would be parsed in an object like this:
+The after submitting the form the data would be parsed in an object like this:
 ```json
 {
   "person": [

--- a/packages/docs/src/routes/docs/(qwikcity)/advanced/speculative-module-fetching/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/advanced/speculative-module-fetching/index.mdx
@@ -11,6 +11,7 @@ contributors:
   - thejackshelton
   - zanettin
   - wtlin1228
+  - aendel
 updated_at: '2023-06-25T19:43:33Z'
 created_at: '2023-03-20T23:45:13Z'
 ---
@@ -182,7 +183,7 @@ Additionally, when "Empty Cache and Hard Reload" is used, the browser sends a `n
 
 ### Emptying the Service Worker Cache
 
-The recommended way to test specualtive module fetching is to:
+The recommended way to test speculative module fetching is to:
 
 - **Unregister the service worker**: In Chrome DevTools, go to the Application tab, and under Service Workers, click the "Unregister" link for the for your site's service worker.
 - **Delete the "QwikBuild" Cache Storage**: In Chrome DevTools, go to the Application tab, and under Cache Storage on the left side, right click "Delete" on the "QwikBuild" cache storage.

--- a/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Qwik in a nutshell | Introduction
-description: Learn the general concepts of Qwik in this shoet introduction guide.
+description: Learn the general concepts of Qwik in this short introduction guide.
 contributors:
   - manucorporat
   - AnthonyPAlicea
@@ -15,6 +15,7 @@ contributors:
   - iancharlesdouglas
   - adamdbradley
   - hamatoyogi
+  - aendel
 updated_at: '2023-10-03T18:53:23Z'
 created_at: '2023-03-30T19:49:50Z'
 ---

--- a/packages/docs/src/routes/docs/(qwikcity)/layout/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/layout/index.mdx
@@ -8,6 +8,7 @@ contributors:
   - nnelgxorz
   - the-r3aper7
   - mrhoodz
+  - aendel
 updated_at: '2023-06-25T19:43:33Z'
 created_at: '2023-03-20T23:45:13Z'
 ---
@@ -90,7 +91,7 @@ export default component$(() => {
 
 ### `src/routes/about/index.tsx`
 
-Same as the `src/routes/index.tsx` file, but for the `about` route, similary it will be rendered under the `Slot` component in the `src/routes/layout.tsx` file, so even though it doesn't have any of the `Header`, `Menu`, or `Footer` components, it will still be rendered with them.
+Same as the `src/routes/index.tsx` file, but for the `about` route, similarly it will be rendered under the `Slot` component in the `src/routes/layout.tsx` file, so even though it doesn't have any of the `Header`, `Menu`, or `Footer` components, it will still be rendered with them.
 
 ```tsx title="src/routes/about/index.tsx"
 import { component$ } from '@builder.io/qwik';

--- a/packages/docs/src/routes/docs/cookbook/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/index.mdx
@@ -9,6 +9,7 @@ contributors:
   - maiieul
   - Adbib
   - gioboa
+  - aendel
 ---
 
 # Cookbook
@@ -24,4 +25,4 @@ Examples:
 - [NavLink](./nav-link/)
 - [Portals](./portals/)
 - [Re-exporting loaders](./re-exporting-loaders/)
-- [Theme Managment](./theme-management/)
+- [Theme Management](./theme-management/)

--- a/packages/docs/src/routes/docs/cookbook/node-docker-deploy/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/node-docker-deploy/index.mdx
@@ -2,6 +2,7 @@
 title: Cookbook | Deploy with Node using Docker
 contributors:
   - nelsonprsousa
+  - aendel
 updated_at: '2023-12-28T16:00:00Z'
 created_at: '2023-12-28T16:00:00Z'
 ---
@@ -29,7 +30,7 @@ FROM node:${NODE_VERSION}-alpine as base
 WORKDIR /usr/src/app
 
 ################################################################################
-# Create a stage for installing production dependecies.
+# Create a stage for installing production dependencies.
 FROM base as deps
 
 # Download dependencies as a separate step to take advantage of Docker's caching.

--- a/packages/docs/src/routes/docs/cookbook/portals/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/portals/index.mdx
@@ -5,6 +5,7 @@ contributors:
   - thejackshelton
   - fabian-hiller
   - igorbabko
+  - aendel
 updated_at: '2023-10-03T18:53:59Z'
 created_at: '2023-08-21T21:16:38Z'
 ---
@@ -46,7 +47,7 @@ Some examples of non-modal components are:
 
 Qwik UI has taken it upon themselves by providing a polyfill with feature parity to the native spec. You can use the Popover API's behavior in production today with [Qwik UI's Popover](https://qwikui.com/docs/headless/popover/) component.
 
-In the case of components like a select or combobox, Qwik UI also provides the abiltiy to opt-in to "floating" behavior. For example, when a listbox anchors to an input element. You can do so by adding `floating={true}` to your Popover component. This will execute a bit of extra javascript needed for floating behavior.
+In the case of components like a select or combobox, Qwik UI also provides the ability to opt-in to "floating" behavior. For example, when a listbox anchors to an input element. You can do so by adding `floating={true}` to your Popover component. This will execute a bit of extra javascript needed for floating behavior.
 
 It is intentionally opt-in, at some point the CSS Anchor API will provide a native solution, and so there should be an easy migration path when that receives more general support.
 

--- a/packages/docs/src/routes/docs/cookbook/re-exporting-loaders/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/re-exporting-loaders/index.mdx
@@ -2,6 +2,7 @@
 title: Cookbook | Re-exporting loaders
 contributors:
   - gioboa
+  - aendel
 updated_at: '2023-12-15T11:00:00Z'
 created_at: '2023-12-15T11:00:00Z'
 ---
@@ -13,7 +14,7 @@ import CodeSandbox, {CodeFile} from '../../../../components/code-sandbox/index.t
 `routeAction$` and `routeLoader$` are typically declared in route boundary files such as layout.tsx, index.tsx and plugin.tsx inside the routesDir directory
 [here is docs](https://qwik.builder.io/docs/route-loader/).
 
-Somethimes you would like to declared them outside of the route boundaries.
+Sometimes you would like to declared them outside of the route boundaries.
 This may be useful when you want to create reusable logic or a library.
 In such a case, it is essential that this function is re-exported from within the router boundary otherwise it will not run or throw exception.
 

--- a/packages/docs/src/routes/docs/cookbook/theme-management/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/theme-management/index.mdx
@@ -3,15 +3,16 @@ title: Cookbook | Dark and Light Theme
 contributors:
   - Inaam-Ur-Rehman
   - gioboa
+  - aendel
 updated_at: '2023-10-10T20:38:51Z'
 created_at: '2023-10-10T16:59:26Z'
 ---
 
 # Theme management
 
-In modern website we have seen that it has the feature of dark and light theme that creates a good impact on the users. They can change the theme according to their prefrences.
+In modern website we have seen that it has the feature of dark and light theme that creates a good impact on the users. They can change the theme according to their preferences.
 
-To achive this we are also using tailwindcss for styling.
+To achieve this we are also using tailwindcss for styling.
 
 First we have to install tailwindcss in our website. To add tailwind in Qwik project is very simple. You have to just run this command in terminal.
 

--- a/packages/docs/src/routes/docs/deployments/static/index.mdx
+++ b/packages/docs/src/routes/docs/deployments/static/index.mdx
@@ -2,6 +2,7 @@
 title: Static Site
 contributors:
   - the-r3aper7
+  - aendel
 updated_at: '2023-10-11T15:09:55Z'
 created_at: '2023-10-11T15:09:55Z'
 ---
@@ -20,7 +21,7 @@ npm run qwik add static
 
 Above command will create a directory at project root named `adapters/static/vite.config.ts` with the below code.
 
-```tsx file="apdaters/static/vite.config.ts"
+```tsx file="adapters/static/vite.config.ts"
 import { extendConfig } from '@builder.io/qwik-city/vite';
 import baseConfig from '../../vite.config';
 

--- a/packages/docs/src/routes/docs/integrations/bootstrap/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/bootstrap/index.mdx
@@ -4,6 +4,7 @@ keywords: 'bootstrap, spinners, alerts, buttons'
 contributors:
   - mugan86
   - mhevery
+  - aendel
 updated_at: '2023-09-26T19:56:54Z'
 created_at: '2023-09-26T19:56:54Z'
 ---
@@ -29,7 +30,7 @@ The previous command updates your app with the necessary dependencies.
 
 It also adds new files inside to your project folder:
 
-- `src/models/bootstrap.ts`: Model to define Boostrap components info to use in props.
+- `src/models/bootstrap.ts`: Model to define Bootstrap components info to use in props.
 - `src/constants/data.ts`: Constant values information that we will use in the example to be created with this integration.
 - `src/components/bootstrap/button.tsx`: Button component feature with Bootstrap.
 - `src/components/bootstrap/alert.tsx`: Alert component feature with Bootstrap.
@@ -37,7 +38,7 @@ It also adds new files inside to your project folder:
 - `src/components/bootstrap/index.ts`: Entry point where we will add the components of the elements that will be used, for easier and cleaner access to them.
 - `src/components/bootstrap/navbar.tsx`: Navbar component functionality with Bootstrap to demonstrate how to add and use JavaScript functionalities without encountering the 'document is not defined' error due to improper import declaration in the Qwik lifecycle.
 - `src/routes/bootstrap/layout.tsx`: Layout where we add Bootstrap styling configuration to ensure styles are applied to all routes nested within the main Bootstrap route.
-- `src/routes/bootstrap/index.tsx`: Boostrap components option home page.
+- `src/routes/bootstrap/index.tsx`: Bootstrap components option home page.
 - `src/routes/bootstrap/buttons/index.tsx`: Example to consume Button component with demo data.
 - `src/routes/bootstrap/alerts/index.tsx`: Example to consume Alert component with demo data.
 - `src/routes/bootstrap/spinners/index.tsx`: Example to consume Spinner component with demo data.

--- a/packages/docs/src/routes/docs/integrations/builderio/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/builderio/index.mdx
@@ -7,6 +7,7 @@ contributors:
   - Benny-Nottonson
   - mrhoodz
   - steve8708
+  - aendel
 updated_at: '2023-09-28T17:30:02Z'
 created_at: '2023-05-02T09:18:30Z'
 ---
@@ -90,7 +91,7 @@ export default component$(() => {
 
 See our full integration guides [here](https://www.builder.io/c/docs/developers)
 
-Also, when you push your integration to production, go back and update your preview URL to your production URL so now anyone on your team can visuall create content in your Qwik app!
+Also, when you push your integration to production, go back and update your preview URL to your production URL so now anyone on your team can visually create content in your Qwik app!
 
 Also, to integrate structured data, see [this guide](https://www.builder.io/c/docs/integrate-cms-data)
 

--- a/packages/docs/src/routes/docs/integrations/icons/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/icons/index.mdx
@@ -7,6 +7,7 @@ contributors:
   - manucorporat
   - Benny-Nottonson
   - mrhoodz
+  - aendel
 updated_at: '2023-07-18T17:47:48Z'
 created_at: '2023-04-25T11:05:50Z'
 ---
@@ -20,7 +21,7 @@ Icons are an important part of any application. There are already more than 180.
 
 ## `qwikest/icons`
 
-This package allows for a stremalined way to add icons to your Qwik app from a variety of icon sets.
+This package allows for a streamlined way to add icons to your Qwik app from a variety of icon sets.
 
 - `Bs`: Bootstrap Icons
 - `Go`: Octicons by GitHub

--- a/packages/docs/src/routes/docs/integrations/image-optimization/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/image-optimization/index.mdx
@@ -15,6 +15,7 @@ contributors:
   - avanderpluijm
   - fabian-hiller
   - manucorporat
+  - aendel
 updated_at: '2023-10-03T18:53:23Z'
 created_at: '2023-04-19T22:13:46Z'
 ---
@@ -212,7 +213,7 @@ export default component$(() => {
 
 ## `qwik-image`
 
-Performant images with automatic optimisation.
+Performant images with automatic optimization.
 
 ```bash
 npm install qwik-image

--- a/packages/docs/src/routes/docs/integrations/og-img/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/og-img/index.mdx
@@ -3,6 +3,7 @@ title: OG Image (og-img) | Integrations
 keywords: 'open-graph, image, satori, resvg'
 contributors:
   - fabian-hiller
+  - aendel
 updated_at: '2024-01-10T21:56:50Z'
 created_at: '2024-01-10T21:56:50Z'
 ---
@@ -67,16 +68,16 @@ Then all you need to do is point to this API endpoint with a meta tag in the hea
 </head>
 ```
 
-You can also generate the meta tag dynamically by exportiert a `head` object in your routes.
+You can also generate the meta tag dynamically by export a `head` object in your routes.
 
 ```tsx title="src/routes/index.tsx"
 import { component$ } from '@builder.io/qwik';
 import type { DocumentHead } from '@builder.io/qwik-city';
- 
+
 export default component$(() => {
   return <h1>Hello, world!</h1>;
 });
- 
+
 export const head: DocumentHead = {
   title: 'Hello, world!',
   meta: [

--- a/packages/docs/src/routes/docs/integrations/prisma/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/prisma/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prisma | Integrations
-keywords: 'prisma, orm, database, data, storage, postgress, mondodb'
+keywords: 'prisma, orm, database, data, storage, postgres, mongodb'
 contributors:
   - manucorporat
   - ulic75
@@ -11,6 +11,7 @@ contributors:
   - mrhoodz
   - enesflow
   - fabian-hiller
+  - aendel
 updated_at: '2023-10-03T18:53:23Z'
 created_at: '2023-04-25T11:05:50Z'
 ---

--- a/packages/docs/src/routes/docs/integrations/supabase/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/supabase/index.mdx
@@ -8,6 +8,7 @@ contributors:
   - Benny-Nottonson
   - mrhoodz
   - samijaber
+  - aendel
 updated_at: '2023-10-03T18:53:23Z'
 created_at: '2023-04-25T11:05:50Z'
 ---
@@ -31,7 +32,7 @@ PUBLIC_SUPABASE_ANON_KEY=eyJhb.......
 
 You should be able to get this values from the Supabase dashboard, create a new `.env.local` file at the root of the project and paste them there.
 
-> Note: It's possible to use Supabase with Qwik completely client-side, however, you would lose some of the performance benefits that you can acheive with leveraging the server. For a working example and code head over to [this repository](https://github.com/hamatoyogi/qwik-supabase-example).
+> Note: It's possible to use Supabase with Qwik completely client-side, however, you would lose some of the performance benefits that you can achieve with leveraging the server. For a working example and code head over to [this repository](https://github.com/hamatoyogi/qwik-supabase-example).
 
 ## Server-side
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

As described with the commit message, with this pull request I'm requesting to add some misspelled words I have found while I was reading the documentation.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
