### PR TITLE
fix(core): assign refs without reactivity during SSR

### DIFF
--- a/packages/qwik/src/core/container/container.ts
+++ b/packages/qwik/src/core/container/container.ts
@@ -1,7 +1,7 @@
 import { qError, QError_invalidRefValue } from '../error/error';
 import type { ResourceReturnInternal, SubscriberEffect } from '../use/use-task';
 import { seal } from '../util/qdev';
-import { isFunction, isObject } from '../util/types';
+import { isFunction } from '../util/types';
 import type { QRL } from '../qrl/qrl.public';
 import { fromKebabToCamelCase } from '../util/case';
 import { QContainerAttr } from '../util/markers';
@@ -11,9 +11,10 @@ import {
   type SubscriberSignal,
   type SubscriptionManager,
 } from '../state/common';
-import type { Signal } from '../state/signal';
+import { isSignal, type Signal, type SignalImpl } from '../state/signal';
 import { directGetAttribute } from '../render/fast-calls';
 import type { QContext } from '../state/context';
+import { isServerPlatform } from '../platform/platform';
 
 export type GetObject = (id: string) => any;
 export type GetObjID = (obj: any) => string | null;
@@ -147,8 +148,12 @@ export const removeContainerState = (containerEl: Element) => {
 export const setRef = (value: any, elm: Element) => {
   if (isFunction(value)) {
     return value(elm);
-  } else if (isObject(value)) {
-    if ('value' in value) {
+  } else if (isSignal(value)) {
+    if (isServerPlatform()) {
+      // During SSR, assigning a ref should not cause reactivity because
+      // the expectation is that the ref is filled in on the client
+      return ((value as SignalImpl<Element>).untrackedValue = elm);
+    } else {
       return ((value as Signal<Element>).value = elm);
     }
   }


### PR DESCRIPTION
During SSR, reactivity on refs will cause dirty tasks, and besides, refs are used to interact with the DOM, which is not possible with the MockElements.

Example script that has dirty tasks without this fix:

```tsx
import { component$, useTask$, useSignal, useVisibleTask$ } from '@builder.io/qwik';

export default component$(() => {
  const ref = useSignal<Element>()

  useTask$(({track}) => {
    console.log(`task runs, ref is ${track(ref) ? '':'un'}defined`)
  })
  useVisibleTask$(({track}) => {
    console.log(`visibleTask runs, ref is ${track(ref) ? '':'un'}defined`)
  })

  return <p ref={ref}>Hello Qwik</p>;
});
```

[playground](https://qwik.dev/playground/#f=Q0o0JoaW2BKNDrySBLMg9TCYiVzQUZy0IOEELL6AwYSo7l1zUkEZxU5DkwuoBl5ba1RD695auH6ICbDqPqEEqE6hqDSvWAdsJrB8UakGa9EAcjUV7BXU1RWsFNRL89Rrgc4Cll0pCZpAU2pBBHoZTti2MoRy8ixFzlsgvbbVQKJ2NJcNk1wGAA)

[Relevant error report on Discord](https://discord.com/channels/842438759945601056/1201636753241542766)

> hylobatidae: I'm getting an error with something internal in Qwik and want to debug it. The error that I get is on 1.4.2 is:
> ```
> [vite] Internal server error: a2.$el$.compareDocumentPosition is not a function
>   File: /Projects/frontend/dist-dev/tsc-out/packages/qwik/src/core/util/implicit_dollar.js:2922:2
> ```
