### PR TITLE
fix(docs): grammar in "Project Structure" page

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/project-structure/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/project-structure/index.mdx
@@ -137,7 +137,7 @@ qwik-app-demo
 └── vite.config.ts
 ```
 
-If you prefer to generate the `Button` component with the `Button/index.tsx` naming convention, you can could use the command:
+If you prefer to generate the `Button` component with the `Button/index.tsx` naming convention, you could use the command:
 ```tsx
 pnpm qwik new --barrel Button
 ```


### PR DESCRIPTION
Update the typo by removing "can" from the text.
![Screenshot from 2024-01-18 09-41-08](https://github.com/BuilderIO/qwik/assets/115472206/e1f392bb-4f72-4230-84dd-806ecc56a53b)


# Overview
There's a typo in the content of document titled "Project Structure".\

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Removed "can" from the content to make it correct sentence.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
