### PR TITLE
docs: Fix broken Markdown on Astro Docs page

### DIFF
--- a/packages/docs/src/routes/docs/integrations/astro/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/astro/index.mdx
@@ -98,6 +98,7 @@ Now, add the integration to your `astro.config.*` file using the `integrations` 
     integrations: [qwikdev()],
     //             ^^^^^
   });
+```
   
 > If you are also using other integrations like `react()` or `preact()`, you will need to put `qwikdev()` before them in the list. Or you will have `Not a QRL` errors. Something like this: `integrations: [qwikdev(), react(), preact()]`.
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

The Astro page included some broken Markdown that rendered parts of the markdown source as a code block. This PR fixes that.

<img width="788" alt="Screenshot 2024-02-07 at 09 54 41" src="https://github.com/BuilderIO/qwik/assets/43482866/c429e724-58de-41a1-9500-fb6450bcf747">

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] Added new tests to cover the fix / functionality
