### PR TITLE
fix(docs): Validate origin on postmessage

### DIFF
--- a/packages/docs/src/repl/repl.tsx
+++ b/packages/docs/src/repl/repl.tsx
@@ -119,6 +119,9 @@ export const Repl = component$((props: ReplProps) => {
 });
 
 export const receiveMessageFromReplServer = (ev: MessageEvent, store: ReplStore) => {
+  if (ev.origin !== window.origin) {
+    return;
+  }
   const msg: ReplMessage = ev.data;
   const type = msg?.type;
   const clientId = msg?.clientId;

--- a/packages/docs/src/repl/worker/repl-server.ts
+++ b/packages/docs/src/repl/worker/repl-server.ts
@@ -46,6 +46,9 @@ export const initReplServer = (win: Window, doc: Document, nav: Navigator) => {
   };
 
   const receiveMessageFromMainApp = (ev: MessageEvent) => {
+    if (ev.origin !== win.location.origin) {
+      return;
+    }
     if (swRegistration && swRegistration.active) {
       try {
         if (ev.data) {
@@ -74,6 +77,9 @@ export const initReplServer = (win: Window, doc: Document, nav: Navigator) => {
   };
 
   const receiveMessageFromUserApp = (ev: MessageEvent) => {
+    if (ev.origin !== win.location.origin) {
+      return;
+    }
     if (ev.data) {
       const msg: ReplMessage = JSON.parse(ev.data);
       if (msg?.type === 'event') {


### PR DESCRIPTION
Messages in the playground weren't validating the origin of the message. This can be dangerous in some contexts.