### PR TITLE
docs: Update README.md to use correct default PORT

### DIFF
--- a/starters/adapters/node-server/README.md
+++ b/starters/adapters/node-server/README.md
@@ -9,4 +9,4 @@ After running a full build, you can preview the build using the command:
 npm run serve
 ```
 
-Then visit [http://localhost:8080/](http://localhost:8080/)
+Then visit [http://localhost:3004/](http://localhost:3004/)


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

The current docs report the default Node server running at port 8080, when in fact, it's 3004. Alternatively, we could change 3004 to 8080.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
