### PR TITLE
docs: improve cookbook re-exporting loaders section

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/re-exporting-loaders/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/re-exporting-loaders/index.mdx
@@ -3,6 +3,7 @@ title: Cookbook | Re-exporting loaders
 contributors:
   - gioboa
   - aendel
+  - extrordinaire
 updated_at: '2023-12-15T11:00:00Z'
 created_at: '2023-12-15T11:00:00Z'
 ---
@@ -84,12 +85,20 @@ export default component$(() => {
 
 <CodeSandbox src="/src/routes/demo/cookbook/re-exporting-loaders/"  style={{ height: '15em' }} />
 
-### Third-party libraries example
+### Preventing issues with <u>indirect</u> `routeLoader$` usage (Third-Party Libraries Example)
 
 It may happen that we need to integrate third-party libraries over which we have no control over how it works.
 Let's think for example about integrating a payment method into our application.
 We are provided with a component to integrate into the page, but we have no control over what happens under the hood of this component.
-Here, if this library needs `routeAction$` or `routeLoader$` we must re-export them to allow the correct functioning of our library.
+
+If these third-party components rely on `routeLoader$` or `routeAction$` functions, we must manually re-export and register those inside 
+a component that exists within the route boundary. This is necessary so the Qwik optimizer can detect and include them during the build.
+
+> **Note:** Starting in Qwik v2.0, manual registration will no longer be needed. However, until then, the optimizer may **miss** 
+> `routeLoader$` functions if they’re used inside components that are **conditionally rendered** (e.g., toggled with a signal).
+>
+> If you don’t manually register the loader in these cases, you may encounter undefined behavior. <u>Avoid skipping this step</u>.
+
 
 #### Here is our code:
 
@@ -102,6 +111,10 @@ import { ThirdPartyPaymentComponent, useThirdPartyPaymentLoader } from './third-
 export { useThirdPartyPaymentLoader } from './third-party-library';
 
 export default component$(() => {
+  
+  // Manually register the loader so the optimizer sees it
+  useThirdPartyPaymentLoader()
+
   return (
     <section>
       <ThirdPartyPaymentComponent />


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description

This PR updates the documentation to clarify how to properly integrate third-party libraries that rely on routeLoader$ or routeAction$, especially when these hooks are not directly consumed within the component's render path.

Changes include:

- Rewritten explanation for better clarity and grammar

- Clear warning about potential optimizer issues

- Code example showing correct re-export and registration pattern

- Improved title for the section to better reflect its purpose

This is especially relevant for components that are conditionally rendered or shadowed, where the optimizer may not detect the loader unless explicitly registered.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] I made corresponding changes to the Qwik docs
