### PR TITLE
fix(docs): trim redirect whitespace

### DIFF
--- a/packages/docs/src/routes/plugin@redirects.ts
+++ b/packages/docs/src/routes/plugin@redirects.ts
@@ -24,17 +24,17 @@ export const onGet = ({ url, redirect }: RequestEvent) => {
 };
 
 const tempRedirects: Record<string, string> = {
-  '/chat': ' https://discord.gg/TsNCMd6uGW',
-  '/chat/': ' https://discord.gg/TsNCMd6uGW',
+  '/chat': 'https://discord.gg/TsNCMd6uGW',
+  '/chat/': 'https://discord.gg/TsNCMd6uGW',
 
-  '/examples ': '/examples/introduction/hello-world/',
-  '/examples/ ': '/examples/introduction/hello-world/',
-  '/guide ': '/docs/',
-  '/guide/ ': '/docs/',
-  '/tutorial ': '/tutorial/welcome/overview/',
-  '/tutorial/ ': '/tutorial/welcome/overview/',
-  '/tutorials ': '/tutorial/welcome/overview/',
-  '/tutorials/ ': '/tutorial/welcome/overview/',
+  '/examples': '/examples/introduction/hello-world/',
+  '/examples/': '/examples/introduction/hello-world/',
+  '/guide': '/docs/',
+  '/guide/': '/docs/',
+  '/tutorial': '/tutorial/welcome/overview/',
+  '/tutorial/': '/tutorial/welcome/overview/',
+  '/tutorials': '/tutorial/welcome/overview/',
+  '/tutorials/': '/tutorial/welcome/overview/',
 };
 
 const redirects: Record<string, string> = {

--- a/packages/docs/src/routes/plugin@redirects.unit.ts
+++ b/packages/docs/src/routes/plugin@redirects.unit.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { onGet } from './plugin@redirects';
+
+const runRedirect = (pathname: string) => {
+  try {
+    onGet({
+      url: new URL(`https://qwik.dev${pathname}`),
+      redirect: (status: number, location: string) => ({ status, location }),
+    } as never);
+  } catch (redirectResponse) {
+    return redirectResponse;
+  }
+
+  throw new Error(`Expected ${pathname} to redirect`);
+};
+
+describe('plugin redirects', () => {
+  it('redirects temporary docs routes without whitespace mismatches', () => {
+    expect(runRedirect('/examples')).toEqual({
+      status: 307,
+      location: '/examples/introduction/hello-world/',
+    });
+  });
+
+  it('redirects chat without leading whitespace in the target URL', () => {
+    expect(runRedirect('/chat')).toEqual({
+      status: 307,
+      location: 'https://discord.gg/TsNCMd6uGW',
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- The server-side docs redirect plugin used exact `pathname` lookups but the temporary redirect map contained stray whitespace (trailing spaces in keys and a leading space in the `/chat` value), causing missed redirects and a malformed `Location` header.

### Description

- Remove stray leading/trailing whitespace from `tempRedirects` in `packages/docs/src/routes/plugin@redirects.ts` so lookups like `/examples`, `/guide`, `/tutorial`, and `/tutorials` match as intended.
- Fix the `/chat` target to remove the leading space so the emitted `Location` is a valid URL (`https://discord.gg/TsNCMd6uGW`).
- Add a focused unit test `packages/docs/src/routes/plugin@redirects.unit.ts` that exercises the temporary `/examples` redirect and the `/chat` redirect target to prevent regression.
- Commit recorded as `fix(docs): trim redirect whitespace`.

### Testing

- Ran a Python validation script that asserts the corrected entries are present in `packages/docs/src/routes/plugin@redirects.ts` and that the synced static `packages/docs/public/_redirects` contains the expected lines, and the script succeeded.
- Ran `git diff --check` to ensure no whitespace/format issues in the diff and it succeeded.
- Attempted to run the focused unit test with `pnpm vitest run packages/docs/src/routes/plugin@redirects.unit.ts` but the test runner could not execute in this environment because Node.js and `node_modules` are not installed (local `vitest` binary unavailable); the test file is included in the PR for CI to run in the normal environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd76948ba08331a3aff0522562d3e0)