### PR TITLE
docs: update theme management cookbook

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/theme-management/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/theme-management/index.mdx
@@ -5,7 +5,8 @@ contributors:
   - gioboa
   - aendel
   - chindris-mihai-alexandru
-updated_at: '2026-01-09T00:00:00Z'
+  - forresst
+updated_at: '2026-02-05T00:00:00Z'
 created_at: '2023-10-10T16:59:26Z'
 ---
 
@@ -44,15 +45,13 @@ bun run qwik add tailwind
 </span>
 </PackageManagerTabs>
 
-Enable dark mode in your `tailwind.config.js`:
+Enable dark mode in your `global.css`:
 
-```js
-module.exports = {
-  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
-  darkMode: "class",
-  theme: {},
-  plugins: [],
-};
+```css
+@import "tailwindcss";
+
+/* Add the line below to enable dark mode */
+@custom-variant dark (&:where(.dark, .dark *));
 ```
 
 ## Basic Implementation


### PR DESCRIPTION
Update to enable dark mode

# What is it?

- Docs

# Description

The method for enabling dark mode was outdated. (I believe it was specific to Tailwind V2).

Now, after running `pnpm run qwik add tailwind`, you need to modify the `global.css` file to enable dark mode.

# Checklist

- [X] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [X] This is a documentation-only change (no changeset needed)
