### PR TITLE
fix(create-qwik): add missing execa dependency

### DIFF
--- a/packages/create-qwik/package.json
+++ b/packages/create-qwik/package.json
@@ -5,6 +5,9 @@
   "author": "Qwik Team",
   "bin": "./create-qwik.mjs",
   "bugs": "https://github.com/QwikDev/qwik/issues",
+  "dependencies": {
+    "execa": "9.6.0"
+  },
   "devDependencies": {
     "@clack/prompts": "0.11.0",
     "@types/yargs": "17.0.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,10 @@ importers:
         version: 19.1.1(react@19.1.1)
 
   packages/create-qwik:
+    dependencies:
+      execa:
+        specifier: 9.6.0
+        version: 9.6.0
     devDependencies:
       '@clack/prompts':
         specifier: 0.11.0
@@ -6794,6 +6798,7 @@ packages:
 
   moize@6.1.6:
     resolution: {integrity: sha512-vSKdIUO61iCmTqhdoIDrqyrtp87nWZUmBPniNjO0fX49wEYmyDO4lvlnFXiGcaH1JLE/s/9HbiK4LSHsbiUY6Q==}
+    deprecated: This library has been deprecated in favor of micro-memoize, which as-of version 5 incorporates most of the functionality that this library offers at nearly half the size and better speed.
 
   monaco-editor@0.54.0:
     resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}


### PR DESCRIPTION
After PR #8103 migrated from CJS to ESM, the execa package was marked as external in the esbuild config but was not declared as a dependency in create-qwik's package.json.

This caused 'Cannot find package execa' error when running: npx create-qwik@2.0.0-beta.15

Fixes the runtime error by adding execa to dependencies.

<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
