### PR TITLE
[v2] fix(core): on resume, visible tasks should only run when visible

### DIFF
--- a/.changeset/two-pets-sniff.md
+++ b/.changeset/two-pets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+FIX: after resuming, visible tasks only run when actually visible, not just when a task needs running. During CSR the behavior remains unchanged, they run immediately.


### PR DESCRIPTION
Right now they will also run if another task is dirty