### PR TITLE
fix: finding inline component's host subscription

### DIFF
--- a/.changeset/rare-words-report.md
+++ b/.changeset/rare-words-report.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: inline components now correctly subscribe to signals

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -1506,7 +1506,7 @@ function expectComponent(diffContext: DiffContext, component: Function) {
             ) === null
           : true)
       ) {
-        componentHost = componentHost.parent;
+        componentHost = componentHost.parent || vnode_getProjectionParentComponent(componentHost);
       }
 
       const jsxOutput = executeComponent(

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -305,7 +305,7 @@ function processJSXNode(
           }
           ssr.openFragment(inlineComponentProps);
           enqueue(ssr.closeFragment);
-          const component = ssr.getComponentFrame(0);
+          const component = ssr.getParentComponentFrame();
           const jsxOutput = applyInlineComponent(
             ssr,
             component && component.componentNode,


### PR DESCRIPTION
Finding inline component's host subscription in projection