### PR TITLE
fix: resuming vnodes with non-qwik element in the middle

### DIFF
--- a/.changeset/lovely-terms-jump.md
+++ b/.changeset/lovely-terms-jump.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: resuming vnodes with non-qwik element in the middle

--- a/packages/qwik/src/core/client/process-vnode-data.unit.tsx
+++ b/packages/qwik/src/core/client/process-vnode-data.unit.tsx
@@ -94,7 +94,7 @@ describe('processVnodeData', () => {
           <div q:container="html" :><span></span></div>
           <div>ignore this</div>
           <b :>HelloWorld</b>
-          ${encodeVNode({ 2: '3', 4: 'FF' })}
+          ${encodeVNode({ 2: '2', 4: 'FF' })}
       </body>
       </html>
     `);
@@ -103,7 +103,6 @@ describe('processVnodeData', () => {
         <head />
         <body>
           <div dangerouslySetInnerHTML="<span></span>" {...qContainerHtml} />
-          <div>ignore this</div>
           <b>
             {'Hello'}
             {'World'}

--- a/packages/qwik/src/core/client/vnode-utils.ts
+++ b/packages/qwik/src/core/client/vnode-utils.ts
@@ -2003,6 +2003,16 @@ function materializeFromVNodeData(
         vnode_ensureElementKeyInflated(elementVNode);
         addVNode(elementVNode);
         child = fastNextSibling(child);
+        while (
+          // skip only elements, not text nodes
+          isElement(child) &&
+          shouldSkipElement(child)
+        ) {
+          child = fastNextSibling(child);
+          if (!child && value > 0) {
+            throw qError(QError.materializeVNodeDataError, [vData, peek(), nextToConsumeIdx]);
+          }
+        }
       }
       // collect the elements;
     } else if (peek() === VNodeDataChar.SCOPED_STYLE) {

--- a/packages/qwik/src/testing/vdom-diff.unit-util.ts
+++ b/packages/qwik/src/testing/vdom-diff.unit-util.ts
@@ -143,11 +143,7 @@ function diffJsxVNode(
     return [path.join(' > ') + ' missing'];
   }
   if (!container.qContainer) {
-    try {
-      _getDomContainer(container);
-    } catch {
-      // ignore and hope for the best
-    }
+    _getDomContainer(container);
   }
 
   const diffs: string[] = [];


### PR DESCRIPTION
Skip non-qwik elements in the middle during resuming