### PR TITLE
fix: Bump optimizer

### DIFF
--- a/.changeset/pretty-cycles-search.md
+++ b/.changeset/pretty-cycles-search.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/optimizer': patch
+---
+
+FEAT: the Qwik optimizer is now in a separate package, which reduces download size for the qwik package


### PR DESCRIPTION
accidentally published the optimizer package without all binaries