### PR TITLE
fix: prevent sibling node duplication when toggling elements with dangerouslySetInnerHTML

### DIFF
--- a/.changeset/tiny-mammals-allow.md
+++ b/.changeset/tiny-mammals-allow.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: sibling node duplication when toggling elements with dangerouslySetInnerHTML

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -380,7 +380,10 @@ function diff(
                   )) ||
                 _hasOwnProperty.call(diffContext.$jsxValue$.varProps, dangerouslySetInnerHTML);
               if (hasDangerousInnerHTML) {
-                expectNoChildren(diffContext, false);
+                // Only clean up children for existing nodes; new nodes have no children yet
+                if (!diffContext.$vNewNode$) {
+                  expectNoChildren(diffContext, false);
+                }
               } else {
                 descend(diffContext, diffContext.$jsxValue$.children, true);
               }

--- a/packages/qwik/src/core/tests/component.spec.tsx
+++ b/packages/qwik/src/core/tests/component.spec.tsx
@@ -945,14 +945,8 @@ describe.each([
       </Component>
     );
 
-    const isSSR = render === ssrRenderToDom;
     await expect(document.querySelector('button')).toMatchDOM(
-      isSSR ? (
-        // @ts-expect-error q:p is not typed
-        <button q:p="0">{`"<script></script>"&<'"0`}</button>
-      ) : (
-        <button>{`"<script></script>"&<'"0`}</button>
-      )
+      <button>{`"<script></script>"&<'"0`}</button>
     );
 
     await trigger(document.body, 'button', 'click');
@@ -967,12 +961,7 @@ describe.each([
     );
 
     await expect(document.querySelector('button')).toMatchDOM(
-      isSSR ? (
-        // @ts-expect-error q:p is not typed
-        <button q:p="0">{`"<script></script>"&<'"1`}</button>
-      ) : (
-        <button>{`"<script></script>"&<'"1`}</button>
-      )
+      <button>{`"<script></script>"&<'"1`}</button>
     );
   });
 
@@ -2509,10 +2498,10 @@ describe.each([
         </main>
       </Component>
     );
-    const isSsr = render === ssrRenderToDom;
     await expect(document.querySelector('main')).toMatchDOM(
-      // @ts-expect-error q:p is not typed
-      <main>{isSsr ? <button q:p="0">Remove</button> : <button>Remove</button>}</main>
+      <main>
+        <button>Remove</button>
+      </main>
     );
   });
 
@@ -2580,17 +2569,10 @@ describe.each([
       );
     });
     const { vNode, document } = await render(<Cmp />, { debug });
