### PR TITLE
fix(insights app): enable CORS

### DIFF
--- a/packages/insights/src/routes/api/v1/[publicApiKey]/layout.ts
+++ b/packages/insights/src/routes/api/v1/[publicApiKey]/layout.ts
@@ -1,0 +1,9 @@
+import type { RequestEvent } from '@builder.io/qwik-city';
+
+export const onRequest = ({ url, headers }: RequestEvent) => {
+  // add CORS headers
+  headers.set('Access-Control-Allow-Origin', url.origin);
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Content-Type');
+  headers.set('Access-Control-Resource-Policy', 'cross-origin');
+};


### PR DESCRIPTION
allow all hosts to send data. It normally works because we're using beacons but in some cases it still complains (e.g. our REPL)