### PR TITLE
feat: Log PORT info at startup in entry.node-server.tsx

### DIFF
--- a/starters/adapters/node-server/src/entry.node-server.tsx
+++ b/starters/adapters/node-server/src/entry.node-server.tsx
@@ -34,5 +34,6 @@ server.on("request", (req, res) => {
 });
 
 server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
   console.log(`Node server listening on http://localhost:${PORT}`);
 });

--- a/starters/adapters/node-server/src/entry.node-server.tsx
+++ b/starters/adapters/node-server/src/entry.node-server.tsx
@@ -33,4 +33,6 @@ server.on("request", (req, res) => {
   });
 });
 
-server.listen(PORT);
+server.listen(PORT, () => {
+  console.log(`Node server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
# Overview

The current Node server starts silently without any indication of what's going on. Adding a log with the PORT information makes it easier to test locally and doesn't really hurt prod.

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Adds a callback after the server `.listen()` function runs to log where the app is running.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
