### PR TITLE
fix(ci): add missing permissions for OpenCode triage action

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -6,7 +6,8 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
+  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
# What is it?
- Bug

# Description
OpenCode needs `contents: write` and `pull-requests: write` permissions to apply labels. Without them it falls back to commenting with the suggested labels instead.