### PR TITLE
test(v2): toMatchDOM matcher

### DIFF
--- a/packages/qwik/src/core/v2/component.unit.tsx
+++ b/packages/qwik/src/core/v2/component.unit.tsx
@@ -250,9 +250,12 @@ Error.stackTraceLimit = 100;
             </svg>
           </Component>
         );
-        expect(getCleanupBodyHTML(container.document)).toContain(
-          '<svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="ka"><fegaussianblur></fegaussianblur><circle cx="50" cy="50" r="50"></circle></svg>'
-        );
+        await expect(container.document.body.firstChild).toMatchDOM(`
+          <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="ka">
+            <fegaussianblur></fegaussianblur>
+            <circle cx="50" cy="50" r="50"></circle>
+          </svg>
+        `);
       });
       // PropsProxy is an empty object, so this does not work!
       it.skip('should write attributes to svg', async () => {
@@ -273,9 +276,11 @@ Error.stackTraceLimit = 100;
             </svg>
           </Component>
         );
-        expect(getCleanupBodyHTML(container.document)).toContain(
-          '<svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="0"><circle cx="10" cy="10" r="50"></circle></svg>'
-        );
+        await expect(container.document.body).toMatchDOM(`
+          <svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="0">
+            <circle cx="10" cy="10" r="50"></circle>
+          </svg>
+        `);
       });
       it('should rerender svg', async () => {
         const SvgComp = component$((props: { cx: string; cy: string }) => {
@@ -300,9 +305,7 @@ Error.stackTraceLimit = 100;
           </Component>
         );
 
-        expect(getCleanupBodyHTML(container.document)).not.toContain(
-          '<svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">'
-        );
+        await expect(container.document.body.firstChild?.textContent).toMatchDOM('');
         await trigger(container.element, 'button', 'click');
         expect(vNode).toMatchVDOM(
           <Component>
@@ -316,9 +319,11 @@ Error.stackTraceLimit = 100;
           </Component>
         );
 
-        expect(getCleanupBodyHTML(container.document)).toContain(
-          '<svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="0"><circle r="50" cx="10" cy="10"></circle></svg>'
-        );
+        await expect(container.document.body.firstChild?.firstChild).toMatchDOM(`
+          <svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="0">
+            <circle r="50" cx="10" cy="10"></circle>
+          </svg>
+        `);
 
         await trigger(container.element, 'button', 'click');
         expect(vNode).toMatchVDOM(
@@ -327,9 +332,7 @@ Error.stackTraceLimit = 100;
           </Component>
         );
 
-        expect(getCleanupBodyHTML(container.document)).not.toContain(
-          '<svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="0">'
-        );
+        await expect(container.document.body.firstChild?.textContent).toMatchDOM('');
       });
       it('should rerender svg child elements', async () => {
         const SvgComp = component$((props: { child: JSXOutput }) => {
@@ -369,9 +372,11 @@ Error.stackTraceLimit = 100;
             </button>
           </Component>
         );
-        expect(getCleanupBodyHTML(container.document)).toMatch(
-          '<svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="hi"><circle cx="15" cy="15" r="50"></circle></svg>'
-        );
+        await expect(container.document.body.firstChild?.firstChild).toMatchDOM(`
+          <svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="hi">
+            <circle cx="15" cy="15" r="50"></circle>
+          </svg>
+        `);
 
         await trigger(container.element, 'button', 'click');
         expect(vNode).toMatchVDOM(
@@ -386,9 +391,13 @@ Error.stackTraceLimit = 100;
             </button>
           </Component>
         );
-        expect(getCleanupBodyHTML(container.document)).toContain(
-          '<svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="hi"><circle cx="15" cy="15" r="50"></circle><line x1="0" y1="80" x2="100" y2="20" stroke="black" q:key="1"></line></svg>'
-        );
+
+        await expect(container.document.body.firstChild?.firstChild).toMatchDOM(`
+          <svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="hi">
+            <circle cx="15" cy="15" r="50"></circle>
+            <line x1="0" y1="80" x2="100" y2="20" stroke="black" q:key="1"></line>
+          </svg>
+        `);
 
         await trigger(container.element, 'button', 'click');
         expect(vNode).toMatchVDOM(
@@ -403,9 +412,11 @@ Error.stackTraceLimit = 100;
             </button>
           </Component>
         );
-        expect(getCleanupBodyHTML(container.document)).toContain(
-          '<svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="hi"><circle cx="15" cy="15" r="50"></circle></svg>'
-        );
+        await expect(container.document.body.firstChild?.firstChild).toMatchDOM(`
+          <svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="hi">
+            <circle cx="15" cy="15" r="50"></circle>
+          </svg>
+        `);
       });
     });
   });
@@ -555,10 +566,3 @@ Error.stackTraceLimit = 100;
     });
   });
 });
-
-function getCleanupBodyHTML(document: QDocument): any {
-  let html = document.body.innerHTML;
-  html = html.toLowerCase();
-  html = html.replace(/ =""/g, '');
-  return html;
-}

--- a/packages/qwik/src/core/v2/use-signal.unit.tsx
+++ b/packages/qwik/src/core/v2/use-signal.unit.tsx
@@ -135,7 +135,7 @@ Error.stackTraceLimit = 100;
         const promise = Promise.resolve('const ');
         const signal = useSignal(Promise.resolve(0));
         return (
-          <button onClick$={() => (signal.value = signal.value.then((v) => v + 1))}>
+          <button key="0" onClick$={() => (signal.value = signal.value.then((v) => v + 1))}>
             {promise}
             {signal.value}
           </button>
@@ -145,7 +145,7 @@ Error.stackTraceLimit = 100;
       const { vNode, container, document } = await render(<MpCmp />, { debug });
       expect(vNode).toMatchVDOM(
         <Component>
-          <button>
+          <button key="0">
             <Awaited>{'const '}</Awaited>
             <Signal>
               <Awaited>{'0'}</Awaited>
@@ -153,7 +153,11 @@ Error.stackTraceLimit = 100;
           </button>
         </Component>
       );
-      expect(document.querySelector('button')?.innerHTML).toBe('const 0');
+      await expect(document.querySelector('button')).toMatchDOM(`
+        <button q:key="0">
+          const 0
+        </button>
+      `);
       await trigger(container.element, 'button', 'click');
       expect(vNode).toMatchVDOM(
         <Component>
@@ -165,7 +169,11 @@ Error.stackTraceLimit = 100;
           </button>
         </Component>
       );
-      expect(document.querySelector('button')?.innerHTML).toBe('const 1');
+      await expect(document.querySelector('button')).toMatchDOM(`
+        <button q:key="0">
+          const 1
+        </button>
+      `);
     });
     it('should handle all ClassList cases', async () => {
       const Cmp = component$(() => {


### PR DESCRIPTION
This adds new vitest matcher `toMatchDOM`.
Example usage:
for vDOM:
```tsx
<Component>
  <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
    <circle cx="10" cy="10" r="50" />
  </svg>
</Component>
```
we can now also compare the HTML:
```tsx
await expect(container.document.body).toMatchDOM(`
  <svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" q:key="0">
    <circle cx="10" cy="10" r="50"></circle>
  </svg>
`);
```