### PR TITLE
fix(optimizer): add support for AVIF images

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/image-size-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/image-size-server.ts
@@ -14,6 +14,7 @@ import psd_1 from 'image-size/dist/types/psd.js';
 import svg_1 from 'image-size/dist/types/svg.js';
 import tga_1 from 'image-size/dist/types/tga.js';
 import webp_1 from 'image-size/dist/types/webp.js';
+import heif_1 from "image-size/dist/types/heif.js";
 
 import type { Connect } from 'vite';
 import type { OptimizerSystem } from '../types';
@@ -37,6 +38,7 @@ const types = {
   png: png_1.PNG,
   svg: svg_1.SVG,
   gif: gif_1.GIF,
+  avif: heif_1.HEIF,
   bmp: bmp_1.BMP,
   cur: cur_1.CUR,
   dds: dds_1.DDS,


### PR DESCRIPTION
fix #6089

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Image resizing optimization is done using the `image-size` dependency. There was a case missing to handle AVIF image types/extensions, which caused the optimizer server to return a `500` to `GET` requests to a `__image-info` endpoint.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

There should be no errors when AVIF images are being served on a page (during development).

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
