### PR TITLE
fix: defer reading QScopedStyle until promise resolves for SSR

### DIFF
--- a/.changeset/all-poets-sink.md
+++ b/.changeset/all-poets-sink.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: defer setting scoped style until jsx is resolved

--- a/packages/qwik/src/core/tests/use-styles.spec.tsx
+++ b/packages/qwik/src/core/tests/use-styles.spec.tsx
@@ -10,17 +10,12 @@ import {
 } from '@qwik.dev/core';
 import { renderToString } from '@qwik.dev/core/server';
 import { createDocument, domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { getPlatform, setPlatform } from '../shared/platform/platform';
 import { QStyleSelector } from '../shared/utils/markers';
 
 const debug = false; //true;
 Error.stackTraceLimit = 100;
-
-vi.hoisted(() => {
-  vi.stubGlobal('QWIK_LOADER_DEFAULT_MINIFIED', 'min');
-  vi.stubGlobal('QWIK_LOADER_DEFAULT_DEBUG', 'debug');
-});
 
 describe.each([
   { render: ssrRenderToDom }, //


### PR DESCRIPTION
Defer reading QScopedStyle until promise resolves for SSR. Without it we can read scoped id to early when it is not set yet