### PR TITLE
fix(ci): scope release workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,7 @@ env:
   CARGO_INCREMENTAL: 0
 
 permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   changes:
@@ -826,6 +824,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
 
     needs:
       - changes


### PR DESCRIPTION
### Motivation
- The workflow granted `id-token: write` and write-scoped `GITHUB_TOKEN` permissions at the workflow level while running on `pull_request`, which exposes OIDC tokens and write access to untrusted PR jobs and increases supply-chain risk.
- The intent is to keep normal CI jobs least-privileged while preserving the elevated permissions required only for publishing in the release job.

### Description
- Reduced workflow-wide permissions in `.github/workflows/ci.yml` to `contents: read` so non-release jobs do not inherit sensitive scopes.
- Added a permissions block to the `release` job that explicitly sets `id-token: write`, `contents: write`, and `pull-requests: write` so release steps retain the privileges they require.
- Made a minimal scoped change that preserves existing release behavior while preventing untrusted pull request runs from obtaining OIDC or write-scoped tokens.

### Testing
- Ran `git diff --check` which completed successfully to validate there are no whitespace or patch issues.
- Verified the permission changes with a repository search (`rg -n "^\s*release:|permissions:|id-token|pull-requests|contents:" .github/workflows/ci.yml`) and inspected the modified file; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6eb8600083318443310e6c410e65)