### PR TITLE
feat: Add Standard Schema validator to Qwik Router

### DIFF
--- a/packages/qwik-router/package.json
+++ b/packages/qwik-router/package.json
@@ -5,15 +5,17 @@
   "bugs": "https://github.com/QwikDev/qwik/issues",
   "dependencies": {
     "@mdx-js/mdx": "^3",
+    "@standard-schema/spec": "^1.0.0-rc.0",
     "@types/mdx": "^2",
     "source-map": "^0.7.4",
     "svgo": "^3.3",
+    "type-fest": "^4.33.0",
     "undici": "*",
-    "valibot": ">=0.36.0 <2",
+    "valibot": "^1.0.0-beta.14",
     "vfile": "6.0.2",
     "vite": "^5",
     "vite-imagetools": "^7",
-    "zod": "3.22.4"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@azure/functions": "3.5.1",

--- a/packages/qwik-router/src/runtime/src/index.ts
+++ b/packages/qwik-router/src/runtime/src/index.ts
@@ -86,8 +86,6 @@ export {
   usePreventNavigateQrl,
 } from './use-functions';
 
-export { z } from 'zod';
-
 export { Form } from './form-component';
 export type { FormProps } from './form-component';
 

--- a/packages/qwik-router/src/runtime/src/index.ts
+++ b/packages/qwik-router/src/runtime/src/index.ts
@@ -41,7 +41,6 @@ export type {
   RouteNavigate,
   StaticGenerate,
   StaticGenerateHandler,
-  ValidatorErrorKeyDotNotation,
   ValidatorErrorType,
   ZodConstructor,
 } from './types';

--- a/packages/qwik-router/src/runtime/src/types.ts
+++ b/packages/qwik-router/src/runtime/src/types.ts
@@ -15,6 +15,8 @@ import type {
   RequestHandler,
   ResolveSyncValue,
 } from '@qwik.dev/router/middleware/request-handler';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type { Paths, Simplify } from 'type-fest';
 import type * as v from 'valibot';
 import type * as z from 'zod';
 
@@ -355,11 +357,7 @@ type StrictUnionHelper<T, TAll> = T extends any
   : never;
 
 /** @public */
-export type StrictUnion<T> = Prettify<StrictUnionHelper<T, T>>;
-
-type Prettify<T> = {} & {
-  [K in keyof T]: T[K];
-};
+export type StrictUnion<T> = Simplify<StrictUnionHelper<T, T>>;
 
 /** @public */
 export type JSONValue = string | number | boolean | { [x: string]: JSONValue } | Array<JSONValue>;
@@ -369,19 +367,23 @@ export type JSONObject = { [x: string]: JSONValue };
 
 /** @public */
 export type GetValidatorInputType<VALIDATOR extends TypedDataValidator> =
-  VALIDATOR extends ValibotDataValidator<infer TYPE>
-    ? v.InferInput<TYPE>
-    : VALIDATOR extends ZodDataValidator<infer TYPE>
-      ? z.input<TYPE>
-      : never;
+  VALIDATOR extends StandardSchemaDataValidator<infer TYPE>
+    ? StandardSchemaV1.InferInput<TYPE>
+    : VALIDATOR extends ValibotDataValidator<infer TYPE>
+      ? v.InferInput<TYPE>
+      : VALIDATOR extends ZodDataValidator<infer TYPE>
+        ? z.input<TYPE>
+        : never;
 
 /** @public */
 export type GetValidatorOutputType<VALIDATOR extends TypedDataValidator> =
-  VALIDATOR extends ValibotDataValidator<infer TYPE>
-    ? v.InferOutput<TYPE>
-    : VALIDATOR extends ZodDataValidator<infer TYPE>
-      ? z.output<TYPE>
-      : never;
+  VALIDATOR extends StandardSchemaDataValidator<infer TYPE>
+    ? StandardSchemaV1.InferOutput<TYPE>
+    : VALIDATOR extends ValibotDataValidator<infer TYPE>
+      ? v.InferOutput<TYPE>
+      : VALIDATOR extends ZodDataValidator<infer TYPE>
+        ? z.output<TYPE>
+        : never;
 
 /** @public */
 export type GetValidatorType<VALIDATOR extends TypedDataValidator> =
@@ -400,36 +402,10 @@ export type FailOfRest<REST extends readonly DataValidator[]> = REST extends rea
   ? ERROR
   : never;
 
-type IsAny<Type> = 0 extends 1 & Type ? true : false;
-
 /** @public */
-export type ValidatorErrorKeyDotNotation<T, Prefix extends string = ''> =
-  IsAny<T> extends true
-    ? never
-    : T extends object
-      ? {
-          [K in keyof T & string]: IsAny<T[K]> extends true
-            ? never
-            : T[K] extends (infer U)[]
-              ? IsAny<U> extends true
-                ? never
-                : U extends object
-                  ? `${Prefix}${K}[]` | ValidatorErrorKeyDotNotation<U, `${Prefix}${K}[].`>
-                  : `${Prefix}${K}[]`
-              : T[K] extends object
-                ? ValidatorErrorKeyDotNotation<T[K], `${Prefix}${K}.`>
-                : `${Prefix}${K}`;
-        }[keyof T & string]
-      : never;
-
-/** @public */
-export type ValidatorErrorType<T, U = string> = {
-  formErrors: U[];
-  fieldErrors: Partial<{
-    [K in ValidatorErrorKeyDotNotation<T>]: K extends `${infer _Prefix}[]${infer _Suffix}`
-      ? U[]
-      : U;
-  }>;
+export type ValidatorErrorType<T> = {
+  formErrors: string[];
+  fieldErrors: Simplify<Partial<Record<T extends {} ? Paths<T> : string, string[]>>>;
 };
 
 /** @public */
@@ -832,7 +808,30 @@ export type ValidatorConstructorQRL = {
   ): T extends ValidatorReturnFail<infer ERROR> ? DataValidator<ERROR> : DataValidator<never>;
 };
 
-/** @beta */
+/** @public */
+export type StandardSchemaDataValidator<T extends StandardSchemaV1 = StandardSchemaV1> = {
+  readonly __brand: 'standard-schema';
+  validate(
+    ev: RequestEvent,
+    data: unknown
+  ): Promise<ValidatorReturn<ValidatorErrorType<StandardSchemaV1.InferInput<T>>>>;
+};
+
+/** @public */
+export type StandardSchemaConstructor = {
+  <T extends StandardSchemaV1>(schema: T): StandardSchemaDataValidator<T>;
+  <T extends StandardSchemaV1>(schema: (ev: RequestEvent) => T): StandardSchemaDataValidator<T>;
+};
+
+/** @public */
+export type StandardSchemaConstructorQRL = {
+  <T extends StandardSchemaV1>(schema: QRL<T>): StandardSchemaDataValidator<T>;
+  <T extends StandardSchemaV1>(
+    schema: QRL<(ev: RequestEvent) => T>
+  ): StandardSchemaDataValidator<T>;
+};
+
+/** @deprecated */
 export type ValibotDataValidator<
   T extends v.GenericSchema | v.GenericSchemaAsync = v.GenericSchema | v.GenericSchemaAsync,
 > = {
@@ -843,7 +842,7 @@ export type ValibotDataValidator<
   ): Promise<ValidatorReturn<ValidatorErrorType<v.InferInput<T>>>>;
 };
 
