### PR TITLE
fix(docs): correct useTask behavior in tutorial

### DIFF
--- a/packages/docs/src/routes/tutorial/hooks/use-task/index.mdx
+++ b/packages/docs/src/routes/tutorial/hooks/use-task/index.mdx
@@ -10,7 +10,7 @@ updated_at: '2023-06-25T19:43:33Z'
 created_at: '2022-12-19T12:14:17Z'
 ---
 
-Use [`useTask$()`](/docs/(qwik)/core/tasks/index.mdx#usetask) to execute a function before the initial render and whenever the tracking values change. The function executes before rendering, but it can't delay rendering, so if [`useTask$()`](/docs/(qwik)/core/tasks/index.mdx#usetask) is asynchronous, the rendering will happen before the [`useTask$()`](/docs/(qwik)/core/tasks/index.mdx#usetask) is fully executed.
+Use [`useTask$()`](/docs/(qwik)/core/tasks/index.mdx#usetask) to execute a function before the initial render and whenever the tracking values change. The function executes before rendering. If [`useTask$()`](/docs/(qwik)/core/tasks/index.mdx#usetask) is asynchronous, the rendering will be blocked until the [`useTask$()`](/docs/(qwik)/core/tasks/index.mdx#usetask) is fully executed.
 
 ## Tracking store changes
 


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description

Currently async tasks block rendering, but the tutorial page states the opposite (https://qwik.dev/tutorial/hooks/use-task/). This PR updates the wording on that page to match the rest of the docs.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
