### PR TITLE
fix(blog): fix up link 🍔

### DIFF
--- a/packages/docs/src/routes/(blog)/blog/(articles)/qwik-1-14-preloader/index.mdx
+++ b/packages/docs/src/routes/(blog)/blog/(articles)/qwik-1-14-preloader/index.mdx
@@ -57,7 +57,7 @@ Thankfully, using a service worker isn't the only way we can prefetch and cache 
 
 ## What's new: a better way to "buffer" javascript bundles
 
-In Qwik 1.14, we've transitioned away from using a service worker in favor of a solution leveraging [`<link rel="modulepreload">`](<https://devdocs.io/html/attributes/rel/modulepreload>) as the new default. 
+In Qwik 1.14, we've transitioned away from using a service worker in favor of a solution leveraging [`<link rel="modulepreload">`](https://devdocs.io/html/reference/attributes/rel/modulepreload) as the new default. 
 
 The solution consists of a small script called the "Qwik Preloader". Once it is downloaded on the client, it adds the `<link rel="modulepreload" href="my-bundle.js#segment123456">` to the html `<head>`, which tells the browser to preload and buffer the corresponding JavaScript bundles.
 


### PR DESCRIPTION
Fix up this link in the Qwik blog.

<img width="907" height="239" alt="image" src="https://github.com/user-attachments/assets/05c0b627-711f-4caf-a37c-7410b97e514a" />
