### PR TITLE
fix: duplicated preload bundles in SSR preload

### DIFF
--- a/.changeset/stale-chairs-boil.md
+++ b/.changeset/stale-chairs-boil.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+fix: duplicated preload bundles in SSR preload

--- a/packages/qwik/src/server/preload-strategy.ts
+++ b/packages/qwik/src/server/preload-strategy.ts
@@ -8,7 +8,7 @@ import { getSymbolHash } from './platform';
 
 const getBundles = (snapshotResult: SnapshotResult | null) => {
   const platform = getPlatform();
-  return (snapshotResult?.qrls as QRLInternal[])
+  const bundles = (snapshotResult?.qrls as QRLInternal[])
     ?.map((qrl) => {
       const symbol = qrl.$refSymbol$ || qrl.$symbol$;
       const chunk = qrl.$chunk$;
@@ -19,6 +19,7 @@ const getBundles = (snapshotResult: SnapshotResult | null) => {
       return chunk;
     })
     .filter(Boolean) as string[];
+  return [...new Set(bundles)];
 };
 /** Returns paths to preload relative to the buildBase, with probabilities */
 export function getPreloadPaths(


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

- Bug

# Description

Removes duplication of the preload bundles in the preload script. Seems like resolves issue: https://github.com/QwikDev/qwik/issues/8244

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
