### PR TITLE
docs: Update documentation for Deno production builds support

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/static-site-generation/index.mdx
@@ -119,7 +119,7 @@ The `outDir` is a file system output directory where the static files should be 
 
 ### Javascript Runtimes
 
-For a Javascript project, it's quite common for the build's runtime to be built on top of [Node.js](https://nodejs.org/en/docs/). However, the core of Qwik City static site generation isn't tied to using only Node.js, which is why the `qwikCityGenerate()` function is imported from `@builder.io/qwik-city/static/node`. By scoping the generate function to a specific runtime, such as Node.js, this gives Qwik City the flexibility to also generate SSG from other runtimes in the future, such as [Deno](https://deno.land/) or [Bun](https://bun.sh/).
+For a Javascript project, it's quite common for the build's runtime to be built on top of [Node.js](https://nodejs.org/en/docs/). However, the core of Qwik City static site generation isn't tied to using only Node.js, which is why the `qwikCityGenerate()` function is imported from `@builder.io/qwik-city/static/node`. By scoping the generate function to a specific runtime, such as Node.js, Qwik City can also generate SSG from other runtimes, including [Deno](https://deno.land/) and [Bun](https://bun.sh/).
 
 ## Dynamic SSG Routes
 

--- a/packages/docs/src/routes/docs/deployments/deno/index.mdx
+++ b/packages/docs/src/routes/docs/deployments/deno/index.mdx
@@ -17,6 +17,8 @@ Qwik City Deno middleware allows you to hook up Qwik City to a Deno server which
 - [Deno's integrated HTTP server](https://docs.deno.com/runtime/tutorials/http_server)
 - [Oak](https://oakserver.github.io/oak/)
 
+You can use either a Node-based package manager (pnpm, npm, yarn, bun) or native Deno commands to manage your project. The sections below show both options.
+
 ## Installation
 
 To integrate the `deno` adapter, use the `add` command:
@@ -74,6 +76,19 @@ bun run build
 </span>
 </PackageManagerTabs>
 
+Or with native Deno:
+
+```shell
+deno task build
+```
+
+You can also run the client and server builds separately:
+
+```shell
+deno task build.client
+deno task build.server
+```
+
 ## Serve
 
 To start the Deno server after a build:
@@ -101,9 +116,15 @@ bun run serve
 </span>
 </PackageManagerTabs>
 
+Or with native Deno:
+
+```shell
+deno task serve
+```
+
 ## Production deploy
 
-Since you are choosing Deno, here you are in your own, after running the `build` command:
+Since you are choosing Deno, here you are on your own after running the `build` command:
 
 - The `dist` folder will be created including all the static files.
 - The `server` folder will be created including all node server files.


### PR DESCRIPTION
Updates documentation to reflect that Deno is now fully supported for production builds in Qwik City:

- **SSG Guide**: Updated outdated language that referred to Deno and Bun as "future" runtimes - they are now supported
- **Deno Deployment Docs**: Added native Deno task commands (`deno task build`, `deno task build.client`, `deno task build.server`, `deno task serve`) as alternatives to Node-based package manager commands
- Also fixed a minor typo in the production deploy section

### Trigger Events

<details>
<summary><a href="https://github.com/QwikDev/qwik/pull/8385">qwikdev/qwik#8385</a></summary>
<br>

**Promptless Research** (1 GitHub PR)

- [Reviewed QwikDev/qwik#8385](https://github.com/QwikDev/qwik/pull/8385)

**Agent Response**

> I've completed the documentation updates for PR #8385 (Deno production builds support). Here's a summary of what I did:
> 
> ## Documentation Changes
> 
> I created a suggestion with the following updates:
> 
> ### 1. Static Site Generation Guide
> Updated outdated language in the "Javascript Runtimes" section that incorrectly stated Deno and Bun were "future" runtimes. The text now accurately reflects that Qwik City **can** generate SSG from these runtimes (not just "in the future").
> 
> ### 2. Deno Deployment Docs
> Since the PR enables using Deno as the package manager (with `deno task` commands), I added:
> - An introductory note explaining users can use either Node-based package managers OR native Deno commands
> - Native Deno build commands:
>   - `deno task build` (runs both client and server builds)
>   - `deno task build.client` / `deno task build.server` (separate builds)
> - Native Deno serve command: `deno task serve`
> - Also fixed a minor typo ("here you are in your own" → "here you are on your own")
> 
> These changes ensure that developers using Deno as their runtime and package manager have clear documentation on how to build and deploy their Qwik City applications using native Deno commands, which is now fully supported thanks to PR #8385.

</details>



---

_Tip: You can ask for follow-up changes by tagging Promptless in comments. If you want to learn more about [Promptless](https://promptless.ai), [chat with us](https://cal.com/team/promptless/15m-discovery-call) to see how Promptless can keep your docs in sync automatically 📅_