### PR TITLE
chore(docs): updated indicator in docs not appearing in mobile sidebar

### DIFF
--- a/packages/docs/src/components/sidebar/sidebar.css
+++ b/packages/docs/src/components/sidebar/sidebar.css
@@ -134,6 +134,7 @@ details li a {
   height: 6px;
   border-radius: 50%;
   margin-top: 0.2rem;
+  margin-right: 0.3rem;
   position: absolute;
   transform: translateX(-15px);
 }

--- a/packages/docs/src/components/sidebar/sidebar.css
+++ b/packages/docs/src/components/sidebar/sidebar.css
@@ -134,7 +134,7 @@ details li a {
   height: 6px;
   border-radius: 50%;
   margin-top: 0.2rem;
-  margin-right: 0.3rem;
+  margin-left: 0.3rem;
   position: absolute;
   transform: translateX(-15px);
 }


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

sorry in my last pr i removed margin left by mistake when trying to fix my original mistake
this caused the updated indicator to be super to the left of the link text in desktop, and in mobile its almost not visible in some screens.
apologise for the wasteful prs (i didnt know if i can update my previous pr any further as it got merged)

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
