### PR TITLE
docs: improve readability

### DIFF
--- a/packages/docs/src/routes/tutorial/events/preventdefault/index.mdx
+++ b/packages/docs/src/routes/tutorial/events/preventdefault/index.mdx
@@ -10,7 +10,7 @@ updated_at: '2023-06-25T19:43:33Z'
 created_at: '2022-08-02T12:07:45Z'
 ---
 
-For some events browsers have default behavior. For example, when you click a link, the browser will usually navigate to the link's `href`. There are times when we would like to prevent that. For this reason the `Event` API contains the `preventDefault()` method.
+For some events, browsers have default behavior. For example, when you click a link, the browser will usually navigate to the link's `href`. There are times when we would like to prevent that. For this reason the `Event` API contains the `preventDefault()` method.
 
 Browser events are synchronous, but because Qwik is fine-grained the loadable Qwik execution model is asynchronous. This means that at the time the event is triggered, the event handler is not yet loaded. By the time the event handler is loaded the event has already been processed by the browser and calling `preventDefault()` will have no effect.
 


### PR DESCRIPTION
In tutorial : adding missing comma to improve reading

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Adding a comma to make the sentence more readable.

# Use cases and why
Before : For some events browsers have default behavior.
After : For some events, browsers have default behavior.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