-    const isSsr = render === ssrRenderToDom;
-    const btn = isSsr ? (
-      // @ts-expect-error q:p is not typed
-      <button q:p="0">Remove</button>
-    ) : (
-      <button>Remove</button>
-    );
     expect(vNode).toMatchVDOM(
       <Component>
         <main>
-          {btn}
+          <button>Remove</button>
           <Fragment ssr-required>
             <div>1</div>
             <div>2</div>
@@ -2608,7 +2590,11 @@ describe.each([
         </main>
       </Component>
     );
-    await expect(document.querySelector('main')).toMatchDOM(<main>{btn}</main>);
+    await expect(document.querySelector('main')).toMatchDOM(
+      <main>
+        <button>Remove</button>
+      </main>
+    );
   });
 
   it('should rerun props subscribers', async () => {
@@ -3291,6 +3277,74 @@ describe.each([
     (globalThis as any).count = undefined;
   });
 
+  it('should not duplicate siblings when toggling element with dangerouslySetInnerHTML', async () => {
+    const Cmp = component$(() => {
+      const toggle = useSignal(false);
+      return (
+        <div>
+          <button onClick$={() => (toggle.value = !toggle.value)}>Toggle</button>
+          {toggle.value && <style dangerouslySetInnerHTML={''} />}
+          <span>{'aaa'}</span>
+        </div>
+      );
+    });
+
+    const { vNode, document } = await render(<Cmp />, { debug });
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <button>Toggle</button>
+          {''}
+          <span>{'aaa'}</span>
+        </div>
+      </Component>
+    );
+
+    await expect(document.body.querySelector('div')).toMatchDOM(
+      <div>
+        <button>Toggle</button>
+        <span>{'aaa'}</span>
+      </div>
+    );
+
+    await trigger(document.body, 'button', 'click');
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <button>Toggle</button>
+          <style />
+          <span>{'aaa'}</span>
+        </div>
+      </Component>
+    );
+
+    await expect(document.body.querySelector('div')).toMatchDOM(
+      <div>
+        <button>Toggle</button>
+        <style />
+        <span>{'aaa'}</span>
+      </div>
+    );
+
+    await trigger(document.body, 'button', 'click');
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <button>Toggle</button>
+          {''}
+          <span>{'aaa'}</span>
+        </div>
+      </Component>
+    );
+
+    await expect(document.body.querySelector('div')).toMatchDOM(
+      <div>
+        <button>Toggle</button>
+        <span>{'aaa'}</span>
+      </div>
+    );
+  });
+
   describe('regression', () => {
     it('#3643', async () => {
       const Issue3643 = component$(() => {
@@ -3313,16 +3367,9 @@ describe.each([
       });
       const { document, container } = await render(<Issue3643 />, { debug });
       const qContainerAttr = { [QContainerAttr]: QContainerValue.HTML };
-      const isSsr = render === ssrRenderToDom;
-      const btn = isSsr ? (
-        // @ts-expect-error q:p is not typed
-        <button q:p="0">Toggle</button>
-      ) : (
-        <button>Toggle</button>
-      );
       await expect(document.querySelector('main')).toMatchDOM(
         <main>
-          {btn}
+          <button>Toggle</button>
           <div>
             <div {...qContainerAttr}>Hello</div>
           </div>
@@ -3335,7 +3382,7 @@ describe.each([
       await trigger(container.element, 'button', 'click');
       await expect(document.querySelector('main')).toMatchDOM(
         <main>
-          {btn}
+          <button>Toggle</button>
           <div>
             {/* TODO: q:container is const and div is reused, is it ok? */}
             <div {...qContainerAttr}>World</div>
@@ -3349,7 +3396,7 @@ describe.each([
       await trigger(container.element, 'button', 'click');
       await expect(document.querySelector('main')).toMatchDOM(
         <main>
-          {btn}
+          <button>Toggle</button>
           <div>
             <div {...qContainerAttr}>Hello</div>
           </div>
@@ -3362,7 +3409,7 @@ describe.each([
       await trigger(container.element, 'button', 'click');
       await expect(document.querySelector('main')).toMatchDOM(
         <main>
-          {btn}
+          <button>Toggle</button>
           <div>
             <div {...qContainerAttr}>World</div>
           </div>
@@ -3375,7 +3422,7 @@ describe.each([
       await trigger(container.element, 'button', 'click');
       await expect(document.querySelector('main')).toMatchDOM(
         <main>
-          {btn}
+          <button>Toggle</button>
           <div>
             <div {...qContainerAttr}>Hello</div>
           </div>

--- a/packages/qwik/src/core/tests/use-signal.spec.tsx
+++ b/packages/qwik/src/core/tests/use-signal.spec.tsx
@@ -158,9 +158,8 @@ describe.each([
         </button>
       </Component>
     );
-    const isSsr = render === ssrRenderToDom;
     await expect(document.querySelector('button')).toMatchDOM(
-      jsx('button', { key: '0', children: 'const 0', ...(isSsr ? { 'q:p': 0 } : {}) })
+      jsx('button', { children: 'const 0' })
     );
     await trigger(container.element, 'button', 'click');
     expect(vNode).toMatchVDOM(
@@ -174,7 +173,7 @@ describe.each([
       </Component>
     );
     await expect(document.querySelector('button')).toMatchDOM(
-      jsx('button', { key: '0', children: 'const 1', ...(isSsr ? { 'q:p': 0 } : {}) })
+      jsx('button', { children: 'const 1' })
     );
   });
   it('should handle all ClassList cases', async () => {

--- a/packages/qwik/src/core/tests/use-task.spec.tsx
+++ b/packages/qwik/src/core/tests/use-task.spec.tsx
@@ -724,12 +724,8 @@ describe.each([
       await vi.advanceTimersToNextTimerAsync();
       const { document } = await renderPromise;
 
-      const isSsr = render === ssrRenderToDom;
       // Initial render
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val1</button> : <button>val1</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val1</button>);
 
       // FIRST CLICK
 
@@ -739,10 +735,7 @@ describe.each([
       // Advance timers but not enough to complete the delay
       await vi.advanceTimersByTimeAsync(99);
       // Should be still old value
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val1</button> : <button>val1</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val1</button>);
       // Advance timers to complete the delay
       await vi.advanceTimersByTimeAsync(1);
       // Wait for the trigger to complete
@@ -750,10 +743,7 @@ describe.each([
       await triggerPromise;
 
       // Should have the new value
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val2</button> : <button>val2</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val2</button>);
 
       // SECOND CLICK
 
@@ -763,10 +753,7 @@ describe.each([
       // Advance timers but not enough to complete the delay
       await vi.advanceTimersByTimeAsync(99);
       // Should be still old value
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val2</button> : <button>val2</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val2</button>);
       // Advance timers to complete the delay
       await vi.advanceTimersByTimeAsync(1);
       // Wait for the trigger to complete
@@ -774,10 +761,7 @@ describe.each([
       await triggerPromise;
 
       // Should have the new value
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val3</button> : <button>val3</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val3</button>);
 
       vi.useRealTimers();
     });
@@ -820,12 +804,8 @@ describe.each([
       await vi.advanceTimersToNextTimerAsync();
       const { document } = await renderPromise;
 
-      const isSsr = render === ssrRenderToDom;
       // Initial render
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val1</button> : <button>val1</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val1</button>);
 
       // FIRST CLICK
 
@@ -835,20 +815,14 @@ describe.each([
       // Advance timers but not enough to complete the delay
       await vi.advanceTimersByTimeAsync(99);
       // Should have the new value
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val2</button> : <button>val2</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val2</button>);
       // Advance timers to complete the delay
       await vi.advanceTimersByTimeAsync(1);
       // Wait for the trigger to complete
       await triggerPromise;
 
       // Should have the new value
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val2</button> : <button>val2</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val2</button>);
 
       // SECOND CLICK
 
@@ -858,20 +832,14 @@ describe.each([
       // Advance timers but not enough to complete the delay
       await vi.advanceTimersByTimeAsync(99);
       // Should have the new value
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val3</button> : <button>val3</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val3</button>);
       // Advance timers to complete the delay
       await vi.advanceTimersByTimeAsync(1);
       // Wait for the trigger to complete
       await triggerPromise;
 
       // Should have the new value
-      await expect(document.body.firstChild).toMatchDOM(
-        // @ts-expect-error q:p is not typed
-        isSsr ? <button q:p="0">val3</button> : <button>val3</button>
-      );
+      await expect(document.body.firstChild).toMatchDOM(<button>val3</button>);
 
       vi.useRealTimers();
     });

--- a/packages/qwik/src/testing/html.ts
+++ b/packages/qwik/src/testing/html.ts
@@ -1,5 +1,10 @@
 import { EventNameHtmlScope } from '../core/shared/utils/event-names';
-import { ELEMENT_KEY, Q_PROPS_SEPARATOR } from '../core/shared/utils/markers';
+import {
+  ELEMENT_KEY,
+  ITERATION_ITEM_MULTI,
+  ITERATION_ITEM_SINGLE,
+  Q_PROPS_SEPARATOR,
+} from '../core/shared/utils/markers';
 import { isSelfClosingTag } from '../server/tag-nesting';
 
 export function isTemplate(node: Node | null | undefined): node is HTMLTemplateElement {
@@ -14,8 +19,9 @@ export function prettyHtml(element: HTMLElement, prefix: string = ''): any {
     .map((attr) => ({ name: attr.name, value: attr.value }))
     .filter(
       (attr) =>
-        [Q_PROPS_SEPARATOR, ELEMENT_KEY].indexOf(attr.name) == -1 &&
-        !attr.name.startsWith(EventNameHtmlScope.on)
+        [Q_PROPS_SEPARATOR, ELEMENT_KEY, ITERATION_ITEM_MULTI, ITERATION_ITEM_SINGLE].indexOf(
+          attr.name
+        ) == -1 && !attr.name.startsWith(EventNameHtmlScope.on)
     )
     .sort((a, b) => a.name.localeCompare(b.name));
   for (let i = 0; i < attrs.length; i++) {


### PR DESCRIPTION
When element with dangerouslySetInnerHTML is newly inserted the vCurrent points to the old vnode. We should take vNewNode instead