### PR TITLE
fix(qwik-city): check all bundle origins for route imports

### DIFF
--- a/.changeset/few-geese-approve.md
+++ b/.changeset/few-geese-approve.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+FIX: include route bundles when their matching origin is not the first manifest origin

--- a/packages/qwik-city/src/buildtime/vite/get-route-imports.ts
+++ b/packages/qwik-city/src/buildtime/vite/get-route-imports.ts
@@ -42,8 +42,8 @@ function isBundlePartOfRoute(bundle: QwikBundle, routeAndLayoutPaths: string[]) 
   if (!bundle.origins) {
     return false;
   }
-  for (const bundleOrigin of bundle.origins) {
+  return bundle.origins.some((bundleOrigin) => {
     const originPath = removeExtension(bundleOrigin);
     return routeAndLayoutPaths.some((path) => path.endsWith(originPath));
-  }
+  });
 }

--- a/packages/qwik-city/src/buildtime/vite/get-route-imports.unit.ts
+++ b/packages/qwik-city/src/buildtime/vite/get-route-imports.unit.ts
@@ -107,4 +107,39 @@ describe('modifyBundleGraph', () => {
       }
     `);
   });
+
+  test(`GIVEN a bundle with multiple origins
+        WHEN a later origin matches the route
+        THEN the bundle should still be included in the route imports`, () => {
+    const size = 0;
+    const total = 0;
+    const fakeManifest = {
+      bundles: {
+        'fake-bundle1.js': {
+          size,
+          total,
+          origins: ['src/components/button.tsx', 'src/routes/index.tsx'],
+        },
+      } as Record<string, QwikBundle>,
+    } as QwikManifest;
+
+    const fakeRoutes: BuildRoute[] = [
+      {
+        routeName: '/',
+        filePath: '/home/qwik-app/src/routes/index.tsx',
+      },
+    ] as BuildRoute[];
+
+    const actualResult = getRouteImports(fakeRoutes, fakeManifest);
+
+    expect(actualResult).toMatchInlineSnapshot(`
+      {
+        "/": {
+          "dynamicImports": [
+            "fake-bundle1.js",
+          ],
+        },
+      }
+    `);
+  });
 });


### PR DESCRIPTION
### Motivation
- A helper used to decide if a manifest bundle belongs to a route returned inside the origins loop, so only the first origin was evaluated and bundles with a matching origin later in the list could be omitted.
- This led to incomplete route-to-bundle mappings and missing prefetch dependencies for some routes.

### Description
- Replace the early `return` inside the `for` loop with `bundle.origins.some(...)` in `packages/qwik-city/src/buildtime/vite/get-route-imports.ts` so every origin is checked before deciding membership.
- Add a regression unit test in `packages/qwik-city/src/buildtime/vite/get-route-imports.unit.ts` that verifies bundles with multiple origins are included when a later origin matches the route.
- Add a patch changeset `.changeset/few-geese-approve.md` for `@builder.io/qwik-city` to document the fix.

### Testing
- Verified the corrected matching logic with a small `node` snippet that exercises the multi-origin case and returned the expected `true` result.
- Attempted to run the unit test via `pnpm vitest run packages/qwik-city/src/buildtime/vite/get-route-imports.unit.ts`, but the run failed in this environment due to Node version mismatch (`Got: v20.19.6`, repo requires `>=22.18.0`), so the added test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd780bbe088331ab4cb11ffbe6d630)