### PR TITLE
docs: remove unnecessary global top margin

### DIFF
--- a/packages/docs/src/routes/index.tsx
+++ b/packages/docs/src/routes/index.tsx
@@ -16,7 +16,6 @@ const builderContent = `<!--cq--><div q:container="paused" q:version="0.100.0" q
 
 main{
     overflow-x: hidden!important;
-    margin-top: -80px!important;
 }
 
 header{
@@ -34,7 +33,6 @@ header{
 
 main{
     overflow-x: hidden!important;
-    margin-top: -80px!important;
 }
 
 header{


### PR DESCRIPTION
# What is it?

- Docs

# Description

This seems to be generated markup coming from elsewhere (#7509) so pardon if it's not meant to be changed, but right now there's a unnecessary global top margin causing layout changes. You can see it if you open home page first then go to blog:

<img width="1342" height="213" alt="Screenshot 2026-01-26 at 8 54 52 PM" src="https://github.com/user-attachments/assets/f55b3d7a-f39d-4dff-bdba-db3efb287a40" />

Reload and it's back to normal:

<img width="1343" height="290" alt="Screenshot 2026-01-26 at 8 54 58 PM" src="https://github.com/user-attachments/assets/de84d7f4-7246-4ae0-a357-9ea3319226df" />


# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
