### PR TITLE
fix: sort backpatch entries before emitting

### DIFF
--- a/packages/qwik/src/backpatch-executor.ts
+++ b/packages/qwik/src/backpatch-executor.ts
@@ -17,15 +17,16 @@ if (executorScript) {
     if (script) {
       const data = JSON.parse(script.textContent || '[]');
       const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT);
-      let currentNode: Node | null = walker.currentNode;
-      let currentNodeIdx = (currentNode as Element).hasAttribute(':') ? 0 : -1;
+
+      let currentNode: Node | null = walker.nextNode();
+      let currentNodeIdx = currentNode && (currentNode as Element).hasAttribute(':') ? 0 : -1;
 
       for (let i = 0; i < data.length; i += 3) {
         const elementIdx = data[i];
         const attrName = data[i + 1];
         let value = data[i + 2];
 
-        while (currentNodeIdx < elementIdx) {
+        while (currentNode && currentNodeIdx < elementIdx - 1) {
           currentNode = walker.nextNode();
           if (!currentNode) {
             break;
@@ -35,12 +36,15 @@ if (executorScript) {
           }
         }
 
+        if (!currentNode || !(currentNode as Element).hasAttribute(':')) {
+          continue;
+        }
+
         const element = currentNode as Element;
         if (value == null || value === false) {
           element.removeAttribute(attrName);
         } else {
           if (typeof value === 'boolean') {
-            // only true value can be here
             value = '';
           }
           element.setAttribute(attrName, value);

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -870,7 +870,10 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
 
   emitPatchDataIfNeeded(): void {
     const patches: (string | number | boolean | null)[] = [];
-    for (const [elementIndex, backpatchEntries] of this.backpatchMap) {
+
+    // does backpatching in order
+    const sortedEntries = Array.from(this.backpatchMap.entries()).sort(([a], [b]) => a - b);
+    for (const [elementIndex, backpatchEntries] of sortedEntries) {
       for (const backpatchEntry of backpatchEntries) {
         patches.push(elementIndex, backpatchEntry.attrName, backpatchEntry.value);
       }


### PR DESCRIPTION
Sorts backpatch entries by element index in emitPatchDataIfNeeded() so the executor can use a single-pass TreeWalker. This simplifies the executor and improves performance.
The executor now assumes patches are in document order, so it can advance through the DOM once instead of searching for each element.

It also fixes a bug where out of order DOM patches skip over existing patches.