### PR TITLE
fix(core): useSerializer$ with Promise throws

### DIFF
--- a/.changeset/full-dodos-smash.md
+++ b/.changeset/full-dodos-smash.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix(core): useSerializer$ now can handle thrown Promises while initializing.

--- a/packages/qwik/src/core/reactive-primitives/impl/serializer-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/serializer-signal-impl.ts
@@ -1,7 +1,7 @@
 import { qwikDebugToString } from '../../debug';
 import type { QRLInternal } from '../../shared/qrl/qrl-class';
 import type { Container } from '../../shared/types';
-import { trackSignal } from '../../use/use-core';
+import { trackSignal, untrack } from '../../use/use-core';
 import type { SerializerArg } from '../types';
 import {
   EffectProperty,
@@ -39,16 +39,13 @@ export class SerializerSignalImpl<T, S> extends ComputedSignalImpl<T> {
     }
     throwIfQRLNotResolved(this.$computeQrl$);
 
-    this.$flags$ &= ~SignalFlags.INVALID;
+    const arg = untrack((this.$computeQrl$ as any as QRLInternal<SerializerArg<T, S>>).resolved!);
 
-    let arg = (this.$computeQrl$ as any as QRLInternal<SerializerArg<T, S>>).resolved!;
-    if (typeof arg === 'function') {
-      arg = arg();
-    }
     const { deserialize, initial } = arg;
     const update = (arg as any).update as ((current: T) => T) | undefined;
     const currentValue =
       this.$untrackedValue$ === NEEDS_COMPUTATION ? initial : this.$untrackedValue$;
+
     const untrackedValue = trackSignal(
       () =>
         this.$didInitialize$
@@ -59,6 +56,9 @@ export class SerializerSignalImpl<T, S> extends ComputedSignalImpl<T> {
       this.$container$!
     );
     this.$didInitialize$ = true;
+
+    // Needs to invalidate only after all possible Promise throws happened
+    this.$flags$ &= ~SignalFlags.INVALID;
 
     DEBUG && log('SerializerSignal.$compute$', untrackedValue);
     // We allow forcing the update of the signal without changing the value, for example when the deserialized value is the same reference as the old value but its internals have changed. In that case we want to trigger effects that depend on this signal, even though the value is the same.

--- a/packages/qwik/src/core/tests/use-serialized.spec.tsx
+++ b/packages/qwik/src/core/tests/use-serialized.spec.tsx
@@ -5,6 +5,7 @@ import {
   Fragment as Component,
   component$,
   useSignal,
+  useAsync$,
 } from '@qwik.dev/core';
 import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
 import { describe, expect, it } from 'vitest';
@@ -184,6 +185,25 @@ describe.each([
         <button>
           <Signal ssr-required>{'2'}</Signal>
         </button>
+      </>
+    );
+  });
+
+  it('should deserialize a Promise initial value as Date', async () => {
+    const DateDisplay = component$(() => {
+      const dateStr = useAsync$(() => Promise.resolve('2025-01-15T12:00:00.000Z'));
+      const date = useSerializer$(() => ({
+        deserialize: (str: string) => new Date(str),
+        serialize: (d) => d.toISOString(),
+        initial: dateStr.value,
+      }));
+      return <span>{date.value.toISOString()}</span>;
+    });
+
+    const { vNode } = await render(<DateDisplay />, { debug });
+    expect(vNode).toMatchVDOM(
+      <>
+        <span>2025-01-15T12:00:00.000Z</span>
       </>
     );
   });


### PR DESCRIPTION
fixes #8464 

The problem was computed signals throwing for the initial value, and the serializer marking the value as handled prematurely.