### PR TITLE
feat: make RequestEvent readonly instead of frozen

### DIFF
--- a/.changeset/shaggy-items-send.md
+++ b/.changeset/shaggy-items-send.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+Make RequestEvents readonly instead of frozen

--- a/packages/qwik-city/src/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/src/middleware/request-handler/request-event.ts
@@ -319,15 +319,15 @@ export function createRequestEvent(
       return writableStream;
     },
   };
-  return Object.freeze(requestEv);
+  return requestEv;
 }
 
-export interface RequestEventInternal extends RequestEvent, RequestEventLoader {
-  [RequestEvLoaders]: Record<string, ValueOrPromise<unknown> | undefined>;
-  [RequestEvMode]: ServerRequestMode;
-  [RequestEvTrailingSlash]: boolean;
-  [RequestEvRoute]: LoadedRoute | null;
-  [RequestEvQwikSerializer]: QwikSerializer;
+export interface RequestEventInternal extends Readonly<RequestEvent>, Readonly<RequestEventLoader> {
+  readonly [RequestEvLoaders]: Record<string, ValueOrPromise<unknown> | undefined>;
+  readonly [RequestEvMode]: ServerRequestMode;
+  readonly [RequestEvTrailingSlash]: boolean;
+  readonly [RequestEvRoute]: LoadedRoute | null;
+  readonly [RequestEvQwikSerializer]: QwikSerializer;
 
   /**
    * Check if this request is already written to.


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature
- types

# Description

Switch from freezing RequestEvents to using readonly so that users can extend the RequestEvent while keeping the event safe from malpractice internally.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
