### PR TITLE
fix: diffing 2 empty text nodes with element or virtual

### DIFF
--- a/.changeset/smooth-forks-make.md
+++ b/.changeset/smooth-forks-make.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: diffing empty texts with element or virtual was sometimes incorrect

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -264,7 +264,7 @@ function diff(diffContext: DiffContext, jsxNode: JSXChildren, vStartNode: VNode)
         if (isJSXNode(diffContext.jsxValue)) {
           const type = diffContext.jsxValue.type;
           if (typeof type === 'string') {
-            expectNoMoreTextNodes(diffContext);
+            expectNoTextNode(diffContext);
             expectElement(diffContext, diffContext.jsxValue, type);
 
             const hasDangerousInnerHTML =
@@ -278,11 +278,11 @@ function diff(diffContext: DiffContext, jsxNode: JSXChildren, vStartNode: VNode)
             }
           } else if (typeof type === 'function') {
             if (type === Fragment) {
-              expectNoMoreTextNodes(diffContext);
+              expectNoTextNode(diffContext);
               expectVirtual(diffContext, VirtualType.Fragment, diffContext.jsxValue.key);
               descend(diffContext, diffContext.jsxValue.children, true);
             } else if (type === Slot) {
-              expectNoMoreTextNodes(diffContext);
+              expectNoTextNode(diffContext);
               if (!expectSlot(diffContext)) {
                 // nothing to project, so try to render the Slot default content.
                 descend(diffContext, diffContext.jsxValue.children, true);
@@ -303,7 +303,7 @@ function diff(diffContext: DiffContext, jsxNode: JSXChildren, vStartNode: VNode)
               expectNoMore(diffContext);
             } else {
               // Must be a component
-              expectNoMoreTextNodes(diffContext);
+              expectNoTextNode(diffContext);
               expectComponent(diffContext, type);
             }
           }
@@ -778,9 +778,8 @@ function expectNoMore(diffContext: DiffContext) {
   }
 }
 
-function expectNoMoreTextNodes(diffContext: DiffContext) {
-  while (diffContext.vCurrent !== null && vnode_isTextVNode(diffContext.vCurrent)) {
-    cleanup(diffContext.container, diffContext.journal, diffContext.vCurrent, diffContext.cursor);
+function expectNoTextNode(diffContext: DiffContext) {
+  if (diffContext.vCurrent !== null && vnode_isTextVNode(diffContext.vCurrent)) {
     const toRemove = diffContext.vCurrent;
     diffContext.vCurrent = peekNextSibling(diffContext.vCurrent);
     vnode_remove(diffContext.journal, diffContext.vParent, toRemove, true);

--- a/packages/qwik/src/core/client/vnode-diff.unit.tsx
+++ b/packages/qwik/src/core/client/vnode-diff.unit.tsx
@@ -1,6 +1,7 @@
 import {
   $,
   Fragment,
+  Slot,
   _fnSignal,
   _jsxSorted,
   component$,
@@ -34,6 +35,7 @@ import { _flushJournal } from '../shared/cursor/cursor-flush';
 import { markVNodeDirty } from '../shared/vnode/vnode-dirty';
 import { ChoreBits } from '../shared/vnode/enums/chore-bits.enum';
 import { NODE_DIFF_DATA_KEY } from '../shared/cursor/cursor-props';
+import type { ElementVNode } from '../shared/vnode/element-vnode';
 
 describe('vNode-diff', () => {
   it('should find no difference', () => {
@@ -95,6 +97,112 @@ describe('vNode-diff', () => {
       vnode_diff(container, journal, <div>{undefined}</div>, vParent, vParent, null);
       _flushJournal(journal);
       expect(vNode).toMatchVDOM(<div></div>);
+    });
+
+    describe('2 empty texts', () => {
+      it('should correctly diff 2 empty texts with element node', () => {
+        const { vNode, vParent, container } = vnode_fromJSX(
+          _jsxSorted('div', null, null, ['', ''], 0, 'KA_0')
+        );
+        const emptyFragment = (vNode as ElementVNode).firstChild?.nextSibling;
+        expect(emptyFragment).toBeDefined();
+        const journal: VNodeJournal = [];
+        vnode_diff(
+          container,
+          journal,
+          _jsxSorted(
+            'div',
+            null,
+            null,
+            [_jsxSorted('div', null, null, 'Child 1', 0, null), ''],
+            0,
+            'KA_0'
+          ),
+          vParent,
+          vParent,
+          null
+        );
+        _flushJournal(journal);
+        expect((vNode as ElementVNode).firstChild?.nextSibling === emptyFragment).toBeTruthy();
+      });
+
+      it('should correctly diff 2 empty texts with fragment node', () => {
+        const { vNode, vParent, container } = vnode_fromJSX(
+          _jsxSorted('div', null, null, ['', ''], 0, 'KA_0')
+        );
+        const emptyFragment = (vNode as ElementVNode).firstChild?.nextSibling;
+        expect(emptyFragment).toBeDefined();
+        const journal: VNodeJournal = [];
+        vnode_diff(
+          container,
+          journal,
+          _jsxSorted(
+            'div',
+            null,
+            null,
+            [_jsxSorted(Fragment, null, null, 'Child 1', 0, null), ''],
+            0,
+            'KA_0'
+          ),
+          vParent,
+          vParent,
+          null
+        );
+        _flushJournal(journal);
+        expect((vNode as ElementVNode).firstChild?.nextSibling === emptyFragment).toBeTruthy();
+      });
+
+      it('should correctly diff 2 empty texts with slot node', () => {
+        const { vNode, vParent, container } = vnode_fromJSX(
+          _jsxSorted('div', null, null, ['', ''], 0, 'KA_0')
+        );
+        const emptyFragment = (vNode as ElementVNode).firstChild?.nextSibling;
+        expect(emptyFragment).toBeDefined();
+        const journal: VNodeJournal = [];
+        vnode_diff(
+          container,
+          journal,
+          _jsxSorted(
+            'div',
+            null,
+            null,
+            [_jsxSorted(Slot, null, null, null, 0, null), ''],
+            0,
+            'KA_0'
+          ),
+          vParent,
+          vParent,
+          null
+        );
+        _flushJournal(journal);
+        expect((vNode as ElementVNode).firstChild?.nextSibling === emptyFragment).toBeTruthy();
+      });
+      it('should correctly diff 2 empty texts with component node', () => {
+        const { vNode, vParent, container } = vnode_fromJSX(
+          _jsxSorted('div', null, null, ['', ''], 0, 'KA_0')
+        );
+        const emptyFragment = (vNode as ElementVNode).firstChild?.nextSibling;
+        expect(emptyFragment).toBeDefined();
+        const journal: VNodeJournal = [];
+        const Cmp = component$(() => <div>Hello</div>);
+        vnode_diff(
+          container,
+          journal,
+          _jsxSorted(
+            'div',
+            null,
+            null,
+            [_jsxSorted(Cmp as JSXChildren, null, null, [], 0, null), ''],
+            0,
+            'KA_0'
+          ),
+          vParent,
+          vParent,
+          null
+        );
+        _flushJournal(journal);
+        expect((vNode as ElementVNode).firstChild?.nextSibling === emptyFragment).toBeTruthy();
+      });
     });
   });
   describe('element', () => {


### PR DESCRIPTION
diffing multiple empty texts with element or virtual was sometimes incorrect. We should just remove current text node, not all in a row