-/** @beta */
+/** @deprecated */
 export type ValibotConstructor = {
   <T extends v.GenericSchema | v.GenericSchemaAsync>(schema: T): ValibotDataValidator<T>;
   <T extends v.GenericSchema | v.GenericSchemaAsync>(
@@ -851,7 +850,7 @@ export type ValibotConstructor = {
   ): ValibotDataValidator<T>;
 };
 
-/** @beta */
+/** @deprecated */
 export type ValibotConstructorQRL = {
   <T extends v.GenericSchema | v.GenericSchemaAsync>(schema: QRL<T>): ValibotDataValidator<T>;
   <T extends v.GenericSchema | v.GenericSchemaAsync>(
@@ -859,7 +858,7 @@ export type ValibotConstructorQRL = {
   ): ValibotDataValidator<T>;
 };
 
-/** @public */
+/** @deprecated */
 export type ZodDataValidator<T extends z.ZodType = z.ZodType> = {
   readonly __brand: 'zod';
   validate(
@@ -868,7 +867,7 @@ export type ZodDataValidator<T extends z.ZodType = z.ZodType> = {
   ): Promise<ValidatorReturn<ValidatorErrorType<z.input<T>>>>;
 };
 
-/** @public */
+/** @deprecated */
 export type ZodConstructor = {
   <T extends z.ZodRawShape>(schema: T): ZodDataValidator<z.ZodObject<T>>;
   <T extends z.ZodRawShape>(
@@ -878,7 +877,7 @@ export type ZodConstructor = {
   <T extends z.Schema>(schema: (zod: typeof z.z, ev: RequestEvent) => T): ZodDataValidator<T>;
 };
 
-/** @public */
+/** @deprecated */
 export type ZodConstructorQRL = {
   <T extends z.ZodRawShape>(schema: QRL<T>): ZodDataValidator<z.ZodObject<T>>;
   <T extends z.ZodRawShape>(
@@ -889,7 +888,10 @@ export type ZodConstructorQRL = {
 };
 
 /** @public */
-export type TypedDataValidator = ValibotDataValidator | ZodDataValidator;
+export type TypedDataValidator =
+  | StandardSchemaDataValidator
+  | ValibotDataValidator
+  | ZodDataValidator;
 
 /** @public */
 export interface ServerConfig {

--- a/packages/qwik/src/optimizer/src/qwik-binding-map.ts
+++ b/packages/qwik/src/optimizer/src/qwik-binding-map.ts
@@ -30,5 +30,15 @@ export const QWIK_BINDING_MAP = {
         "platformArchABI": "qwik.win32-x64-msvc.node"
       }
     ]
+  },
+  "linux": {
+    "x64": [
+      {
+        "platform": "linux",
+        "arch": "x64",
+        "abi": "gnu",
+        "platformArchABI": "qwik.linux-x64-gnu.node"
+      }
+    ]
   }
 };

--- a/packages/qwik/src/optimizer/src/qwik-binding-map.ts
+++ b/packages/qwik/src/optimizer/src/qwik-binding-map.ts
@@ -30,15 +30,5 @@ export const QWIK_BINDING_MAP = {
         "platformArchABI": "qwik.win32-x64-msvc.node"
       }
     ]
-  },
-  "linux": {
-    "x64": [
-      {
-        "platform": "linux",
-        "arch": "x64",
-        "abi": "gnu",
-        "platformArchABI": "qwik.linux-x64-gnu.node"
-      }
-    ]
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -615,6 +615,9 @@ importers:
       '@mdx-js/mdx':
         specifier: ^3
         version: 3.0.1
+      '@standard-schema/spec':
+        specifier: ^1.0.0-rc.0
+        version: 1.0.0-rc.0
       '@types/mdx':
         specifier: ^2
         version: 2.0.13
@@ -624,12 +627,15 @@ importers:
       svgo:
         specifier: ^3.3
         version: 3.3.2
+      type-fest:
+        specifier: ^4.33.0
+        version: 4.33.0
       undici:
         specifier: '*'
         version: 6.18.2
       valibot:
-        specifier: '>=0.36.0 <2'
-        version: 0.42.1(typescript@5.4.5)
+        specifier: ^1.0.0-beta.14
+        version: 1.0.0-beta.14(typescript@5.4.5)
       vfile:
         specifier: 6.0.2
         version: 6.0.2
@@ -640,8 +646,8 @@ importers:
         specifier: ^7
         version: 7.0.4(rollup@4.24.2)
       zod:
-        specifier: 3.22.4
-        version: 3.22.4
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@azure/functions':
         specifier: 3.5.1
@@ -3257,6 +3263,9 @@ packages:
   '@sindresorhus/transliterate@1.6.0':
     resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
     engines: {node: '>=12'}
+
+  '@standard-schema/spec@1.0.0-rc.0':
+    resolution: {integrity: sha512-DcY/ICFcZIESNTLTexIT108HOqd1FtxsiLV4ZYGluySWyjF6TZ6troNyXjiqoHU6j0wN3A6SmYnTA5CHQp9blw==}
 
   '@supabase/auth-helpers-shared@0.6.3':
     resolution: {integrity: sha512-xYQRLFeFkL4ZfwC7p9VKcarshj3FB2QJMgJPydvOY7J5czJe6xSG5/wM1z63RmAzGbCkKg+dzpq61oeSyWiGBQ==}
@@ -9183,12 +9192,12 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
-  type-fest@4.19.0:
-    resolution: {integrity: sha512-CN2l+hWACRiejlnr68vY0/7734Kzu+9+TOslUXbSCQ1ruY9XIHDBSceVXCcHm/oXrdzhtLMMdJEKfemf1yXiZQ==}
-    engines: {node: '>=16'}
-
   type-fest@4.30.0:
     resolution: {integrity: sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==}
+    engines: {node: '>=16'}
+
+  type-fest@4.33.0:
+    resolution: {integrity: sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==}
     engines: {node: '>=16'}
 
   type-is@1.6.18:
@@ -9421,8 +9430,8 @@ packages:
   valibot@0.33.3:
     resolution: {integrity: sha512-/fuY1DlX8uiQ7aphlzrrI2DbG0YJk84JMgvz2qKpUIdXRNsS53varfo4voPjSrjUr5BSV2K0miSEJUOlA5fQFg==}
 
-  valibot@0.42.1:
-    resolution: {integrity: sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw==}
+  valibot@1.0.0-beta.14:
+    resolution: {integrity: sha512-tLyV2rE5QL6U29MFy3xt4AqMrn+/HErcp2ZThASnQvPMwfSozjV1uBGKIGiegtZIGjinJqn0SlBdannf18wENA==}
     peerDependencies:
       typescript: 5.4.5
     peerDependenciesMeta:
@@ -9840,6 +9849,9 @@ packages:
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -11807,7 +11819,7 @@ snapshots:
       unixify: 1.0.0
       urlpattern-polyfill: 8.0.2
       yargs: 17.7.2
-      zod: 3.23.8
+      zod: 3.24.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -12178,6 +12190,8 @@ snapshots:
   '@sindresorhus/transliterate@1.6.0':
     dependencies:
       escape-string-regexp: 5.0.0
+
+  '@standard-schema/spec@1.0.0-rc.0': {}
 
   '@supabase/auth-helpers-shared@0.6.3(@supabase/supabase-js@2.44.4)':
     dependencies:
@@ -14065,7 +14079,7 @@ snapshots:
 
   dot-prop@9.0.0:
     dependencies:
-      type-fest: 4.19.0
+      type-fest: 4.30.0
 
   dotenv@16.4.5: {}
 
@@ -16927,7 +16941,7 @@ snapshots:
       workerd: 1.20240718.0
       ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       youch: 3.3.3
-      zod: 3.22.4
+      zod: 3.24.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -17606,7 +17620,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.24.6
       index-to-position: 0.1.2
-      type-fest: 4.19.0
+      type-fest: 4.30.0
 
   parse-ms@3.0.0: {}
 
@@ -18053,7 +18067,7 @@ snapshots:
     dependencies:
       find-up-simple: 1.0.0
       read-pkg: 9.0.1
-      type-fest: 4.19.0
+      type-fest: 4.30.0
 
   read-pkg-up@9.1.0:
     dependencies:
@@ -18073,7 +18087,7 @@ snapshots:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 6.0.1
       parse-json: 8.1.0
-      type-fest: 4.19.0
+      type-fest: 4.30.0
       unicorn-magic: 0.1.0
 
   read-yaml-file@1.1.0:
@@ -19221,9 +19235,9 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  type-fest@4.19.0: {}
-
   type-fest@4.30.0: {}
+
+  type-fest@4.33.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -19462,7 +19476,7 @@ snapshots:
 
   valibot@0.33.3: {}
 
-  valibot@0.42.1(typescript@5.4.5):
+  valibot@1.0.0-beta.14(typescript@5.4.5):
     optionalDependencies:
       typescript: 5.4.5
 
@@ -19944,5 +19958,7 @@ snapshots:
   zod@3.22.4: {}
 
   zod@3.23.8: {}
+
+  zod@3.24.1: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
# What is it?

- Feature / enhancement

# Description

I implemented a `schema$` validator function based on [Standard Schema](https://github.com/standard-schema/standard-schema) that should replace `zod$` and `valibot$` in the long run.

> I added [`type-fest`](https://github.com/sindresorhus/type-fest) to simplify the type implementation, but I could write the types mysefle instead. Please give me feedback.

New features:
- Add new `schema$` function that supports any Standard Schema copatiple schema library including Zod, ArkType and Valibot

Breaking changes:
- Remove export of Zod's `z`
  - Users should import that from Zod directly
- Change return type of `.fieldErrors`
  - Arrays paths are changed from `array[].key` to `array.${number}.key`
  - This allows to directly access specific array index error messages
  - Furthermore, it simplifies the implementation

Other changes:
- Deprecate `zod$` and `valibot$` as well as any directly related functions and types
  - We could also remove `valibot$` as it was in `@beta` stage and marked as experimental

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
