### PR TITLE
updated release script to OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ env:
   # Disable incremental build, speeds up CI
   CARGO_INCREMENTAL: 0
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 jobs:
   changes:
     name: Setup
@@ -909,8 +914,6 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Fixup package.json files
         run: pnpm run release.fixup-package-json


### PR DESCRIPTION

# What is it?

<!-- pick one and remove the others -->

- Infra

# Description

NPM granular tokens are annoying as they require renewal every 90 days. 

So we switched to OIDC which require a one time setup connection, hence we don't need the NPM_TOKEN to release versions now.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
