### PR TITLE
fix: correct escaping separator characters in attributes

### DIFF
--- a/.changeset/rich-parts-rest.md
+++ b/.changeset/rich-parts-rest.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: correct escaping separator characters in attributes

--- a/packages/qwik/src/core/client/vnode-utils.ts
+++ b/packages/qwik/src/core/client/vnode-utils.ts
@@ -1718,10 +1718,10 @@ export function vnode_toString(
         attrs.push(` dirtyChildren[${vnode.dirtyChildren.length}]`);
       }
       const keys = vnode_getAttrKeys(vnode);
-      keys.forEach((key) => {
+      for (const key of keys) {
         const value = vnode_getProp(vnode!, key, null);
         attrs.push(' ' + key + '=' + qwikDebugToString(value));
-      });
+      }
       const node = vnode_getNode(vnode) as HTMLElement;
       if (node) {
         const vnodeData = (fastOwnerDocument(node) as QDocument).qVNodeData?.get(node);
@@ -1875,7 +1875,7 @@ function materializeFromVNodeData(
       vFirst = vLast = null;
     } else if (peek() === VNodeDataChar.SEPARATOR) {
       // Custom attribute: |key|value
-      const key = consumeValue();
+      const key = decodeVNodeDataString(consumeValue());
       const value = decodeVNodeDataString(consumeValue());
       vnode_setProp(vParent, key, value);
     } else if (peek() === VNodeDataChar.CLOSE) {
@@ -1887,7 +1887,8 @@ function materializeFromVNodeData(
       vFirst = stack.pop();
       vParent = stack.pop();
     } else if (peek() === VNodeDataChar.SLOT) {
-      vnode_setProp(vParent, QSlot, consumeValue());
+      const value = decodeVNodeDataString(consumeValue());
+      vnode_setProp(vParent, QSlot, value);
     } else {
       // skip over style or non-qwik elements in front of text nodes, where text node is the first child (except the style node)
       while (isElement(child) && shouldSkipElement(child)) {

--- a/packages/qwik/src/core/reactive-primitives/utils.ts
+++ b/packages/qwik/src/core/reactive-primitives/utils.ts
@@ -136,7 +136,6 @@ export const scheduleEffects = (
               node.setProp(NODE_PROPS_DATA_KEY, data);
             }
             data.set(property, payload);
-            (consumer as ISsrNode).setProp(property, payload);
           }
           markVNodeDirty(container, consumer, ChoreBits.NODE_PROPS);
         }

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -165,6 +165,107 @@ describe.each([
       </Component>
     );
   });
+  it('should project to named slot', async () => {
+    const Child = component$(() => {
+      return (
+        <div>
+          <Slot name="header" />
+          <Slot />
+        </div>
+      );
+    });
+    const Parent = component$(() => {
+      return (
+        <Child>
+          <h1 q:slot="header">Title</h1>
+          body-content
+        </Child>
+      );
+    });
+    const { vNode } = await render(<Parent />, { debug: DEBUG });
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <Component>
+          <div>
+            <Projection>
+              <h1 q:slot="header">Title</h1>
+            </Projection>
+            <Projection>body-content</Projection>
+          </div>
+        </Component>
+      </Component>
+    );
+  });
+  it('should project to named slot with separator character', async () => {
+    const Child = component$(() => {
+      return (
+        <div>
+          <Slot name="main-header" />
+          <Slot />
+        </div>
+      );
+    });
+    const Parent = component$(() => {
+      const toggle = useSignal(true);
+      return (
+        <>
+          <button onClick$={() => (toggle.value = !toggle.value)}></button>
+          <Child>
+            {toggle.value && <h1 q:slot="main-header">Title</h1>}
+            body-content
+          </Child>
+        </>
+      );
+    });
+    const { vNode, document } = await render(<Parent />, { debug: DEBUG });
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Fragment ssr-required>
+          <button></button>
+          <Component ssr-required>
+            <div>
+              <Projection ssr-required>
+                <h1 q:slot="main-header">Title</h1>
+              </Projection>
+              <Projection ssr-required>body-content</Projection>
+            </div>
+          </Component>
+        </Fragment>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Fragment ssr-required>
+          <button></button>
+          <Component ssr-required>
+            <div>
+              <Projection ssr-required></Projection>
+              <Projection ssr-required>body-content</Projection>
+            </div>
+          </Component>
+        </Fragment>
+      </Component>
+    );
+    await trigger(document.body, 'button', 'click');
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Fragment ssr-required>
+          <button></button>
+          <Component ssr-required>
+            <div>
+              <Projection ssr-required>
+                <h1 q:slot="main-header">Title</h1>
+              </Projection>
+              <Projection ssr-required>body-content</Projection>
+            </div>
+          </Component>
+        </Fragment>
+      </Component>
+    );
+  });
+
   it('should project projected', async () => {
     const Child = component$(() => {
       return (

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -851,12 +851,13 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
           this.write(VNodeDataChar.SLOT_CHAR);
           break;
         default: {
+          encodeValue = true;
           this.write(VNodeDataChar.SEPARATOR_CHAR);
-          this.write(key);
+          this.write(encodeVNodeDataString(key));
           this.write(VNodeDataChar.SEPARATOR_CHAR);
         }
       }
-      const encodedValue = encodeValue ? encodeVNodeDataString(encodeURI(value)) : value;
+      const encodedValue = encodeVNodeDataString(encodeValue ? encodeURI(value) : value);
       const isEncoded = encodeValue ? encodedValue !== value : false;
       if (isEncoded) {
         // add separator only before and after the encoded value


### PR DESCRIPTION
Correctly escape separator characters like `-` in attributes to be sure that its materialized later