### PR TITLE
fix: rendering var prop svg attributes with correct namespaces

### DIFF
--- a/.changeset/curvy-tools-relate.md
+++ b/.changeset/curvy-tools-relate.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: rendering var prop svg attributes with correct namespaces

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -84,7 +84,7 @@ import {
   vnode_walkVNode,
   type VNodeJournal,
 } from './vnode-utils';
-import { getAttributeNamespace, getNewElementNamespaceData } from './vnode-namespace';
+import { getNewElementNamespaceData } from './vnode-namespace';
 import { cleanupDestroyable } from '../use/utils/destroyable';
 import { SignalImpl } from '../reactive-primitives/impl/signal-impl';
 import { isStore } from '../reactive-primitives/impl/store';
@@ -99,6 +99,7 @@ import { _EFFECT_BACK_REF } from '../reactive-primitives/backref';
 import type { Cursor } from '../shared/cursor/cursor';
 import { createSetAttributeOperation } from '../shared/vnode/types/dom-vnode-operation';
 import { callQrl } from './run-qrl';
+import { directSetAttribute } from '../shared/utils/attribute';
 
 export interface DiffContext {
   container: ClientContainer;
@@ -155,14 +156,6 @@ function peekNextSibling(vCurrent: VNode | null): VNode | null {
 }
 
 const _hasOwnProperty = Object.prototype.hasOwnProperty;
-let _setAttribute: typeof Element.prototype.setAttribute | null = null;
-
-const fastSetAttribute = (target: Element, name: string, value: string): void => {
-  if (!_setAttribute) {
-    _setAttribute = target.setAttribute;
-  }
-  _setAttribute.call(target, name, value);
-};
 
 /** Helper to set an attribute on a vnode. Extracted to module scope to avoid closure allocation. */
 function setAttribute(
@@ -179,7 +172,13 @@ function setAttribute(
   vnode_setProp(vnode, key, originalValue);
   addVNodeOperation(
     journal,
-    createSetAttributeOperation(vnode.node, key, value, scopedStyleIdPrefix)
+    createSetAttributeOperation(
+      vnode.node,
+      key,
+      value,
+      scopedStyleIdPrefix,
+      (vnode.flags & VNodeFlags.NS_svg) !== 0
+    )
   );
 }
 
@@ -855,7 +854,12 @@ function createNewElement(
       if (isPromise(value)) {
         const vHost = diffContext.vNewNode as ElementVNode;
         const attributePromise = value.then((resolvedValue) =>
-          setDirectAttribute(diffContext, element, key, resolvedValue, vHost)
+          directSetAttribute(
+            element,
+            key,
+            serializeAttribute(key, resolvedValue, diffContext.scopedStyleIdPrefix),
+            (vHost.flags & VNodeFlags.NS_svg) !== 0
+          )
         );
         diffContext.asyncAttributePromises.push(attributePromise);
         continue;
@@ -880,7 +884,12 @@ function createNewElement(
         continue;
       }
 
-      setDirectAttribute(diffContext, element, key, value, diffContext.vNewNode as ElementVNode);
+      directSetAttribute(
+        element,
+        key,
+        serializeAttribute(key, value, diffContext.scopedStyleIdPrefix),
+        ((diffContext.vNewNode as ElementVNode).flags & VNodeFlags.NS_svg) !== 0
+      );
     }
   }
   const key = jsx.key;
@@ -906,27 +915,6 @@ function createNewElement(
   );
 
   return needsQDispatchEventPatch;
-}
-
-function setDirectAttribute(
-  diffContext: DiffContext,
-  element: Element,
-  key: string,
-  value: any,
-  vHost: ElementVNode
-) {
-  value = serializeAttribute(key, value, diffContext.scopedStyleIdPrefix);
-  if (value != null) {
-    if (vHost.flags & VNodeFlags.NS_svg) {
-      // only svg elements can have namespace attributes
-      const namespace = getAttributeNamespace(key);
-      if (namespace) {
-        element.setAttributeNS(namespace, key, value);
-        return;
-      }
-    }
-    fastSetAttribute(element, key, value);
-  }
 }
 
 function createElementWithNamespace(diffContext: DiffContext, elementName: string): Element {

--- a/packages/qwik/src/core/client/vnode-utils.ts
+++ b/packages/qwik/src/core/client/vnode-utils.ts
@@ -425,7 +425,13 @@ export const vnode_setAttr = (
     vnode_setProp(vNode, key, value);
     addVNodeOperation(
       journal,
-      createSetAttributeOperation(vNode.node, key, value, scopedStyleIdPrefix)
+      createSetAttributeOperation(
+        vNode.node,
+        key,
+        value,
+        scopedStyleIdPrefix,
+        (vNode.flags & VNodeFlags.NS_svg) !== 0
+      )
     );
   }
 };

--- a/packages/qwik/src/core/shared/cursor/chore-execution.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.ts
@@ -233,7 +233,15 @@ function setNodeProp(
   isConst: boolean,
   scopedStyleIdPrefix: string | null = null
 ): void {
-  journal.push(createSetAttributeOperation(domVNode.node!, property, value, scopedStyleIdPrefix));
+  journal.push(
+    createSetAttributeOperation(
+      domVNode.node!,
+      property,
+      value,
+      scopedStyleIdPrefix,
+      (domVNode.flags & VNodeFlags.NS_svg) !== 0
+    )
+  );
   if (!isConst) {
     if (domVNode.props && value == null) {
       delete domVNode.props[property];

--- a/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
@@ -462,6 +462,7 @@ describe('executeNodeProps', () => {
       attrName: 'id',
       attrValue: 'test-id',
       scopedStyleIdPrefix: null,
+      isSvg: false,
     });
     expect(vNode.props!['id']).toBe('test-id');
   });
@@ -499,7 +500,8 @@ describe('executeNodeProps', () => {
       vNode.node,
       'data-test',
       'signal-value',
-      null
+      null,
+      false
     );
   });
 
@@ -521,6 +523,7 @@ describe('executeNodeProps', () => {
       attrName: 'id',
       attrValue: null,
       scopedStyleIdPrefix: null,
+      isSvg: false,
     });
     expect(vNode.props!['id']).toBeUndefined();
   });
