### PR TITLE
fix(sw-prefetch): clone on reuse

### DIFF
--- a/packages/qwik/src/prefetch-service-worker/direct-fetch.ts
+++ b/packages/qwik/src/prefetch-service-worker/direct-fetch.ts
@@ -39,7 +39,7 @@ function getResponse(swState: SWState, url: URL): Promise<Response> {
     swState.$log$('CACHE HIT', url.pathname);
     return swState.$match$(url) as Promise<Response>;
   } else {
-    return currentRequestTask.$response$;
+    return currentRequestTask.$response$.then((response) => response.clone());
   }
 }
 

--- a/packages/qwik/src/prefetch-service-worker/index.unit.tsx
+++ b/packages/qwik/src/prefetch-service-worker/index.unit.tsx
@@ -57,10 +57,10 @@ describe('service-worker', async () => {
     it('should load graph from network', async () => {
       const swState = mockSwState();
       const graph = createGraph([['a.js', 'b.js'], ['b.js']]);
-      processMessage(swState, ['graph-url', '/base/', 'q-graph.json']);
+      const p = processMessage(swState, ['graph-url', '/base/', 'q-graph.json']);
       await delay(0);
       swState.$fetch$.mock.get('/base/q-graph.json')!.resolve(new Response(JSON.stringify(graph)));
-      await delay(0);
+      await p;
       expect(swState.$bases$.length).toBe(1);
       expect(swState.$bases$[0].$path$).toBe('/base/');
       expect(swState.$bases$[0].$graph$).toEqual([...graph, 'q-graph.json']);

--- a/packages/qwik/src/prefetch-service-worker/state.ts
+++ b/packages/qwik/src/prefetch-service-worker/state.ts
@@ -49,16 +49,16 @@ export interface SWTask {
 }
 
 class SWStateImpl implements SWState {
-  $queue$ = [];
-  $bases$ = [];
-  $cache$: SWState['$cache$'] = null;
-  $msgQueue$ = [];
-  $msgQueuePromise$ = null;
-  $maxPrefetchRequests$ = 10;
-
   constructor(
     readonly $fetch$: ServiceWorkerGlobalScope['fetch'],
-    readonly $url$: URL
+    readonly $url$: URL,
+    // We initialize here so the minifier works correctly
+    public $maxPrefetchRequests$ = 10,
+    public $cache$: SWState['$cache$'] = null,
+    public $msgQueuePromise$ = null,
+    readonly $queue$ = [],
+    readonly $bases$ = [],
+    readonly $msgQueue$ = []
   ) {}
 
   $getCache$() {


### PR DESCRIPTION
This also works around the minifier renaming properties in the class but not the ones that are initializers.
