### PR TITLE
fix(core): spread props, className

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -1158,7 +1158,7 @@
         }
       ],
       "kind": "Function",
-      "content": "```typescript\njsx: <T extends string | FunctionComponent<any>>(type: T, props: T extends FunctionComponent<infer PROPS> ? PROPS : Record<any, unknown>, key?: string | number | null) => JSXNode<T>\n```\n\n\n|  Parameter | Type | Description |\n|  --- | --- | --- |\n|  type | T |  |\n|  props | T extends [FunctionComponent](#functioncomponent)<!-- -->&lt;infer PROPS&gt; ? PROPS : Record&lt;any, unknown&gt; |  |\n|  key | string \\| number \\| null | _(Optional)_ |\n\n**Returns:**\n\n[JSXNode](#jsxnode)<!-- -->&lt;T&gt;",
+      "content": "Used by the JSX transpilers to create a JSXNode. Note that the optimizer will not use this, instead using \\_jsxQ, \\_jsxS, and \\_jsxC directly.\n\n\n```typescript\njsx: <T extends string | FunctionComponent<any>>(type: T, props: T extends FunctionComponent<infer PROPS> ? PROPS : Record<any, unknown>, key?: string | number | null) => JSXNode<T>\n```\n\n\n|  Parameter | Type | Description |\n|  --- | --- | --- |\n|  type | T |  |\n|  props | T extends [FunctionComponent](#functioncomponent)<!-- -->&lt;infer PROPS&gt; ? PROPS : Record&lt;any, unknown&gt; |  |\n|  key | string \\| number \\| null | _(Optional)_ |\n\n**Returns:**\n\n[JSXNode](#jsxnode)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/BuilderIO/qwik/tree/main/packages/qwik/src/core/render/jsx/jsx-runtime.ts",
       "mdFile": "qwik.jsx.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -1295,6 +1295,8 @@ Boolean - True if the object is a `Signal`.
 
 ## jsx
 
