### PR TITLE
fix(eslint valid scope): check only value of signals

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -1184,7 +1184,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Returned type of the `noSerialize()` function. It will be TYPE or undefined.\n\n\n```typescript\nexport type NoSerialize<T> = (T & {\n    __no_serialize__: true;\n}) | undefined;\n```",
+      "content": "Returned type of the `noSerialize()` function. It will be TYPE or undefined.\n\n\n```typescript\nexport type NoSerialize<T> = (T & {\n    __no_serialize__?: true;\n}) | undefined;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/serdes/verify.ts",
       "mdFile": "core.noserialize.md"
     },
@@ -1198,7 +1198,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "Returned type of the `noSerialize()` function. It will be TYPE or undefined.\n\n\n```typescript\nexport type NoSerialize<T> = (T & {\n    __no_serialize__: true;\n}) | undefined;\n```",
+      "content": "Returned type of the `noSerialize()` function. It will be TYPE or undefined.\n\n\n```typescript\nexport type NoSerialize<T> = (T & {\n    __no_serialize__?: true;\n}) | undefined;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/serdes/verify.ts",
       "mdFile": "core.noserialize.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.mdx
+++ b/packages/docs/src/routes/api/qwik/index.mdx
@@ -2671,7 +2671,7 @@ Returned type of the `noSerialize()` function. It will be TYPE or undefined.
 ```typescript
 export type NoSerialize<T> =
   | (T & {
-      __no_serialize__: true;
+      __no_serialize__?: true;
     })
   | undefined;
 ```
@@ -2685,7 +2685,7 @@ Returned type of the `noSerialize()` function. It will be TYPE or undefined.
 ```typescript
 export type NoSerialize<T> =
   | (T & {
-      __no_serialize__: true;
+      __no_serialize__?: true;
     })
   | undefined;
 ```

--- a/packages/eslint-plugin-qwik/src/validLexicalScope.ts
+++ b/packages/eslint-plugin-qwik/src/validLexicalScope.ts
@@ -436,7 +436,11 @@ function _isTypeCapturable(
       };
     }
 
-    for (const symbol of type.getProperties()) {
+    const props =
+      (type.symbol.escapedName as string).endsWith('Signal') && type.getProperty('value')
+        ? [type.getProperty('value')!]
+        : type.getProperties();
+    for (const symbol of props) {
       const result = isSymbolCapturable(context, checker, symbol, node, opts, level + 1, seen);
       if (result) {
         const loc = result.location;

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -639,7 +639,7 @@ export const _noopQrlDEV: <T>(symbolName: string, opts: QRLDev, lexicalScopeCapt
 
 // @public
 export type NoSerialize<T> = (T & {
-    __no_serialize__: true;
+    __no_serialize__?: true;
 }) | undefined;
 
 // @public

--- a/packages/qwik/src/core/reactive-primitives/impl/signal.unit.tsx
+++ b/packages/qwik/src/core/reactive-primitives/impl/signal.unit.tsx
@@ -22,6 +22,7 @@ import {
   type ComputedSignal,
   type SerializerSignal,
   type Signal,
+  type AsyncSignal,
 } from '../signal.public';
 import { getSubscriber } from '../subscriber';
 import { vnode_newVirtual, vnode_setProp } from '../../client/vnode-utils';
@@ -110,6 +111,20 @@ describe('signal types', () => {
       expectTypeOf(signal).toEqualTypeOf<SerializerSignal<Foo>>();
       expectTypeOf(signal.value).toEqualTypeOf<Foo>();
     }
+  });
+  it('AsyncSignal<T>', () => async () => {
+    const signal = createAsync$(() => Promise.resolve(42));
+    expectTypeOf(signal).toEqualTypeOf<AsyncSignal<number>>();
+    expectTypeOf(signal).toExtend<Signal<number>>();
+    expectTypeOf(signal.trigger()).toEqualTypeOf<void>();
+    expectTypeOf(await signal.promise()).toEqualTypeOf<void>();
+    expectTypeOf(signal.value).toEqualTypeOf<number>();
+    expectTypeOf(signal.loading).toEqualTypeOf<boolean>();
+    expectTypeOf(signal.error).toEqualTypeOf<Error | undefined>();
+    expectTypeOf(signal.interval).toEqualTypeOf<number>();
+    expectTypeOf(signal.untrackedValue).toEqualTypeOf<number>();
+    expectTypeOf(signal.abort()).toEqualTypeOf<void>();
+    expectTypeOf(signal.invalidate()).toEqualTypeOf<void>();
   });
 });
 

--- a/packages/qwik/src/core/shared/serdes/verify.ts
+++ b/packages/qwik/src/core/shared/serdes/verify.ts
@@ -114,7 +114,7 @@ export const fastSkipSerialize = (obj: unknown): boolean => {
  * @public
  * @see noSerialize
  */
-export type NoSerialize<T> = (T & { __no_serialize__: true }) | undefined;
+export type NoSerialize<T> = (T & { __no_serialize__?: true }) | undefined;
 
 // <docs markdown="../../readme.md#noSerialize">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!


### PR DESCRIPTION
this changes the eslint plugin so it only checks the .value of signals for valid lexical scoping