### PR TITLE
fix(qwik-city): address lint issues in sitemap stream implementation

### DIFF
--- a/packages/qwik-city/src/static/node/node-main.ts
+++ b/packages/qwik-city/src/static/node/node-main.ts
@@ -17,7 +17,7 @@ import { normalizePath } from '../../utils/fs';
 export async function createNodeMainProcess(sys: System, opts: StaticGenerateOptions) {
   const ssgWorkers: StaticGeneratorWorker[] = [];
   const sitemapBuffer: string[] = [];
-  let sitemapPromise: Promise<any> | null = null;
+  let sitemapStream: fs.WriteStream | null = null;
 
   opts = { ...opts };
 
@@ -155,12 +155,11 @@ export async function createNodeMainProcess(sys: System, opts: StaticGenerateOpt
     if (sitemapOutFile && result.ok && result.resourceType === 'page') {
       sitemapBuffer.push(`<url><loc>${result.url}</loc></url>`);
       if (sitemapBuffer.length > 50) {
-        if (sitemapPromise) {
-          await sitemapPromise;
-        }
         const siteMapUrls = sitemapBuffer.join('\n') + '\n';
         sitemapBuffer.length = 0;
-        sitemapPromise = fs.promises.appendFile(sitemapOutFile, siteMapUrls);
+        if (sitemapStream) {
+          sitemapStream.write(siteMapUrls);
+        }
       }
     }
 
@@ -168,15 +167,28 @@ export async function createNodeMainProcess(sys: System, opts: StaticGenerateOpt
   };
 
   const close = async () => {
-    const promises: Promise<any>[] = [];
+    const promises: Promise<unknown>[] = [];
 
-    if (sitemapOutFile) {
-      if (sitemapPromise) {
-        await sitemapPromise;
-      }
+    if (sitemapStream) {
       sitemapBuffer.push(`</urlset>`);
-      promises.push(fs.promises.appendFile(sitemapOutFile, sitemapBuffer.join('\n')));
+      sitemapStream.write(sitemapBuffer.join('\n'));
       sitemapBuffer.length = 0;
+
+      await new Promise<void>((resolve, reject) => {
+        if (sitemapStream) {
+          sitemapStream.end((err?: Error | null) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
+        } else {
+          resolve();
+        }
+      });
+
+      sitemapStream = null;
     }
 
     for (const ssgWorker of ssgWorkers) {
@@ -199,8 +211,11 @@ export async function createNodeMainProcess(sys: System, opts: StaticGenerateOpt
 
   if (sitemapOutFile) {
     await ensureDir(sitemapOutFile);
-    await fs.promises.writeFile(
-      sitemapOutFile,
+    sitemapStream = fs.createWriteStream(sitemapOutFile, {
+      flags: 'w',
+    });
+
+    sitemapStream.write(
       `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n`
     );
   }


### PR DESCRIPTION
# What is it?

- Bug

# Description

During Qwik City SSG runs on FreeBSD we observed intermittent failures:

EBADF: bad file descriptor, write

The issue originates from repeated `fs.promises.appendFile` calls used to flush
the sitemap buffer while workers are still active.

Each `appendFile` performs an open → write → close cycle. When many SSG workers
are rendering concurrently this creates frequent descriptor churn. On FreeBSD
this can lead to attempts to write to a descriptor that has already been closed,
triggering the EBADF error.

This patch replaces the repeated `appendFile` calls with a persistent
`fs.createWriteStream` that is opened once when the sitemap generation starts
and closed when the SSG process shuts down.

Benefits of this approach:

- prevents EBADF errors observed on FreeBSD
- avoids repeated file descriptor open/close cycles
- reduces filesystem overhead during large SSG runs
- preserves the existing sitemap output behavior

The change is limited to the sitemap generation path and does not affect other
SSG logic.

# Checklist

- [x] My code follows the developer guidelines of this project
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality