### PR TITLE
fix(Docs): Social media OG image URL generation update

### DIFF
--- a/packages/docs/src/components/router-head/router-head.tsx
+++ b/packages/docs/src/components/router-head/router-head.tsx
@@ -1,10 +1,16 @@
-import { component$, useSignal, useTask$ } from '@builder.io/qwik';
-import { useDocumentHead, useLocation } from '@builder.io/qwik-city';
+/* eslint-disable no-console */
+import { component$,  useTask$ } from '@builder.io/qwik';
+import {  useDocumentHead, useLocation } from '@builder.io/qwik-city';
 import { Social } from './social';
 import { Vendor } from './vendor';
 import { ThemeScript } from './theme-script';
 
+
+
+
 export const RouterHead = component$(() => {
+
+
   const { url } = useLocation();
   const head = useDocumentHead();
   const title = head.title
@@ -25,36 +31,72 @@ export const RouterHead = component$(() => {
   let isBaseRoute = true;
   isBaseRoute = arrayedTitle.length > 0 ? false : true;
 
+  
+
+
+  const OGImage= {
+
+
+    isBaseRoute:arrayedTitle.length > 0 ? false : true,
+     routeLevelX:0,
+       imageURL:"",
+    ogImgTitle:"",
+    ogImgSubTitle:"",
+
+get URL(){
+
+console.log(this.isBaseRoute)
+
   // set the text for the ogimage
   const biggerTitle = isBaseRoute ? undefined : arrayedTitle[0];
+  // console.log("biggerTitle ", biggerTitle)
   const smallerTitle = isBaseRoute ? undefined : arrayedTitle[1];
+  // console.log("smallerTitle ", smallerTitle)
 
-  const routeLevel = useSignal(0);
 
-  const imageUrl = useSignal('');
-  const ogImgTitle = useSignal('');
-  const ogImgSubTitle = useSignal('');
 
-  useTask$(() => {
-    //change the value of the title and subtitle
-    ogImgTitle.value = biggerTitle!;
-    ogImgSubTitle.value = smallerTitle!;
+  this.ogImgTitle = biggerTitle as any;
+  this.ogImgSubTitle= smallerTitle  as any;
+
+
+
 
     //decide whether or not to show subtitle
-    if (ogImgSubTitle.value == undefined || ogImgTitle == undefined) {
-      ogImgTitle.value = biggerTitle!;
+    if (this.ogImgSubTitle == undefined || this.ogImgTitle == undefined) {
+      this.ogImgTitle = biggerTitle  as any;
 
-      routeLevel.value = 0;
-      imageUrl.value = new URL(`/logos/social-card.jpg`, url).href;
+      this.routeLevelX = 0;
+      // console.log("you are currently on level ", this.routeLevelX)
+      this.imageURL = new URL(`/logos/social-card.jpg`, url).href;
+
+// console.log("your image url is ", this.imageURL)
+return this.imageURL
+
+
     } else {
-      routeLevel.value = 1;
-      ogImageUrl.searchParams.set('title', ogImgTitle.value);
-      ogImageUrl.searchParams.set('subtitle', ogImgSubTitle.value);
-      ogImageUrl.searchParams.set('level', routeLevel.value.toString());
+      this.routeLevelX = 1;
+      // console.log("you are currently on level ", this.routeLevelX)
 
-      imageUrl.value = ogImageUrl.toString();
+      ogImageUrl.searchParams.set('title', this.ogImgTitle);
+      ogImageUrl.searchParams.set('subtitle', this.ogImgSubTitle);
+      ogImageUrl.searchParams.set('level', this.routeLevelX.toString());
+
+      // console.log("2222 ", this.imageURL)
+
+      this.imageURL = ogImageUrl.toString();
+      console.log("333333 ", true)
+      return this.imageURL
     }
-  });
+
+
+  // return "kkkk"
+}
+
+
+  }
+
+
+
   return (
     <>
       <title>{title}</title>
@@ -70,17 +112,17 @@ export const RouterHead = component$(() => {
       <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
       <link rel="icon" href="/favicons/favicon.svg" type="image/svg+xml" />
 
-      {import.meta.env.PROD && (
+      {/* {import.meta.env.PROD && ( */}
         <>
           <Social
             title={title}
             description={description}
             href={url.href}
-            ogImage={imageUrl.value}
+            ogImage={OGImage.URL}
           />
           <Vendor />
         </>
-      )}
+      {/* )} */}
 
       {head.meta
         // Skip description because that was already added at the top

--- a/packages/docs/src/components/router-head/router-head.tsx
+++ b/packages/docs/src/components/router-head/router-head.tsx
@@ -15,44 +15,35 @@ export const RouterHead = component$(() => {
     head.meta.find((m) => m.name === 'description')?.content ||
     `No hydration, auto lazy-loading, edge-optimized, and fun 🎉!`;
 
-  const pageTitle = head.title;
-
-  const ogImageUrl = new URL('https://opengraphqwik.vercel.app/api/og');
-
-  //turn the title into array with [0] -> Title [1] -> subTitle
-  const arrayedTitle = pageTitle.split(' | ');
-
   const OGImage = {
-    //check if we are on home route
-    isBaseRoute: arrayedTitle.length > 0 ? false : true,
-
-    routeLevel: 0,
     imageURL: '',
     ogImgTitle: '',
-    ogImgSubTitle: '',
+    ogImgSubTitle: '' as string | undefined,
 
     get URL() {
-      const biggerTitle = this.isBaseRoute ? undefined : arrayedTitle[0];
-      const smallerTitle = this.isBaseRoute ? undefined : arrayedTitle[1];
+      //turn the title into array with [0] -> Title [1] -> subTitle
+      const arrayedTitle = title.split(' | ');
+      const ogImageUrl = new URL('https://opengraphqwik.vercel.app/api/og?level=1');
 
-      // set the text for title and subtitle
-      this.ogImgTitle = biggerTitle as string;
-      this.ogImgSubTitle = smallerTitle as string;
+      // biggerTitle
+      this.ogImgTitle = arrayedTitle[0];
+      //smallerTitle
+      this.ogImgSubTitle = arrayedTitle[1]
+        ? arrayedTitle[1].replace(' 📚 Qwik Documentation', '')
+        : undefined;
 
-      //decide whether or not to show subtitle and title
+      //decide whether or not to show dynamic OGimage or use docs default social card
       if (this.ogImgSubTitle == undefined || this.ogImgTitle == undefined) {
-        this.routeLevel = 0;
         this.imageURL = new URL(`/logos/social-card.jpg`, url).href;
 
         return this.imageURL;
       } else {
-        this.routeLevel = 1;
-
         ogImageUrl.searchParams.set('title', this.ogImgTitle);
         ogImageUrl.searchParams.set('subtitle', this.ogImgSubTitle);
-        ogImageUrl.searchParams.set('level', this.routeLevel.toString());
+        // ogImageUrl.searchParams.set('level', this.routeLevel.toString());
 
         this.imageURL = ogImageUrl.toString();
+
         return this.imageURL;
       }
     },

--- a/packages/docs/src/components/router-head/router-head.tsx
+++ b/packages/docs/src/components/router-head/router-head.tsx
@@ -1,16 +1,11 @@
 /* eslint-disable no-console */
-import { component$,  useTask$ } from '@builder.io/qwik';
-import {  useDocumentHead, useLocation } from '@builder.io/qwik-city';
+import { component$ } from '@builder.io/qwik';
+import { useDocumentHead, useLocation } from '@builder.io/qwik-city';
 import { Social } from './social';
 import { Vendor } from './vendor';
 import { ThemeScript } from './theme-script';
 
-
-
-
 export const RouterHead = component$(() => {
-
-
   const { url } = useLocation();
   const head = useDocumentHead();
   const title = head.title
@@ -24,78 +19,44 @@ export const RouterHead = component$(() => {
 
   const ogImageUrl = new URL('https://opengraphqwik.vercel.app/api/og');
 
-  //turn the title into array
+  //turn the title into array with [0] -> Title [1] -> subTitle
   const arrayedTitle = pageTitle.split(' | ');
 
-  //check if we are on home page or level 0 or 1 route
-  let isBaseRoute = true;
-  isBaseRoute = arrayedTitle.length > 0 ? false : true;
+  const OGImage = {
+    //check if we are on home route
+    isBaseRoute: arrayedTitle.length > 0 ? false : true,
 
-  
+    routeLevel: 0,
+    imageURL: '',
+    ogImgTitle: '',
+    ogImgSubTitle: '',
 
+    get URL() {
+      const biggerTitle = this.isBaseRoute ? undefined : arrayedTitle[0];
+      const smallerTitle = this.isBaseRoute ? undefined : arrayedTitle[1];
 
-  const OGImage= {
+      // set the text for title and subtitle
+      this.ogImgTitle = biggerTitle as string;
+      this.ogImgSubTitle = smallerTitle as string;
 
+      //decide whether or not to show subtitle and title
+      if (this.ogImgSubTitle == undefined || this.ogImgTitle == undefined) {
+        this.routeLevel = 0;
+        this.imageURL = new URL(`/logos/social-card.jpg`, url).href;
 
-    isBaseRoute:arrayedTitle.length > 0 ? false : true,
-     routeLevelX:0,
-       imageURL:"",
-    ogImgTitle:"",
-    ogImgSubTitle:"",
+        return this.imageURL;
+      } else {
+        this.routeLevel = 1;
 
-get URL(){
+        ogImageUrl.searchParams.set('title', this.ogImgTitle);
+        ogImageUrl.searchParams.set('subtitle', this.ogImgSubTitle);
+        ogImageUrl.searchParams.set('level', this.routeLevel.toString());
 
-console.log(this.isBaseRoute)
-
-  // set the text for the ogimage
-  const biggerTitle = isBaseRoute ? undefined : arrayedTitle[0];
-  // console.log("biggerTitle ", biggerTitle)
-  const smallerTitle = isBaseRoute ? undefined : arrayedTitle[1];
-  // console.log("smallerTitle ", smallerTitle)
-
-
-
-  this.ogImgTitle = biggerTitle as any;
-  this.ogImgSubTitle= smallerTitle  as any;
-
-
-
-
-    //decide whether or not to show subtitle
-    if (this.ogImgSubTitle == undefined || this.ogImgTitle == undefined) {
-      this.ogImgTitle = biggerTitle  as any;
-
-      this.routeLevelX = 0;
-      // console.log("you are currently on level ", this.routeLevelX)
-      this.imageURL = new URL(`/logos/social-card.jpg`, url).href;
-
-// console.log("your image url is ", this.imageURL)
-return this.imageURL
-
-
-    } else {
-      this.routeLevelX = 1;
-      // console.log("you are currently on level ", this.routeLevelX)
-
-      ogImageUrl.searchParams.set('title', this.ogImgTitle);
-      ogImageUrl.searchParams.set('subtitle', this.ogImgSubTitle);
-      ogImageUrl.searchParams.set('level', this.routeLevelX.toString());
-
-      // console.log("2222 ", this.imageURL)
-
-      this.imageURL = ogImageUrl.toString();
-      console.log("333333 ", true)
-      return this.imageURL
-    }
-
-
-  // return "kkkk"
-}
-
-
-  }
-
-
+        this.imageURL = ogImageUrl.toString();
+        return this.imageURL;
+      }
+    },
+  };
 
   return (
     <>
@@ -112,17 +73,12 @@ return this.imageURL
       <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
       <link rel="icon" href="/favicons/favicon.svg" type="image/svg+xml" />
 
-      {/* {import.meta.env.PROD && ( */}
+      {import.meta.env.PROD && (
         <>
-          <Social
-            title={title}
-            description={description}
-            href={url.href}
-            ogImage={OGImage.URL}
-          />
+          <Social title={title} description={description} href={url.href} ogImage={OGImage.URL} />
           <Vendor />
         </>
-      {/* )} */}
+      )}
 
       {head.meta
         // Skip description because that was already added at the top

--- a/packages/docs/src/routes/layout.tsx
+++ b/packages/docs/src/routes/layout.tsx
@@ -1,5 +1,5 @@
 import { component$, Slot } from '@builder.io/qwik';
-import { type RequestHandler } from '@builder.io/qwik-city';
+import type { RequestHandler } from '@builder.io/qwik-city';
 
 export default component$(() => {
   return <Slot />;

--- a/packages/docs/src/routes/layout.tsx
+++ b/packages/docs/src/routes/layout.tsx
@@ -1,5 +1,15 @@
 import { component$, Slot } from '@builder.io/qwik';
-import type { RequestHandler } from '@builder.io/qwik-city';
+import { routeLoader$, type RequestHandler } from '@builder.io/qwik-city';
+
+
+
+export const useOgParamsloader = routeLoader$( (request)  => {
+
+  request
+  // request
+  // console.log( request.params )
+return request.params
+} )
 
 export default component$(() => {
   return <Slot />;

--- a/packages/docs/src/routes/layout.tsx
+++ b/packages/docs/src/routes/layout.tsx
@@ -1,15 +1,5 @@
 import { component$, Slot } from '@builder.io/qwik';
-import { routeLoader$, type RequestHandler } from '@builder.io/qwik-city';
-
-
-
-export const useOgParamsloader = routeLoader$( (request)  => {
-
-  request
-  // request
-  // console.log( request.params )
-return request.params
-} )
+import { type RequestHandler } from '@builder.io/qwik-city';
 
 export default component$(() => {
   return <Slot />;


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

The previous implementation used useSignals and useTask$ unnecessarily, which could cause delays in generating the Open Graph (OG) image URL and result in blank OG previews when shared. This pull request introduces an OGImage object that efficiently handles the dynamic OG image generation, leading to faster generation of the image URL and improved performance in creating OG previews.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
