### PR TITLE
fix(deno): replace deprecated Deno server module with `Deno.serve`

### DIFF
--- a/packages/docs/src/routes/docs/deployments/deno/index.mdx
+++ b/packages/docs/src/routes/docs/deployments/deno/index.mdx
@@ -11,14 +11,14 @@ created_at: '2023-04-28T16:43:21Z'
 
 Qwik City Deno middleware allows you to hook up Qwik City to a Deno server which uses the standard Request/Response that's well supported by Deno. Some Deno server implementations include:
 
-- [Deno's integrated HTTP server](https://deno.com/manual/examples/http_server)
+- [Deno's integrated HTTP server](https://docs.deno.com/runtime/tutorials/http_server)
 - [Oak](https://oakserver.github.io/oak/)
 
 ## Installation
 
 To integrate the `deno` adapter, use the `add` command:
 
-- For the [integrated HTTP server](https://deno.com/manual/examples/http_server):
+- For the [integrated HTTP server](https://docs.deno.com/runtime/tutorials/http_server):
 
 ```shell
 npm run qwik add deno

--- a/packages/qwik-city/middleware/deno/api.md
+++ b/packages/qwik-city/middleware/deno/api.md
@@ -8,7 +8,14 @@ import type { ClientConn } from '@builder.io/qwik-city/middleware/request-handle
 import type { ServerRenderOptions } from '@builder.io/qwik-city/middleware/request-handler';
 
 // @public (undocumented)
-export interface Addr {
+export function createQwikCity(opts: QwikCityDenoOptions): {
+    router: (request: Request, info: ServeHandlerInfo) => Promise<Response | null>;
+    notFound: (request: Request) => Promise<Response>;
+    staticFile: (request: Request) => Promise<Response | null>;
+};
+
+// @public (undocumented)
+export interface NetAddr {
     // (undocumented)
     hostname: string;
     // (undocumented)
@@ -18,28 +25,19 @@ export interface Addr {
 }
 
 // @public (undocumented)
-export interface ConnInfo {
-    // (undocumented)
-    readonly localAddr: Addr;
-    // (undocumented)
-    readonly remoteAddr: Addr;
-}
-
-// @public (undocumented)
-export function createQwikCity(opts: QwikCityDenoOptions): {
-    router: (request: Request, conn: ConnInfo) => Promise<Response | null>;
-    notFound: (request: Request) => Promise<Response>;
-    staticFile: (request: Request) => Promise<Response | null>;
-};
-
-// @public (undocumented)
 export interface QwikCityDenoOptions extends ServerRenderOptions {
     // (undocumented)
-    getClientConn?: (request: Request, conn: ConnInfo) => ClientConn;
+    getClientConn?: (request: Request, info: ServeHandlerInfo) => ClientConn;
     static?: {
         root?: string;
         cacheControl?: string;
     };
+}
+
+// @public (undocumented)
+export interface ServeHandlerInfo {
+    // (undocumented)
+    remoteAddr: NetAddr;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/qwik-city/middleware/deno/index.ts
+++ b/packages/qwik-city/middleware/deno/index.ts
@@ -17,16 +17,15 @@ import { extname, fromFileUrl, join } from 'https://deno.land/std/path/mod.ts';
 // @builder.io/qwik-city/middleware/deno
 
 /** @public */
-export interface Addr {
+export interface NetAddr {
   transport: 'tcp' | 'udp';
   hostname: string;
   port: number;
 }
 
 /** @public */
-export interface ConnInfo {
-  readonly localAddr: Addr;
-  readonly remoteAddr: Addr;
+export interface ServeHandlerInfo {
+  remoteAddr: NetAddr;
 }
 
 /** @public */
@@ -42,7 +41,7 @@ export function createQwikCity(opts: QwikCityDenoOptions) {
 
   const staticFolder = opts.static?.root ?? join(fromFileUrl(import.meta.url), '..', '..', 'dist');
 
-  async function router(request: Request, conn: ConnInfo) {
+  async function router(request: Request, info: ServeHandlerInfo) {
     try {
       const url = new URL(request.url);
 
@@ -66,9 +65,9 @@ export function createQwikCity(opts: QwikCityDenoOptions) {
         },
         getClientConn: () => {
           return opts.getClientConn
-            ? opts.getClientConn(request, conn)
+            ? opts.getClientConn(request, info)
             : {
-                ip: conn.remoteAddr.hostname,
+                ip: info.remoteAddr.hostname,
               };
         },
       };
@@ -175,5 +174,5 @@ export interface QwikCityDenoOptions extends ServerRenderOptions {
     /** Set the Cache-Control header for all static files */
     cacheControl?: string;
   };
-  getClientConn?: (request: Request, conn: ConnInfo) => ClientConn;
+  getClientConn?: (request: Request, info: ServeHandlerInfo) => ClientConn;
 }

--- a/starters/adapters/deno/README.md
+++ b/starters/adapters/deno/README.md
@@ -1,6 +1,6 @@
 ## Deno Server
 
-This app has a minimal [Deno server](https://deno.com/manual/examples/http_server) implementation. After running a full build, you can preview the build using the command:
+This app has a minimal [Deno server](https://docs.deno.com/runtime/tutorials/http_server) implementation. After running a full build, you can preview the build using the command:
 
 ```
 npm run serve

--- a/starters/adapters/deno/package.json
+++ b/starters/adapters/deno/package.json
@@ -9,7 +9,7 @@
     "displayName": "Adapter: Deno Server",
     "docs": [
       "https://qwik.builder.io/deployments/deno/",
-      "https://deno.com/manual/examples/http_server"
+      "https://docs.deno.com/runtime/tutorials/http_server"
     ],
     "nextSteps": {
       "title": "Next Steps",

--- a/starters/adapters/deno/src/entry.deno.ts
+++ b/starters/adapters/deno/src/entry.deno.ts
@@ -5,15 +5,13 @@
  *
  * Learn more about the Deno integration here:
  * - https://qwik.builder.io/docs/deployments/deno/
- * - https://deno.com/manual/examples/http_server
+ * - https://docs.deno.com/runtime/tutorials/http_server
  *
  */
 import { createQwikCity } from "@builder.io/qwik-city/middleware/deno";
 import qwikCityPlan from "@qwik-city-plan";
 import { manifest } from "@qwik-client-manifest";
 import render from "./entry.ssr";
-// @ts-ignore
-import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
 
 // Create the Qwik City Deno middleware
 const { router, notFound, staticFile } = createQwikCity({
@@ -28,23 +26,20 @@ const port = Number(Deno.env.get("PORT") ?? 3009);
 /* eslint-disable */
 console.log(`Server starter: http://localhost:${port}/app/`);
 
-serve(
-  async (request: Request, conn: any) => {
-    const staticResponse = await staticFile(request);
-    if (staticResponse) {
-      return staticResponse;
-    }
+Deno.serve({ port }, async (request: Request, info: any) => {
+  const staticResponse = await staticFile(request);
+  if (staticResponse) {
+    return staticResponse;
+  }
 
-    // Server-side render this request with Qwik City
-    const qwikCityResponse = await router(request, conn);
-    if (qwikCityResponse) {
-      return qwikCityResponse;
-    }
+  // Server-side render this request with Qwik City
+  const qwikCityResponse = await router(request, info);
+  if (qwikCityResponse) {
+    return qwikCityResponse;
+  }
 
-    // Path not found
-    return notFound(request);
-  },
-  { port },
-);
+  // Path not found
+  return notFound(request);
+});
 
 declare const Deno: any;


### PR DESCRIPTION
# Overview

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

This pull request updates the codebase to use the recommended [`Deno.serve`](https://deno.land/api?s=Deno.serve) API for creating HTTP servers, replacing the deprecated [`serve`](https://deno.land/std@0.217.0/http/mod.ts?s=serve) function from the Deno standard library.

```ts
// Before:
import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
serve(/* ... */);

// After:
Deno.serve(/* ... */);
```

You can find the `Deno.serve` signature [here](https://github.com/denoland/deno/blob/v1.41.0/cli/tsc/dts/lib.deno.ns.d.ts#L6496-L6499).

I also replace the docs URL for Deno servers. The former redirects to the latter.

```diff
- https://deno.com/manual/examples/http_server
+ https://docs.deno.com/runtime/tutorials/http_server
```

# Use cases and why

The [latest `serve` docs](https://deno.land/std@0.217.0/http/mod.ts?s=serve) says this is deprecated.

> Deprecated
> (will be removed after 1.0.0) Use [Deno.serve](https://deno.land/api?s=Deno.serve) instead.

`Deno.serve` is available since [Deno 1.35](https://deno.com/blog/v1.35#denoserve-is-now-stable) released on July 2023.

> The long awaited new web server API, `Deno.serve()`, is now stable. It offers a much easier API while significantly enhancing performance.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
