### PR TITLE
feat(QwikCityMockProvider): add optional goto prop

### DIFF
--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -477,7 +477,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface QwikCityMockProps \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [params?](#) |  | Record&lt;string, string&gt; | _(Optional)_ |\n|  [url?](#) |  | string | _(Optional)_ |",
+      "content": "```typescript\nexport interface QwikCityMockProps \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [goto?](#) |  | [RouteNavigate](#routenavigate) | _(Optional)_ |\n|  [params?](#) |  | Record&lt;string, string&gt; | _(Optional)_ |\n|  [url?](#) |  | string | _(Optional)_ |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/qwik-city-component.tsx",
       "mdFile": "qwik-city.qwikcitymockprops.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -554,10 +554,11 @@ export declare type PathParams = Record<string, string>;
 export interface QwikCityMockProps
 ```
 
-| Property     | Modifiers | Type                         | Description  |
-| ------------ | --------- | ---------------------------- | ------------ |
-| [params?](#) |           | Record&lt;string, string&gt; | _(Optional)_ |
-| [url?](#)    |           | string                       | _(Optional)_ |
+| Property     | Modifiers | Type                            | Description  |
+| ------------ | --------- | ------------------------------- | ------------ |
+| [goto?](#)   |           | [RouteNavigate](#routenavigate) | _(Optional)_ |
+| [params?](#) |           | Record&lt;string, string&gt;    | _(Optional)_ |
+| [url?](#)    |           | string                          | _(Optional)_ |
 
 [Edit this section](https://github.com/BuilderIO/qwik/tree/main/packages/qwik-city/runtime/src/qwik-city-component.tsx)
 

--- a/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
@@ -286,8 +286,6 @@ It is recommended that you use this in your test files.
 
 > `QwikCityMockProvider` does not render any DOM elements, meaning it won't be visible in snapshots
 
-> a `goto` prop can be passed to customize the `navigate` behavior during tests
-
 If you are looking for a general example on how to integrate vitest into your Qwik look checkout the [vitest integration documentation](/docs/integrations/vitest/index.mdx)
 
 ```tsx title="src/components/card.spec.tsx"
@@ -306,14 +304,39 @@ const cases = [
 test.each(cases)('should render card with %s %s', async ({text, link}) => {
   const { screen, render } = await createDOM();
   await render(
-    <QwikCityMockProvider
-      goto={$(async (path) => {
-        // Do something
-      })}>
+    <QwikCityMockProvider>
       <Card text={text} link={link} />
     </QwikCityMockProvider>,
   );
   expect(screen.innerHTML).toMatchSnapshot();
+});
+```
+
+> a `goto` prop can be passed to customize the `navigate` behavior during tests
+
+```tsx title="src/components/button.spec.tsx"
+import { $ } from '@builder.io/qwik';
+import { createDOM } from '@builder.io/qwik/testing';
+import { test, expect, vi } from 'vitest';
+
+// Component with one prop. Uses useNavigate internally. Omitted for brevity
+import { Button } from '../button';
+
+const goto = vi.fn(async (path, options) => {
+  console.log(`Navigating to ${path} with ${options}`);
+});
+
+test('should render the button and navigate', async () => {
+  const { screen, render, userEvent } = await createDOM();
+  const goto$ = $(goto);
+  await render(
+    <QwikCityMockProvider goto={goto$}>
+      <Button id="button" />
+    </QwikCityMockProvider>,
+  );
+  expect(screen.innerHTML).toMatchSnapshot();
+  await userEvent('#button', 'click');
+  expect(goto).toHaveBeenCalled();
 });
 ```
 

--- a/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
@@ -306,7 +306,10 @@ const cases = [
 test.each(cases)('should render card with %s %s', async ({text, link}) => {
   const { screen, render } = await createDOM();
   await render(
-    <QwikCityMockProvider>
+    <QwikCityMockProvider
+      goto={$(async (path) => {
+        // Do something
+      })}>
       <Card text={text} link={link} />
     </QwikCityMockProvider>,
   );

--- a/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
@@ -286,6 +286,8 @@ It is recommended that you use this in your test files.
 
 > `QwikCityMockProvider` does not render any DOM elements, meaning it won't be visible in snapshots
 
+> a `goto` prop can be passed to customize the `navigate` behavior during tests
+
 If you are looking for a general example on how to integrate vitest into your Qwik look checkout the [vitest integration documentation](/docs/integrations/vitest/index.mdx)
 
 ```tsx title="src/components/card.spec.tsx"

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -310,6 +310,8 @@ export type PathParams = Record<string, string>;
 // @public (undocumented)
 export interface QwikCityMockProps {
     // (undocumented)
+    goto?: RouteNavigate;
+    // (undocumented)
     params?: Record<string, string>;
     // (undocumented)
     url?: string;

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -551,7 +551,7 @@ export const QwikCityMockProvider = component$<QwikCityMockProps>((props) => {
 
   const goto: RouteNavigate =
     props.goto ??
-    $(async (path) => {
+    $(async () => {
       console.warn('Not implemented');
     });
 

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -529,6 +529,7 @@ function getContainer(elm: Node): HTMLElement {
 export interface QwikCityMockProps {
   url?: string;
   params?: Record<string, string>;
+  goto?: RouteNavigate;
 }
 
 /** @public */
@@ -548,8 +549,8 @@ export const QwikCityMockProvider = component$<QwikCityMockProps>((props) => {
   const loaderState = useSignal({});
   const routeInternal = useSignal<RouteStateInternal>({ type: 'initial', dest: url });
 
-  const goto: RouteNavigate = $(async (path) => {
-    throw new Error('Not implemented');
+  const goto: RouteNavigate = props.goto ?? $(async (path) => {
+    console.warn('Not implemented');
   });
 
   const documentHead = useStore(createDocumentHead, { deep: false });

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -552,7 +552,7 @@ export const QwikCityMockProvider = component$<QwikCityMockProps>((props) => {
   const goto: RouteNavigate =
     props.goto ??
     $(async () => {
-      console.warn('Not implemented');
+      console.warn('QwikCityMockProvider: goto not provided');
     });
 
   const documentHead = useStore(createDocumentHead, { deep: false });

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -549,9 +549,11 @@ export const QwikCityMockProvider = component$<QwikCityMockProps>((props) => {
   const loaderState = useSignal({});
   const routeInternal = useSignal<RouteStateInternal>({ type: 'initial', dest: url });
 
-  const goto: RouteNavigate = props.goto ?? $(async (path) => {
-    console.warn('Not implemented');
-  });
+  const goto: RouteNavigate =
+    props.goto ??
+    $(async (path) => {
+      console.warn('Not implemented');
+    });
 
   const documentHead = useStore(createDocumentHead, { deep: false });
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

While trying to run a Cypress e2e test based on a storybook, I've challenged an issue due to the thrown error of the `goto` function not implemented in `QwikCityMockProvider`.
In order to tackle, I've moved the error to a warning. On top of that I've added an optional prop that allows users to pass a custom goto function.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
