### PR TITLE
implementing bind_store to bind store values

### DIFF
--- a/starters/apps/starter-partytown-test/src/components/app/app.tsx
+++ b/starters/apps/starter-partytown-test/src/components/app/app.tsx
@@ -83,6 +83,10 @@ export const App = component$(() => {
           .
         </li>
         <li>
+          Bound to input by keys within store
+          <input bind_store:value={state.name}></input>.
+        </li>
+        <li>
           Observe that the binding changes: <code>Hello {state.name}!</code>
         </li>
         <li>


### PR DESCRIPTION

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement


# Description

Allowing to bind stores
```
          <input bind_store:value={state.nested.x.a}></input>.
```

No more updates to documentation done yet because no idea whether you like it.
If you do I will put in the work. Tested store.name and store.nested.nested.value (not includedin the patch but works). The code was written by Gemini ;) So maybe it can be improved a lot. Just didn't have the time to read through > 1000 lines of code. So treat this as proof of concept that the feature can be implemented easily. Maybe you can help me tell me where a good place would be to add the feature to the test suite. Cause partytown eventually should be minimal to stay as readable as possible ? Adding it to docs would be trivial replacing "stores not supported" by 2 lines of sample code:

```
const state = useStore({ nested: { nested: { value: ""} } });
return ( <input bind_store:value={state.nested.nested.value}></input> )
```

But there is also the tutorial maybe more to think about ...