### PR TITLE
fix(docs): escape Prism fallback HTML to prevent XSS

### DIFF
--- a/packages/docs/src/components/code-block/prismjs.ts
+++ b/packages/docs/src/components/code-block/prismjs.ts
@@ -2,9 +2,22 @@ import prismjs from 'prismjs';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-tsx';
 
+const escapeHtml = (code: string) =>
+  code
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
 export const highlight = (code?: string, language?: string) => {
-  if (!code || !language || !prismjs.languages[language]) {
-    return `<code class="language-${language}"><pre>${code}</pre></code>`;
+  if (!code) {
+    return '';
   }
+
+  if (!language || !prismjs.languages[language]) {
+    return escapeHtml(code);
+  }
+
   return prismjs.highlight(code, prismjs.languages[language], language);
 };

--- a/packages/docs/src/components/code-block/prismjs.unit.ts
+++ b/packages/docs/src/components/code-block/prismjs.unit.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { highlight } from './prismjs';
+
+describe('highlight', () => {
+  it('escapes unsupported languages before injecting HTML', () => {
+    const code = '</pre></code><img src=x onerror="alert(1)">';
+
+    expect(highlight(code, 'json')).toBe(
+      '&lt;/pre&gt;&lt;/code&gt;&lt;img src=x onerror=&quot;alert(1)&quot;&gt;'
+    );
+  });
+
+  it('keeps Prism highlighting for supported languages', () => {
+    expect(highlight('const value = 1;', 'tsx')).toContain('token keyword');
+  });
+});


### PR DESCRIPTION
### Motivation
- The `highlight()` fallback previously interpolated raw `code` into HTML when a Prism language was missing or unsupported, enabling XSS via the `dangerouslySetInnerHTML` sink in `CodeBlock`. 
- This change prevents user-provided code from breaking out of the `<code>` element when Prism does not provide a formatter for the requested language.

### Description
- Add an `escapeHtml` helper and update `highlight()` to return an empty string for missing `code` and to return escaped HTML when `language` is missing or unsupported, while preserving `prismjs.highlight` for supported languages. 
- Add a focused unit test `packages/docs/src/components/code-block/prismjs.unit.ts` that asserts unsupported-language input is escaped and that supported languages still produce Prism token markup.

### Testing
- Ran `git diff --check` to ensure no whitespace/git-diff issues and it succeeded. 
- Attempted to run the new unit test with `pnpm vitest run packages/docs/src/components/code-block/prismjs.unit.ts`, but the test run could not be executed in this environment due to the repository `engines.node` requirement and missing local dependencies; the test is included and should pass when run in CI or a local environment meeting `engines.node` and with dependencies installed. 
- Performed local code inspection to verify the fallback path no longer returns raw HTML and now escapes user content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd769403f88331b51d9dca2703590b)