### PR TITLE
chore(docs): change indicator side from left to the right

### DIFF
--- a/packages/docs/src/components/sidebar/sidebar.css
+++ b/packages/docs/src/components/sidebar/sidebar.css
@@ -134,7 +134,8 @@ details li a {
   height: 6px;
   border-radius: 50%;
   margin-top: 0.2rem;
-  margin-right: 0.3rem;
+  position: absolute;
+  transform: translateX(-15px);
 }
 
 @media (max-width: 1023px) {

--- a/packages/docs/src/components/sidebar/sidebar.css
+++ b/packages/docs/src/components/sidebar/sidebar.css
@@ -134,7 +134,7 @@ details li a {
   height: 6px;
   border-radius: 50%;
   margin-top: 0.2rem;
-  margin-left: 0.3rem;
+  margin-right: 0.3rem;
 }
 
 @media (max-width: 1023px) {

--- a/packages/docs/src/components/sidebar/sidebar.tsx
+++ b/packages/docs/src/components/sidebar/sidebar.tsx
@@ -114,17 +114,17 @@ export function Items({
                 <Items items={item.items} pathname={pathname} markdownItems={markdownItems} />
               </details>
             ) : (
-              <>
-              {item.text}
-              {renderUpdated(item.href!, markdownItems)}
-            </>
               <a
                 href={item.href}
                 class={{
                   'is-active': pathname === item.href,
                 }}
-                style={{ display: 'flex',position: 'relative' }}
+                style={{ display: 'flex', position: 'relative' }}
               >
+                <>
+                  {renderUpdated(item.href!, markdownItems)}
+                  {item.text}
+                </>
               </a>
             )}
           </li>

--- a/packages/docs/src/components/sidebar/sidebar.tsx
+++ b/packages/docs/src/components/sidebar/sidebar.tsx
@@ -114,6 +114,10 @@ export function Items({
                 <Items items={item.items} pathname={pathname} markdownItems={markdownItems} />
               </details>
             ) : (
+              <>
+              {item.text}
+              {renderUpdated(item.href!, markdownItems)}
+            </>
               <a
                 href={item.href}
                 class={{
@@ -121,10 +125,6 @@ export function Items({
                 }}
                 style={{ display: 'flex' }}
               >
-                <>
-                  {item.text}
-                  {renderUpdated(item.href!, markdownItems)}
-                </>
               </a>
             )}
           </li>

--- a/packages/docs/src/components/sidebar/sidebar.tsx
+++ b/packages/docs/src/components/sidebar/sidebar.tsx
@@ -123,7 +123,7 @@ export function Items({
                 class={{
                   'is-active': pathname === item.href,
                 }}
-                style={{ display: 'flex' }}
+                style={{ display: 'flex',position: 'relative' }}
               >
               </a>
             )}


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

switched the updated indicator to be on the right of the a tag text, as on desktop it is not visible due to the small sidebar width
![after change](https://github.com/BuilderIO/qwik/assets/93722724/d0c310f1-aa0a-4a60-9e94-2d8086f52b0d)
vs
![before change](https://github.com/BuilderIO/qwik/assets/93722724/8e0fb4b7-0441-4f42-85da-22caac9a20ea)

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
