### PR TITLE
updated v2 release script to OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ env:
   # Disable incremental build, speeds up CI
   CARGO_INCREMENTAL: 0
 
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 jobs:
   changes:
     name: Setup
@@ -912,20 +918,14 @@ jobs:
           branch: build/v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Delete this after V2 is released
       - name: Tag with latest
         if: steps.changesets.outputs.published == 'true'
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > $GITHUB_WORKSPACE/.npmrc
           npm dist-tag add @qwik.dev/core@${{ fromJSON(steps.changesets.outputs.publishedPackages)[0].version }} latest
           npm dist-tag add @qwik.dev/router@${{ fromJSON(steps.changesets.outputs.publishedPackages)[0].version }} latest
           npm dist-tag add @qwik.dev/react@${{ fromJSON(steps.changesets.outputs.publishedPackages)[0].version }} latest
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc
 
       - name: Fixup package.json files
         run: pnpm run release.fixup-package-json


### PR DESCRIPTION
# What is it?

<!-- pick one and remove the others -->

- Infra

# Description

NPM granular tokens are annoying as they require renewal every 90 days. 

So we switched to OIDC which require a one time setup connection, hence we don't need the NPM_TOKEN to release versions now.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
