### PR TITLE
docs: fix Edit this Page link for guides routes

### DIFF
--- a/packages/docs/src/components/on-this-page/on-this-page.tsx
+++ b/packages/docs/src/components/on-this-page/on-this-page.tsx
@@ -36,6 +36,7 @@ const QWIKCITY_GROUP = [
   'caching',
   'endpoints',
   'error-handling',
+  'guides',
   'html-attributes',
   'layout',
   'middleware',


### PR DESCRIPTION
# What is it?

- **Docs / tests / types / typos**

# Description

This PR fixes the **“Edit this Page”** link for documentation pages under  
`/docs/guides/*`.

Guides live under `docs/(qwikcity)/guides`, but the edit link was previously
generated without the `(qwikcity)` group, leading to a 404 on GitHub.
The route mapping has been updated so the edit URL resolves to the correct
MDX source file.

Fixes #8190

# Checklist

- [x] My code follows the developer guidelines of this project
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change` *(not required for docs-only change)*
- [x] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality *(not applicable)*\

This change was validated against the repo filesystem layout;
e.g., `/docs/guides/capacitor/` now resolves to
`docs/(qwikcity)/guides/capacitor/index.mdx` on GitHub.

