### PR TITLE
fix(ci): pin update-project-fields action to immutable commit SHA

### DIFF
--- a/.github/workflows/auto-assign-core-team.yml
+++ b/.github/workflows/auto-assign-core-team.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set status to "In progress" (draft)
         if: steps.team.outputs.isCore == 'true' && github.event.pull_request.draft == true
-        uses: titoportas/update-project-fields@v0.1.0
+        uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751 # v0.1.0
         with:
           project-url: https://github.com/orgs/QwikDev/projects/1
           github-token: ${{ secrets.QWIK_AUTO_ASSIGN_PR_PAT }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Set status to "Waiting For Review" (ready)
         if: steps.team.outputs.isCore == 'true' && github.event.pull_request.draft == false
-        uses: titoportas/update-project-fields@v0.1.0
+        uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751 # v0.1.0
         with:
           project-url: https://github.com/orgs/QwikDev/projects/1
           github-token: ${{ secrets.QWIK_AUTO_ASSIGN_PR_PAT }}


### PR DESCRIPTION
### Motivation
- Remove a supply-chain risk where a third-party action used in a `pull_request_target` workflow ran with the privileged `QWIK_AUTO_ASSIGN_PR_PAT` while referenced by a mutable tag.

### Description
- Pin the `titoportas/update-project-fields` action to its `v0.1.0` commit SHA in ` .github/workflows/auto-assign-core-team.yml` to preserve behavior while preventing tag retagging from executing arbitrary code with repository secrets.

### Testing
- Verified the change with `rg -n "update-project-fields@" .github/workflows/auto-assign-core-team.yml` and validated the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/auto-assign-core-team.yml'); puts 'YAML OK'"`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6d1b33988331a0cd4b478debff62)