### PR TITLE
fix(router): sync history push for webkit engine

### DIFF
--- a/.changeset/cruel-taxis-talk.md
+++ b/.changeset/cruel-taxis-talk.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: SPA navigation should not be skipped on webkit engine

--- a/e2e/qwik-e2e/tests/qwikrouter/nav.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/nav.e2e.ts
@@ -36,6 +36,26 @@ test.describe('nav', () => {
       await expect(increment).toHaveText('Click me 1');
     });
 
+    test('should update history before async SPA route load completes', async ({ page }) => {
+      await page.route('**/products/jacket/q-data.json', async (route) => {
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        await route.continue();
+      });
+
+      await page.goto('/qwikrouter-test/products/hat/');
+      const link = page.locator('[data-test-link="products-jacket"]');
+      const heading = page.locator('h1');
+
+      await expect(heading).toHaveText('Product: hat');
+      await link.click();
+
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .toBe('/qwikrouter-test/products/jacket/');
+      await expect(heading).toHaveText('Product: hat');
+      await expect(heading).toHaveText('Product: jacket');
+    });
+
     test.describe('scroll-restoration', () => {
       test('should not refresh again on popstate after manual refresh', async ({ page }) => {
         await page.goto('/qwikrouter-test/scroll-restoration/page-long/');

--- a/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
+++ b/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
@@ -77,7 +77,7 @@ import type {
 } from './types';
 import { loadClientData } from './use-endpoint';
 import { useQwikRouterEnv } from './use-functions';
-import { createLoaderSignal, isSameOrigin, isSamePath, toUrl } from './utils';
+import { createLoaderSignal, isSameOrigin, isSamePath, toPath, toUrl } from './utils';
 import { startViewTransition } from './view-transition';
 
 declare const window: ClientSPAWindow;
@@ -282,6 +282,19 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
     };
   });
 
+  const getScroller = $(() => {
+    let scroller = document.getElementById(QWIK_ROUTER_SCROLLER);
+    if (!scroller) {
+      scroller = document.getElementById(QWIK_CITY_SCROLLER);
+      if (scroller && isDev) {
+        console.warn(
+          `Please update your scroller ID to "${QWIK_ROUTER_SCROLLER}" as "${QWIK_CITY_SCROLLER}" is deprecated and will be removed in V3`
+        );
+      }
+    }
+    return scroller ?? document.documentElement;
+  });
+
   const goto: RouteNavigate = $(async (path, opt) => {
     const {
       type = 'link',
@@ -353,18 +366,7 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
         }
 
         // Always scroll on same-page popstates, #hash clicks, or links.
-        let scroller = document.getElementById(QWIK_ROUTER_SCROLLER);
-        if (!scroller) {
-          scroller = document.getElementById(QWIK_CITY_SCROLLER);
-          if (scroller && isDev) {
-            console.warn(
-              `Please update your scroller ID to "${QWIK_ROUTER_SCROLLER}" as "${QWIK_CITY_SCROLLER}" is deprecated and will be removed in V3`
-            );
-          }
-        }
-        if (!scroller) {
-          scroller = document.documentElement;
-        }
+        const scroller = await getScroller();
 
         restoreScroll(type, dest, new URL(location.href), scroller, getScrollHistory());
 
@@ -383,12 +385,28 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
       return;
     }
 
+    let historyUpdated = false;
+    if (isBrowser && type === 'link' && !forceReload) {
+      // WebKit on iOS may treat async pushState() calls as skippable history entries.
+      // Commit the navigation entry while the original tap/click is still active.
+      const scroller = await getScroller();
+
+      window._qRouterScrollEnabled = false;
+      clearTimeout(window._qRouterScrollDebounce);
+
+      const scrollState = currentScrollState(scroller);
+      saveScrollHistory(scrollState);
+      clientNavigate(window, type, new URL(location.href), dest, replaceState);
+      historyUpdated = true;
+    }
+
     routeInternal.value = {
       type,
       dest,
       forceReload,
       replaceState,
       scroll,
+      historyUpdated,
     };
 
     if (isBrowser) {
@@ -556,8 +574,7 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
           if (navType === 'popstate') {
             scrollState = getScrollHistory();
           }
-          const scroller =
-            document.getElementById(QWIK_ROUTER_SCROLLER) ?? document.documentElement;
+          const scroller = await getScroller();
 
           if (
             (navigation.scroll &&
@@ -759,14 +776,26 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
             window._qRouterScrollEnabled = false;
             clearTimeout(window._qRouterScrollDebounce);
 
-            // Save the final scroll state before pushing new state.
-            // Upgrades/replaces state with scroll pos on nav as needed.
-            const scrollState = currentScrollState(scroller);
-            saveScrollHistory(scrollState);
+            if (!navigation.historyUpdated) {
+              // Save the final scroll state before pushing new state.
+              // Upgrades/replaces state with scroll pos on nav as needed.
+              const scrollState = currentScrollState(scroller);
+              saveScrollHistory(scrollState);
+            }
           }
 
           const navigate = () => {
-            clientNavigate(window, navType, prevUrl, trackUrl, replaceState);
+            if (navigation.historyUpdated) {
+              const currentPath = location.pathname + location.search + location.hash;
+              const nextPath = toPath(trackUrl);
+              if (currentPath !== nextPath) {
+                // The history entry was already created under the original user gesture.
+                // We only normalize the current entry here once async navigation resolves.
+                history.replaceState(history.state, '', nextPath);
+              }
+            } else {
+              clientNavigate(window, navType, prevUrl, trackUrl, replaceState);
+            }
             contentInternal.trigger();
             return _waitUntilRendered(container!);
           };

--- a/packages/qwik-router/src/runtime/src/types.ts
+++ b/packages/qwik-router/src/runtime/src/types.ts
@@ -94,6 +94,7 @@ export type RouteStateInternal = {
   forceReload?: boolean;
   replaceState?: boolean;
   scroll?: boolean;
+  historyUpdated?: boolean;
 };
 
 export type RebuildRouteInfoInternal = (


### PR DESCRIPTION
Webkit can decide to ignore pushed history if it was not done during user interaction. Thats why we should do it in sync with user interaction.
We push the history in sync and update it later after loading all necessary data.