### PR TITLE
fix(cloudflare): cache-control ignored by cf (#3679)"

### DIFF
--- a/packages/qwik-city/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-city/middleware/cloudflare-pages/index.ts
@@ -104,9 +104,7 @@ export function createQwikCity(opts: QwikCityCloudflarePagesOptions) {
             // Store the fetched response as cacheKey
             // Use waitUntil so you can return the response without blocking on
             // writing to cache
-            ctx.waitUntil(
-              handledResponse.completion.then(() => cache.put(cacheKey, response.clone()))
-            );
+            ctx.waitUntil(cache.put(cacheKey, response.clone()));
           }
           return response;
         }


### PR DESCRIPTION
This reverts commit 1995753ff587d9938dcc08515ca64693a805d14f.

Somehow, this causes cloudflare not to honor Cache-Control headers. The answers do not have the cache-hit header.

Fixes #5947 