### PR TITLE
perf: dont serialize back refs

### DIFF
--- a/.changeset/fine-eggs-teach.md
+++ b/.changeset/fine-eggs-teach.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': minor
+---
+
+feat: serialized state should be up to 30% smaller

--- a/packages/qwik/src/core/reactive-primitives/types.ts
+++ b/packages/qwik/src/core/reactive-primitives/types.ts
@@ -8,6 +8,7 @@ import type { AsyncFn } from '../use/use-async';
 import type { Container, SerializationStrategy } from '../shared/types';
 import type { VNode } from '../shared/vnode/vnode';
 import type { ISsrNode } from '../ssr/ssr-types';
+import type { PropsProxy } from '../shared/jsx/props-proxy';
 
 /**
  * # ================================
@@ -179,10 +180,12 @@ export class EffectSubscription {
   constructor(
     public consumer: Consumer,
     public property: EffectProperty | string,
-    public backRef: Set<SignalImpl | StoreTarget> | null = null,
+    public backRef: Set<EffectBackRef> | null = null,
     public data: SubscriptionData | null = null
   ) {}
 }
+
+export type EffectBackRef = SignalImpl | StoreTarget | PropsProxy;
 
 export const enum EffectProperty {
   COMPONENT = ':',

--- a/packages/qwik/src/core/shared/serdes/serialize.ts
+++ b/packages/qwik/src/core/shared/serdes/serialize.ts
@@ -329,12 +329,7 @@ export class Serializer {
         value.data.$isConst$,
       ]);
     } else if (value instanceof EffectSubscription) {
-      this.output(TypeIds.EffectSubscription, [
-        value.consumer,
-        value.property,
-        value.backRef,
-        value.data,
-      ]);
+      this.output(TypeIds.EffectSubscription, [value.consumer, value.property, value.data]);
     } else if (isStore(value)) {
       const storeHandler = getStoreHandler(value)!;
       const storeTarget = getStoreTarget(value);

--- a/packages/qwik/src/core/tests/render-api.spec.tsx
+++ b/packages/qwik/src/core/tests/render-api.spec.tsx
@@ -874,7 +874,7 @@ describe('render api', () => {
           streaming,
         });
         // This can change when the size of the output changes
-        expect(stream.write).toHaveBeenCalledTimes(5);
+        expect(stream.write).toHaveBeenCalledTimes(4);
       });
     });
   });


### PR DESCRIPTION
Dont serialize back refs, just restore them from current informations.
Serialized state should be even up to 30% smaller