### PR TITLE
chore: fix devcontainer updateContentCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
     "dockerfile": "Dockerfile"
   },
   "waitFor": "updateContentCommand",
-  "updateContentCommand": "corepack prepare & pnpm install",
+  "updateContentCommand": "corepack install && pnpm install",
   "forwardPorts": [3300, 9229],
   "customizations": {
     "codespaces": {


### PR DESCRIPTION
# What is it?

- Infra

# Description

There are two issues in `updateContentCommand` in devcontainer config:

- [`corepack prepare` is deprecated in favor of `corepack install`](https://github.com/nodejs/corepack/releases/tag/v0.20.0)
- Mistakenly uses backgrounding (`&`) instead of logical AND (`&&`)

  This causes codespaces for this repo hang on creation because an interactive terminal required to confirm is not available:

  ![telegram-cloud-photo-size-5-6321251455607705423-y](https://github.com/user-attachments/assets/53800926-9c0f-4e58-aeda-4d88e4b18665)

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
