### PR TITLE
fix: blocking slot parent and parent order

### DIFF
--- a/.changeset/ninety-pets-win.md
+++ b/.changeset/ninety-pets-win.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: blocking slot parent and parent order

--- a/packages/qwik/src/core/client/vnode.ts
+++ b/packages/qwik/src/core/client/vnode.ts
@@ -1701,7 +1701,7 @@ export const vnode_isDescendantOf = (vnode: VNode, ancestor: VNode): boolean => 
 };
 
 export const vnode_getProjectionParentOrParent = (vnode: VNode): VNode | null => {
-  return vnode.slotParent || vnode.parent;
+  return vnode.parent || vnode.slotParent;
 };
 
 export const vnode_getNode = (vnode: VNode | null): Element | Text | null => {


### PR DESCRIPTION
Parent should be checked first, before slot parent for blocking chores