### PR TITLE
docs: explain how to enable root view transitions in Qwik

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/view-transition/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/view-transition/index.mdx
@@ -36,7 +36,7 @@ export default component$(({ list }) => {
 }
 ```
 
-By default, Qwik overrides the user agent default `view-transition-name: root` on `:root` and sets `view-transition-name: none`.
+In version 1, Qwik overrides the user agent default `view-transition-name: root` on `:root` and sets `view-transition-name: none`.
 
 If you want to animate the whole page during SPA navigation, you need to explicitly give the `<html>` element a view transition name.
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos
- [ ] Infra

# Description

This PR updates the View Transition API documentation:

- Explain that Qwik overrides the UA default `view-transition-name: root` on `:root` with `view-transition-name: none`.
- Document how to enable page-level view transitions via `html.transition` in `global.css`.
- Add an example for setting `containerAttributes.class` to `"transition"` in `entry.ssr.tsx`, so the `<html>` element gets the class.
- Mention an alternative using `:root { view-transition-name: root !important; }` to globally force a root view transition.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [x] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
