### PR TITLE
docs: add guide for finding leftover console.log statements

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/debugging/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/debugging/index.mdx
@@ -5,7 +5,7 @@ contributors:
   - gioboa
   - KyeongJooni
 updated_at: '2025-12-13T00:00:00Z'
-created_at: '2025-12-13T00:00:00Z'
+created_at: '2025-08-08T00:00:00Z'
 ---
 # Debugging
 
@@ -15,6 +15,7 @@ During development, you can quickly access the source code of any element on a w
 click on whatever you're curious about, and Qwik will immediately open your source code right on top of that element.
 Seriously, any component, link, header - you name it, you can peek at its code.
 
+Qwik tries to guess what code editor you like to use.
 If it guesses wrong, no biggie! Just give Qwik a hint by setting the `LAUNCH_EDITOR` environment variable.
 For example, if you're on a Mac and use VS Code, you'd type `export LAUNCH_EDITOR=code` in your terminal.
 
@@ -24,7 +25,7 @@ Under the hood [launch-editor library](https://github.com/yyx990803/launch-edito
 
 When working on larger codebases, you might occasionally leave `console.log` statements in your code unintentionally. These can clutter your terminal output, and it's often difficult to identify which file and line number produced each log message.
 
-### Using ESLint rules
+### Using ESLint rules (recommended)
 
 The recommended approach is to configure ESLint to prevent `console.log` statements from being committed:
 


### PR DESCRIPTION
Fixes #7661

<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

- Docs / tests / types / typos

# Description
<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

Added a section to the debugging guide explaining how to find leftover console.log statements using stack traces. Includes examples for both client-side components and server-side entry files, plus alternative approaches with ESLint and IDE search.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality