### PR TITLE
fix(qwik-city): fix import ./@qwik-city files in prod

### DIFF
--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -137,13 +137,13 @@ function qwikCityPlugin(userOpts?: QwikCityVitePluginOptions): any {
       }
       if (id === STATIC_PATHS_ID) {
         return {
-          id: join(outDir!, RESOLVED_STATIC_PATHS_ID),
+          id: './' + RESOLVED_STATIC_PATHS_ID,
           external: true,
         };
       }
       if (id === NOT_FOUND_PATHS_ID) {
         return {
-          id: join(outDir!, RESOLVED_NOT_FOUND_PATHS_ID),
+          id: './' + RESOLVED_NOT_FOUND_PATHS_ID,
           external: true,
         };
       }

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -195,6 +195,15 @@ export function normalizeRollupOutputOptions(
         outputOpts.chunkFileNames = 'build/[name].js';
       }
     }
+  } else if (opts.buildMode === 'production') {
+    // server production output
+    // everything in same dir so './@qwik-city...' imports work from entry and chunks
+    if (!outputOpts.chunkFileNames) {
+      outputOpts.chunkFileNames = 'q-[hash].js';
+    }
+    if (!outputOpts.assetFileNames) {
+      outputOpts.assetFileNames = 'assets/[hash].[ext]';
+    }
   }
 
   if (opts.target === 'client') {


### PR DESCRIPTION
This reverts commit d2380feb80a221c0376d1754838cc24376baab06 and fixes the relative qwik-city imports by co-locating entry and chunks.

The previous fix broke deploys because the build contained the build path.

Fixes #5774