### PR TITLE
docs: Add missing server$ import in Getting started example

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -332,7 +332,7 @@ export default component$(() => {
 In Qwik, a [task](/docs/components/tasks/#usetask) is work that needs to happen when a state changes. (This is similar to an "effect" in other frameworks.) In this example, we use the task to invoke code on the server.
 
 1. Import `useTask$` from `qwik` and `$server` from `qwik-city.
-   ```tsx /useTask$/ /$server/
+   ```tsx /useTask\$/ /\$server/
    import { component$, useSignal, useTask$ } from "@builder.io/qwik";
    import {
      routeLoader$,

--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -331,7 +331,7 @@ export default component$(() => {
 
 In Qwik, a [task](/docs/components/tasks/#usetask) is work that needs to happen when a state changes. (This is similar to an "effect" in other frameworks.) In this example, we use the task to invoke code on the server.
 
-1. Import `useTask$` from `qwik` and `$server` from `qwik-city.
+1. Import `useTask$` from `qwik` and `$server` from `qwik-city`.
    ```tsx /useTask\$/ /\$server/
    import { component$, useSignal, useTask$ } from "@builder.io/qwik";
    import {

--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -331,9 +331,17 @@ export default component$(() => {
 
 In Qwik, a [task](/docs/components/tasks/#usetask) is work that needs to happen when a state changes. (This is similar to an "effect" in other frameworks.) In this example, we use the task to invoke code on the server.
 
-1. Import `useTask$` from `qwik`.
-   ```tsx /useTask$/
+1. Import `useTask$` from `qwik` and `$server` from `qwik-city.
+   ```tsx /useTask$/ /$server/
    import { component$, useSignal, useTask$ } from "@builder.io/qwik";
+   import {
+     routeLoader$,
+     Form,
+     routeAction$,
+     server$,
+   } from '@builder.io/qwik-city';
+   ```
+
 2. Create a new task that tracks the `isFavoriteSignal` state:
    ```tsx /useTask\$/
    useTask$(({ track }) => {});


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Adds a missing import in [part 5 of the  Getting started tutorial](https://qwik.dev/docs/getting-started/#5-tasks-and-invoking-server-code).

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
