### PR TITLE
fix: handle special characters in dynamic route

### DIFF
--- a/.changeset/small-candies-train.md
+++ b/.changeset/small-candies-train.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+fix: handle special characters in dynamic route

--- a/packages/qwik-city/src/static/node/node-system.ts
+++ b/packages/qwik-city/src/static/node/node-system.ts
@@ -42,7 +42,7 @@ export async function createSystem(opts: StaticGenerateOptions) {
   const basenameLen = basePathname.length;
 
   const getRouteFilePath = (pathname: string, isHtml: boolean) => {
-    pathname = pathname.slice(basenameLen);
+    pathname = decodeURIComponent(pathname.slice(basenameLen));
     if (isHtml) {
       if (!pathname.endsWith('.html')) {
         if (pathname.endsWith('/')) {
@@ -60,7 +60,7 @@ export async function createSystem(opts: StaticGenerateOptions) {
   };
 
   const getDataFilePath = (pathname: string) => {
-    pathname = pathname.slice(basenameLen);
+    pathname = decodeURIComponent(pathname.slice(basenameLen));
     if (pathname.endsWith('/')) {
       pathname += 'q-data.json';
     } else {

--- a/packages/qwik-city/src/utils/pathname.unit.ts
+++ b/packages/qwik-city/src/utils/pathname.unit.ts
@@ -176,6 +176,18 @@ test('dynamic pathname', () => {
   assert.equal(p, '/docs/introduction/basics');
 });
 
+test('dynamic pathname with special characters', () => {
+  const p = getPathname({
+    originalPathname: '/docs/[category]/[slugId]',
+    basePathname: '/',
+    params: {
+      category: 'my category',
+      slugId: 'héllo wörld',
+    },
+  });
+  assert.equal(p, '/docs/my%20category/h%C3%A9llo%20w%C3%B6rld');
+});
+
 function getPathname(t: { originalPathname: string; basePathname: string; params?: PathParams }) {
   const p = parseRoutePathname(t.basePathname, t.originalPathname);
   const d = getPathnameForDynamicRoute(t.originalPathname, p.paramNames, t.params);


### PR DESCRIPTION
Close #1999

## Before

<img width="152" height="166" alt="Screenshot 2026-03-03 at 16 10 37" src="https://github.com/user-attachments/assets/94184894-28b5-454f-8768-a40f5d977cc4" />

## After

<img width="198" height="152" alt="Screenshot 2026-03-03 at 16 15 44" src="https://github.com/user-attachments/assets/066efdd2-de2b-4473-a636-9c3af2c3f082" />


<img width="1016" height="362" alt="Screenshot 2026-03-03 at 16 18 32" src="https://github.com/user-attachments/assets/c4e9225e-c119-4b5c-853e-22d5045c2c85" />
