### PR TITLE
fix: dont clear the console

### DIFF
--- a/packages/create-qwik/index.ts
+++ b/packages/create-qwik/index.ts
@@ -6,8 +6,6 @@ import { red, yellow } from 'kleur/colors';
 import { createAppFacade } from './src/create-app-facade';
 
 export async function runCli() {
-  console.clear();
-
   printHeader();
 
   checkNodeVersion();

--- a/packages/qwik/src/cli/add/run-add-interactive.ts
+++ b/packages/qwik/src/cli/add/run-add-interactive.ts
@@ -16,7 +16,6 @@ export async function runAddInteractive(app: AppCommand, id: string | undefined)
   const integrations = await loadIntegrations();
   let integration: IntegrationData | undefined;
 
-  console.clear();
   printHeader();
 
   if (typeof id === 'string') {

--- a/packages/qwik/src/cli/run.ts
+++ b/packages/qwik/src/cli/run.ts
@@ -62,7 +62,6 @@ const COMMANDS = [
 ];
 
 export async function runCli() {
-  console.clear();
   printHeader();
 
   try {


### PR DESCRIPTION
fix #6102

based on

```
$ grep -r console.clear packages
packages/create-qwik/index.ts:  console.clear();
packages/qwik/src/cli/add/run-add-interactive.ts:  console.clear();
packages/qwik/src/cli/run.ts:  console.clear();
```
