### PR TITLE
fix(ci): add id-token permission for OpenCode triage action

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -5,6 +5,7 @@ on:
     types: [opened]
 
 permissions:
+  id-token: write
   contents: read
   issues: write
 


### PR DESCRIPTION
# What is it?
- Bug

# Description
OpenCode GitHub Action needs `id-token: write` permission for OIDC authentication. Without it the action fails immediately.