### PR TITLE
fix: build path for html files in ssg

### DIFF
--- a/.changeset/ready-lions-swim.md
+++ b/.changeset/ready-lions-swim.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: build path for html files in ssg

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -105,8 +105,6 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
     async config(viteConfig, viteEnv) {
       await qwikPlugin.init();
 
-      const path = qwikPlugin.getPath();
-
       let target: QwikBuildTarget;
       if (viteConfig.build?.ssr || viteEnv.mode === 'ssr') {
         target = 'ssr';
@@ -200,9 +198,8 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
       if (!qwikViteOpts.csr) {
         clientOutDir = opts.clientOutDir;
 
-        clientPublicOutDir = viteConfig.base
-          ? path.join(clientOutDir, viteConfig.base)
-          : clientOutDir;
+        // Don't join base to clientOutDir - vite handles the base internally for assets.
+        clientPublicOutDir = clientOutDir;
 
         ssrOutDir = opts.ssrOutDir;
       }


### PR DESCRIPTION
Correctly build path for 404.html, index.html etc, when project is in subdir