### PR TITLE
fix: correctly reset vnode cursor data

### DIFF
--- a/.changeset/bright-pants-crash.md
+++ b/.changeset/bright-pants-crash.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: getting flags on undefined

--- a/packages/qwik/src/core/shared/cursor/cursor-walker.spec.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-walker.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { vnode_newVirtual } from '../../client/vnode-utils';
+import { ChoreBits } from '../vnode/enums/chore-bits.enum';
+import type { VirtualVNode } from '../vnode/virtual-vnode';
+import type { Cursor } from './cursor';
+import { getNextVNode } from './cursor-walker';
+
+describe('getNextVNode', () => {
+  it('should reset vnode cursor data when no dirty children remain', () => {
+    const parent = vnode_newVirtual();
+    parent.dirty |= ChoreBits.CHILDREN;
+    parent.nextDirtyChildIndex = 2;
+    parent.dirtyChildren = [];
+
+    const child1 = vnode_newVirtual();
+    child1.parent = parent as VirtualVNode;
+    const child2 = vnode_newVirtual();
+    child2.parent = parent as VirtualVNode;
+    const child3 = vnode_newVirtual();
+    child3.parent = parent as VirtualVNode;
+
+    parent.dirtyChildren = [child1, child2, child3];
+
+    const cursor: Cursor = vnode_newVirtual();
+
+    getNextVNode(child1, cursor);
+
+    expect(parent.dirtyChildren).toBeNull();
+    expect(parent.nextDirtyChildIndex).toBe(0);
+    expect((parent.dirty & ChoreBits.CHILDREN) === 0).toBe(true);
+  });
+});

--- a/packages/qwik/src/core/shared/cursor/cursor-walker.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-walker.ts
@@ -280,7 +280,7 @@ function partitionDirtyChildren(dirtyChildren: VNode[], parent: VNode): void {
 }
 
 /** @returns Next vNode to process, or null if traversal is complete */
-function getNextVNode(vNode: VNode, cursor: Cursor): VNode | null {
+export function getNextVNode(vNode: VNode, cursor: Cursor): VNode | null {
   if (vNode === cursor) {
     if (cursor.dirty & ChoreBits.DIRTY_MASK) {
       return cursor;
@@ -320,5 +320,6 @@ function getNextVNode(vNode: VNode, cursor: Cursor): VNode | null {
   // all array items checked, children are no longer dirty
   parent!.dirty &= ~ChoreBits.CHILDREN;
   parent!.dirtyChildren = null;
+  parent!.nextDirtyChildIndex = 0;
   return getNextVNode(parent!, cursor);
 }


### PR DESCRIPTION
Reset next index to 0 when we reset dirtyChildren