### PR TITLE
test(v2): revert changes for vnode-diff

### DIFF
--- a/packages/qwik/src/core/v2/client/vnode-diff.ts
+++ b/packages/qwik/src/core/v2/client/vnode-diff.ts
@@ -717,16 +717,7 @@ export const vnode_diff = (container: ClientContainer, jsxNode: JSXOutput, vStar
       // Component
       const [componentQRL] = componentMeta;
       if (componentQRL.$hash$ !== vNodeQrl?.$hash$) {
-        if (vnode_getNextSibling(host) && jsxIdx > 0) {
-          journal.push(
-            VNodeJournalOpCode.Remove,
-            vParent,
-            host
-          );
-          jsxIdx--;
-        } else {
-          vnode_setProp(host, OnRenderProp, componentQRL);
-        }
+        vnode_setProp(host, OnRenderProp, componentQRL);
         shouldRender = true;
       }
       const vNodeProps = vnode_getProp<any>(host, ELEMENT_PROPS, container.$getObjectById$);

--- a/packages/qwik/src/core/v2/rendering.unit-util.tsx
+++ b/packages/qwik/src/core/v2/rendering.unit-util.tsx
@@ -43,8 +43,10 @@ export async function domRender(
   const container = getDomContainer(document.body);
   const styles: Record<string, string> = {};
   const styleElements = container.document.head.querySelectorAll(QStyleSelector);
-  styleElements.forEach((style) => {
-    const id = style.getAttribute(QStyle)!;
+  styleElements.forEach((style, index) => {
+    const styleId = style.getAttribute(QStyle);
+    // for non scoped styles styleId is empty
+    const id = styleId && styleId.length ? styleId : index;
     styles[id] = style.textContent!;
   });
   if (opts.debug) {

--- a/packages/qwik/src/core/v2/use-styles.unit.tsx
+++ b/packages/qwik/src/core/v2/use-styles.unit.tsx
@@ -38,7 +38,7 @@ Error.stackTraceLimit = 100;
         );
       } else {
         expect(styles).toEqual({
-          '': STYLE_RED,
+          '0': STYLE_RED,
         });
         expect(vNode).toMatchVDOM(
           <>
@@ -150,8 +150,8 @@ Error.stackTraceLimit = 100;
         );
       } else {
         expect(styles).toEqual({
-          '': STYLE_RED,
-          '': STYLE_BLUE,
+          '0': STYLE_RED,
+          '1': STYLE_BLUE,
         });
         expect(vNode).toMatchVDOM(
           <>


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

This PR reverts the problematic code in vnode-diff

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
