### PR TITLE
docs: add Google Structured Data example

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/pages/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/pages/index.mdx
@@ -142,3 +142,53 @@ export const head: DocumentHead = ({ head }) => {
   };
 };
 ```
+
+### Head `script` export and Google Structured Data
+```tsx {8} /head/ title="src/routes/about/index.tsx"
+import { component$ } from '@builder.io/qwik';
+import type { DocumentHead } from '@builder.io/qwik-city';
+
+export default component$(() => {
+  return <h1>About page</h1>;
+});
+
+export const head: DocumentHead = {
+  scripts: [
+    {
+      props: {
+        type: "application/ld+json",
+      },
+      script: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+      }),
+    },
+  ],
+};
+```
+The example above sets some [Structured Data Markup](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data?hl=en).
+
+> **Note**: You need to change `router-head` to render `head.scripts`.
+
+```tsx {8} /head/ title="src\components\router-head\router-head.tsx"
+import { component$ } from "@builder.io/qwik";
+import { useDocumentHead, useLocation } from "@builder.io/qwik-city";
+
+export const RouterHead = component$(() => {
+  const head = useDocumentHead();
+  const loc = useLocation();
+
+  return (
+    <>
+      <title>{head.title}</title>
+
+      {/* add this  */}
+      {head.scripts.map((s) => (
+        <script key={s.key} {...s.props} dangerouslySetInnerHTML={s.script} />
+      ))}
+    </>
+  );
+});
+
+```
+

--- a/packages/docs/src/routes/docs/(qwikcity)/pages/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/pages/index.mdx
@@ -11,7 +11,9 @@ contributors:
   - solamichealolawale
   - mrhoodz
   - VinuB-Dev
-updated_at: '2023-09-19T17:37:26Z'
+  - nhayhoc
+  - gioboa
+updated_at: '2024-03-27T18:37:26Z'
 created_at: '2023-03-20T23:45:13Z'
 ---
 
@@ -143,7 +145,13 @@ export const head: DocumentHead = ({ head }) => {
 };
 ```
 
-### Head `script` export and Google Structured Data
+### Google Structured Data
+
+This example integrates [Google Structured Data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+this helps by providing explicit clues about the meaning of a page to Google.
+If you want to embed custom JavaScript code, it would be ideal to do it lazily with [Partytown](https://partytown.builder.io/).
+Sometimes, however, you are forced to load them immediately, as in the case we see in the example.
+
 ```tsx {8} /head/ title="src/routes/about/index.tsx"
 import { component$ } from '@builder.io/qwik';
 import type { DocumentHead } from '@builder.io/qwik-city';
@@ -168,7 +176,7 @@ export const head: DocumentHead = {
 ```
 The example above sets some [Structured Data Markup](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data?hl=en).
 
-> **Note**: You need to change `router-head` to render `head.scripts`.
+> **Note**: You need to change `router-head` component to render `head.scripts`.
 
 ```tsx {8} /head/ title="src\components\router-head\router-head.tsx"
 import { component$ } from "@builder.io/qwik";


### PR DESCRIPTION
- Added instructions for inserting scripts into the <head> section.
- Included guidelines for adding Google Structured Data, beneficial for SEO.


# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

I and a few other people I know have had difficulty adding script and schema to the head of the page. So I created this pull request to add documentation, helping to save time for future developers.
