### PR TITLE
docs: re-add OnThisPage for docs pages

### DIFF
--- a/packages/docs/src/components/on-this-page/on-this-page.css
+++ b/packages/docs/src/components/on-this-page/on-this-page.css
@@ -1,5 +1,5 @@
 .on-this-page {
-  @apply py-8 pt-10 ml-8;
+  @apply py-8 pt-10;
   @apply text-base;
 
   position: sticky;

--- a/packages/docs/src/routes/docs/docs.css
+++ b/packages/docs/src/routes/docs/docs.css
@@ -1,11 +1,12 @@
 .docs .content-container {
   @apply px-8 lg:pl-0 xl:pr-0;
   @apply mx-auto min-h-[100vh];
-  max-width: var(--container-max-width);
+  max-width: min(var(--container-max-width), 100vw);
 }
 
 .docs .docs-container {
   @apply pt-8 lg:pt-5;
+  @apply min-w-48;
 
   @screen lg {
     /* approx 85ch, but since the contents use font-sizes in absolute values,

--- a/packages/docs/src/routes/docs/layout.tsx
+++ b/packages/docs/src/routes/docs/layout.tsx
@@ -51,7 +51,7 @@ export default component$(() => {
           </ol>
         ) : null}
       </nav>
-      <div class="flex gap-12 xl:gap-20 items-stretch content-container">
+      <div class="md:flex gap-12 xl:gap-20 items-stretch content-container">
         <SideBar />
         <main class="contents">
           <div class="docs-container">

--- a/packages/docs/src/routes/docs/layout.tsx
+++ b/packages/docs/src/routes/docs/layout.tsx
@@ -4,6 +4,7 @@ import { ContentNav } from '../../components/content-nav/content-nav';
 import Contributors from '../../components/contributors';
 import { Footer } from '../../components/footer/footer';
 import { Header } from '../../components/header/header';
+import { OnThisPage } from '../../components/on-this-page/on-this-page';
 import { createBreadcrumbs, SideBar } from '../../components/sidebar/sidebar';
 import { GlobalStore } from '../../context';
 import styles from './docs.css?inline';
@@ -13,6 +14,9 @@ export { useMarkdownItems } from '../../components/sidebar/sidebar';
 
 export default component$(() => {
   useStyles$(styles);
+  const loc = useLocation();
+  // hide OnThisPage on docs overview page; only show on sub-pages
+  const hasOnThisPage = !['/docs/'].includes(loc.url.pathname);
   const { menu } = useContent();
   const globalStore = useContext(GlobalStore);
   const { url } = useLocation();
@@ -47,15 +51,18 @@ export default component$(() => {
           </ol>
         ) : null}
       </nav>
-      <div class="md:flex gap-12 xl:gap-20 items-stretch content-container">
+      <div class="flex gap-12 xl:gap-20 items-stretch content-container">
         <SideBar />
-        <main class="docs-container">
-          <article>
-            <Slot />
-            <Contributors />
-          </article>
-          <ContentNav />
-          <Footer />
+        <main class="contents">
+          <div class="docs-container">
+            <article>
+              <Slot />
+              <Contributors />
+            </article>
+            <ContentNav />
+            <Footer />
+          </div>
+          {hasOnThisPage ? <OnThisPage /> : null}
         </main>
       </div>
     </div>

--- a/packages/docs/src/routes/docs/layout.tsx
+++ b/packages/docs/src/routes/docs/layout.tsx
@@ -51,7 +51,7 @@ export default component$(() => {
           </ol>
         ) : null}
       </nav>
-      <div class="md:flex gap-12 xl:gap-20 items-stretch content-container">
+      <div class="flex gap-12 xl:gap-20 items-stretch content-container">
         <SideBar />
         <main class="contents">
           <div class="docs-container">

--- a/packages/docs/src/routes/docs/layout.tsx
+++ b/packages/docs/src/routes/docs/layout.tsx
@@ -16,7 +16,7 @@ export default component$(() => {
   useStyles$(styles);
   const loc = useLocation();
   // hide OnThisPage on docs overview page; only show on sub-pages
-  const hasOnThisPage = !['/docs/'].includes(loc.url.pathname);
+  const hasOnThisPage = '/docs/' !== loc.url.pathname;
   const { menu } = useContent();
   const globalStore = useContext(GlobalStore);
   const { url } = useLocation();
@@ -62,7 +62,7 @@ export default component$(() => {
             <ContentNav />
             <Footer />
           </div>
-          {hasOnThisPage ? <OnThisPage /> : null}
+          {hasOnThisPage && <OnThisPage />}
         </main>
       </div>
     </div>

--- a/packages/docs/src/routes/docs/layout.tsx
+++ b/packages/docs/src/routes/docs/layout.tsx
@@ -16,7 +16,7 @@ export default component$(() => {
   useStyles$(styles);
   const loc = useLocation();
   // hide OnThisPage on docs overview page; only show on sub-pages
-  const hasOnThisPage = '/docs/' !== loc.url.pathname;
+  const hasOnThisPage = loc.url.pathname !== '/docs/';
   const { menu } = useContent();
   const globalStore = useContext(GlobalStore);
   const { url } = useLocation();


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos
- [x] Layout Glitch

# Description

Re-add OnThisPage for docs pages (removed by mistake).
See https://github.com/BuilderIO/qwik/pull/6073#issuecomment-2041116199 and following discussion.

@shairez 

I replaced your fix for horizontal scrolling on mobile with `min-w-48` on `.docs-container` to mitigate possible issues on larger screens as well. Unfortunately, I didn't figure out why the code fragments messed up the `min-content` value in the first place.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~Added new tests to cover the fix / functionality~
