### PR TITLE
fix(Qwik City): Remove `view-transition-name: none`

### DIFF
--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -11,7 +11,6 @@ import {
   useTask$,
   _getContextElement,
   _weakSerialize,
-  useStyles$,
   _waitUntilRendered,
 } from '@builder.io/qwik';
 import { isBrowser, isDev, isServer } from '@builder.io/qwik/build';

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -87,7 +87,6 @@ export interface QwikCityProps {
 
 /** @public */
 export const QwikCityProvider = component$<QwikCityProps>((props) => {
-  useStyles$(`:root{view-transition-name:none}`);
   const env = useQwikCityEnv();
   if (!env?.params) {
     throw new Error(`Missing Qwik City Env Data`);


### PR DESCRIPTION
To allow the browser to do its default transition without having to undo what Qwik does.

Closes #6067 

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Removes view-transition-name: none style. This prevents the page from doing standard crossfade unless the dev reverts this override. Can’t see a good reason to prevent standard browser behavior when you have to add a special meta tag to trigger it. 

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. You want the browser’s default view transition 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
