### PR TITLE
docs: fix code highlight by downgrading rehype-pretty-code

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -39,7 +39,7 @@
     "qwik-image": "^0.0.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "rehype-pretty-code": "^0.12.3",
+    "rehype-pretty-code": "^0.11.0",
     "shiki": "^0.14.7",
     "shikiji": "^0.7.0 || ^0.8.0 || ^0.9.0",
     "snarkdown": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       rehype-pretty-code:
-        specifier: ^0.12.3
-        version: 0.12.3(shikiji@0.9.18)
+        specifier: ^0.11.0
+        version: 0.11.0(shiki@0.14.7)
       shiki:
         specifier: ^0.14.7
         version: 0.14.7
@@ -9543,6 +9543,15 @@ packages:
       async: 1.5.2
     dev: true
 
+  /hash-obj@4.0.0:
+    resolution: {integrity: sha512-FwO1BUVWkyHasWDW4S8o0ssQXjvyghLV2rfVhnN36b2bbcj45eGiuzdn9XOvOpjV3TKQD7Gm2BWNXdE9V4KKYg==}
+    engines: {node: '>=12'}
+    dependencies:
+      is-obj: 3.0.0
+      sort-keys: 5.0.0
+      type-fest: 1.4.0
+    dev: true
+
   /hasha@5.2.2:
     resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
     engines: {node: '>=8'}
@@ -10403,6 +10412,11 @@ packages:
   /is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
+    dev: true
+
+  /is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /is-observable@1.1.0:
@@ -14513,17 +14527,18 @@ packages:
       unified: 11.0.4
     dev: true
 
-  /rehype-pretty-code@0.12.3(shikiji@0.9.18):
-    resolution: {integrity: sha512-6NbIit8A3hLrkKBEbNs862jVnTLeIOM2AmM0VZ/MtyHb+OuNMeCa6UZSx6UG4zrobm5tY9efTwhih1exsGYsiw==}
-    engines: {node: '>=18'}
+  /rehype-pretty-code@0.11.0(shiki@0.14.7):
+    resolution: {integrity: sha512-VCyDXrVio14Ipt+A5rTw3My17yjNOen12HqYuYaMIOj6m+WuqpAeYdTIlqIab+2PkWuTgzA2XCZgAHMHjUS4IQ==}
+    engines: {node: '>=16'}
     peerDependencies:
-      shikiji: ^0.7.0 || ^0.8.0 || ^0.9.0
+      shiki: 0.x
     dependencies:
       '@types/hast': 3.0.3
+      hash-obj: 4.0.0
       hast-util-to-string: 3.0.0
       parse-numeric-range: 1.3.0
       rehype-parse: 9.0.0
-      shikiji: 0.9.18
+      shiki: 0.14.7
       unified: 11.0.4
       unist-util-visit: 5.0.0
     dev: true
@@ -15253,6 +15268,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-plain-obj: 1.1.0
+    dev: true
+
+  /sort-keys@5.0.0:
+    resolution: {integrity: sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==}
+    engines: {node: '>=12'}
+    dependencies:
+      is-plain-obj: 4.1.0
     dev: true
 
   /source-map-js@1.0.2:


### PR DESCRIPTION
With #5705 a lot of dependencies have been updated, including `rehype-pretty-code` in `packages/docs` from version `^0.10.1` to `^0.12.3`.

## Problem

This introduces a bug in the highlight of many code snippets in the docs, for example:
Context page: https://qwik.builder.io/docs/components/context/
![image](https://github.com/BuilderIO/qwik/assets/7253929/199733ad-580a-471f-83b1-a7b4797234bf)

Rendering page: https://qwik.builder.io/docs/components/rendering/
![image](https://github.com/BuilderIO/qwik/assets/7253929/ede7b660-9e0a-427c-9d39-b20904051e78)

## Solution

The most updated version without this issue seems to be `0.11.0` (tested on local). If we do not need any particular feature in version 0.12 we should probably go back there.
