### PR TITLE
fix(starter): adjust padding for 768px devices

### DIFF
--- a/starters/apps/basic/src/routes/styles.css
+++ b/starters/apps/basic/src/routes/styles.css
@@ -107,7 +107,7 @@ ul {
 
 @media screen and (min-width: 768px) {
   .container {
-    padding: 50px 80px;
+    padding: 60px 80px;
   }
   .container.container-spacing-xl {
     padding: 100px 60px;


### PR DESCRIPTION
# Overview
Adjust padding over the hero section.  Fix #5786
<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

I adjusted the boilerplate overlay to ensure it fits seamlessly with the hero section.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
