### PR TITLE
fix: prevent SW exception

### DIFF
--- a/packages/qwik/src/prefetch-service-worker/direct-fetch.ts
+++ b/packages/qwik/src/prefetch-service-worker/direct-fetch.ts
@@ -79,8 +79,8 @@ function taskTick(swState: SWState) {
     if (task.$isFetching$) {
       outstandingRequests++;
     } else if (
-      outstandingRequests < swState.$maxPrefetchRequests$ ||
-      task.$priority$ >= DIRECT_PRIORITY
+      swState.$getCache$() &&
+      (outstandingRequests < swState.$maxPrefetchRequests$ || task.$priority$ >= DIRECT_PRIORITY)
     ) {
       task.$isFetching$ = true;
       outstandingRequests++;

--- a/packages/qwik/src/prefetch-service-worker/process-message.ts
+++ b/packages/qwik/src/prefetch-service-worker/process-message.ts
@@ -100,14 +100,16 @@ async function processBundleGraph(
   if (cleanup) {
     const bundles = new Set<string>(graph.filter((item) => typeof item === 'string') as string[]);
     const cache = await swState.$getCache$();
-    for (const request of await cache.keys()) {
-      const [cacheBase, filename] = parseBaseFilename(new URL(request.url));
-      const promises: Promise<boolean>[] = [];
-      if (cacheBase === base && !bundles.has(filename)) {
-        swState.$log$('deleting', request.url);
-        promises.push(cache.delete(request));
+    if (cache) {
+      for (const request of await cache.keys()) {
+        const [cacheBase, filename] = parseBaseFilename(new URL(request.url));
+        const promises: Promise<boolean>[] = [];
+        if (cacheBase === base && !bundles.has(filename)) {
+          swState.$log$('deleting', request.url);
+          promises.push(cache.delete(request));
+        }
+        await Promise.all(promises);
       }
-      await Promise.all(promises);
     }
   }
 }

--- a/packages/qwik/src/prefetch-service-worker/state.ts
+++ b/packages/qwik/src/prefetch-service-worker/state.ts
@@ -13,7 +13,7 @@ export interface SWState {
   $msgQueuePromise$: Promise<void> | null;
   /** List of Base paths */
   $bases$: SWStateBase[];
-  $getCache$: () => Promise<Cache> | Cache;
+  $getCache$: () => Promise<Cache> | Cache | null;
   /** Browser Cache */
   $cache$: Cache | null;
   $put$: Cache['put'];
@@ -62,15 +62,15 @@ class SWStateImpl implements SWState {
   ) {}
 
   $getCache$() {
-    return this.$cache$!;
+    return this.$cache$;
   }
   async $put$(request: URL | RequestInfo, response: Response) {
     const cache = await this.$getCache$();
-    return cache.put(request, response);
+    return cache?.put(request, response);
   }
   async $match$(request: URL | RequestInfo) {
     const cache = await this.$getCache$();
-    return cache.match(request);
+    return cache?.match(request);
   }
 
   $log$() {}


### PR DESCRIPTION
This fix will solve this edge case error. 
With:
- empty browser cache
- no active service worker

sometimes the variable `$cache$` is null when that code is evaluated.
 
![Pasted image 1](https://github.com/BuilderIO/qwik/assets/35845425/75f2ab99-e92c-4466-a1e2-e3af7638d12e)
![Pasted image](https://github.com/BuilderIO/qwik/assets/35845425/a41a935c-8927-4623-902a-7c3467ed03fe)

This code could be the problem https://github.com/BuilderIO/qwik/blob/157f7b01df22448638f7cc55546a051aa4eea5f0/packages/qwik/src/prefetch-service-worker/setup.ts#L42