### PR TITLE
fix: less and stylus support in development

### DIFF
--- a/packages/docs/src/repl/worker/repl-plugins.ts
+++ b/packages/docs/src/repl/worker/repl-plugins.ts
@@ -109,7 +109,9 @@ const getRuntimeBundle = (runtimeBundle: string) => {
 
 export const replCss = (options: ReplInputOptions): Plugin => {
   const isStylesheet = (id: string) =>
-    ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) => id.endsWith(`${ext}?inline`));
+    ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) =>
+      id.endsWith(`${ext}?inline`)
+    );
 
   return {
     name: 'repl-css',

--- a/packages/docs/src/repl/worker/repl-plugins.ts
+++ b/packages/docs/src/repl/worker/repl-plugins.ts
@@ -109,7 +109,7 @@ const getRuntimeBundle = (runtimeBundle: string) => {
 
 export const replCss = (options: ReplInputOptions): Plugin => {
   const isStylesheet = (id: string) =>
-    ['.css', '.scss', '.sass'].some((ext) => id.endsWith(`${ext}?inline`));
+    ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) => id.endsWith(`${ext}?inline`));
 
   return {
     name: 'repl-css',

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -521,6 +521,9 @@ const SKIP_SRC_EXTS: { [ext: string]: boolean } = {
   '.css': true,
   '.scss': true,
   '.sass': true,
+  '.less': true,
+  '.styl': true,
+  '.stylus': true,
 };
 
 const STATIC_CONTENT_TYPES: { [ext: string]: string } = {

--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -111,7 +111,7 @@ export async function configureDevServer(
               }
 
               const { pathId, query } = parseId(v.url);
-              if (query === '' && ['.css', '.scss', '.sass'].some((ext) => pathId.endsWith(ext))) {
+              if (query === '' && ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) => pathId.endsWith(ext))) {
                 added.add(v.url);
                 manifest.injections!.push({
                   tag: 'link',
@@ -174,7 +174,7 @@ export async function configureDevServer(
               if (
                 !added.has(v.url) &&
                 query === '' &&
-                ['.css', '.scss', '.sass'].some((ext) => pathId.endsWith(ext))
+                ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) => pathId.endsWith(ext))
               ) {
                 res.write(`<link rel="stylesheet" href="${v.url}">`);
               }

--- a/packages/qwik/src/optimizer/src/plugins/vite-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-server.ts
@@ -111,7 +111,12 @@ export async function configureDevServer(
               }
 
               const { pathId, query } = parseId(v.url);
-              if (query === '' && ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) => pathId.endsWith(ext))) {
+              if (
+                query === '' &&
+                ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) =>
+                  pathId.endsWith(ext)
+                )
+              ) {
                 added.add(v.url);
                 manifest.injections!.push({
                   tag: 'link',
@@ -174,7 +179,9 @@ export async function configureDevServer(
               if (
                 !added.has(v.url) &&
                 query === '' &&
-                ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) => pathId.endsWith(ext))
+                ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'].some((ext) =>
+                  pathId.endsWith(ext)
+                )
               ) {
                 res.write(`<link rel="stylesheet" href="${v.url}">`);
               }

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -37,7 +37,7 @@ import { VITE_DEV_CLIENT_QS, configureDevServer, configurePreviewServer } from '
 
 const DEDUPE = [QWIK_CORE_ID, QWIK_JSX_RUNTIME_ID, QWIK_JSX_DEV_RUNTIME_ID];
 
-const STYLING = ['.css', '.scss', '.sass', '.less'];
+const STYLING = ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'];
 const FONTS = ['.woff', '.woff2', '.ttf'];
 
 /** @public */


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Less and Styles did not work with development server, because these extensions were missing.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- Less and Stylus should work in development.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
