### PR TITLE
fix(ci): use QWIK_API_TOKEN_GITHUB for team membership check

### DIFF
--- a/.github/workflows/auto-assign-core-team.yml
+++ b/.github/workflows/auto-assign-core-team.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check team membership via REST
         id: team
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.QWIK_AUTO_ASSIGN_PR_PAT }}
           ORG: QwikDev
           TEAM_SLUG: qwik-team
           AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -36,7 +36,7 @@ jobs:
       - name: Assign PR to author
         if: steps.team.outputs.isCore == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.QWIK_AUTO_ASSIGN_PR_PAT }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           AUTHOR=${{ github.event.pull_request.user.login }}
@@ -51,14 +51,14 @@ jobs:
         uses: actions/add-to-project@v0.6.1
         with:
           project-url: https://github.com/orgs/QwikDev/projects/1
-          github-token: ${{ secrets.QWIK_API_TOKEN_GITHUB }}
+          github-token: ${{ secrets.QWIK_AUTO_ASSIGN_PR_PAT }}
 
       - name: Ensure project + set Status to "In progress" (draft)
         if: steps.team.outputs.isCore == 'true' && github.event.pull_request.draft == true
         uses: actions/add-to-project@v0.6.1
         with:
           project-url: https://github.com/orgs/QwikDev/projects/1
-          github-token: ${{ secrets.QWIK_API_TOKEN_GITHUB }}
+          github-token: ${{ secrets.QWIK_AUTO_ASSIGN_PR_PAT }}
           fields: |
             Status: In progress
 
@@ -67,6 +67,6 @@ jobs:
         uses: actions/add-to-project@v0.6.1
         with:
           project-url: https://github.com/orgs/QwikDev/projects/1
-          github-token: ${{ secrets.QWIK_API_TOKEN_GITHUB }}
+          github-token: ${{ secrets.QWIK_AUTO_ASSIGN_PR_PAT }}
           fields: |
             Status: Waiting For Review


### PR DESCRIPTION
# What is it?
- Bug

# Description
GITHUB_TOKEN can't read org team memberships so the check always silently failed — no PRs were ever auto-assigned. Switched to QWIK_AUTO_ASSIGN_PR_PAT.