@@ -552,7 +555,8 @@ describe('executeNodeProps', () => {
       vNode.node,
       'class',
       'my-class',
-      'scope-123'
+      'scope-123',
+      false
     );
   });
 });

--- a/packages/qwik/src/core/shared/cursor/cursor-flush.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-flush.ts
@@ -1,6 +1,7 @@
 import { type VNodeJournal } from '../../client/vnode-utils';
 import { runTask } from '../../use/use-task';
 import { QContainerValue, type Container } from '../types';
+import { directSetAttribute } from '../utils/attribute';
 import { dangerouslySetInnerHTML, QContainerAttr } from '../utils/markers';
 import { isPromise } from '../utils/promises';
 import { serializeAttribute } from '../utils/styles';
@@ -170,7 +171,7 @@ export function _flushJournal(journal: VNodeJournal): void {
       } else if (attrName === 'value' && attrName in element) {
         (element as any).value = attrValue;
       } else {
-        element.setAttribute(attrName, attrValue as string);
+        directSetAttribute(element, attrName, attrValue, operation.isSvg);
       }
     }
   }

--- a/packages/qwik/src/core/shared/utils/attribute.ts
+++ b/packages/qwik/src/core/shared/utils/attribute.ts
@@ -1,0 +1,43 @@
+import { getAttributeNamespace } from '../../client/vnode-namespace';
+
+let _setAttribute: typeof Element.prototype.setAttribute | null = null;
+
+const fastSetAttribute = (target: Element, name: string, value: string): void => {
+  if (!_setAttribute) {
+    _setAttribute = target.setAttribute;
+  }
+  _setAttribute.call(target, name, value);
+};
+
+let _setAttributeNS: typeof Element.prototype.setAttributeNS | null = null;
+
+const fastSetAttributeNS = (
+  target: Element,
+  namespace: string,
+  name: string,
+  value: string
+): void => {
+  if (!_setAttributeNS) {
+    _setAttributeNS = target.setAttributeNS;
+  }
+  _setAttributeNS.call(target, namespace, name, value);
+};
+
+export function directSetAttribute(
+  element: Element,
+  attrName: string,
+  attrValue: any,
+  isSvg: boolean
+): void {
+  if (attrValue != null) {
+    if (isSvg) {
+      // only svg elements can have namespace attributes
+      const namespace = getAttributeNamespace(attrName);
+      if (namespace) {
+        fastSetAttributeNS(element, namespace, attrName, attrValue);
+        return;
+      }
+    }
+    fastSetAttribute(element, attrName, attrValue);
+  }
+}

