### PR TITLE
feat(v2): add more renderToString2 tests

### DIFF
--- a/packages/qwik/src/core/v2/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/v2/ssr/ssr-render-jsx.ts
@@ -22,15 +22,15 @@ import { isClassAttr } from '../shared/scoped-styles';
 import { qrlToString, type SerializationContext } from '../shared/shared-serialization';
 import { DEBUG_TYPE, VirtualType, type fixMeAny } from '../shared/types';
 import { applyInlineComponent, applyQwikComponentBody } from './ssr-render-component';
-import type { OpenContainerOptions, SSRContainer, SsrAttrs } from './types';
+import type { SSRContainer, SsrAttrs } from './types';
 
 /**
  * We support Promises in JSX but we don't expose this in the public API because it breaks signal
  * tracking after the first await.
  */
 type JSXValue = ValueOrPromise<JSXOutput>;
-export async function ssrRenderToContainer(ssr: SSRContainer, jsx: JSXOutput, opts?: OpenContainerOptions) {
-  ssr.openContainer(opts);
+export async function ssrRenderToContainer(ssr: SSRContainer, jsx: JSXOutput) {
+  ssr.openContainer();
   await walkJSX(ssr, jsx, true);
   ssr.closeContainer();
 }

--- a/packages/qwik/src/core/v2/ssr/ssr-render2.ts
+++ b/packages/qwik/src/core/v2/ssr/ssr-render2.ts
@@ -12,6 +12,7 @@ import { ssrCreateContainer } from './ssr-container';
 import { ssrRenderToContainer } from './ssr-render-jsx';
 import { setServerPlatform } from '../../../server/platform';
 import { getBuildBase } from '../../../server/utils';
+import { manifest } from '@qwik-client-manifest';
 
 export const renderToString2: typeof renderToString = async (
   jsx: JSXOutput,
@@ -74,12 +75,20 @@ export const renderToStream2: typeof renderToStream = async (
   const resolvedManifest = resolveManifest(opts.manifest);
 
   const locale = typeof opts.locale === 'function' ? opts.locale(opts) : opts.locale;
-  const ssrContainer = ssrCreateContainer({ tagName: containerTagName, locale, writer: stream, timing });
+
+  const ssrContainer = ssrCreateContainer({
+    tagName: containerTagName,
+    locale,
+    writer: stream,
+    timing,
+    buildBase,
+    containerAttributes,
+    serverData: opts.serverData,
+    manifestHash: resolvedManifest?.manifest.manifestHash,
+  });
 
   await setServerPlatform(opts, resolvedManifest);
-  await ssrRenderToContainer(ssrContainer, jsx, {
-    buildBase,
-  });
+  await ssrRenderToContainer(ssrContainer, jsx);
 
   const isDynamic = false;
   const result: RenderToStreamResult = {

--- a/packages/qwik/src/core/v2/ssr/ssr-render2.ts
+++ b/packages/qwik/src/core/v2/ssr/ssr-render2.ts
@@ -12,7 +12,6 @@ import { ssrCreateContainer } from './ssr-container';
 import { ssrRenderToContainer } from './ssr-render-jsx';
 import { setServerPlatform } from '../../../server/platform';
 import { getBuildBase } from '../../../server/utils';
-import { manifest } from '@qwik-client-manifest';
 
 export const renderToString2: typeof renderToString = async (
   jsx: JSXOutput,

--- a/packages/qwik/src/core/v2/ssr/types.ts
+++ b/packages/qwik/src/core/v2/ssr/types.ts
@@ -14,7 +14,7 @@ export interface SSRContainer extends Container2 {
   writer: StreamWriter;
   serializationCtx: SerializationContext;
 
-  openContainer(opts?: OpenContainerOptions): void;
+  openContainer(): void;
   closeContainer(): void;
 
   openElement(tag: string, attrs: SsrAttrs): void;
@@ -35,10 +35,6 @@ export interface SSRContainer extends Container2 {
   addRoot(obj: any): number;
   getLastNode(): SsrNode;
   addUnclaimedProjection(node: SsrNode, name: string, children: JSXChildren): void;
-}
-
-export interface OpenContainerOptions {
-  buildBase?: string;
 }
 
 export type SsrAttrs = Array<string | null>;


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

This PR adds tests and impl for locale, containerTagName, containerAttributes, serverData, manifest hash attribute and version option.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
