### PR TITLE
fix(qwik-city): spa-shim.ts import scripts from wrong path

### DIFF
--- a/packages/qwik-city/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/runtime/src/spa-shim.ts
@@ -42,7 +42,7 @@ const shim = async (path: string, symbol: string) => {
       const imp = new Function('url', 'return import(url)');
       (await imp(url.href))[symbol](currentScript);
     } else {
-      (await import(path))[symbol](currentScript);
+      (await import(url.href))[symbol](currentScript);
     }
   }
 };


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

spa-shim.ts does not respect q:base attribute when importing script

In a subpath, for example http://localhost:3000/blog/
It will import the script from http://localhost:3000/blog/eg.js
Not from http://localhost:3000/build/eg.js

![CleanShot 2024-03-06 at 00 47 30@2x](https://github.com/BuilderIO/qwik/assets/61572188/fcbdea6b-f8c8-4a40-af6d-6f13a3da903e)

# Use cases and why
Just a mistype maybe

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