--- a/packages/qwik/src/core/shared/vnode/types/dom-vnode-operation.ts
+++ b/packages/qwik/src/core/shared/vnode/types/dom-vnode-operation.ts
@@ -36,7 +36,8 @@ export class SetAttributeOperation {
     public target: Element,
     public attrName: string,
     public attrValue: any,
-    public scopedStyleIdPrefix: string | null
+    public scopedStyleIdPrefix: string | null,
+    public isSvg: boolean
   ) {}
 }
 
@@ -60,6 +61,7 @@ export const createSetAttributeOperation = (
   target: Element,
   attrName: string,
   attrValue: any,
-  scopedStyleIdPrefix: string | null = null
+  scopedStyleIdPrefix: string | null = null,
+  isSvg: boolean = false
 ): SetAttributeOperation =>
-  new SetAttributeOperation(target, attrName, attrValue, scopedStyleIdPrefix);
+  new SetAttributeOperation(target, attrName, attrValue, scopedStyleIdPrefix, isSvg);

--- a/packages/qwik/src/core/tests/render-namespace.spec.tsx
+++ b/packages/qwik/src/core/tests/render-namespace.spec.tsx
@@ -397,6 +397,44 @@ describe.each([
         const xmlLang = textElement?.attributes.getNamedItem('xml:lang');
         expect(xmlLang?.namespaceURI).toEqual(XML_NS);
       });
+
+      it('should render xlink:href and xml:lang as var props', async () => {
+        const SvgComp = component$(() => {
+          const useProps = { 'xlink:href': '#logo-c' };
+          const textProps = { 'xml:lang': 'en-US' };
+          return (
+            <svg xmlns="http://www.w3.org/2000/svg" xlink:href="http://www.w3.org/1999/xlink">
+              <g>
+                <mask id="logo-d" fill="#fff">
+                  <use {...useProps}></use>
+                </mask>
+              </g>
+              <text {...textProps}>This is some English text</text>
+            </svg>
+          );
+        });
+        const { vNode, document } = await render(<SvgComp />, { debug });
+        expect(vNode).toMatchVDOM(
+          <Component>
+            <svg xmlns="http://www.w3.org/2000/svg" xlink:href="http://www.w3.org/1999/xlink">
+              <g>
+                <mask id="logo-d" fill="#fff">
+                  <use xlink:href="#logo-c"></use>
+                </mask>
+              </g>
+              <text xml:lang="en-US">This is some English text</text>
+            </svg>
+          </Component>
+        );
+
+        const useElement = document.querySelector('use');
+        const xLinkHref = useElement?.attributes.getNamedItem('xlink:href');
+        expect(xLinkHref?.namespaceURI).toEqual(XLINK_NS);
+
+        const textElement = document.querySelector('text');
+        const xmlLang = textElement?.attributes.getNamedItem('xml:lang');
+        expect(xmlLang?.namespaceURI).toEqual(XML_NS);
+      });
     });
   });
 


### PR DESCRIPTION
Set var props attributes the same way as we do it for const props. We need to sometimes set namespace for svg's.