### PR TITLE
fix(ssr): dirty tasks

### DIFF
--- a/packages/qwik/src/core/render/dom/notify-render.ts
+++ b/packages/qwik/src/core/render/dom/notify-render.ts
@@ -297,6 +297,54 @@ const executeTasksBefore = async (containerState: ContainerState, rCtx: RenderCo
   }
 };
 
+/** Execute tasks that are dirty during SSR render */
+export const executeSSRTasks = (containerState: ContainerState, rCtx: RenderContext) => {
+  const containerEl = containerState.$containerEl$;
+  const staging = containerState.$taskStaging$;
+  if (!staging.size) {
+    return;
+  }
+  const taskPromises: ValueOrPromise<SubscriberEffect>[] = [];
+
+  let tries = 20;
+  const runTasks = () => {
+    // SSR dirty tasks are in taskStaging
+    staging.forEach((task) => {
+      console.error('task', task.$qrl$.$symbol$);
+      if (isTask(task)) {
+        taskPromises.push(maybeThen(task.$qrl$.$resolveLazy$(containerEl), () => task));
+      }
+      // We ignore other types of tasks, they are handled via waitOn
+    });
+
+    staging.clear();
+
+    // Wait for all promises
+    if (taskPromises.length > 0) {
+      return Promise.all(taskPromises).then(async (tasks): Promise<unknown> => {
+        sortTasks(tasks);
+        await Promise.all(
+          tasks.map((task) => {
+            return runSubscriber(task, containerState, rCtx);
+          })
+        );
+        taskPromises.length = 0;
+        if (--tries && staging.size > 0) {
+          return runTasks();
+        }
+        if (!tries) {
+          logWarn(
+            `Infinite task loop detected. Tasks:\n${Array.from(staging)
+              .map((task) => `  ${task.$qrl$.$symbol$}`)
+              .join('\n')}`
+          );
+        }
+      });
+    }
+  };
+  return runTasks();
+};
+
 const executeTasksAfter = async (
   containerState: ContainerState,
   rCtx: RenderContext,

--- a/starters/apps/e2e/src/components/computed/computed.tsx
+++ b/starters/apps/e2e/src/components/computed/computed.tsx
@@ -1,5 +1,10 @@
 /* eslint-disable */
-import { component$, useComputed$, useSignal } from "@builder.io/qwik";
+import {
+  component$,
+  useComputed$,
+  useSignal,
+  useTask$,
+} from "@builder.io/qwik";
 
 export const ComputedRoot = component$(() => {
   const rerender = useSignal(0);
@@ -12,6 +17,7 @@ export const ComputedRoot = component$(() => {
       <ComputedBasic />
       <Issue3482 />
       <Issue3488 />
+      <Issue5738 />
     </div>
   );
 });
@@ -89,4 +95,15 @@ export const Issue3488 = component$(() => {
       <div id="issue-3488-result">{data.value.class}</div>
     </>
   );
+});
+
+export const Issue5738 = component$(() => {
+  const foo = useSignal(0);
+  const comp = useComputed$(() => {
+    return foo.value * 2;
+  });
+  useTask$(() => {
+    foo.value = 1;
+  });
+  return <div id="issue-5738-result">Calc: {comp.value}</div>;
 });

--- a/starters/e2e/e2e.computed.spec.ts
+++ b/starters/e2e/e2e.computed.spec.ts
@@ -65,6 +65,11 @@ test.describe("slot", () => {
       await button.click();
       await expect(result).toHaveText("class-2");
     });
+
+    test("dirty tasks", async ({ page }) => {
+      const result = page.locator("#issue-5738-result");
+      await expect(result).toHaveText("Calc: 2");
+    });
   }
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
Fixes #5738.

The problem is that dirty tasks never run again, whereas on the client they are run on the next tick.

This PR makes executeComponent rerun tasks during SSR until they are no longer dirty.