### PR TITLE
fix: rendering arrays without keys

### DIFF
--- a/.changeset/short-ads-decide.md
+++ b/.changeset/short-ads-decide.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: rendering arrays without keys

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -1343,6 +1343,12 @@ function moveOrCreateKeyedNode(
   diffContext.vNewNode = retrieveChildWithKey(diffContext, nodeName, lookupKey);
 
   if (diffContext.vNewNode) {
+    vnode_insertBefore(
+      diffContext.journal,
+      parentForInsert as ElementVNode | VirtualVNode,
+      diffContext.vNewNode,
+      diffContext.vCurrent
+    );
     diffContext.vCurrent = diffContext.vNewNode;
     diffContext.vNewNode = null;
     return false;

--- a/packages/qwik/src/core/tests/component.spec.tsx
+++ b/packages/qwik/src/core/tests/component.spec.tsx
@@ -2864,6 +2864,51 @@ describe.each([
     );
   });
 
+  it('should correctly rerender array without keys', async () => {
+    const Cmp = component$(() => {
+      const arrData = useSignal<number[]>([1, 2, 3, 4, 5]);
+      return (
+        <div>
+          {arrData.value.map((item) => (
+            <div>Item: {item}</div>
+          ))}
+
+          <button
+            onClick$={() => {
+              arrData.value = [3, 4, 5];
+            }}
+          ></button>
+        </div>
+      );
+    });
+    const { vNode, document } = await render(<Cmp />, { debug });
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <div>Item: 1</div>
+          <div>Item: 2</div>
+          <div>Item: 3</div>
+          <div>Item: 4</div>
+          <div>Item: 5</div>
+          <button></button>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <div>Item: 3</div>
+          <div>Item: 4</div>
+          <div>Item: 5</div>
+          <button></button>
+        </div>
+      </Component>
+    );
+  });
   describe('regression', () => {
     it('#3643', async () => {
       const Issue3643 = component$(() => {


### PR DESCRIPTION
Correctly render arrays without keys when there is another element after it