### PR TITLE
feat(repl): use bundled qwik and prettier versions

### DIFF
--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -4,6 +4,10 @@ dist
 server
 functions/**/*.js
 
+# Bundled files for REPL
+# Managed by check-qwik-build.ts
+public/repl/bundled
+
 !src/routes/api/qwik/server/
 
 # Development

--- a/packages/docs/check-qwik-build.ts
+++ b/packages/docs/check-qwik-build.ts
@@ -1,17 +1,45 @@
 // verify that ../qwik/dist/core.d.ts exists or run `pnpm run build.core` in the root directory
 // we need it for development and for the REPL
-import fs from 'fs';
+import fs, { copyFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
+import { qwikFiles } from './src/repl/qwikFiles';
 
-const coreDtsPath = path.join(__dirname, '../qwik/dist/core.d.ts');
-if (!fs.existsSync(coreDtsPath)) {
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const qwikPkgDir = path.join(__dirname, '..', 'qwik', 'dist');
+
+if (!fs.existsSync(path.join(qwikPkgDir, 'core.d.ts'))) {
   console.warn(
-    `Missing ${coreDtsPath}. Running 'pnpm run build.core' in the root directory to generate it.`
+    `\n\n=== Running 'pnpm run build.local' to generate missing imports for the docs ===\n`
   );
-  // now run `pnpm run build.core` in the root directory
-  spawnSync('pnpm', ['run', 'build.core'], {
-    cwd: path.join(__dirname, '../..'),
+  const out = spawnSync('pnpm', ['run', 'build.local'], {
+    cwd: path.join(__dirname, '..', '..'),
     stdio: 'inherit',
   });
+  if (out.status !== 0) {
+    console.error('Failed to build local packages');
+    process.exit(1);
+  }
+}
+
+// Copy the qwik files to public/ for the REPL
+const qwikBundleDir = path.join(__dirname, 'public', 'repl', 'bundled', 'qwik');
+// We cheat, knowing that build/ is the deepest dir
+mkdirSync(path.join(qwikBundleDir, 'build'), { recursive: true });
+for (const f of qwikFiles) {
+  const p = f.split('/');
+  copyFileSync(path.join(qwikPkgDir, ...p), path.join(qwikBundleDir, ...p));
+}
+
+if (!fs.existsSync(path.join(__dirname, 'dist', 'repl', '~repl-server-host.js'))) {
+  console.warn(
+    `\n\n=== Running 'pnpm run build.client' to generate missing REPL service worker dist/repl/~repl-server-host.js ===\n`
+  );
+  const out = spawnSync('pnpm', ['run', 'build.client'], {
+    stdio: 'inherit',
+  });
+  if (out.status !== 0) {
+    console.error('Failed to build REPL service worker');
+    process.exit(1);
+  }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -63,7 +63,7 @@
   "packageManager": "pnpm@8.14.0",
   "private": true,
   "scripts": {
-    "prebuild": "tsm check-qwik-build.ts",
+    "prebuild.core": "tsm check-qwik-build.ts",
     "build": "qwik build",
     "build.client": "vite build",
     "build.preview": "vite build --ssr src/entry.preview.tsx",
@@ -72,7 +72,7 @@
     "codesandbox.sync": "tsm codesandbox.sync.ts",
     "contributors": "tsm contributors.ts",
     "deploy": "wrangler pages publish ./dist",
-    "dev": "vite --mode ssr --open",
+    "dev": "tsm check-qwik-build.ts && vite --mode ssr --open",
     "dev.debug": "node --inspect-brk ../../node_modules/vite/bin/vite.js --mode ssr --force",
     "preview": "qwik build preview && vite preview --open",
     "preview.only": "NODE_DEBUG=net,http node --inspect-brk ../../node_modules/vite/bin/vite.js preview",

--- a/packages/docs/src/repl/bundled.tsx
+++ b/packages/docs/src/repl/bundled.tsx
@@ -1,0 +1,43 @@
+import { version as qwikVersion } from '../../../qwik';
+
+import prettierPkgJson from 'prettier/package.json';
+import prettierParserHtml from 'prettier/plugins/html.js?url';
+import prettierStandaloneJs from 'prettier/standalone.js?url';
+import type { BundledFiles } from './types';
+import { qwikFiles } from './qwikFiles';
+
+export const bundled: BundledFiles = {
+  '@builder.io/qwik': {
+    version: qwikVersion,
+    ...Object.fromEntries(
+      qwikFiles.map((f) => [`/${f}`, `${import.meta.env.BASE_URL}repl/bundled/qwik/${f}`])
+    ),
+  },
+  prettier: {
+    version: prettierPkgJson.version,
+    '/plugins/html.js': prettierParserHtml,
+    '/standalone.js': prettierStandaloneJs,
+  },
+};
+
+export const getNpmCdnUrl = (
+  bundled: BundledFiles,
+  pkgName: string,
+  pkgVersion: string,
+  pkgPath: string
+) => {
+  if (pkgVersion === 'bundled') {
+    const files = bundled[pkgName];
+    if (files) {
+      pkgVersion = files.version;
+      const url = files[pkgPath];
+      if (url) {
+        return url;
+      }
+    } else {
+      // fall back to latest
+      pkgVersion = '';
+    }
+  }
+  return `https://cdn.jsdelivr.net/npm/${pkgName}${pkgVersion ? '@' + pkgVersion : ''}${pkgPath}`;
+};

--- a/packages/docs/src/repl/editor.tsx
+++ b/packages/docs/src/repl/editor.tsx
@@ -52,11 +52,11 @@ export const Editor = component$((props: EditorProps) => {
   });
 
   useTask$(async ({ track }) => {
-    track(() => props.input.version);
+    const v = track(() => props.input.version);
     track(() => store.editor);
 
-    if (props.input.version && store.editor) {
-      await addQwikLibs(props.input.version);
+    if (v && store.editor) {
+      await addQwikLibs(v);
     }
   });
 

--- a/packages/docs/src/repl/monaco.tsx
+++ b/packages/docs/src/repl/monaco.tsx
@@ -4,6 +4,7 @@ import type MonacoTypes from 'monaco-editor';
 import type { EditorProps, EditorStore } from './editor';
 import type { ReplStore } from './types';
 import { getColorPreference } from '../components/theme-toggle/theme-toggle';
+import { bundled, getNpmCdnUrl } from './bundled';
 
 export const initMonacoEditor = async (
   containerElm: any,
@@ -26,7 +27,6 @@ export const initMonacoEditor = async (
     noEmit: true,
     skipLibCheck: true,
     target: ts.ScriptTarget.Latest,
-    typeRoots: ['node_modules/@types'],
   });
 
   ts.javascriptDefaults.setDiagnosticsOptions({
@@ -199,9 +199,10 @@ export const addQwikLibs = async (version: string) => {
 
   const deps = await loadDeps(version);
   deps.forEach((dep) => {
-    if (dep && typeof dep.code === 'string' && typeof dep.path === 'string') {
+    if (dep && typeof dep.code === 'string') {
       typescriptDefaults.addExtraLib(
-        `declare module '${dep.pkgName}${dep.import}' { ${dep.code} }`
+        `declare module '${dep.pkgName}${dep.import}' { ${dep.code}\n }`,
+        `/node_modules/${dep.pkgName}${dep.pkgPath}`
       );
     }
   });
@@ -217,7 +218,6 @@ const loadDeps = async (qwikVersion: string) => {
       pkgVersion: qwikVersion,
       pkgPath: '/core.d.ts',
       import: '',
-      path: '/node_modules/@types/builder.io__qwik/index.d.ts',
     },
     // JSX runtime
     {
@@ -225,7 +225,6 @@ const loadDeps = async (qwikVersion: string) => {
       pkgVersion: qwikVersion,
       pkgPath: '/jsx-runtime.d.ts',
       import: '/jsx-runtime',
-      path: '/node_modules/@types/builder.io__qwik/jsx-runtime.d.ts',
     },
     // server API
     {
@@ -233,7 +232,6 @@ const loadDeps = async (qwikVersion: string) => {
       pkgVersion: qwikVersion,
       pkgPath: '/server.d.ts',
       import: '/server',
-      path: '/node_modules/@types/builder.io__qwik/server.d.ts',
     },
     // build constants
     {
@@ -241,7 +239,6 @@ const loadDeps = async (qwikVersion: string) => {
       pkgVersion: qwikVersion,
       pkgPath: '/build/index.d.ts',
       import: '/build',
-      path: '/node_modules/@types/builder.io__qwik/build/index.d.ts',
     },
   ];
 
@@ -258,7 +255,6 @@ const loadDeps = async (qwikVersion: string) => {
           pkgName: dep.pkgName,
           pkgVersion: dep.pkgVersion,
           pkgPath: dep.pkgPath,
-          path: dep.path,
           import: dep.import,
         };
         monacoCtx.deps.push(storedDep);
@@ -278,18 +274,19 @@ const loadDeps = async (qwikVersion: string) => {
 };
 
 const fetchDep = async (cache: Cache, dep: NodeModuleDep) => {
-  const url = getCdnUrl(dep.pkgName, dep.pkgVersion, dep.pkgPath);
+  const url = getNpmCdnUrl(bundled, dep.pkgName, dep.pkgVersion, dep.pkgPath);
   const req = new Request(url);
   const cachedRes = await cache.match(req);
   if (cachedRes) {
-    return cachedRes.clone().text();
+    return cachedRes.text();
   }
   const fetchRes = await fetch(req);
   if (fetchRes.ok) {
-    if (!req.url.includes('localhost')) {
+    // dev mode uses / and prod bundles use data: urls
+    if (/^(http|\/)/.test(req.url) && !req.url.includes('localhost')) {
       await cache.put(req, fetchRes.clone());
     }
-    return fetchRes.clone().text();
+    return fetchRes.text();
   }
   throw new Error(`Unable to fetch: ${url}`);
 };
@@ -336,12 +333,8 @@ const monacoCtx: MonacoContext = {
   tsWorker: null,
 };
 
-const getCdnUrl = (pkgName: string, pkgVersion: string, pkgPath: string) => {
-  return `https://cdn.jsdelivr.net/npm/${pkgName}@${pkgVersion}${pkgPath}`;
-};
-
 const MONACO_VERSION = '0.45.0';
-const MONACO_VS_URL = getCdnUrl('monaco-editor', MONACO_VERSION, '/min/vs');
+const MONACO_VS_URL = getNpmCdnUrl(bundled, 'monaco-editor', MONACO_VERSION, '/min/vs');
 const MONACO_LOADER_URL = `${MONACO_VS_URL}/loader.js`;
 
 const CLIENT_LIB = `
@@ -373,7 +366,6 @@ interface NodeModuleDep {
   pkgPath: string;
   import: string;
   pkgVersion: string;
-  path: string;
   code?: string;
   promise?: Promise<void>;
 }

--- a/packages/docs/src/repl/qwikFiles.tsx
+++ b/packages/docs/src/repl/qwikFiles.tsx
@@ -1,0 +1,13 @@
+// Special case for qwik, we serve that from /public, populated by the prebuild script
+
+export const qwikFiles = [
+  'build/index.d.ts',
+  'core.cjs',
+  'core.d.ts',
+  'core.min.mjs',
+  'core.mjs',
+  'jsx-runtime.d.ts',
+  'optimizer.cjs',
+  'server.cjs',
+  'server.d.ts',
+];

--- a/packages/docs/src/repl/repl-detail-panel.tsx
+++ b/packages/docs/src/repl/repl-detail-panel.tsx
@@ -1,3 +1,4 @@
+import { bundled } from './bundled';
 import { ReplConsole } from './repl-console';
 import { ReplOptions } from './repl-options';
 import { ReplTabButton } from './repl-tab-button';
@@ -27,7 +28,11 @@ export const ReplDetailPanel = ({ input, store }: ReplDetailPanelProps) => {
       <div class="repl-tab">
         {store.selectedOutputDetail === 'console' ? <ReplConsole store={store} /> : null}
         {store.selectedOutputDetail === 'options' ? (
-          <ReplOptions input={input} versions={store.versions} />
+          <ReplOptions
+            input={input}
+            versions={store.versions}
+            qwikVersion={bundled['@builder.io/qwik'].version}
+          />
         ) : null}
       </div>
     </div>

--- a/packages/docs/src/repl/repl-options.tsx
+++ b/packages/docs/src/repl/repl-options.tsx
@@ -1,6 +1,6 @@
 import type { ReplAppInput } from './types';
 
-export const ReplOptions = ({ input, versions }: ReplOptionsProps) => {
+export const ReplOptions = ({ input, versions, qwikVersion }: ReplOptionsProps) => {
   return (
     <div class="output-detail detail-options">
       <StoreOption
@@ -16,6 +16,7 @@ export const ReplOptions = ({ input, versions }: ReplOptionsProps) => {
         label="Version"
         inputProp="version"
         options={versions}
+        labels={{ bundled: qwikVersion }}
         input={input}
         isLoading={versions.length === 0}
       />
@@ -58,7 +59,7 @@ const StoreOption = (props: StoreOptionProps) => {
             selected={value === props.input[props.inputProp] ? true : undefined}
             key={value}
           >
-            {value}
+            {props.labels?.[value] || value}
           </option>
         ))}
         {props.isLoading ? <option>Loading...</option> : null}
@@ -74,6 +75,7 @@ export const ENTRY_STRATEGY_OPTIONS = ['component', 'hook', 'single', 'smart', '
 interface StoreOptionProps {
   label: string;
   options: string[];
+  labels?: { [value: string]: string };
   input: ReplAppInput;
   inputProp: keyof ReplAppInput;
   isLoading?: boolean;
@@ -88,4 +90,5 @@ interface StoreBooleanProps {
 interface ReplOptionsProps {
   input: ReplAppInput;
   versions: string[];
+  qwikVersion: string;
 }

--- a/packages/docs/src/repl/repl-share-url.ts
+++ b/packages/docs/src/repl/repl-share-url.ts
@@ -15,9 +15,8 @@ export const parsePlaygroundShareUrl = (shareable: string) => {
       const data = { ...dataDefaults };
 
       const version = params.get('v')! || params.get('version')!;
-      if (typeof version === 'string' && version.split('.').length > 2) {
-        data.version = version;
-      }
+      data.version =
+        typeof version === 'string' && version.split('.').length > 2 ? version : 'bundled';
 
       const buildMode = params.get('buildMode')!;
       if (BUILD_MODE_OPTIONS.includes(buildMode)) {
@@ -117,7 +116,9 @@ export const dictionary = strToU8(
 
 export const createPlaygroundShareUrl = (data: PlaygroundShareUrl, pathname = '/playground/') => {
   const params = new URLSearchParams();
-  params.set('v', data.version);
+  if (data.version !== 'bundled') {
+    params.set('v', data.version);
+  }
   if (data.buildMode !== dataDefaults.buildMode) {
     params.set('buildMode', data.buildMode);
   }

--- a/packages/docs/src/repl/repl.tsx
+++ b/packages/docs/src/repl/repl.tsx
@@ -15,6 +15,7 @@ import type { ReplStore, ReplUpdateMessage, ReplMessage, ReplAppInput } from './
 import { ReplDetailPanel } from './repl-detail-panel';
 import { getReplVersion } from './repl-version';
 import { updateReplOutput } from './repl-output-update';
+import { bundled } from './bundled';
 
 export const Repl = component$((props: ReplProps) => {
   useStyles$(styles);
@@ -76,19 +77,27 @@ export const Repl = component$((props: ReplProps) => {
     }
   });
 
-  useVisibleTask$(async () => {
-    // only run on the client
-    const v = await getReplVersion(input.version);
-    if (v.version) {
+  useVisibleTask$(
+    async () => {
+      // only run on the client
+      // Get the version asap, most likely it will be cached.
+      const v = await getReplVersion(input.version, true);
       store.versions = v.versions;
       input.version = v.version;
       store.serverUrl = new URL(`/repl/~repl-server-host.html?${store.clientId}`, origin).href;
 
-      window.addEventListener('message', (ev) => receiveMessageFromReplServer(ev, store));
-    } else {
-      console.debug(`Qwik REPL version not set`);
-    }
-  });
+      window.addEventListener('message', (ev) => receiveMessageFromReplServer(ev, store, input));
+
+      // Now get the version from the network
+      const vNew = await getReplVersion(input.version, false);
+      store.versions = vNew.versions;
+      if (vNew.version !== input.version) {
+        input.version = v.version;
+        sendUserUpdateToReplServer(input, store);
+      }
+    },
+    { strategy: 'document-idle' }
+  );
 
   useTask$(({ track }) => {
     track(() => input.buildId);
@@ -118,26 +127,34 @@ export const Repl = component$((props: ReplProps) => {
   );
 });
 
-export const receiveMessageFromReplServer = (ev: MessageEvent, store: ReplStore) => {
+export const receiveMessageFromReplServer = (
+  ev: MessageEvent,
+  store: ReplStore,
+  input: ReplAppInput
+) => {
   if (ev.origin !== window.origin) {
     return;
   }
   const msg: ReplMessage = ev.data;
-  const type = msg?.type;
-  const clientId = msg?.clientId;
-  if (clientId === store.clientId) {
-    if (type === 'replready') {
-      // keep a reference to the repl server window
-      store.serverWindow = noSerialize(ev.source as any);
-    } else if (type === 'result') {
-      // received a message from the server
-      updateReplOutput(store, msg);
-    } else if (type === 'event') {
-      // received an event from the user's app
-      store.events = [...store.events, msg.event];
-    } else if (type === 'apploaded') {
-      store.isLoading = false;
-    }
+
+  if (!(msg && msg.type && msg.clientId === store.clientId)) {
+    return;
+  }
+  const type = msg.type;
+  if (type === 'replready') {
+    // keep a reference to the repl server window
+    store.serverWindow = noSerialize(ev.source as any);
+    sendUserUpdateToReplServer(input, store);
+  } else if (type === 'result') {
+    // received a message from the server
+    updateReplOutput(store, msg);
+  } else if (type === 'event') {
+    // received an event from the user's app
+    store.events = [...store.events, msg.event];
+  } else if (type === 'apploaded') {
+    store.isLoading = false;
+  } else {
+    console.log('unknown repl message', msg);
   }
 };
 
@@ -156,6 +173,7 @@ export const sendUserUpdateToReplServer = (input: ReplAppInput, store: ReplStore
         },
         version: input.version,
         serverUrl: store.serverUrl,
+        bundled,
       },
     };
 

--- a/packages/docs/src/repl/types.ts
+++ b/packages/docs/src/repl/types.ts
@@ -15,12 +15,14 @@ export interface ReplAppInput {
   debug?: boolean;
 }
 
+export type BundledFiles = { [pkgName: string]: { [path: string]: string; version: string } };
 export interface ReplInputOptions extends Omit<QwikRollupPluginOptions, 'srcDir'> {
   buildId: number;
   srcInputs: ReplModuleInput[];
   version: string;
   buildMode: 'development' | 'production';
   serverUrl: string;
+  bundled: BundledFiles;
 }
 
 export interface ReplStore {

--- a/packages/docs/src/repl/worker/repl-constants.ts
+++ b/packages/docs/src/repl/worker/repl-constants.ts
@@ -1,6 +1,5 @@
 export const QWIK_PKG_NAME = '@builder.io/qwik';
 export const ROLLUP_VERSION = '2.75.6';
-export const PRETTIER_VERSION = '2.7.1';
 export const TERSER_VERSION = '5.14.1';
 
 export const QWIK_REPL_DEPS_CACHE = 'QwikReplDeps';

--- a/packages/docs/src/repl/worker/repl-dependencies.ts
+++ b/packages/docs/src/repl/worker/repl-dependencies.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
-import type { ReplInputOptions } from '../types';
+import type { BundledFiles, ReplInputOptions } from '../types';
 import {
-  PRETTIER_VERSION,
   QWIK_PKG_NAME,
   QWIK_REPL_DEPS_CACHE,
   ROLLUP_VERSION,
@@ -9,12 +8,33 @@ import {
 } from './repl-constants';
 import type { QwikWorkerGlobal } from './repl-service-worker';
 
-export const depResponse = async (
-  cache: Cache,
+let options: ReplInputOptions;
+let cache: Cache;
+
+// Copied from bundled.tsx. Can't import it because it breaks the sw bundle.
+const getNpmCdnUrl = (
+  bundled: BundledFiles,
   pkgName: string,
   pkgVersion: string,
   pkgPath: string
 ) => {
+  if (pkgVersion === 'bundled') {
+    const files = bundled[pkgName];
+    if (files) {
+      pkgVersion = files.version;
+      const url = files[pkgPath];
+      if (url) {
+        return url;
+      }
+    } else {
+      // fall back to latest
+      pkgVersion = '';
+    }
+  }
+  return `https://cdn.jsdelivr.net/npm/${pkgName}${pkgVersion ? '@' + pkgVersion : ''}${pkgPath}`;
+};
+
+export const depResponse = async (pkgName: string, pkgVersion: string, pkgPath: string) => {
   const req = getNpmCdnRequest(pkgName, pkgVersion, pkgPath);
   const cachedRes = await cache.match(req);
   if (cachedRes) {
@@ -22,7 +42,7 @@ export const depResponse = async (
   }
   const fetchRes = await fetch(req);
   if (fetchRes.ok) {
-    if (!req.url.includes('localhost')) {
+    if (/^(http|\/)/.test(req.url) && !req.url.includes('localhost')) {
       await cache.put(req, fetchRes.clone());
     }
     return fetchRes;
@@ -30,31 +50,33 @@ export const depResponse = async (
 };
 
 const exec = async (cache: Cache, pkgName: string, pkgVersion: string, pkgPath: string) => {
-  const res = await depResponse(cache, pkgName, pkgVersion, pkgPath);
+  const res = await depResponse(pkgName, pkgVersion, pkgPath);
   if (res) {
     console.debug(`Run: ${res.url}`);
     // eslint-disable-next-line no-new-func
     const run = new Function(await res.clone().text());
     run();
   } else {
-    throw new Error(`Unable to run: ${getNpmCdnUrl(pkgName, pkgVersion, pkgPath)}`);
+    throw new Error(
+      `Unable to run: ${getNpmCdnUrl(options.bundled, pkgName, pkgVersion, pkgPath)}`
+    );
   }
 };
 
-export const loadDependencies = async (options: ReplInputOptions) => {
-  const version = options.version;
+export const loadDependencies = async (replOptions: ReplInputOptions) => {
+  options = replOptions;
+  const qwikVersion = options.version;
 
-  const cache = await caches.open(QWIK_REPL_DEPS_CACHE);
-
+  cache = await caches.open(QWIK_REPL_DEPS_CACHE);
   await Promise.all([
-    depResponse(cache, QWIK_PKG_NAME, version, '/core.cjs'),
-    depResponse(cache, QWIK_PKG_NAME, version, '/core.mjs'),
-    depResponse(cache, QWIK_PKG_NAME, version, '/core.min.mjs'),
-    depResponse(cache, QWIK_PKG_NAME, version, '/optimizer.cjs'),
-    depResponse(cache, QWIK_PKG_NAME, version, '/server.cjs'),
-    depResponse(cache, 'rollup', ROLLUP_VERSION, '/dist/rollup.browser.js'),
-    depResponse(cache, 'prettier', PRETTIER_VERSION, '/standalone.js'),
-    depResponse(cache, 'prettier', PRETTIER_VERSION, '/parser-html.js'),
+    depResponse(QWIK_PKG_NAME, qwikVersion, '/core.cjs'),
+    depResponse(QWIK_PKG_NAME, qwikVersion, '/core.mjs'),
+    depResponse(QWIK_PKG_NAME, qwikVersion, '/core.min.mjs'),
+    depResponse(QWIK_PKG_NAME, qwikVersion, '/optimizer.cjs'),
+    depResponse(QWIK_PKG_NAME, qwikVersion, '/server.cjs'),
+    depResponse('rollup', ROLLUP_VERSION, '/dist/rollup.browser.js'),
+    depResponse('prettier', 'bundled', '/standalone.js'),
+    depResponse('prettier', 'bundled', '/plugins/html.js'),
   ]);
 
   self.qwikBuild = {
@@ -63,30 +85,30 @@ export const loadDependencies = async (options: ReplInputOptions) => {
     isDev: false,
   };
 
-  if (!isSameQwikVersion(self.qwikCore?.version, version)) {
-    await exec(cache, QWIK_PKG_NAME, version, '/core.cjs');
+  if (!isSameQwikVersion(self.qwikCore?.version, qwikVersion)) {
+    await exec(cache, QWIK_PKG_NAME, qwikVersion, '/core.cjs');
     if (self.qwikCore) {
       console.debug(`Loaded @builder.io/qwik: ${self.qwikCore.version}`);
     } else {
-      throw new Error(`Unable to load @builder.io/qwik ${version}`);
+      throw new Error(`Unable to load @builder.io/qwik ${qwikVersion}`);
     }
   }
 
-  if (!isSameQwikVersion(self.qwikOptimizer?.versions.qwik, version)) {
-    await exec(cache, QWIK_PKG_NAME, version, '/optimizer.cjs');
+  if (!isSameQwikVersion(self.qwikOptimizer?.versions.qwik, qwikVersion)) {
+    await exec(cache, QWIK_PKG_NAME, qwikVersion, '/optimizer.cjs');
     if (self.qwikOptimizer) {
       console.debug(`Loaded @builder.io/qwik/optimizer: ${self.qwikOptimizer.versions.qwik}`);
     } else {
-      throw new Error(`Unable to load @builder.io/qwik/optimizer ${version}`);
+      throw new Error(`Unable to load @builder.io/qwik/optimizer ${qwikVersion}`);
     }
   }
 
-  if (!isSameQwikVersion(self.qwikServer?.versions.qwik, version)) {
-    await exec(cache, QWIK_PKG_NAME, version, '/server.cjs');
+  if (!isSameQwikVersion(self.qwikServer?.versions.qwik, qwikVersion)) {
+    await exec(cache, QWIK_PKG_NAME, qwikVersion, '/server.cjs');
     if (self.qwikServer) {
       console.debug(`Loaded @builder.io/qwik/server: ${self.qwikServer.versions.qwik}`);
     } else {
-      throw new Error(`Unable to load @builder.io/qwik/server ${version}`);
+      throw new Error(`Unable to load @builder.io/qwik/server ${qwikVersion}`);
     }
   }
 
@@ -99,18 +121,18 @@ export const loadDependencies = async (options: ReplInputOptions) => {
     }
   }
 
-  if (self.prettier?.version !== PRETTIER_VERSION) {
-    await exec(cache, 'prettier', PRETTIER_VERSION, '/standalone.js');
-    await exec(cache, 'prettier', PRETTIER_VERSION, '/parser-html.js');
+  if (!self.prettier) {
+    await exec(cache, 'prettier', 'bundled', '/standalone.js');
+    await exec(cache, 'prettier', 'bundled', '/plugins/html.js');
     if (self.prettier) {
-      console.debug(`Loaded prettier: ${self.prettier!.version}`);
+      console.debug(`Loaded prettier: ${(self.prettier as any)!.version}`);
     } else {
-      throw new Error(`Unable to load prettier ${PRETTIER_VERSION}`);
+      throw new Error(`Unable to load prettier`);
     }
   }
 
   if (options.buildMode === 'production' && !self.Terser) {
-    await depResponse(cache, 'terser', TERSER_VERSION, '/dist/bundle.min.js');
+    await depResponse('terser', TERSER_VERSION, '/dist/bundle.min.js');
     await exec(cache, 'terser', TERSER_VERSION, '/dist/bundle.min.js');
     if (self.Terser) {
       console.debug(`Loaded terser: ${TERSER_VERSION}`);
@@ -131,15 +153,14 @@ export const loadDependencies = async (options: ReplInputOptions) => {
 };
 
 const getNpmCdnRequest = (pkgName: string, pkgVersion: string, pkgPath: string) => {
-  return new Request(getNpmCdnUrl(pkgName, pkgVersion, pkgPath));
-};
-
-const getNpmCdnUrl = (pkgName: string, pkgVersion: string, pkgPath: string) => {
-  return `https://cdn.jsdelivr.net/npm/${pkgName}${pkgVersion ? '@' + pkgVersion : ''}${pkgPath}`;
+  return new Request(getNpmCdnUrl(options.bundled, pkgName, pkgVersion, pkgPath));
 };
 
 const isSameQwikVersion = (a: string | undefined, b: string) => {
-  if (!a || (a !== b && !a.includes('-dev') && !b.includes('-dev'))) {
+  if (b === 'bundled') {
+    b = options.bundled['@builder.io/qwik'].version;
+  }
+  if (!a || a !== b) {
     return false;
   }
   return true;

--- a/packages/docs/src/repl/worker/repl-plugins.ts
+++ b/packages/docs/src/repl/worker/repl-plugins.ts
@@ -4,7 +4,6 @@ import type { QwikWorkerGlobal } from './repl-service-worker';
 import type { MinifyOptions } from 'terser';
 import type { ReplInputOptions } from '../types';
 import { depResponse } from './repl-dependencies';
-import { QWIK_REPL_DEPS_CACHE } from './repl-constants';
 
 export const replResolver = (options: ReplInputOptions, buildMode: 'client' | 'ssr'): Plugin => {
   const srcInputs = options.srcInputs;
@@ -76,20 +75,14 @@ export const replResolver = (options: ReplInputOptions, buildMode: 'client' | 's
       `;
       }
       if (id === '\0qwikCore') {
-        const cache = await caches.open(QWIK_REPL_DEPS_CACHE);
         if (options.buildMode === 'production') {
-          const rsp = await depResponse(
-            cache,
-            '@builder.io/qwik',
-            options.version,
-            '/core.min.mjs'
-          );
+          const rsp = await depResponse('@builder.io/qwik', options.version, '/core.min.mjs');
           if (rsp) {
             return rsp.clone().text();
           }
         }
 
-        const rsp = await depResponse(cache, '@builder.io/qwik', options.version, '/core.mjs');
+        const rsp = await depResponse('@builder.io/qwik', options.version, '/core.mjs');
         if (rsp) {
           return rsp.clone().text();
         }

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -110,18 +110,7 @@ export default defineConfig(async () => {
           ],
         },
       }),
-      qwikVite({
-        // Entry strategy provided by qwik insights
-        // entryStrategy: {
-        //   type: 'smart',
-        //   manual: {
-        //     ...page,
-        //     ...menus,
-        //     ...algoliaSearch,
-        //     ...repl,
-        //   },
-        // },
-      }),
+      qwikVite(),
       partytownVite({
         dest: resolve('dist', '~partytown'),
       }),
@@ -156,72 +145,3 @@ export default defineConfig(async () => {
     },
   };
 });
-
-export const page = {
-  KnNE9eL0qfc: 'page',
-  '9t1uPE4yoLA': 'page',
-};
-
-export const menus = {
-  S0wV0vUzzSo: 'right',
-  '5wL0DAwmu0A': 'left',
-};
-
-export const algoliaSearch = bundle('algoliasearch', [
-  'hW',
-  '9t1uPE4yoLA',
-  'I5CyQjO9FjQ',
-  'NsnidK2eXPg',
-  'kDw0latGeM0',
-  '7YcOLMha9lM',
-  'Ly5oFWTkofs',
-  'NCpn2iO0Vo0',
-  'X3ZkFa9P7Dc',
-  'cGb8pS0shrs',
-  '0TG0b0n4wNg',
-  'qQlSSnFvEvs',
-  'qolFAthnlPo',
-  'vXb90XKAnjE',
-  'hYpp40gCb60',
-  'J3Nim3Y9sio',
-  'aWt0AqHIkGQ',
-  'H7LftCVcX8A',
-  'EhtTJVluy08',
-  'Rtwief4DyrI',
-  'uCl5Lf0Typ8',
-  'DCgB1xiHL28',
-  'VRTvy2D80Ww',
-  'r1y7UDjTtCw',
-  'ZiJmJ6Or9eY',
-  'UyYdc56f0ig',
-  'OmOFy2W4aT4',
-  'mnN5FJ8qddY',
-  '5o2hfyxmyXo',
-  'yqKaTNK0QR0',
-  'S0wV0vUzzSo',
-  'S0wV0vUzzSo',
-]);
-
-export const repl = bundle('repl', [
-  's_XoQB11UZ1S0',
-  's_AqHBIVNKf34',
-  's_IRhp4u7HN3o',
-  's_Qf2nEuUdHpM',
-  's_oEksvFPgMEM',
-  's_eePwnt3YTI8',
-  's_iw211Du0bw8',
-  's_lWGaPPYlcvs',
-  's_uCl5Lf0Typ8',
-  's_IW29huCoDkc',
-]);
-
-function bundle(bundleName: string, symbols: string[]) {
-  return symbols.reduce(
-    (obj, key) => {
-      // Sometimes symbols are prefixed with `s_`, remove it.
-      obj[key.replace('s_', '')] = obj[key] = bundleName;
-      return obj;
-    },
-    {} as Record<string, string>
-  );
-}


### PR DESCRIPTION
# Overview

# What is it?

- [x] Feature / enhancement

# Description

This serves the local qwik build to the REPL so that it enables easy testing of new features and eventually it enables running the docs offline (for airplane developmen), although that still needs extra work for rollup, terser and monaco.

It also includes prebuild checks to make `docs.dev` work on a fresh checkout.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
