### PR TITLE
fix: v2 noExternal and optimizeDeps

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -683,7 +683,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
  * because they use Qwik. If they are not included, the optimizer won't process them, and there will
  * be two instances of Qwik Core loaded.
  */
-function checkExternals() {
+async function checkExternals() {
   let fs: typeof import('fs').promises;
   let path: typeof import('path');
   let loaded = false;


### PR DESCRIPTION
## Problem

  Qwik library packages (like `@qds.dev/ui`) that ship `.qwik.` files containing `$()` calls fail during SSR builds:

  @qds.dev/ui is being treated as an external dependency, but it should be
  included in the server bundle, because it uses Qwik and it needs to be
  processed by the optimizer.

  Users had to manually add every Qwik library to both `ssr.noExternal` and `optimizeDeps.exclude` in their Vite config for them to render.

  ## Root cause

  `checkExternals()` had two bugs that prevented automatic discovery from working with Vite 7 and packages like `@qds.dev/ui`:

  1. `isQwikDep()` only checked `dependencies` and `peerDependencies` for `@qwik.dev/core`. Packages like `@qds.dev/ui` that list it in `devDependencies` were never detected as Qwik packages.

  2. The plugin set `ssr.noExternal` via the top-level `config` hook, but Vite 7's environment API (used by Astro 6) ignores top-level `ssr.noExternal`. Frameworks using `configEnvironment` set
  per-environment `resolve.noExternal`, overriding the top-level config entirely.

  ## Fix

  - `isQwikDep()` now also checks `devDependencies` for both `@qwik.dev/core` and `@builder.io/qwik`.

  - Added a `configEnvironment` hook that injects discovered Qwik deps into each environment's `resolve.noExternal`, which is what Vite 7's environment API actually reads. The top-level
  `ssr.noExternal` is kept for backward compatibility with Vite 6.

  - Discovered deps are stored in a shared `qwikDeps` array populated by the `config` hook (which runs first) and read by `configEnvironment` (which runs after).

  ## Result

  Any package with a `qwik` field or `@qwik.dev/core` in its dependencies/peerDependencies/devDependencies is automatically handled — in both Vite 6 (`ssr.noExternal`) and Vite 7
  (`resolve.noExternal` per environment). No manual config needed.