### PR TITLE
perf: optimize style hoisting and remove setting x-qwik/vnode

### DIFF
--- a/.changeset/fresh-states-begin.md
+++ b/.changeset/fresh-states-begin.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+perf: less style recalculations on resume

--- a/packages/qwik/src/core/client/dom-container.ts
+++ b/packages/qwik/src/core/client/dom-container.ts
@@ -148,9 +148,14 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
   $hoistStyles$(): void {
     const document = this.element.ownerDocument;
     const head = document.head;
-    const styles = document.querySelectorAll(QStylesAllSelector);
-    for (let i = 0; i < styles.length; i++) {
-      head.appendChild(styles[i]);
+    const styles = document.body.querySelectorAll(QStylesAllSelector);
+    const styleTagCount = styles.length;
+    if (styleTagCount) {
+      const fragment = document.createDocumentFragment();
+      for (let i = 0; i < styleTagCount; i++) {
+        fragment.appendChild(styles[i]);
+      }
+      head.appendChild(fragment);
     }
   }
 

--- a/packages/qwik/src/core/client/process-vnode-data.ts
+++ b/packages/qwik/src/core/client/process-vnode-data.ts
@@ -86,7 +86,6 @@ export function processVNodeData(document: Document) {
   // Process all of the `qwik/vnode` script tags by attaching them to the corresponding containers.
   const attachVnodeDataAndRefs = (element: Document | ShadowRoot) => {
     Array.from(element.querySelectorAll('script[type="qwik/vnode"]')).forEach((script) => {
-      script.setAttribute('type', 'x-qwik/vnode');
       const qContainerElement = script.closest('[q\\:container]') as ContainerElement | null;
       qContainerElement!.qVnodeData = script.textContent!;
       qContainerElement!.qVNodeRefs = new Map<number, Element | ElementVNode>();

--- a/packages/qwik/src/core/shared/vnode/enums/vnode-operation-type.enum.ts
+++ b/packages/qwik/src/core/shared/vnode/enums/vnode-operation-type.enum.ts
@@ -1,9 +1,0 @@
-export const enum VNodeOperationType {
-  None = 0,
-  Delete = 1,
-  InsertOrMove = 2,
-  RemoveAllChildren = 4,
-  SetAttribute = 8,
-  /** Only for text nodes */
-  SetText = 16,
-}

--- a/packages/qwik/src/core/shared/vnode/types/dom-vnode-operation.ts
+++ b/packages/qwik/src/core/shared/vnode/types/dom-vnode-operation.ts
@@ -1,5 +1,3 @@
-import { VNodeOperationType } from '../enums/vnode-operation-type.enum';
-
 export type VNodeOperation =
   | DeleteOperation
   | RemoveAllChildrenOperation
@@ -16,7 +14,6 @@ export class RemoveAllChildrenOperation {
 }
 
 export class SetTextOperation {
-  operationType = VNodeOperationType.SetText;
   constructor(
     public target: Text,
     public text: string


### PR DESCRIPTION
- wrap hoisting styles in document fragment and dont move styles inside head.
- remove setting attribute x-qwik/vnode, the container is created only once, and vnode processing is done during container creating, so its not needed