### PR TITLE
fix(#5665): rewritten routes get ignored by dynamic and catchAll routes

### DIFF
--- a/packages/qwik-city/buildtime/build.ts
+++ b/packages/qwik-city/buildtime/build.ts
@@ -104,7 +104,10 @@ function rewriteRoutes(ctx: BuildContext, resolved: ReturnType<typeof resolveSou
         const translatedPath = translatedPathParts.join('/');
         const translatedRoute = translatedRouteParts.join('/');
 
-        resolved.routes.push({
+        // push the rewritten route after the original route
+        const originalRouteIndex = resolved.routes.indexOf(rewriteRoute);
+
+        resolved.routes.splice(originalRouteIndex + 1, 0, {
           ...rewriteRoute,
           id: rewriteRoute.id + (idSuffix || rewriteIndex),
           pathname: pathnamePrefix + translatedPath,

--- a/starters/apps/qwikcity-test/src/routes/issue5665/projects/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue5665/projects/index.tsx
@@ -1,0 +1,19 @@
+import { component$ } from "@builder.io/qwik";
+import { Link, useLocation } from "@builder.io/qwik-city";
+
+export default component$((props) => {
+  const { url: { pathname } } = useLocation();
+
+  const isProjects = pathname.includes('projects')
+  const hrefPath = isProjects ? 'projekte' : 'projects'
+
+  return (
+    <div>
+      <h1>Issue 5665</h1>
+      <p>Translated routes from rewriteRoutes get ignored for [...catchall] route in same folder</p>
+      <Link href={`/qwikcity-test/issue5665/${hrefPath}`}>
+        Go to {isProjects ? 'projekte' : 'projects'}
+      </Link>
+    </div>
+  );
+});

--- a/starters/dev-server.ts
+++ b/starters/dev-server.ts
@@ -165,7 +165,15 @@ export {
     const qwikCityVite: typeof import("@builder.io/qwik-city/vite") =
       await import(file(qwikCityDistVite));
 
-    plugins.push(qwikCityVite.qwikCity());
+    plugins.push(qwikCityVite.qwikCity({
+      rewriteRoutes: [
+        {
+          paths: {
+            'projects': 'projekte'
+          },
+        },
+      ]
+    }));
   }
 
   const getInlineConf = (extra?: InlineConfig): InlineConfig => ({


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Fixes https://github.com/BuilderIO/qwik/issues/5665. As the `rewriteRoutes` were pushed at the end of the `routes` array at build time, when the `loadRoute` (runtime) got called and iterate through all the routes, the `matchRoute` function matched any dynamic or catchAll route first (because they were before).

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [-] Added new tests to cover the fix / functionality ---> Not necessary?
