### PR TITLE
fix(create-qwik): update engine version in package.json for generated projects

### DIFF
--- a/packages/qwik/src/cli/utils/utils.ts
+++ b/packages/qwik/src/cli/utils/utils.ts
@@ -81,7 +81,7 @@ export function cleanPackageJson(srcPkg: IntegrationPackageJson) {
     types: srcPkg.types,
     exports: srcPkg.exports,
     files: srcPkg.files,
-    engines: { node: '>=15.0.0' },
+    engines: { node: '^18.17.0 || ^20.3.0 || >=21.0.0' },
   };
 
   Object.keys(cleanedPkg).forEach((prop) => {


### PR DESCRIPTION
create-qwik

This PR is fixing a minor issue

I created a new project using `npx create-qwik@latest` and tried to run `npm run dev`. Although I had Node.js v16 and the `package.json` in the generated project specified that the appropriate version is `>=15.0.0`, I encountered an error because `sharp` does not support this version.