### PR TITLE
docs: Remove 'dev' mode from ServerRequestMode API documentation

### DIFF
--- a/packages/docs/src/routes/api/qwik-city-middleware-request-handler/api.json
+++ b/packages/docs/src/routes/api/qwik-city-middleware-request-handler/api.json
@@ -484,7 +484,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type ServerRequestMode = 'dev' | 'static' | 'server';\n```",
+      "content": "```typescript\nexport type ServerRequestMode = 'static' | 'server';\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/middleware/request-handler/types.ts",
       "mdFile": "qwik-city.serverrequestmode.md"
     },

--- a/packages/docs/src/routes/api/qwik-city-middleware-request-handler/index.mdx
+++ b/packages/docs/src/routes/api/qwik-city-middleware-request-handler/index.mdx
@@ -1879,7 +1879,7 @@ URL
 ## ServerRequestMode
 
 ```typescript
-export type ServerRequestMode = "dev" | "static" | "server";
+export type ServerRequestMode = "static" | "server";
 ```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/middleware/request-handler/types.ts)


### PR DESCRIPTION
Updates the API documentation for `@builder.io/qwik-city/middleware/request-handler` to reflect that the `'dev'` mode has been removed from the `ServerRequestMode` type. The type now only includes `'static'` and `'server'` modes. Updated both the MDX documentation and the corresponding `api.json` file.

### Trigger Events

<details>
<summary><a href="https://github.com/QwikDev/qwik/pull/8389">qwikdev/qwik#8389</a></summary>
<br>

**Promptless Research** (2 GitHub PRs)

- [Reviewed QwikDev/qwik#8389](https://github.com/QwikDev/qwik/pull/8389)
- [Reviewed QwikDev/qwik#8389](https://github.com/QwikDev/qwik/pull/8389)

**Agent Response**

> I've completed the documentation update for PR #8389. Here's a summary:
> 
> ## Summary
> 
> I reviewed PR #8389 which removes the `'dev'` mode from the `ServerRequestMode` type in Qwik's middleware request handler.
> 
> ### Documentation Changes Made
> 
> I updated two files in the `@builder.io/qwik-city/middleware/request-handler` API reference:
> 
> 1. **`index.mdx`** - Updated the `ServerRequestMode` type definition from:
>    ```typescript
>    export type ServerRequestMode = "dev" | "static" | "server";
>    ```
>    to:
>    ```typescript
>    export type ServerRequestMode = "static" | "server";
>    ```
> 
> 2. **`api.json`** - Updated the corresponding type definition in the API JSON data file to match.
> 
> ### Note on Repository Structure
> 
> The PR modifies files in the `qwik-router` directories, while the current docs mirror contains the equivalent `qwik-city` directories. I updated the `qwik-city` version of the API documentation to keep it consistent with the change being made. Both sets of documentation reference the same `ServerRequestMode` type, so this ensures the documentation remains accurate.
> 
> A documentation suggestion has been created and is ready for your review.

</details>



---

_Tip: You can ask for follow-up changes by tagging Promptless in comments. If you want to learn more about [Promptless](https://promptless.ai), [chat with us](https://cal.com/team/promptless/15m-discovery-call) to see how Promptless can keep your docs in sync automatically 📅_