### PR TITLE
fix: finding context in unclaimed projections

### DIFF
--- a/.changeset/thirty-trains-sleep.md
+++ b/.changeset/thirty-trains-sleep.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: finding context in unclaimed projections

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -652,6 +652,7 @@ function expectSlot(diffContext: DiffContext) {
     // All is good.
   } else {
     // move from q:template to the target node
+    const oldParent = vProjectedNode.parent;
     vnode_insertBefore(
       diffContext.journal,
       diffContext.vParent as ElementVNode | VirtualVNode,
@@ -663,6 +664,21 @@ function expectSlot(diffContext: DiffContext) {
     isDev &&
       vnode_setProp(diffContext.vNewNode as VirtualVNode, DEBUG_TYPE, VirtualType.Projection);
     isDev && vnode_setProp(diffContext.vNewNode as VirtualVNode, 'q:code', 'expectSlot' + count++);
+
+    // If we moved from a q:template and it's now empty, remove it
+    if (
+      oldParent &&
+      vnode_isElementVNode(oldParent) &&
+      !oldParent.firstChild &&
+      vnode_getElementName(oldParent) === QTemplate
+    ) {
+      vnode_remove(
+        diffContext.journal,
+        oldParent.parent as ElementVNode | VirtualVNode,
+        oldParent,
+        true
+      );
+    }
   }
   return true;
 }

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -421,9 +421,9 @@ export interface ISsrComponentFrame {
     // (undocumented)
     projectionScopedStyle: string | null;
     // (undocumented)
-    releaseUnclaimedProjections(unclaimedProjections: (ISsrComponentFrame | JSXChildren | string)[]): void;
-    // (undocumented)
     scopedStyleIds: Set<string>;
+    // (undocumented)
+    slots: (string | JSXChildren)[];
 }
 
 // @internal (undocumented)

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -215,8 +215,7 @@ function processJSXNode(
           const children = jsx.children as JSXOutput;
           children != null && enqueue(children);
         } else if (type === Slot) {
-          const componentFrame =
-            options.parentComponentFrame || ssr.unclaimedProjectionComponentFrameQueue.shift();
+          const componentFrame = options.parentComponentFrame;
           if (componentFrame) {
             const compId = componentFrame.componentNode.id || '';
             const projectionAttrs = isDev ? [DEBUG_TYPE, VirtualType.Projection] : [];

--- a/packages/qwik/src/core/ssr/ssr-types.ts
+++ b/packages/qwik/src/core/ssr/ssr-types.ts
@@ -42,13 +42,11 @@ export interface ISsrNode {
 /** @internal */
 export interface ISsrComponentFrame {
   componentNode: ISsrNode;
+  slots: (string | JSXChildren)[];
   scopedStyleIds: Set<string>;
   projectionScopedStyle: string | null;
   projectionComponentFrame: ISsrComponentFrame | null;
   projectionDepth: number;
-  releaseUnclaimedProjections(
-    unclaimedProjections: (ISsrComponentFrame | JSXChildren | string)[]
-  ): void;
   consumeChildrenForSlot(projectionNode: ISsrNode, slotName: string): JSXChildren | null;
   distributeChildrenIntoSlots(
     children: JSXChildren,
@@ -70,7 +68,6 @@ export interface SSRContainer extends Container {
   readonly resolvedManifest: ResolvedManifest;
   additionalHeadNodes: Array<JSXNodeInternal>;
   additionalBodyNodes: Array<JSXNodeInternal>;
-  unclaimedProjectionComponentFrameQueue: ISsrComponentFrame[];
 
   write(text: string): void;
 
@@ -95,7 +92,7 @@ export interface SSRContainer extends Container {
   openComponent(attrs: SsrAttrs): void;
   getComponentFrame(projectionDepth: number): ISsrComponentFrame | null;
   getParentComponentFrame(): ISsrComponentFrame | null;
-  closeComponent(): void;
+  closeComponent(): Promise<void>;
 
   textNode(text: string): void;
   htmlNode(rawHtml: string): void;

--- a/packages/qwik/src/core/tests/README.spec.tsx
+++ b/packages/qwik/src/core/tests/README.spec.tsx
@@ -36,6 +36,7 @@ import {
 } from '../shared/jsx/jsx-runtime';
 import { Slot } from '../shared/jsx/slot.public';
 import { useSignal } from '../use/use-signal';
+import type { VirtualVNode } from '../shared/vnode/virtual-vnode';
 
 // To better understand what is going on in the test, set DEBUG to true and run the test.
 const DEBUG = false;
@@ -197,7 +198,9 @@ describe.each([
     );
     if (render === ssrRenderToDom) {
       // We can only assert this is SSR, as CSR does just keeps unused nodes in memory. (No need to write them to DOM)
-      expect(vNode!.nextSibling).toMatchVDOM(
+      expect(
+        ((vNode as VirtualVNode).firstChild as VirtualVNode).firstChild?.nextSibling
+      ).toMatchVDOM(
         <q:template hidden aria-hidden="true">
           <Fragment>
             <span q:slot="my-slot">

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -92,7 +92,12 @@ describe.each([
     if (render === ssrRenderToDom) {
       expect(vNode!.nextSibling).toMatchVDOM(
         <q:template hidden aria-hidden="true">
-          parent-contentrender-content
+          parent-content
+        </q:template>
+      );
+      expect(vNode!.nextSibling!.nextSibling).toMatchVDOM(
+        <q:template hidden aria-hidden="true">
+          render-content
         </q:template>
       );
     }
@@ -1810,9 +1815,7 @@ describe.each([
       await trigger(document.body, '#reload', 'click');
       await trigger(document.body, '#slot', 'click');
       if (render == ssrRenderToDom) {
-        await expect(document.querySelector('q\\:template')).toMatchDOM(
-          <q:template key={undefined} hidden aria-hidden="true"></q:template>
-        );
+        expect(document.querySelector('q\\:template')).toBeUndefined();
       }
     });
 
@@ -2765,9 +2768,18 @@ describe.each([
         </Component>
       );
       await expect(document.querySelector('div')).toMatchDOM(
-        <div>
-          <div q:slot="a">Alpha 123</div>
-        </div>
+        render === ssrRenderToDom ? (
+          <div>
+            <div q:slot="a">Alpha 123</div>
+            <q:template aria-hidden="true" hidden>
+              <div q:slot="b">Bravo 123</div>
+            </q:template>
+          </div>
+        ) : (
+          <div>
+            <div q:slot="a">Alpha 123</div>
+          </div>
+        )
       );
       await trigger(document.body, '#flip', 'click');
       await trigger(document.body, '#counter', 'click');

--- a/packages/qwik/src/server/ssr-node.ts
+++ b/packages/qwik/src/server/ssr-node.ts
@@ -230,12 +230,4 @@ export class SsrComponentFrame implements ISsrComponentFrame {
     projectionNode.setProp(QSlotParent, this.componentNode.id);
     return children;
   }
-
-  releaseUnclaimedProjections(unclaimedProjections: (ISsrComponentFrame | JSXChildren | string)[]) {
-    if (this.slots.length) {
-      unclaimedProjections.push(this);
-      unclaimedProjections.push(this.projectionScopedStyle);
-      unclaimedProjections.push.apply(unclaimedProjections, this.slots);
-    }
-  }
 }

--- a/packages/qwik/src/testing/vdom-diff.unit-util.ts
+++ b/packages/qwik/src/testing/vdom-diff.unit-util.ts
@@ -50,6 +50,7 @@ import {
   debugStyleScopeIdPrefixAttr,
   ITERATION_ITEM_MULTI,
   ITERATION_ITEM_SINGLE,
+  QTemplate,
 } from '../core/shared/utils/markers';
 import { HANDLER_PREFIX } from '../core/client/vnode-diff';
 import { prettyJSX } from './jsx';
@@ -416,12 +417,18 @@ function tagToString(tag: any): string {
 function shouldSkip(vNode: _VNode | null) {
   if (vNode && vnode_isElementVNode(vNode)) {
     const tag = vnode_getElementName(vNode);
+
+    // Skip script tags with qwik types
     if (
       tag === 'script' &&
       (vnode_getProp(vNode, 'type', null) === 'qwik/vnode' ||
         vnode_getProp(vNode, 'type', null) === 'x-qwik/vnode' ||
         vnode_getProp(vNode, 'type', null) === 'qwik/state')
     ) {
+      return true;
+    }
+
+    if (tag === QTemplate) {
       return true;
     }
   }


### PR DESCRIPTION
Make sure that context can be found in unclaimed projections. This PR also renders q:template when closing component and not at the end of html, because its simpler logic. This behavior is the same as v1 now.