### PR TITLE
fix(ci): pass GITHUB_TOKEN to OpenCode triage action

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -37,8 +37,10 @@ jobs:
         if: steps.check.outputs.result == 'true'
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode/kimi-k2.5
+          use_github_token: true
           prompt: |
             You are a Qwik framework issue triager. Analyze the newly opened issue and apply the correct labels.
 


### PR DESCRIPTION
# What is it?
- Bug

# Description
OpenCode action crashed with `undefined is not an object (evaluating 'octoRest.rest')` — it needs `GITHUB_TOKEN` and `use_github_token: true` to interact with issues.