### PR TITLE
fix(qwik-loader): run only once + better minify

### DIFF
--- a/packages/docs/src/routes/api/qwik-server/api.json
+++ b/packages/docs/src/routes/api/qwik-server/api.json
@@ -124,7 +124,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface QwikLoaderOptions \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [events?](#) |  | string\\[\\] | _(Optional)_ |\n|  [include?](#) |  | 'always' \\| 'never' \\| 'auto' | _(Optional)_ |\n|  [position?](#) |  | 'top' \\| 'bottom' | _(Optional)_ |",
+      "content": "```typescript\nexport interface QwikLoaderOptions \n```\n\n\n|  Property | Modifiers | Type | Description |\n|  --- | --- | --- | --- |\n|  [include?](#) |  | 'always' \\| 'never' \\| 'auto' | _(Optional)_ |\n|  [position?](#) |  | 'top' \\| 'bottom' | _(Optional)_ |",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/server/types.ts",
       "mdFile": "qwik.qwikloaderoptions.md"
     },

--- a/packages/docs/src/routes/api/qwik-server/index.md
+++ b/packages/docs/src/routes/api/qwik-server/index.md
@@ -138,7 +138,6 @@ export interface QwikLoaderOptions
 
 | Property       | Modifiers | Type                          | Description  |
 | -------------- | --------- | ----------------------------- | ------------ |