+Used by the JSX transpilers to create a JSXNode. Note that the optimizer will not use this, instead using \_jsxQ, \_jsxS, and \_jsxC directly.
+
 ```typescript
 jsx: <T extends string | FunctionComponent<any>>(
   type: T,

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -392,7 +392,7 @@ export type IntrinsicSVGElements = {
 // @public
 export const isSignal: <T = unknown>(obj: any) => obj is Signal<T>;
 
-// @public (undocumented)
+// @public
 const jsx: <T extends string | FunctionComponent<any>>(type: T, props: T extends FunctionComponent<infer PROPS> ? PROPS : Record<any, unknown>, key?: string | number | null) => JSXNode<T>;
 export { jsx }
 export { jsx as jsxs }

--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -956,6 +956,7 @@ const noop: PropHandler = () => {
 export const PROP_HANDLER_MAP: Record<string, PropHandler | undefined> = {
   style: handleStyle,
   class: handleClass,
+  className: handleClass,
   value: checkBeforeAssign,
   checked: checkBeforeAssign,
   href: forceAttribute,

--- a/packages/qwik/src/core/render/dom/visitor.ts
+++ b/packages/qwik/src/core/render/dom/visitor.ts
@@ -737,11 +737,23 @@ export const createElm = (
       }
     }
     if (vnode.$immutableProps$) {
-      setProperties(staticCtx, elCtx, currentComponent, vnode.$immutableProps$, isSvg, true);
+      const immProps =
+        props !== EMPTY_OBJ
+          ? Object.fromEntries(
+              Object.entries(vnode.$immutableProps$).map(([k, v]) => [
+                k,
+                v === _IMMUTABLE ? props[k] : v,
+              ])
+            )
+          : vnode.$immutableProps$;
+      setProperties(staticCtx, elCtx, currentComponent, immProps, isSvg, true);
     }
     if (props !== EMPTY_OBJ) {
       elCtx.$vdom$ = vnode;
-      vnode.$props$ = setProperties(staticCtx, elCtx, currentComponent, props, isSvg, false);
+      const p = vnode.$immutableProps$
+        ? Object.fromEntries(Object.entries(props).filter(([k]) => !(k in vnode.$immutableProps$!)))
+        : props;
+      vnode.$props$ = setProperties(staticCtx, elCtx, currentComponent, p, isSvg, false);
     }
     if (isSvg && tag === 'foreignObject') {
       isSvg = false;
@@ -928,7 +940,12 @@ const checkBeforeAssign: PropHandler = (ctx, elm, newValue, prop) => {
   if (prop in elm) {
     // a selected <option> is different from a selected <option value> (innerText vs '')
     if ((elm as any)[prop] !== newValue || (prop === 'value' && !elm.hasAttribute(prop))) {
-      if (elm.tagName === 'SELECT') {
+      if (
+        // we must set value last so that it adheres to min,max,step
+        prop === 'value' &&
+        // but we must also set options first so they are present before updating select
+        elm.tagName !== 'OPTION'
+      ) {
         setPropertyPost(ctx, elm, prop, newValue);
       } else {
         setProperty(ctx, elm, prop, newValue);

--- a/packages/qwik/src/core/render/jsx/jsx-runtime.ts
+++ b/packages/qwik/src/core/render/jsx/jsx-runtime.ts
@@ -58,7 +58,7 @@ export const _jsxQ = <T extends string>(
 /**
  * @internal
  *
- * Create a JSXNode for a string tag, with the children extracted from the mutableProps
+ * A string tag with dynamic props, possibly containing children
  */
 export const _jsxS = <T extends string>(
   type: T,
@@ -127,7 +127,11 @@ export const _jsxC = <T extends string | FunctionComponent<Record<any, unknown>>
   return node;
 };
 
-/** @public */
+/**
+ * @public
+ * Used by the JSX transpilers to create a JSXNode.
+ * Note that the optimizer will not use this, instead using _jsxQ, _jsxS, and _jsxC directly.
+ */
 export const jsx = <T extends string | FunctionComponent<any>>(
   type: T,
   props: T extends FunctionComponent<infer PROPS> ? PROPS : Record<any, unknown>,

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -535,7 +535,7 @@ const renderNode = (
   if (typeof tagName === 'string') {
     const key = node.key;
     const props = node.props;
-    const immutable = node.immutableProps;
+    const immutable = node.immutableProps || EMPTY_OBJ;
     const elCtx = createMockQContext(1);
     const elm = elCtx.$element$ as Element;
     const isHead = tagName === 'head';
@@ -599,13 +599,28 @@ const renderNode = (
         }
       }
     };
-    if (immutable) {
-      for (const prop in immutable) {
-        handleProp(prop, immutable[prop], true);
-      }
-    }
     for (const prop in props) {
-      handleProp(prop, props[prop], false);
+      let isImmutable = false;
+      let value;
+      if (prop in immutable) {
+        isImmutable = true;
+        value = immutable[prop];
+        if (value === _IMMUTABLE) {
+          value = props[prop];
+        }
+      } else {
+        value = props[prop];
+      }
+      handleProp(prop, value, isImmutable);
+    }
+    for (const prop in immutable) {
+      if (prop in props) {
+        continue;
+      }
+      const value = immutable[prop];
+      if (value !== _IMMUTABLE) {
+        handleProp(prop, value, true);
+      }
     }
     const listeners = elCtx.li;
     if (hostCtx) {

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -544,9 +544,6 @@ const renderNode = (
     let hasRef = false;
     let classStr = '';
     let htmlStr = null;
-    if (qDev && props.class && props.className) {
-      throw new TypeError('Can only have one of class or className');
-    }
     const handleProp = (rawProp: string, value: unknown, isImmutable: boolean) => {
       if (rawProp === 'ref') {
         if (value !== undefined) {
@@ -577,7 +574,7 @@ const renderNode = (
       }
       let attrValue;
       const prop = rawProp === 'htmlFor' ? 'for' : rawProp;
-      if (prop === 'class') {
+      if (prop === 'class' || prop === 'className') {
         classStr = serializeClass(value as ClassList);
       } else if (prop === 'style') {
         attrValue = stringifyStyle(value);

--- a/packages/qwik/src/optimizer/core/src/is_immutable.rs
+++ b/packages/qwik/src/optimizer/core/src/is_immutable.rs
@@ -36,6 +36,10 @@ impl<'a> ImmutableCollector<'a> {
     }
 }
 
+// A prop is considered mutable if it:
+// - calls a function
+// - accesses a member
+// - is a variable that is not an import, an export, or in the immutable stack
 impl<'a> Visit for ImmutableCollector<'a> {
     noop_visit_type!();
 

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_class_name.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_class_name.snap
@@ -47,18 +47,18 @@ export const App2_component_3yveMqbQ3Fs = ()=>{
     return /*#__PURE__*/ _jsxC(_Fragment, {
         children: [
             /*#__PURE__*/ _jsxQ("div", null, {
-                class: "hola"
+                className: "hola"
             }, null, 3, null),
             /*#__PURE__*/ _jsxQ("div", null, {
-                class: _fnSignal((p0)=>p0.value, [
+                className: _fnSignal((p0)=>p0.value, [
                     signal
                 ], "p0.value")
             }, null, 3, null),
             /*#__PURE__*/ _jsxQ("div", null, {
-                class: signal
+                className: signal
             }, null, 3, null),
             /*#__PURE__*/ _jsxQ("div", {
-                class: computed
+                className: computed
             }, null, null, 3, null),
             /*#__PURE__*/ _jsxC(Foo, {
                 className: "hola",
@@ -90,7 +90,7 @@ export const App2_component_3yveMqbQ3Fs = ()=>{
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;0CAG+B,IAAM;IACjC,MAAM,SAAS;IACf,MAAM,WAAW,OAAO,KAAK,GAAG;IAChC,qBACI;;0BACI,MAAC;uBAAc;;0BACf,MAAC;uCAAe,GAAO,KAAK;;;;0BAC5B,MAAC;uBAAe;;0BAChB,MAAC;uBAAe;;0BAEhB,MAAC;gBAAI,WAAU;;oBAAV,SAAS;;;0BACd,MAAC;oBAAI;2BAAW,OAAO,KAAK;;;oBAAvB,SAAS,kBAAE,GAAO,KAAK;;;;;0BAC5B,MAAC;gBAAI,WAAW;;oBAAX,SAAS;;;0BACd,MAAC;gBAAI,WAAW;;;;AAG5B\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;0CAG+B,IAAM;IACjC,MAAM,SAAS;IACf,MAAM,WAAW,OAAO,KAAK,GAAG;IAChC,qBACI;;0BACI,MAAC;gBAAI,WAAU;;0BACf,MAAC;gBAAI,SAAS,kBAAE,GAAO,KAAK;;;;0BAC5B,MAAC;gBAAI,WAAW;;0BAChB,MAAC;gBAAI,WAAW;;0BAEhB,MAAC;gBAAI,WAAU;;oBAAV,SAAS;;;0BACd,MAAC;oBAAI;2BAAW,OAAO,KAAK;;;oBAAvB,SAAS,kBAAE,GAAO,KAAK;;;;;0BAC5B,MAAC;gBAAI,WAAW;;oBAAX,SAAS;;;0BACd,MAAC;gBAAI,WAAW;;;;AAG5B\"}")
 /*
 {
   "origin": "test.tsx",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_derived_signals_cmp.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_derived_signals_cmp.snap
@@ -61,13 +61,13 @@ const App_component_ckEPmXZlub0 = ()=>{
     const signal = useSignal(0);
     const store = useStore({});
     return /*#__PURE__*/ _jsxC(Cmp, {
-        signal: signal,
+        staticText: "text",
+        staticText2: `text`,
+        staticNumber: 1,
         staticBoolean: true,
         staticExpr: `text${12}`,
         staticExpr2: typeof `text${12}` === 'string' ? 12 : 43,
-        staticNumber: 1,
-        staticText: "text",
-        staticText2: `text`,
+        signal: signal,
         get signalValue () {
             return signal.value;
         },
@@ -105,6 +105,25 @@ const App_component_ckEPmXZlub0 = ()=>{
         noInline3: mutable(signal),
         noInline4: signal.value + dep,
         [_IMMUTABLE]: {
+            staticText: _IMMUTABLE,
+            staticText2: _IMMUTABLE,
+            staticNumber: _IMMUTABLE,
+            staticBoolean: _IMMUTABLE,
+            staticExpr: _IMMUTABLE,
+            staticExpr2: _IMMUTABLE,
+            signal: _IMMUTABLE,
+            signalValue: _fnSignal((p0)=>p0.value, [
+                signal
+            ], "p0.value"),
+            signalComputedValue: _fnSignal((p0)=>12 + p0.value, [
+                signal
+            ], "12+p0.value"),
+            store: _fnSignal((p0)=>p0.address.city.name, [
+                store
+            ], "p0.address.city.name"),
+            storeComputed: _fnSignal((p0)=>p0.address.city.name ? 'true' : 'false', [
+                store
+            ], 'p0.address.city.name?"true":"false"'),
             dep: _IMMUTABLE,
             depAccess: _IMMUTABLE,
             depComputed: _IMMUTABLE,
@@ -116,33 +135,14 @@ const App_component_ckEPmXZlub0 = ()=>{
             ], "p0.value()"),
             noInline2: _fnSignal((p0)=>p0.value + unknown(), [
                 signal
-            ], "p0.value+unknown()"),
-            signal: _IMMUTABLE,
-            signalComputedValue: _fnSignal((p0)=>12 + p0.value, [
-                signal
-            ], "12+p0.value"),
-            signalValue: _fnSignal((p0)=>p0.value, [
-                signal
-            ], "p0.value"),
-            staticBoolean: _IMMUTABLE,
-            staticExpr: _IMMUTABLE,
-            staticExpr2: _IMMUTABLE,
-            staticNumber: _IMMUTABLE,
-            staticText: _IMMUTABLE,
-            staticText2: _IMMUTABLE,
-            store: _fnSignal((p0)=>p0.address.city.name, [
-                store
-            ], "p0.address.city.name"),
-            storeComputed: _fnSignal((p0)=>p0.address.city.name ? 'true' : 'false', [
-                store
-            ], 'p0.address.city.name?"true":"false"')
+            ], "p0.value+unknown()")
         }
     }, 3, "u6_0");
 };
 export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(App_component_ckEPmXZlub0, "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AACA,SAAqB,QAAQ,EAAE,OAAO,QAAQ,mBAAmB;AAEjE,SAAQ,GAAG,QAAO,SAAS;AAC3B,SAAQ,GAAG,QAAO,QAAQ;kCAEI,IAAM;IAChC,MAAM,SAAS,UAAU;IACzB,MAAM,QAAQ,SAAS,CAAC;IACxB,qBACI,MAAC;QAQG,QAAQ;QAJR,eAAe,IAAI;QACnB,YAAY,CAAC,IAAI,EAAE,GAAG,CAAC;QACvB,aAAa,OAAO,CAAC,IAAI,EAAE,GAAG,CAAC,KAAK,WAAW,KAAK,EAAE;QAHtD,cAAc;QAFd,YAAW;QACX,aAAa,CAAC,IAAI,CAAC;YAOnB;mBAAa,OAAO,KAAK;;YACzB;mBAAqB,KAAK,OAAO,KAAK;;YAEtC;mBAAO,MAAM,OAAO,CAAC,IAAI,CAAC,IAAI;;YAC9B;mBAAe,MAAM,OAAO,CAAC,IAAI,CAAC,IAAI,GAAG,SAAS,OAAO;;QAEzD,KAAK;YACL;mBAAW,IAAI,KAAK;;YACpB;mBAAa,IAAI,KAAK,GAAG;;YAEzB;mBAAQ;;YACR;mBAAc,YAAY,KAAK;;YAC/B;mBAAgB,YAAY,KAAK,GAAG;;YAGpC;mBAAU,OAAO,KAAK;;YACtB;mBAAW,OAAO,KAAK,GAAG;;QAC1B,WAAW,QAAQ;QACnB,WAAW,OAAO,KAAK,GAAG;;YAZ1B,GAAG;YACH,SAAS;YACT,WAAW;YAEX,MAAM;YACN,YAAY;YACZ,cAAc;YAGd,QAAQ,kBAAE,GAAO,KAAK;;;YACtB,SAAS,kBAAE,GAAO,KAAK,GAAG;;;YAjB1B,MAAM;YAEN,mBAAmB,kBAAE,KAAK,GAAO,KAAK;;;YADtC,WAAW,kBAAE,GAAO,KAAK;;;YALzB,aAAa;YACb,UAAU;YACV,WAAW;YAHX,YAAY;YAFZ,UAAU;YACV,WAAW;YAUX,KAAK,kBAAE,GAAM,OAAO,CAAC,IAAI,CAAC,IAAI;;;YAC9B,aAAa,kBAAE,GAAM,OAAO,CAAC,IAAI,CAAC,IAAI,GAAG,SAAS,OAAO;;;;;AAiBrE;AAlCA,OAAO,MAAM,oBAAM,+FAkChB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AACA,SAAqB,QAAQ,EAAE,OAAO,QAAQ,mBAAmB;AAEjE,SAAQ,GAAG,QAAO,SAAS;AAC3B,SAAQ,GAAG,QAAO,QAAQ;kCAEI,IAAM;IAChC,MAAM,SAAS,UAAU;IACzB,MAAM,QAAQ,SAAS,CAAC;IACxB,qBACI,MAAC;QACG,YAAW;QACX,aAAa,CAAC,IAAI,CAAC;QACnB,cAAc;QACd,eAAe,IAAI;QACnB,YAAY,CAAC,IAAI,EAAE,GAAG,CAAC;QACvB,aAAa,OAAO,CAAC,IAAI,EAAE,GAAG,CAAC,KAAK,WAAW,KAAK,EAAE;QAEtD,QAAQ;YACR;mBAAa,OAAO,KAAK;;YACzB;mBAAqB,KAAK,OAAO,KAAK;;YAEtC;mBAAO,MAAM,OAAO,CAAC,IAAI,CAAC,IAAI;;YAC9B;mBAAe,MAAM,OAAO,CAAC,IAAI,CAAC,IAAI,GAAG,SAAS,OAAO;;QAEzD,KAAK;YACL;mBAAW,IAAI,KAAK;;YACpB;mBAAa,IAAI,KAAK,GAAG;;YAEzB;mBAAQ;;YACR;mBAAc,YAAY,KAAK;;YAC/B;mBAAgB,YAAY,KAAK,GAAG;;YAGpC;mBAAU,OAAO,KAAK;;YACtB;mBAAW,OAAO,KAAK,GAAG;;QAC1B,WAAW,QAAQ;QACnB,WAAW,OAAO,KAAK,GAAG;;YA1B1B,UAAU;YACV,WAAW;YACX,YAAY;YACZ,aAAa;YACb,UAAU;YACV,WAAW;YAEX,MAAM;YACN,WAAW,kBAAE,GAAO,KAAK;;;YACzB,mBAAmB,kBAAE,KAAK,GAAO,KAAK;;;YAEtC,KAAK,kBAAE,GAAM,OAAO,CAAC,IAAI,CAAC,IAAI;;;YAC9B,aAAa,kBAAE,GAAM,OAAO,CAAC,IAAI,CAAC,IAAI,GAAG,SAAS,OAAO;;;YAEzD,GAAG;YACH,SAAS;YACT,WAAW;YAEX,MAAM;YACN,YAAY;YACZ,cAAc;YAGd,QAAQ,kBAAE,GAAO,KAAK;;;YACtB,SAAS,kBAAE,GAAO,KAAK,GAAG;;;;;AAKtC;AAlCA,OAAO,MAAM,oBAAM,+FAkChB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_derived_signals_complext_children.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_derived_signals_complext_children.snap
@@ -1,6 +1,6 @@
 ---
 source: packages/qwik/src/optimizer/core/src/test.rs
-assertion_line: 2829
+assertion_line: 2830
 expression: output
 ---
 ==INPUT==

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_derived_signals_div.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_derived_signals_div.snap
@@ -11,7 +11,7 @@ import { component$, useStore, mutable } from '@builder.io/qwik';
 import {dep} from './file';
 import styles from './styles.module.css';
 
-export const App = component$(() => {
+export const App = component$((props) => {
     const signal = useSignal(0);
     const store = useStore({});
     const count = props.counter.count;
@@ -67,7 +67,7 @@ import { inlinedQrl } from "@builder.io/qwik";
 import { useStore, mutable } from '@builder.io/qwik';
 import { dep } from './file';
 import styles from './styles.module.css';
-const App_component_ckEPmXZlub0 = ()=>{
+const App_component_ckEPmXZlub0 = (props)=>{
     const signal = useSignal(0);
     const store = useStore({});
     const count = props.counter.count;
@@ -81,6 +81,27 @@ const App_component_ckEPmXZlub0 = ()=>{
         noInline3: mutable(signal),
         noInline4: signal.value + dep
     }, {
+        staticClass: styles.foo,
+        staticDocument: window.document,
+        staticText: "text",
+        staticText2: `text`,
+        staticNumber: 1,
+        staticBoolean: true,
+        staticExpr: `text${12}`,
+        staticExpr2: typeof `text${12}` === 'string' ? 12 : 43,
+        signal: signal,
+        signalValue: _fnSignal((p0)=>p0.value, [
+            signal
+        ], "p0.value"),
+        signalComputedValue: _fnSignal((p0)=>12 + p0.value, [
+            signal
+        ], "12+p0.value"),
+        store: _fnSignal((p0)=>p0.address.city.name, [
+            store
+        ], "p0.address.city.name"),
+        storeComputed: _fnSignal((p0)=>p0.address.city.name ? 'true' : 'false', [
+            store
+        ], 'p0.address.city.name?"true":"false"'),
         dep: dep,
         depAccess: dep.thing,
         depComputed: dep.thing + 'stuff',
@@ -92,34 +113,13 @@ const App_component_ckEPmXZlub0 = ()=>{
         ], "p0.value()"),
         noInline2: _fnSignal((p0)=>p0.value + unknown(), [
             signal
-        ], "p0.value+unknown()"),
-        signal: signal,
-        signalComputedValue: _fnSignal((p0)=>12 + p0.value, [
-            signal
-        ], "12+p0.value"),
-        signalValue: _fnSignal((p0)=>p0.value, [
-            signal
-        ], "p0.value"),
-        staticBoolean: true,
-        staticClass: styles.foo,
-        staticDocument: window.document,
-        staticExpr: `text${12}`,
-        staticExpr2: typeof `text${12}` === 'string' ? 12 : 43,
-        staticNumber: 1,
-        staticText: "text",
-        staticText2: `text`,
-        store: _fnSignal((p0)=>p0.address.city.name, [
-            store
-        ], "p0.address.city.name"),
-        storeComputed: _fnSignal((p0)=>p0.address.city.name ? 'true' : 'false', [
-            store
-        ], 'p0.address.city.name?"true":"false"')
+        ], "p0.value+unknown()")
     }, null, 3, "u6_0");
 };
 export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(App_component_ckEPmXZlub0, "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;AACA,SAAqB,QAAQ,EAAE,OAAO,QAAQ,mBAAmB;AAEjE,SAAQ,GAAG,QAAO,SAAS;AAC3B,OAAO,YAAY,sBAAsB;kCAEX,IAAM;IAChC,MAAM,SAAS,UAAU;IACzB,MAAM,QAAQ,SAAS,CAAC;IACxB,MAAM,QAAQ,MAAM,OAAO,CAAC,KAAK;IAEjC,qBACI,MAAC;QACG,OAAO;YACH,MAAM,QAAQ,MAAM;YACpB,KAAK,QAAQ,MAAM;YACnB,SAAS,IAAI;YACb,QAAQ,KAAK;QACjB;QA4BA,WAAW,QAAQ;QACnB,WAAW,OAAO,KAAK,GAAG;;QAZ1B,KAAK;QACL,WAAW,IAAI,KAAK;QACpB,aAAa,IAAI,KAAK,GAAG;QAEzB,QAAQ;QACR,cAAc,YAAY,KAAK;QAC/B,gBAAgB,YAAY,KAAK,GAAG;QAGpC,QAAQ,kBAAE,GAAO,KAAK;;;QACtB,SAAS,kBAAE,GAAO,KAAK,GAAG;;;QAjB1B,QAAQ;QAER,mBAAmB,kBAAE,KAAK,GAAO,KAAK;;;QADtC,WAAW,kBAAE,GAAO,KAAK;;;QALzB,eAAe,IAAI;QALnB,aAAa,OAAO,GAAG;QACvB,gBAAgB,OAAO,QAAQ;QAK/B,YAAY,CAAC,IAAI,EAAE,GAAG,CAAC;QACvB,aAAa,OAAO,CAAC,IAAI,EAAE,GAAG,CAAC,KAAK,WAAW,KAAK,EAAE;QAHtD,cAAc;QAFd,YAAW;QACX,aAAa,CAAC,IAAI,CAAC;QAUnB,KAAK,kBAAE,GAAM,OAAO,CAAC,IAAI,CAAC,IAAI;;;QAC9B,aAAa,kBAAE,GAAM,OAAO,CAAC,IAAI,CAAC,IAAI,GAAG,SAAS,OAAO;;;;AAkBrE;AA7CA,OAAO,MAAM,oBAAM,+FA6ChB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;AACA,SAAqB,QAAQ,EAAE,OAAO,QAAQ,mBAAmB;AAEjE,SAAQ,GAAG,QAAO,SAAS;AAC3B,OAAO,YAAY,sBAAsB;kCAEX,CAAC,QAAU;IACrC,MAAM,SAAS,UAAU;IACzB,MAAM,QAAQ,SAAS,CAAC;IACxB,MAAM,QAAQ,MAAM,OAAO,CAAC,KAAK;IAEjC,qBACI,MAAC;QACG,OAAO;YACH,MAAM,QAAQ,MAAM;YACpB,KAAK,QAAQ,MAAM;YACnB,SAAS,IAAI;YACb,QAAQ,KAAK;QACjB;QA4BA,WAAW,QAAQ;QACnB,WAAW,OAAO,KAAK,GAAG;;QA5B1B,aAAa,OAAO,GAAG;QACvB,gBAAgB,OAAO,QAAQ;QAC/B,YAAW;QACX,aAAa,CAAC,IAAI,CAAC;QACnB,cAAc;QACd,eAAe,IAAI;QACnB,YAAY,CAAC,IAAI,EAAE,GAAG,CAAC;QACvB,aAAa,OAAO,CAAC,IAAI,EAAE,GAAG,CAAC,KAAK,WAAW,KAAK,EAAE;QAEtD,QAAQ;QACR,WAAW,kBAAE,GAAO,KAAK;;;QACzB,mBAAmB,kBAAE,KAAK,GAAO,KAAK;;;QAEtC,KAAK,kBAAE,GAAM,OAAO,CAAC,IAAI,CAAC,IAAI;;;QAC9B,aAAa,kBAAE,GAAM,OAAO,CAAC,IAAI,CAAC,IAAI,GAAG,SAAS,OAAO;;;QAEzD,KAAK;QACL,WAAW,IAAI,KAAK;QACpB,aAAa,IAAI,KAAK,GAAG;QAEzB,QAAQ;QACR,cAAc,YAAY,KAAK;QAC/B,gBAAgB,YAAY,KAAK,GAAG;QAGpC,QAAQ,kBAAE,GAAO,KAAK;;;QACtB,SAAS,kBAAE,GAAO,KAAK,GAAG;;;;AAMtC;AA7CA,OAAO,MAAM,oBAAM,+FA6ChB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_getter_generation.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_getter_generation.snap
@@ -1,6 +1,6 @@
 ---
 source: packages/qwik/src/optimizer/core/src/test.rs
-assertion_line: 2941
+assertion_line: 2943
 expression: output
 ---
 ==INPUT==
@@ -128,13 +128,13 @@ export const App_component_ckEPmXZlub0 = ()=>{
             return signal.formData?.get('username');
         },
         [_IMMUTABLE]: {
+            prop: _IMMUTABLE,
             count: _fnSignal((p0)=>p0.count, [
                 store
             ], "p0.count"),
             nested: _fnSignal((p0)=>p0.nested.count, [
                 store
             ], "p0.nested.count"),
-            prop: _IMMUTABLE,
             signal: _IMMUTABLE,
             store: _fnSignal((p0)=>p0.stuff + 12, [
                 store
@@ -147,7 +147,7 @@ export const App_component_ckEPmXZlub0 = ()=>{
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;yCAG8B,IAAM;IAChC,MAAM,QAAQ,SAAS;QACnB,OAAO;QACP,OAAO;QACP,QAAQ;YACJ,OAAO;QACX;IACJ;IACA,MAAM,SAAS,UAAU;IACzB,qBACI,MAAC;QACG,MAAmB;YACnB;mBAAO,MAAM,KAAK;;YAClB;mBAAQ,MAAM,MAAM,CAAC,KAAK;;QAC1B,QAAQ;YACR;mBAAO,MAAM,KAAK,GAAG;;YACrB;mBAAO,OAAO,QAAQ,EAAE,IAAI;;;YAJ5B,KAAK,kBAAE,GAAM,KAAK;;;YAClB,MAAM,kBAAE,GAAM,MAAM,CAAC,KAAK;;;YAF1B,IAAI;YAGJ,MAAM;YACN,KAAK,kBAAE,GAAM,KAAK,GAAG;;;YACrB,KAAK,kBAAE,GAAO,QAAQ,EAAE,IAAI;;;;;AAIxC\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;yCAG8B,IAAM;IAChC,MAAM,QAAQ,SAAS;QACnB,OAAO;QACP,OAAO;QACP,QAAQ;YACJ,OAAO;QACX;IACJ;IACA,MAAM,SAAS,UAAU;IACzB,qBACI,MAAC;QACG,MAAmB;YACnB;mBAAO,MAAM,KAAK;;YAClB;mBAAQ,MAAM,MAAM,CAAC,KAAK;;QAC1B,QAAQ;YACR;mBAAO,MAAM,KAAK,GAAG;;YACrB;mBAAO,OAAO,QAAQ,EAAE,IAAI;;;YAL5B,IAAI;YACJ,KAAK,kBAAE,GAAM,KAAK;;;YAClB,MAAM,kBAAE,GAAM,MAAM,CAAC,KAAK;;;YAC1B,MAAM;YACN,KAAK,kBAAE,GAAM,KAAK,GAAG;;;YACrB,KAAK,kBAAE,GAAO,QAAQ,EAAE,IAAI;;;;;AAIxC\"}")
 /*
 {
   "origin": "test.tsx",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_immutable_analysis.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_immutable_analysis.snap
@@ -150,17 +150,16 @@ export const App_component_ckEPmXZlub0 = (props)=>{
                 get document () {
                     return window.document;
                 },
-                immutable1: "stuff",
                 onClick$: props.onClick$,
                 onEvent$: /*#__PURE__*/ qrl(()=>import("./app_component__fragment_div_onevent_p0vwsfvwp1k"), "App_component__Fragment_Div_onEvent_p0vWsfvWP1k"),
                 transparent$: /*#__PURE__*/ qrl(()=>import("./app_component__fragment_div_transparent_jtd8sctndsg"), "App_component__Fragment_Div_transparent_jTD8SCTNDsg"),
+                immutable1: "stuff",
                 get immutable2 () {
                     return {
                         foo: 'bar',
                         baz: importedValue ? true : false
                     };
                 },
-                children: /*#__PURE__*/ _jsxQ("p", null, null, "Hello Qwik", 3, null),
                 immutable3: 2,
                 immutable4$: /*#__PURE__*/ qrl(()=>import("./app_component__fragment_div_immutable4_qt1dno4izxo"), "App_component__Fragment_Div_immutable4_QT1DNo4IZXo", [
                     state
@@ -172,16 +171,17 @@ export const App_component_ckEPmXZlub0 = (props)=>{
                     null,
                     {}
                 ],
+                children: /*#__PURE__*/ _jsxQ("p", null, null, "Hello Qwik", 3, null),
                 [_IMMUTABLE]: {
                     class: _IMMUTABLE,
                     document: _IMMUTABLE,
+                    onEvent$: _IMMUTABLE,
+                    transparent$: _IMMUTABLE,
                     immutable1: _IMMUTABLE,
                     immutable2: _IMMUTABLE,
                     immutable3: _IMMUTABLE,
                     immutable4$: _IMMUTABLE,
-                    immutable5: _IMMUTABLE,
-                    onEvent$: _IMMUTABLE,
-                    transparent$: _IMMUTABLE
+                    immutable5: _IMMUTABLE
                 }
             }, 2, "u6_0"),
             "[].map(() => (",
@@ -204,14 +204,14 @@ export const App_component_ckEPmXZlub0 = (props)=>{
                 ],
                 [_IMMUTABLE]: {
                     class: _IMMUTABLE,
+                    remove$: _IMMUTABLE,
                     mutable1: _fnSignal((p0)=>({
                             foo: 'bar',
                             baz: p0.count ? true : false
                         }), [
                         state
                     ], '{foo:"bar",baz:p0.count?true:false}'),
-                    mutable3: _IMMUTABLE,
-                    remove$: _IMMUTABLE
+                    mutable3: _IMMUTABLE
                 }
             }, 3, "u6_1"),
             "));"
@@ -220,7 +220,7 @@ export const App_component_ckEPmXZlub0 = (props)=>{
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;;;;yCAK8B,CAAC,QAAU;IAErC,MAAM,QAAQ,SAAS;QAAC,OAAO;IAAC;IAChC,MAAM;;;IAON,qBACI;;0BACI,MAAC;gBAAgB,UAAU,MAAM,QAAQ;;gBAAtC,OAAM;eAAkC;0BAC3C,MAAC;oBACG;2BAAO,OAAO,GAAG;;oBACjB;2BAAU,OAAO,QAAQ;;gBAIzB,YAAW;gBAHX,UAAU,MAAM,QAAQ;gBACxB,QAAQ;gBACR,YAAY;oBAEZ;2BAAY;wBACR,KAAK;wBACL,KAAK,gBAAgB,IAAI,GAAG,KAAK;oBACrC;;0BAKA,cAAA,MAAC,iBAAE;gBAJH,YAAY;gBACZ,WAAW;;;gBACX,YAAY;oBAAC;oBAAG;oBAAG;oBAAe,IAAI;oBAAE,CAAC;iBAAE;;oBAZ3C,KAAK;oBACL,QAAQ;oBAIR,UAAU;oBACV,UAAU;oBAIV,UAAU;oBACV,WAAW;oBACX,UAAU;oBATV,QAAQ;oBACR,YAAY;;;YAWV;0BAEF,MA9BI,MAAT;gBA+BS,OAAO;gBACP,SAAS;oBACT;2BAAU;wBACN,KAAK;wBACL,KAAK,MAAM,KAAK,GAAG,IAAI,GAAG,KAAK;oBACnC;;gBACA,UAAU,AAAC,CAAA,IAAM,QAAQ,GAAG,CAAC,MAAM,KAAK,CAAA;gBACxC,UAAU;oBAAC;oBAAG;oBAAG;oBAAO,IAAI;oBAAE,CAAC;iBAAE;;oBAPjC,KAAK;oBAEL,QAAQ,kBAAE,CAAA;4BACN,KAAK;4BACL,KAAK,GAAM,KAAK,GAAG,IAAI,GAAG,KAAK;wBACnC,CAAA;;;oBAEA,QAAQ;oBANR,OAAO;;;YAOT;;;AAIlB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;;;;yCAK8B,CAAC,QAAU;IAErC,MAAM,QAAQ,SAAS;QAAC,OAAO;IAAC;IAChC,MAAM;;;IAON,qBACI;;0BACI,MAAC;gBAAgB,UAAU,MAAM,QAAQ;;gBAAtC,OAAM;eAAkC;0BAC3C,MAAC;oBACG;2BAAO,OAAO,GAAG;;oBACjB;2BAAU,OAAO,QAAQ;;gBACzB,UAAU,MAAM,QAAQ;gBACxB,QAAQ;gBACR,YAAY;gBACZ,YAAW;oBACX;2BAAY;wBACR,KAAK;wBACL,KAAK,gBAAgB,IAAI,GAAG,KAAK;oBACrC;;gBACA,YAAY;gBACZ,WAAW;;;gBACX,YAAY;oBAAC;oBAAG;oBAAG;oBAAe,IAAI;oBAAE,CAAC;iBAAE;0BAE3C,cAAA,MAAC,iBAAE;;oBAdH,KAAK;oBACL,QAAQ;oBAER,QAAQ;oBACR,YAAY;oBACZ,UAAU;oBACV,UAAU;oBAIV,UAAU;oBACV,WAAW;oBACX,UAAU;;;YAGR;0BAEF,MA9BI,MAAT;gBA+BS,OAAO;gBACP,SAAS;oBACT;2BAAU;wBACN,KAAK;wBACL,KAAK,MAAM,KAAK,GAAG,IAAI,GAAG,KAAK;oBACnC;;gBACA,UAAU,AAAC,CAAA,IAAM,QAAQ,GAAG,CAAC,MAAM,KAAK,CAAA;gBACxC,UAAU;oBAAC;oBAAG;oBAAG;oBAAO,IAAI;oBAAE,CAAC;iBAAE;;oBAPjC,KAAK;oBACL,OAAO;oBACP,QAAQ,kBAAE,CAAA;4BACN,KAAK;4BACL,KAAK,GAAM,KAAK,GAAG,IAAI,GAAG,KAAK;wBACnC,CAAA;;;oBAEA,QAAQ;;;YACV;;;AAIlB\"}")
 /*
 {
   "origin": "test.tsx",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_input_bind.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_input_bind.snap
@@ -40,13 +40,13 @@ export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(()=>{
     return /*#__PURE__*/ _jsxC(_Fragment, {
         children: [
             /*#__PURE__*/ _jsxQ("input", null, {
+                "value": value,
                 "onInput$": /*#__PURE__*/ inlinedQrl((_, elm)=>{
                     const [value] = useLexicalScope();
                     return value.value = elm.value;
                 }, "s_SO0WIOE0Sqc", [
                     value
-                ]),
-                "value": value
+                ])
             }, null, 3, null),
             /*#__PURE__*/ _jsxQ("input", null, {
                 "checked": checked,
@@ -58,13 +58,13 @@ export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(()=>{
                 ])
             }, null, 3, null),
             /*#__PURE__*/ _jsxQ("input", null, {
+                "stuff": stuff,
                 "onChange$": /*#__PURE__*/ inlinedQrl((_, elm)=>{
                     const [stuff] = useLexicalScope();
                     return stuff.value = elm.stuff;
                 }, "s_HplsUb3Bodg", [
                     stuff
-                ]),
-                "stuff": stuff
+                ])
             }, null, 3, null),
             /*#__PURE__*/ _jsxQ("div", null, null, value, 3, null),
             /*#__PURE__*/ _jsxQ("div", null, null, _fnSignal((p0)=>p0.value, [
@@ -75,7 +75,7 @@ export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(()=>{
 }, "s_n7HuG2hhU0Q"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;;AAGA,OAAO,MAAM,wBAAU,sCAAW,IAAM;IACpC,MAAM,QAAQ,UAAU;IACxB,MAAM,UAAU,UAAU,KAAK;IAC/B,MAAM,QAAQ;IACd,qBACI;;0BACI,MAAC;;;2BAAkB;;;;yBAAA;;0BACnB,MAAC;2BAAoB;;;2BAAA;;;;;0BACrB,MAAC;;;2BAAkB;;;;yBAAA;;0BACnB,MAAC,mBAAK;0BACN,MAAC,mCAAK,GAAM,KAAK;;;;;AAI7B,qBAAG\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;;AAGA,OAAO,MAAM,wBAAU,sCAAW,IAAM;IACpC,MAAM,QAAQ,UAAU;IACxB,MAAM,UAAU,UAAU,KAAK;IAC/B,MAAM,QAAQ;IACd,qBACI;;0BACI,MAAC;yBAAkB;;;2BAAA;;;;;0BACnB,MAAC;2BAAoB;;;2BAAA;;;;;0BACrB,MAAC;yBAAkB;;;2BAAA;;;;;0BACnB,MAAC,mBAAK;0BACN,MAAC,mCAAK,GAAM,KAAK;;;;;AAI7B,qBAAG\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_listeners.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_listeners.snap
@@ -133,25 +133,25 @@ import { qrl } from "@builder.io/qwik";
 export const Foo_component_1_DvU6FitWglY = ()=>{
     const handler = /*#__PURE__*/ qrl(()=>import("./foo_component_handler_h10xztd0e7w"), "Foo_component_handler_H10xZtD0e7w");
     return /*#__PURE__*/ _jsxQ("div", null, {
-        custom$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_custom_pyhnxab17ms"), "Foo_component_div_custom_pyHnxab17ms"),
+        onClick$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_onclick_m48dyiidsjw"), "Foo_component_div_onClick_M48DYiidSJw"),
+        onDocumentScroll$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocumentscroll_rwfftfivukc"), "Foo_component_div_onDocumentScroll_rwFFtFiVuKc"),
+        onDocumentScroll$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocumentscroll_1_cwneogpmtzi"), "Foo_component_div_onDocumentScroll_1_CwneoGpmTZI"),
+        "on-cLick$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_on_click_ioasjw8vyjc"), "Foo_component_div_on_cLick_IoAsJW8vYJc"),
+        "onDocument-sCroll$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocument_scroll_5vnik61pzom"), "Foo_component_div_onDocument_sCroll_5VNik61PZOM"),
+        "onDocument-scroLL$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocument_scroll_1q0sgr8te3g"), "Foo_component_div_onDocument_scroLL_1q0Sgr8te3g"),
         "host:onClick$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_host_onclick_cpeh970jbey"), "Foo_component_div_host_onClick_cPEH970JbEY"),
         "host:onDocumentScroll$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_host_ondocumentscroll_zip7mifsjry"), "Foo_component_div_host_onDocumentScroll_Zip7mifsjRY"),
         "host:onDocumentScroll$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_host_ondocumentscroll_1_em1lspk7jvg"), "Foo_component_div_host_onDocumentScroll_1_Em1LspK7JVg"),
-        "on-cLick$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_on_click_ioasjw8vyjc"), "Foo_component_div_on_cLick_IoAsJW8vYJc"),
-        onClick$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_onclick_m48dyiidsjw"), "Foo_component_div_onClick_M48DYiidSJw"),
-        "onDocument-sCroll$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocument_scroll_5vnik61pzom"), "Foo_component_div_onDocument_sCroll_5VNik61PZOM"),
-        "onDocument-scroLL$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocument_scroll_1q0sgr8te3g"), "Foo_component_div_onDocument_scroLL_1q0Sgr8te3g"),
-        "onDocument:keyup$": handler,
-        onDocumentScroll$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocumentscroll_rwfftfivukc"), "Foo_component_div_onDocumentScroll_rwFFtFiVuKc"),
-        onDocumentScroll$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocumentscroll_1_cwneogpmtzi"), "Foo_component_div_onDocumentScroll_1_CwneoGpmTZI"),
         onKeyup$: handler,
-        "onWindow:keyup$": handler
+        "onDocument:keyup$": handler,
+        "onWindow:keyup$": handler,
+        custom$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_custom_pyhnxab17ms"), "Foo_component_div_custom_pyHnxab17ms")
     }, null, 3, "u6_0");
 };
 export { _hW } from "@builder.io/qwik";
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;2CAKa,IAAM;IACX,MAAM;IACN,qBACI,MAAC;QAiBG,OAAO;QAjBX,eAkBE;QAlBF,wBAkBE;QAlBF,wBAkBE;QAbE,WAAS;QAJT,QAAQ;QAKR,oBAAkB;QAClB,oBAAkB;QAPtB,qBAcuB;QAZnB,iBAAiB;QACjB,iBAAiB;QAUjB,UAAU;QAbd,mBAeqB;;AAK7B\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;2CAKa,IAAM;IACX,MAAM;IACN,qBACI,MAAC;QACG,QAAQ;QACR,iBAAiB;QACjB,iBAAiB;QAEjB,WAAS;QACT,oBAAkB;QAClB,oBAAkB;QAPtB,eAkBE;QAlBF,wBAkBE;QAlBF,wBAkBE;QALE,UAAU;QAbd,qBAcuB;QAdvB,mBAeqB;QAEjB,OAAO;;AAGnB\"}")
 /*
 {
   "origin": "test.tsx",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_props_optimization.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_props_optimization.snap
@@ -21,7 +21,7 @@ export const Works = component$(({
         console.log(count, rest, hey, some, hey2);
     });
     return (
-        <div some={some} params={{ some }} class={count} {...rest}>{count}</div>
+        <div some={some} params={{ some }} class={count} {...rest} override>{count}</div>
     );
 });
 
@@ -55,6 +55,7 @@ import { useTaskQrl } from "@builder.io/qwik";
 import { useLexicalScope } from "@builder.io/qwik";
 import { inlinedQrl } from "@builder.io/qwik";
 import { _fnSignal } from "@builder.io/qwik";
+import { _IMMUTABLE } from "@builder.io/qwik";
 import { _jsxS } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
 export const Works = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl((props)=>{
@@ -75,22 +76,35 @@ export const Works = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl((props)
         rest
     ]));
     return /*#__PURE__*/ _jsxS("div", {
+        get some () {
+            return props.some ?? 3;
+        },
+        get params () {
+            return {
+                some: props.some ?? 3
+            };
+        },
+        get class () {
+            return props.count;
+        },
         ...rest,
+        override: true,
         children: _fnSignal((p0)=>p0.count, [
             props
         ], "p0.count")
     }, {
-        class: _fnSignal((p0)=>p0.count, [
+        some: _fnSignal((p0)=>p0.some ?? 3, [
             props
-        ], "p0.count"),
+        ], "p0.some??1+2"),
         params: _fnSignal((p0)=>({
                 some: p0.some ?? 3
             }), [
             props
         ], "{some:p0.some??1+2}"),
-        some: _fnSignal((p0)=>p0.some ?? 3, [
+        class: _fnSignal((p0)=>p0.count, [
             props
-        ], "p0.some??1+2")
+        ], "p0.count"),
+        override: _IMMUTABLE
     }, 0, "u6_0");
 }, "Works_component_t45qL4vNGv0"));
 export const NoWorks2 = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(({ count , stuff: { hey  }  })=>{
@@ -121,7 +135,7 @@ export const NoWorks3 = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(({ c
 }, "NoWorks3_component_fc13h5yYn14"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;;;AAGA,OAAO,MAAM,sBAAQ,sCAAW,SAMf;;;;;;;;IACb,QAAQ,GAAG,OAHX,aAFA,QAAO;IAMP,oCAAS,CAAC,EAAC,MAAK,EAAC;;QACb,MAAM,UARV;QASI,QAAQ,GAAG,OATf,OASuB,YANvB,aAFA,QAAO,SAGP,gBAAqB;;;;;IAOrB,qBACI,MAAC;QAAiD,GAAG,IAAI;qCAZ7D;;;;QAYuC,KAAK,qBAZ5C;;;QAYqB,MAAM,kBAAE,CAAA;gBAAE,IAAI,KAXnC,QAAO;YAW6B,CAAA;;;QAA3B,IAAI,qBAXb,QAAO;;;;AAaX,mCAAG;AAEH,OAAO,MAAM,yBAAW,sCAAW,CAAC,EAAC,MAAK,EAAE,OAAO,EAAC,IAAG,EAAC,CAAA,EAAC,GAAK;IAC1D,QAAQ,GAAG,CAAC;IACZ,oCAAS,CAAC,EAAC,MAAK,EAAC;;QACb,MAAM,IAAM;QACZ,QAAQ,GAAG,CAAC;;;;IAEhB,qBACI,MAAC;QAAI,OAAO;aAAQ;AAE5B,sCAAG;AAEH,OAAO,MAAM,yBAAW,sCAAW,CAAC,EAAC,MAAK,EAAE,OAAQ,OAAM,EAAC,GAAK;IAC5D,QAAQ,GAAG,CAAC;IACZ,oCAAS,CAAC,EAAC,MAAK,EAAC;;QACb,MAAM,IAAM;QACZ,QAAQ,GAAG,CAAC;;;;IAEhB,qBACI,MAAC;QAAI,OAAO;aAAQ;AAE5B,sCAAG\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;;;;AAGA,OAAO,MAAM,sBAAQ,sCAAW,SAMf;;;;;;;;IACb,QAAQ,GAAG,OAHX,aAFA,QAAO;IAMP,oCAAS,CAAC,EAAC,MAAK,EAAC;;QACb,MAAM,UARV;QASI,QAAQ,GAAG,OATf,OASuB,YANvB,aAFA,QAAO,SAGP,gBAAqB;;;;;IAOrB,qBACI,MAAC;YAAI;yBAXT,QAAO;;YAWc;mBAAQ;gBAAE,IAAI,QAXnC,QAAO;YAW6B;;YAAG;yBAZvC;;QAYsD,GAAG,IAAI;QAAE,QAAQ;qCAZvE;;;;QAYS,IAAI,qBAXb,QAAO;;;QAWc,MAAM,kBAAE,CAAA;gBAAE,IAAI,KAXnC,QAAO;YAW6B,CAAA;;;QAAG,KAAK,qBAZ5C;;;QAY+D,QAAQ;;AAE3E,mCAAG;AAEH,OAAO,MAAM,yBAAW,sCAAW,CAAC,EAAC,MAAK,EAAE,OAAO,EAAC,IAAG,EAAC,CAAA,EAAC,GAAK;IAC1D,QAAQ,GAAG,CAAC;IACZ,oCAAS,CAAC,EAAC,MAAK,EAAC;;QACb,MAAM,IAAM;QACZ,QAAQ,GAAG,CAAC;;;;IAEhB,qBACI,MAAC;QAAI,OAAO;aAAQ;AAE5B,sCAAG;AAEH,OAAO,MAAM,yBAAW,sCAAW,CAAC,EAAC,MAAK,EAAE,OAAQ,OAAM,EAAC,GAAK;IAC5D,QAAQ,GAAG,CAAC;IACZ,oCAAS,CAAC,EAAC,MAAK,EAAC;;QACb,MAAM,IAAM;QACZ,QAAQ,GAAG,CAAC;;;;IAEhB,qBACI,MAAC;QAAI,OAAO;aAAQ;AAE5B,sCAAG\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_spread_jsx.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_spread_jsx.snap
@@ -65,19 +65,19 @@ export const RouterHead_component_DPA76mgIou0 = ()=>{
         children: [
             /*#__PURE__*/ _jsxQ("title", null, null, head.title, 1, null),
             /*#__PURE__*/ _jsxQ("link", null, {
+                rel: "canonical",
                 href: _fnSignal((p0)=>p0.href, [
                     loc
-                ], "p0.href"),
-                rel: "canonical"
+                ], "p0.href")
             }, null, 3, null),
             /*#__PURE__*/ _jsxQ("meta", null, {
-                content: "width=device-width, initial-scale=1.0",
-                name: "viewport"
+                name: "viewport",
+                content: "width=device-width, initial-scale=1.0"
             }, null, 3, null),
             /*#__PURE__*/ _jsxQ("link", null, {
-                href: "/favicon.svg",
                 rel: "icon",
-                type: "image/svg+xml"
+                type: "image/svg+xml",
+                href: "/favicon.svg"
             }, null, 3, null),
             head.meta.map((m)=>/*#__PURE__*/ _jsxS("meta", {
                     ...m
@@ -96,7 +96,7 @@ export const RouterHead_component_DPA76mgIou0 = ()=>{
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;;;gDAOqC,IAAM;IACzC,MAAM,OAAO;IACb,MAAM,MAAM;IAEZ,qBACE;;0BACE,MAAC,qBAAO,KAAK,KAAK;0BAElB,MAAC;gBAAqB,IAAI,kBAAE,GAAI,IAAI;;;gBAA9B,KAAI;;0BACV,MAAC;gBAAqB,SAAQ;gBAAxB,MAAK;;0BACX,MAAC;gBAAqC,MAAK;gBAArC,KAAI;gBAAO,MAAK;;YAErB,KAAK,IAAI,CAAC,GAAG,CAAC,CAAC,kBACd,MAAC;oBAAM,GAAG,CAAC;;YAGZ,KAAK,KAAK,CAAC,GAAG,CAAC,CAAC,kBACf,eAAC;oBAAM,GAAG,CAAC;oBAAE,KAAK,EAAE,GAAG;;YAGxB,KAAK,MAAM,CAAC,GAAG,CAAC,CAAC,kBAChB,eAAC;oBAAO,GAAG,EAAE,KAAK;oBAAE,yBAAyB,EAAE,KAAK;oBAAE,KAAK,EAAE,GAAG;;;;AAIxE\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;;;gDAOqC,IAAM;IACzC,MAAM,OAAO;IACb,MAAM,MAAM;IAEZ,qBACE;;0BACE,MAAC,qBAAO,KAAK,KAAK;0BAElB,MAAC;gBAAK,KAAI;gBAAY,IAAI,kBAAE,GAAI,IAAI;;;;0BACpC,MAAC;gBAAK,MAAK;gBAAW,SAAQ;;0BAC9B,MAAC;gBAAK,KAAI;gBAAO,MAAK;gBAAgB,MAAK;;YAE1C,KAAK,IAAI,CAAC,GAAG,CAAC,CAAC,kBACd,MAAC;oBAAM,GAAG,CAAC;;YAGZ,KAAK,KAAK,CAAC,GAAG,CAAC,CAAC,kBACf,eAAC;oBAAM,GAAG,CAAC;oBAAE,KAAK,EAAE,GAAG;;YAGxB,KAAK,MAAM,CAAC,GAAG,CAAC,CAAC,kBAChB,eAAC;oBAAO,GAAG,EAAE,KAAK;oBAAE,yBAAyB,EAAE,KAAK;oBAAE,KAAK,EAAE,GAAG;;;;AAIxE\"}")
 /*
 {
   "origin": "test.tsx",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_strip_client_code.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_strip_client_code.snap
@@ -70,10 +70,10 @@ export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(()=>{
     // Code
     }, "Parent_component_useTask_ngmvcygWux8"));
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ _noopQrl("Parent_component_div_onClick_0PioS4FByUg", [
+        shouldRemove$: /*#__PURE__*/ _noopQrl("Parent_component_div_shouldRemove_EBj69wTX1do", [
             state
         ]),
-        shouldRemove$: /*#__PURE__*/ _noopQrl("Parent_component_div_shouldRemove_EBj69wTX1do", [
+        onClick$: /*#__PURE__*/ _noopQrl("Parent_component_div_onClick_0PioS4FByUg", [
             state
         ])
     }, [
@@ -97,7 +97,7 @@ export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrl(()=>{
 }, "Parent_component_t6Wy3C0Q0XM"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/components/component.tsx\"],\"names\":[],\"mappings\":\";;;;;;;;;;;;AACA,SAAsC,QAAQ,QAAkB,mBAAmB;AAQnF,OAAO,MAAM,uBAAS,sCAAW,IAAM;IACnC,MAAM,QAAQ,SAAS;QACnB,MAAM;IACV;IAEA,qBAAqB;IACrB;;;IAKA,oCAAS,IAAM;IACX,OAAO;IACX;IAEA,qBACI,MAAC;QAEG,QAAQ;;;QADR,aAAa;;;;sBAGb,MAAC;YACG,QAAQ,2BAAE,IAAM,QAAQ,GAAG,CAAC;YAC5B,OAAO,2BAAE;;uBAAM,MAAM,IAAI;;;;;gBADzB,QAAQ;gBACR,OAAO;;;wBAEV,GAAM,IAAI;;;;AAGvB,oCAAG\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/components/component.tsx\"],\"names\":[],\"mappings\":\";;;;;;;;;;;;AACA,SAAsC,QAAQ,QAAkB,mBAAmB;AAQnF,OAAO,MAAM,uBAAS,sCAAW,IAAM;IACnC,MAAM,QAAQ,SAAS;QACnB,MAAM;IACV;IAEA,qBAAqB;IACrB;;;IAKA,oCAAS,IAAM;IACX,OAAO;IACX;IAEA,qBACI,MAAC;QACG,aAAa;;;QACb,QAAQ;;;;sBAER,MAAC;YACG,QAAQ,2BAAE,IAAM,QAAQ,GAAG,CAAC;YAC5B,OAAO,2BAAE;;uBAAM,MAAM,IAAI;;;;;gBADzB,QAAQ;gBACR,OAAO;;;wBAEV,GAAM,IAAI;;;;AAGvB,oCAAG\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -528,7 +528,7 @@ export const Works = component$(({
         console.log(count, rest, hey, some, hey2);
     });
     return (
-        <div some={some} params={{ some }} class={count} {...rest}>{count}</div>
+        <div some={some} params={{ some }} class={count} {...rest} override>{count}</div>
     );
 });
 
@@ -2644,7 +2644,7 @@ import { component$, useStore, mutable } from '@builder.io/qwik';
 import {dep} from './file';
 import styles from './styles.module.css';
 
-export const App = component$(() => {
+export const App = component$((props) => {
     const signal = useSignal(0);
     const store = useStore({});
     const count = props.counter.count;

--- a/packages/qwik/src/optimizer/core/src/transform.rs
+++ b/packages/qwik/src/optimizer/core/src/transform.rs
@@ -1466,21 +1466,12 @@ impl<'a> QwikTransform<'a> {
                                         )));
                                         mutable_props.push(prop.fold_with(self));
                                     } else {
-                                        immutable_props.push(ast::PropOrSpread::Prop(Box::new(
-                                            ast::Prop::KeyValue(ast::KeyValueProp {
-                                                key: normalize_jsx_key(&node.key, &key_word),
-                                                value: node.value.clone(),
-                                            }),
-                                        )));
+                                        immutable_props.push(prop.fold_with(self));
                                     }
                                 } else if let Some((getter, is_immutable)) =
                                     self.convert_to_getter(&node.value, is_fn)
                                 {
-                                    let key = if is_fn {
-                                        node.key.clone()
-                                    } else {
-                                        normalize_jsx_key(&node.key, &key_word)
-                                    };
+                                    let key = node.key.clone();
                                     if is_fn {
                                         mutable_props.push(ast::PropOrSpread::Prop(Box::new(
                                             ast::Prop::Getter(ast::GetterProp {
@@ -1510,13 +1501,6 @@ impl<'a> QwikTransform<'a> {
                                     } else {
                                         mutable_props.push(entry);
                                     }
-                                } else if !is_fn && key_word == *CLASS_NAME {
-                                    mutable_props.push(ast::PropOrSpread::Prop(Box::new(
-                                        ast::Prop::KeyValue(ast::KeyValueProp {
-                                            key: normalize_jsx_key(&node.key, &key_word),
-                                            value: node.value.clone(),
-                                        }),
-                                    )));
                                 } else {
                                     mutable_props.push(prop.fold_with(self));
                                 }
@@ -2427,13 +2411,6 @@ fn make_wrap(method: &Id, obj: Box<ast::Expr>, prop: JsWord) -> ast::Expr {
         span: DUMMY_SP,
         type_args: None,
     })
-}
-
-fn normalize_jsx_key(key: &ast::PropName, key_word: &JsWord) -> PropName {
-    if key_word == "className" {
-        return ast::PropName::Ident(ast::Ident::new("class".into(), DUMMY_SP));
-    }
-    key.clone()
 }
 
 fn get_null_arg() -> ast::ExprOrSpread {

--- a/packages/qwik/src/optimizer/core/src/words.rs
+++ b/packages/qwik/src/optimizer/core/src/words.rs
@@ -5,7 +5,6 @@ pub const SIGNAL: char = '$';
 pub const LONG_SUFFIX: &str = "Qrl";
 
 lazy_static! {
-    pub static ref CLASS_NAME: JsWord = JsWord::from("className");
     pub static ref REF: JsWord = JsWord::from("ref");
     pub static ref QSLOT: JsWord = JsWord::from("q:slot");
     pub static ref CHILDREN: JsWord = JsWord::from("children");

--- a/starters/e2e/e2e.render.spec.ts
+++ b/starters/e2e/e2e.render.spec.ts
@@ -295,18 +295,18 @@ test.describe("render", () => {
       await expect(result1).toHaveText("Hello 0");
       await expect(result2).toHaveText("Hello 0");
       await expect(result1).toHaveCSS("color", "rgb(0, 0, 255)");
-      await expect(result2).toHaveCSS("color", "rgb(0, 0, 255)");
+      await expect(result2).toHaveCSS("color", "rgb(255, 0, 0)");
       await increment.click();
       await expect(result1).toHaveText("Hello 1");
       await expect(result2).toHaveText("Hello 1");
       await expect(result1).toHaveCSS("color", "rgb(0, 0, 255)");
-      await expect(result2).toHaveCSS("color", "rgb(0, 0, 255)");
+      await expect(result2).toHaveCSS("color", "rgb(255, 0, 0)");
 
       await increment.click();
       await expect(result1).toHaveText("Hello 2");
       await expect(result2).toHaveText("Hello 2");
       await expect(result1).toHaveCSS("color", "rgb(0, 0, 255)");
-      await expect(result2).toHaveCSS("color", "rgb(0, 0, 255)");
+      await expect(result2).toHaveCSS("color", "rgb(255, 0, 0)");
     });
 
     test("issue3468", async ({ page }) => {


### PR DESCRIPTION
- be agnostic towards className
- fix `{...props}` overriding
- re-fixes #3622
- properly fixes #3481
- Fixes #5292
- makes @PatrickJS happy about the className

It works by, when a component has spread props (`dynamic_component` is `true`), putting all props in the mutable props and tagging them as immutable by also setting their key in the immutable props to _IMMUTABLE.
Then, in SSR and DOM, the visitors are changed to give precedence to immutable props when both mutable and immutable are defined.