### PR TITLE
fix(docs): restore glob import demo rendering

### DIFF
--- a/packages/docs/src/routes/demo/cookbook/glob-import/index.tsx
+++ b/packages/docs/src/routes/demo/cookbook/glob-import/index.tsx
@@ -25,7 +25,7 @@ export const MetaGlobExample = component$<{ name: string }>(({ name }) => {
   const componentPath = `/src/routes/demo/cookbook/glob-import/examples/${name}.tsx`;
 
   useTask$(async () => {
-    await metaGlobComponents[componentPath]();
+    MetaGlobComponent.value = await metaGlobComponents[componentPath]();
   });
 
   return <>{MetaGlobComponent.value && <MetaGlobComponent.value />}</>;


### PR DESCRIPTION
### Motivation
- The glob-import demo awaited the `import.meta.glob()` loader but never stored the imported default export, leaving `MetaGlobComponent.value` undefined and causing the example components to render nothing.

### Description
- Store the dynamically imported default export into the signal inside `useTask$` in `packages/docs/src/routes/demo/cookbook/glob-import/index.tsx` by assigning `MetaGlobComponent.value = await metaGlobComponents[componentPath]();` (one-line change) to restore rendering.

### Testing
- Ran `pnpm exec prettier --check packages/docs/src/routes/demo/cookbook/glob-import/index.tsx`, which passed.
- Ran `git diff --check`, which reported no issues.
- Attempted `pnpm exec eslint packages/docs/src/routes/demo/cookbook/glob-import/index.tsx`, but the lint check could not complete in this environment due to a missing `globals` package referenced from `eslint.config.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd76939dc88331a9e696eafc0e9500)