### PR TITLE
fix(starters): use latest qwik sdk in starters and fixes

### DIFF
--- a/starters/README.md
+++ b/starters/README.md
@@ -11,7 +11,7 @@ Here are steps to try out the CLI in a local environment.
 1. Build CLI:
 
    ```
-   # yarn build.cli
+   # pnpm build.cli
    ```
 
 1. Run CLI:

--- a/starters/features/builder.io/package.json
+++ b/starters/features/builder.io/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "devDependencies": {
-    "@builder.io/dev-tools": "^0.2.19",
-    "@builder.io/sdk-qwik": "^0.14.2"
+    "@builder.io/dev-tools": "^1.0.1",
+    "@builder.io/sdk-qwik": "^0.14.10"
   }
 }

--- a/starters/features/builder.io/src/components/gauge/gauge.module.css
+++ b/starters/features/builder.io/src/components/gauge/gauge.module.css
@@ -1,0 +1,27 @@
+.wrapper {
+  position: relative;
+}
+
+.gauge {
+  width: 160px;
+}
+
+.value {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  color: white;
+  font-size: 3rem;
+  transform: translate(-50%, -50%);
+  width: 200px;
+  text-align: center;
+}
+
+@media screen and (min-width: 768px) {
+  .gauge {
+    width: 400px;
+  }
+  .value {
+    font-size: 7rem;
+  }
+}

--- a/starters/features/builder.io/src/components/gauge/index.tsx
+++ b/starters/features/builder.io/src/components/gauge/index.tsx
@@ -1,0 +1,38 @@
+import { component$ } from "@builder.io/qwik";
+import styles from "./gauge.module.css";
+
+export default component$(({ value = 50 }: { value?: number }) => {
+  const safeValue = value < 0 || value > 100 ? 50 : value;
+
+  return (
+    <div class={styles.wrapper}>
+      <svg viewBox="0 0 120 120" class={styles.gauge}>
+        <defs>
+          <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#18B6F6" />
+            <stop offset="1000%" stop-color="#AC7FF4" />
+          </linearGradient>
+        </defs>
+
+        <circle
+          r="56"
+          cx="60"
+          cy="60"
+          stroke-width="8"
+          style="fill: #000; stroke: #0000"
+        ></circle>
+
+        <circle
+          r="56"
+          cx="60"
+          cy="60"
+          stroke-width="8"
+          style={`transform: rotate(-87.9537deg); stroke-dasharray: ${
+            safeValue * 3.51
+          }, 351.858; fill:none; transform-origin:50% 50%; stroke-linecap:round; stroke:url(#gradient)`}
+        ></circle>
+      </svg>
+      <span class={styles.value}>{safeValue}</span>
+    </div>
+  );
+});

--- a/starters/features/builder.io/src/components/gauge/index.tsx
+++ b/starters/features/builder.io/src/components/gauge/index.tsx
@@ -2,7 +2,7 @@ import { component$ } from "@builder.io/qwik";
 import styles from "./gauge.module.css";
 
 export default component$(({ value = 50 }: { value?: number }) => {
-  const safeValue = value < 0 || value > 100 ? 50 : value;
+  const safeValue = value >= 0 && value <= 100 ? value : 50;
 
   return (
     <div class={styles.wrapper}>

--- a/starters/features/builder.io/src/routes/[...index]/index.tsx
+++ b/starters/features/builder.io/src/routes/[...index]/index.tsx
@@ -12,7 +12,7 @@ export const useBuilderContent = routeLoader$(async (event) => {
   const isPreviewing = event.url.searchParams.has("builder.preview");
 
   const builderContent = await fetchOneEntry({
-    model: "page",
+    model: BUILDER_MODEL,
     apiKey: import.meta.env.PUBLIC_BUILDER_API_KEY,
     userAttributes: { urlPath: event.url.pathname },
     options: event.query,
@@ -35,7 +35,7 @@ export default component$(() => {
   // of your space (specified by the API Key)
   return (
     <Content
-      model="page"
+      model={BUILDER_MODEL}
       content={content.value}
       apiKey={import.meta.env.PUBLIC_BUILDER_API_KEY}
       customComponents={CUSTOM_COMPONENTS}

--- a/starters/features/builder.io/src/routes/[...index]/index.tsx
+++ b/starters/features/builder.io/src/routes/[...index]/index.tsx
@@ -1,33 +1,27 @@
 import { component$ } from "@builder.io/qwik";
 import { routeLoader$ } from "@builder.io/qwik-city";
-import {
-  getContent,
-  RenderContent,
-  getBuilderSearchParams,
-} from "@builder.io/sdk-qwik";
+import { fetchOneEntry, Content } from "@builder.io/sdk-qwik";
 import { CUSTOM_COMPONENTS } from "~/components/builder-registry";
 
 export const BUILDER_MODEL = "page";
 
 // Use Qwik City's `useBuilderContent` to get your content from Builder.
 // `routeLoader$()` takes an async function to fetch content
-// from Builder with `getContent()`.
-export const useBuilderContent = routeLoader$(async ({ url, error }) => {
-  const isPreviewing = url.searchParams.has("builder.preview");
+// from Builder with `fetchOneEntry()`.
+export const useBuilderContent = routeLoader$(async (event) => {
+  const isPreviewing = event.url.searchParams.has("builder.preview");
 
-  const builderContent = await getContent({
-    model: BUILDER_MODEL,
+  const builderContent = await fetchOneEntry({
+    model: "page",
     apiKey: import.meta.env.PUBLIC_BUILDER_API_KEY,
-    options: getBuilderSearchParams(url.searchParams),
-    userAttributes: {
-      urlPath: url.pathname,
-    },
+    userAttributes: { urlPath: event.url.pathname },
+    options: event.query,
   });
 
   // If there's no content, throw a 404.
   // You can use your own 404 component here
   if (!builderContent && !isPreviewing) {
-    throw error(404, "Page not found");
+    throw event.error(404, "Page not found");
   }
   // return content fetched from Builder, which is JSON
   return builderContent;
@@ -36,12 +30,12 @@ export const useBuilderContent = routeLoader$(async ({ url, error }) => {
 export default component$(() => {
   const content = useBuilderContent();
 
-  // RenderContent uses `content` to
+  // Content uses `content` to
   // render the content of the given model, here a page,
   // of your space (specified by the API Key)
   return (
-    <RenderContent
-      model={BUILDER_MODEL}
+    <Content
+      model="page"
       content={content.value}
       apiKey={import.meta.env.PUBLIC_BUILDER_API_KEY}
       customComponents={CUSTOM_COMPONENTS}


### PR DESCRIPTION
# Overview

This PR upgrades the version of qwik sdk as well as qwik dev tools to their latest in builder_io integration starters. This also fixes couple of issues:
- Uses latest SDK functions (fetchOneEntry, Content)
- Fixes the Counter component by adding the missing Gauge component

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Loom
https://www.loom.com/share/de19fe84f7fb400f9566b95f77a2738c

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Unblocks user to smoothly onboard using the builder.io integration

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
