### PR TITLE
fix: finding projections after client partial rerender

### DIFF
--- a/.changeset/sweet-candles-arrive.md
+++ b/.changeset/sweet-candles-arrive.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: finding projections after client partial rerender

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -22,8 +22,10 @@ import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
 import { cleanupAttrs } from 'packages/qwik/src/testing/element-fixture';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { vnode_locate } from '../client/vnode';
-import { HTML_NS, QContainerAttr, SVG_NS } from '../shared/utils/markers';
+import { HTML_NS, QContainerAttr, QDefaultSlot, SVG_NS } from '../shared/utils/markers';
 import { QContainerValue } from '../shared/types';
+import { VNodeFlags } from '../client/types';
+import { VirtualVNode } from '../client/vnode-impl';
 
 const DEBUG = false;
 
@@ -1571,6 +1573,23 @@ describe.each([
           <span>here my raw HTML</span>
         </div>
       );
+    });
+
+    it('should resolve projection when component is resumed', async () => {
+      const Child = component$(() => {
+        return <div></div>;
+      });
+      const Cmp = component$(() => {
+        return <Slot />;
+      });
+      const { vNode } = await render(
+        <Cmp>
+          <Child />
+        </Cmp>,
+        { debug: DEBUG }
+      );
+      expect((vNode!.flags & VNodeFlags.Resolved) === VNodeFlags.Resolved).toBe(true);
+      expect(vNode?.getProp(QDefaultSlot, null)).toBeInstanceOf(VirtualVNode);
     });
   });
 

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -23,6 +23,7 @@ export const enum TaskFlags {
   RESOURCE = 1 << 2,
   DIRTY = 1 << 3,
   RENDER_BLOCKING = 1 << 4,
+  EVENTS_REGISTERED = 1 << 5,
 }
 
 // <docs markdown="../readme.md#Tracker">


### PR DESCRIPTION
When system rerender part of vnodes on client we lose index from server rendering. After resuming locate all projections to prevent that