### PR TITLE
fix: Fix input reactivity in `useResource$()` tutorial

### DIFF
--- a/packages/docs/src/routes/tutorial/reactivity/resource/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/reactivity/resource/solution/app.tsx
@@ -27,7 +27,12 @@ export default component$(() => {
       <p>
         <label>
           GitHub username:
-          <input value={github.org} onInput$={(ev, el) => el.value} />
+          <input
+            value={github.org}
+            onInput$={(ev) =>
+              (github.org = (ev.target as HTMLInputElement).value)
+            }
+          />
         </label>
       </p>
       <section>

--- a/packages/docs/src/routes/tutorial/reactivity/resource/solution/app.tsx
+++ b/packages/docs/src/routes/tutorial/reactivity/resource/solution/app.tsx
@@ -27,12 +27,7 @@ export default component$(() => {
       <p>
         <label>
           GitHub username:
-          <input
-            value={github.org}
-            onInput$={(ev) =>
-              (github.org = (ev.target as HTMLInputElement).value)
-            }
-          />
+          <input value={github.org} onInput$={(ev, el) => (github.org = el.value)} />
         </label>
       </p>
       <section>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Restored dynamic input reactivity in the `useResource$()` tutorial by updating the `onInput$` handler to properly reflect changes. Previously, updates to the `github.org` input did not refresh repository data due to static value assignment, preventing the expected reactive behavior.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