-| [events?](#)   |           | string[]                      | _(Optional)_ |
 | [include?](#)  |           | 'always' \| 'never' \| 'auto' | _(Optional)_ |
 | [position?](#) |           | 'top' \| 'bottom'             | _(Optional)_ |
 

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -161,8 +161,6 @@
     "qwik-prefetch.js",
     "qwikloader.js",
     "qwikloader.debug.js",
-    "qwikloader.optimize.js",
-    "qwikloader.optimize.debug.js",
     "qwik-cli.cjs",
     "server.cjs",
     "server.mjs",

--- a/packages/qwik/src/core/container/pause.ts
+++ b/packages/qwik/src/core/container/pause.ts
@@ -196,9 +196,7 @@ export const pauseContainer = async (
   // Emit event registration
   const extraListeners = Array.from(containerState.$events$, (s) => JSON.stringify(s));
   const eventsScript = doc.createElement('script');
-  eventsScript.textContent = `window.qwikevents||=[];window.qwikevents.push(${extraListeners.join(
-    ', '
-  )})`;
+  eventsScript.textContent = `(window.qwikevents||=[]).push(${extraListeners.join(', ')})`;
   parentJSON.appendChild(eventsScript);
 
   return data;

--- a/packages/qwik/src/core/container/store.unit.tsx
+++ b/packages/qwik/src/core/container/store.unit.tsx
@@ -49,8 +49,7 @@ test.skip('should serialize content', async () => {
         <!--/qv-->
       </div>
       <script>
-        window.qwikevents ||= [];
-        window.qwikevents.push("click");
+        (window.qwikevents ||= []).push("click");
       </script>
     </body>`
   );

--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -1235,8 +1235,8 @@ export const registerQwikEvent = (prop: string) => {
   if (!qTest) {
     const eventName = getEventName(prop);
     try {
-      const qwikevents = ((globalThis as any).qwikevents ||= []);
-      qwikevents.push(eventName);
+      // This is managed by qwik-loader
+      ((globalThis as any).qwikevents ||= []).push(eventName);
     } catch (err) {
       logWarn(err);
     }

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -175,11 +175,15 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
     }
   };
 
-  if (!(doc as any).qR) {
+  if (!(Q_CONTEXT in doc)) {
+    // Mark qwik-loader presence
+    (doc as any)[Q_CONTEXT] = undefined;
     const qwikevents = win.qwikevents;
+    // If `qwikEvents` is an array, process it.
     if (Array.isArray(qwikevents)) {
       push(qwikevents);
     }
+    // Now rig up `qwikEvents` so we get notified of new registrations by other containers.
     win.qwikevents = {
       push: (...e: string[]) => push(e),
     };

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -16,28 +16,32 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
   const win = window as any;
   const events = new Set();
 
+  // Some shortenings for minification
+  const replace = 'replace';
+  const forEach = 'forEach';
+  const target = 'target';
+  const getAttribute = 'getAttribute';
+  const isConnected = 'isConnected';
+  const qvisible = 'qvisible';
+  const Q_JSON = '_qwikjson_';
   const querySelectorAll = (query: string) => {
     return doc.querySelectorAll(query);
   };
 
   const broadcast = (infix: string, ev: Event, type = ev.type) => {
-    querySelectorAll('[on' + infix + '\\:' + type + ']').forEach((target) =>
-      dispatch(target, infix, ev, type)
+    querySelectorAll('[on' + infix + '\\:' + type + ']')[forEach]((el) =>
+      dispatch(el, infix, ev, type)
     );
   };
 
-  const getAttribute = (el: Element, name: string) => {
-    return el.getAttribute(name);
-  };
-
   const resolveContainer = (containerEl: Element) => {
-    if ((containerEl as QContainerElement)['_qwikjson_'] === undefined) {
+    if ((containerEl as QContainerElement)[Q_JSON] === undefined) {
       const parentJSON = containerEl === doc.documentElement ? doc.body : containerEl;
       let script = parentJSON.lastElementChild;
       while (script) {
-        if (script.tagName === 'SCRIPT' && getAttribute(script, 'type') === 'qwik/json') {
-          (containerEl as QContainerElement)['_qwikjson_'] = JSON.parse(
-            script.textContent!.replace(/\\x3C(\/?script)/gi, '<$1')
+        if (script.tagName === 'SCRIPT' && script[getAttribute]('type') === 'qwik/json') {
+          (containerEl as QContainerElement)[Q_JSON] = JSON.parse(
+            script.textContent![replace](/\\x3C(\/?script)/gi, '<$1')
           );
           break;
         }
@@ -57,21 +61,21 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
       ev.preventDefault();
     }
     const ctx = (element as any)['_qc_'] as QContext | undefined;
-    const relevantListeners = ctx?.li.filter((li) => li[0] === attrName);
+    const relevantListeners = ctx && ctx.li.filter((li) => li[0] === attrName);
     if (relevantListeners && relevantListeners.length > 0) {
       for (const listener of relevantListeners) {
         // listener[1] holds the QRL
-        await listener[1].getFn([element, ev], () => element.isConnected)(ev, element);
+        await listener[1].getFn([element, ev], () => element[isConnected])(ev, element);
       }
       return;
     }
-    const attrValue = getAttribute(element, attrName);
+    const attrValue = element[getAttribute](attrName);
     if (attrValue) {
       const container = element.closest('[q\\:container]')!;
-      const base = new URL(getAttribute(container, 'q:base')!, doc.baseURI);
+      const base = new URL(container[getAttribute]('q:base')!, doc.baseURI);
       for (const qrl of attrValue.split('\n')) {
         const url = new URL(qrl, base);
-        const symbolName = url.hash.replace(/^#?([^?[|]*).*$/, '$1') || 'default';
+        const symbolName = url.hash[replace](/^#?([^?[|]*).*$/, '$1') || 'default';
         const reqTime = performance.now();
         let handler: any;
         const isSync = qrl.startsWith('#');
@@ -83,7 +87,7 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
           handler = (await module)[symbolName];
         }
         const previousCtx = (doc as any)[Q_CONTEXT];
-        if (element.isConnected) {
+        if (element[isConnected]) {
           try {
             (doc as any)[Q_CONTEXT] = [element, ev, url];
             isSync ||
@@ -105,7 +109,7 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
     doc.dispatchEvent(createEvent<T>(eventName, detail));
   };
 
-  const camelToKebab = (str: string) => str.replace(/([A-Z])/g, (a) => '-' + a.toLowerCase());
+  const camelToKebab = (str: string) => str[replace](/([A-Z])/g, (a) => '-' + a.toLowerCase());
 
   /**
    * Event handler responsible for processing browser events.
@@ -118,10 +122,10 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
   const processDocumentEvent = async (ev: Event) => {
     // eslint-disable-next-line prefer-const
     let type = camelToKebab(ev.type);
-    let element = ev.target as Element | null;
+    let element = ev[target] as Element | null;
     broadcast('-document', ev, type);
 
-    while (element && element.getAttribute) {
+    while (element && element[getAttribute]) {
       await dispatch(element, '', ev, type);
       element = ev.bubbles && ev.cancelBubble !== true ? element.parentElement : null;
     }
@@ -141,17 +145,17 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
       const riC = win.requestIdleCallback ?? win.setTimeout;
       riC.bind(win)(() => emitEvent('qidle'));
 
-      if (events.has('qvisible')) {
-        const results = querySelectorAll('[on\\:qvisible]');
+      if (events.has(qvisible)) {
+        const results = querySelectorAll('[on\\:' + qvisible + ']');
         const observer = new IntersectionObserver((entries) => {
           for (const entry of entries) {
             if (entry.isIntersecting) {
-              observer.unobserve(entry.target);
-              dispatch(entry.target, '', createEvent<QwikVisibleEvent>('qvisible', entry));
+              observer.unobserve(entry[target]);
+              dispatch(entry[target], '', createEvent<QwikVisibleEvent>(qvisible, entry));
             }
           }
         });
-        results.forEach((el) => observer.observe(el));
+        results[forEach]((el) => observer.observe(el));
       }
     }
   };
@@ -176,8 +180,8 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
   };
 
   if (!(Q_CONTEXT in doc)) {
-    // Mark qwik-loader presence
-    (doc as any)[Q_CONTEXT] = undefined;
+    // Mark qwik-loader presence but falsy
+    (doc as any)[Q_CONTEXT] = 0;
     const qwikevents = win.qwikevents;
     // If `qwikEvents` is an array, process it.
     if (Array.isArray(qwikevents)) {

--- a/packages/qwik/src/server/api.md
+++ b/packages/qwik/src/server/api.md
@@ -69,8 +69,6 @@ export interface PrefetchStrategy {
 // @public (undocumented)
 export interface QwikLoaderOptions {
     // (undocumented)
-    events?: string[];
-    // (undocumented)
     include?: 'always' | 'never' | 'auto';
     // (undocumented)
     position?: 'top' | 'bottom';

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -195,7 +195,6 @@ export async function renderToStream(
       const includeLoader = includeMode === 'always' || (includeMode === 'auto' && needLoader);
       if (includeLoader) {
         const qwikLoaderScript = getQwikLoaderScript({
-          events: opts.qwikLoader?.events,
           debug: opts.debug,
         });
         children.push(
@@ -207,12 +206,12 @@ export async function renderToStream(
         );
       }
 
+      // We emit the events separately so other qwikloaders can see them
       const extraListeners = Array.from(containerState.$events$, (s) => JSON.stringify(s));
       if (extraListeners.length > 0) {
-        let content = `window.qwikevents.push(${extraListeners.join(', ')})`;
-        if (!includeLoader) {
-          content = `window.qwikevents||=[];${content}`;
-        }
+        const content =
+          (includeLoader ? `window.qwikevents` : `(window.qwikevents||=[])`) +
+          `.push(${extraListeners.join(', ')})`;
         children.push(
           jsx('script', {
             dangerouslySetInnerHTML: content,

--- a/packages/qwik/src/server/scripts.ts
+++ b/packages/qwik/src/server/scripts.ts
@@ -1,7 +1,5 @@
 const QWIK_LOADER_DEFAULT_MINIFIED: string = (globalThis as any).QWIK_LOADER_DEFAULT_MINIFIED;
 const QWIK_LOADER_DEFAULT_DEBUG: string = (globalThis as any).QWIK_LOADER_DEFAULT_DEBUG;
-const QWIK_LOADER_OPTIMIZE_MINIFIED: string = (globalThis as any).QWIK_LOADER_OPTIMIZE_MINIFIED;
-const QWIK_LOADER_OPTIMIZE_DEBUG: string = (globalThis as any).QWIK_LOADER_OPTIMIZE_DEBUG;
 
 /**
  * Provides the `qwikloader.js` file as a string. Useful for tooling to inline the qwikloader script
@@ -10,12 +8,6 @@ const QWIK_LOADER_OPTIMIZE_DEBUG: string = (globalThis as any).QWIK_LOADER_OPTIM
  * @public
  */
 export function getQwikLoaderScript(opts: { events?: string[]; debug?: boolean } = {}) {
-  if (Array.isArray(opts.events) && opts.events.length > 0) {
-    // inject exact known events used
-    const loader = opts.debug ? QWIK_LOADER_OPTIMIZE_DEBUG : QWIK_LOADER_OPTIMIZE_MINIFIED;
-    return loader.replace('window.qEvents', JSON.stringify(opts.events));
-  }
-
   // default script selector behavior
   return opts.debug ? QWIK_LOADER_DEFAULT_DEBUG : QWIK_LOADER_DEFAULT_MINIFIED;
 }

--- a/packages/qwik/src/server/types.ts
+++ b/packages/qwik/src/server/types.ts
@@ -102,7 +102,6 @@ export interface RenderResult {
 
 /** @public */
 export interface QwikLoaderOptions {
-  events?: string[];
   include?: 'always' | 'never' | 'auto';
   position?: 'top' | 'bottom';
 }

--- a/starters/apps/e2e/src/entry.ssr.tsx
+++ b/starters/apps/e2e/src/entry.ssr.tsx
@@ -99,7 +99,6 @@ export default function (opts: RenderToStreamOptions) {
         qwikLoader: {
           include:
             url.searchParams.get("loader") === "false" ? "never" : "auto",
-          events: ["click"],
         },
         ...opts,
       },


### PR DESCRIPTION
- only run once in the browser
- qEvents is no longer used
- qwikloader.optimize.js is the same as regular, remove
- some tricks to allow smaller code after minify
- remove @vite-ignore comment
