### PR TITLE
fix(eslint): Allow JSXNode to serialize

### DIFF
--- a/packages/eslint-plugin-qwik/src/validLexicalScope.ts
+++ b/packages/eslint-plugin-qwik/src/validLexicalScope.ts
@@ -485,6 +485,7 @@ const ALLOWED_CLASSES = {
   Error: true,
   Set: true,
   Map: true,
+  JSXNodeImpl: true,
 };
 
 const referencesOutsideGood = `


### PR DESCRIPTION
# Overview

Allow the `JSXNode` to serialize.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Even though there is the `JSXNodeSerializer`, the eslint has been warning when you use the `JSXNode` across the `$` sign.
This PR solves this issue.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Fixes #5864 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
