### PR TITLE
fix(link): Prefetch redirects to error pages. Fixes #5474

### DIFF
--- a/packages/qwik-city/runtime/src/link-component.tsx
+++ b/packages/qwik-city/runtime/src/link-component.tsx
@@ -48,7 +48,10 @@ export const Link = component$<LinkProps>((props) => {
           prefetchSymbols(url.pathname);
 
           if (elm.hasAttribute('data-prefetch')) {
-            loadClientData(url, elm, { prefetchSymbols: false });
+            loadClientData(url, elm, {
+              prefetchSymbols: false,
+              isPrefetch: true,
+            });
           }
         }
       })

--- a/packages/qwik-city/runtime/src/use-endpoint.ts
+++ b/packages/qwik-city/runtime/src/use-endpoint.ts
@@ -11,6 +11,7 @@ export const loadClientData = async (
     action?: RouteActionValue;
     clearCache?: boolean;
     prefetchSymbols?: boolean;
+    isPrefetch?: boolean;
   }
 ) => {
   const pagePathname = url.pathname;
@@ -61,7 +62,9 @@ export const loadClientData = async (
           return clientData;
         });
       } else {
-        location.href = url.href;
+        if (opts?.isPrefetch !== true) {
+          location.href = url.href;
+        }
         return undefined;
       }
     });


### PR DESCRIPTION
# Overview

Fixes: https://github.com/BuilderIO/qwik/issues/5474

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

This PR fixes the bug by adding a flag to the `loadClientData` function, and update `handlePrefetch` in link-component to use the flag to indicate that the call is intended to just prefetch not actual navigation, So in-case the route does occur unexpected error or doesn't exist it shouldn't redirect to the page.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
