### PR TITLE
fix: computed signal memory leak when reusing effect subscriber in loop

### DIFF
--- a/.changeset/short-terms-see.md
+++ b/.changeset/short-terms-see.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: computed signal memory leak when reusing effect subscriber in loop

--- a/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
@@ -12,6 +12,7 @@ import { SignalImpl } from './signal-impl';
 import type { QRLInternal } from '../../shared/qrl/qrl-class';
 import { _EFFECT_BACK_REF, type BackRef } from '../backref';
 import { isDev } from '@qwik.dev/core/build';
+import { clearEffectSubscription } from '../cleanup';
 
 const DEBUG = false;
 // eslint-disable-next-line no-console
@@ -90,7 +91,11 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
 
     const ctx = tryGetInvokeContext();
     const previousEffectSubscription = ctx?.$effectSubscriber$;
-    ctx && (ctx.$effectSubscriber$ = getSubscriber(this, EffectProperty.VNODE));
+    if (ctx) {
+      const effectSubscriber = getSubscriber(this, EffectProperty.VNODE);
+      clearEffectSubscription(this.$container$!, effectSubscriber);
+      ctx.$effectSubscriber$ = effectSubscriber;
+    }
     try {
       const untrackedValue = (computeQrl.getFn(ctx) as S)() as T;
       if (isPromise(untrackedValue)) {

--- a/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
@@ -87,6 +87,11 @@ vi.mock('../../use/utils/destroyable', () => ({
   cleanupDestroyable: vi.fn(),
 }));
 
+vi.mock('../../reactive-primitives/cleanup', () => ({
+  clearEffectSubscription: vi.fn(),
+  clearAllEffects: vi.fn(),
+}));
+
 function createMockVNode(
   flags: VNodeFlags = VNodeFlags.Element,
   dirty: ChoreBits = ChoreBits.NONE


### PR DESCRIPTION
Clear back refs for effect subscriber when reusing in computed signal computation