### PR TITLE
fix(eslint): allow use* hooks inside renderHook callback

### DIFF
--- a/packages/eslint-plugin-qwik/src/useMethodUsage.ts
+++ b/packages/eslint-plugin-qwik/src/useMethodUsage.ts
@@ -56,7 +56,8 @@ export const useMethodUsage: Rule.RuleModule = {
               if (parent.parent.type === 'CallExpression') {
                 if (
                   parent.parent.callee.type === 'Identifier' &&
-                  parent.parent.callee.name === 'component$'
+                  (parent.parent.callee.name === 'component$' ||
+                    parent.parent.callee.name === 'renderHook')
                 ) {
                   return;
                 }

--- a/packages/eslint-plugin-qwik/tests/use-method-usage/valid-inside-render-hook.tsx
+++ b/packages/eslint-plugin-qwik/tests/use-method-usage/valid-inside-render-hook.tsx
@@ -1,0 +1,11 @@
+import { useSignal } from '@builder.io/qwik';
+
+declare function renderHook<T>(hook: () => T): Promise<{ result: T }>;
+
+export async function testUseCounter() {
+  const { result } = await renderHook(() => {
+    const count = useSignal(0);
+    return count;
+  });
+  return result;
+}


### PR DESCRIPTION
# What is it?

- Bug

# Description

Closes #8381

The `qwik/use-method-usage` ESLint rule only allowed `use*` calls inside `component$()` callbacks. Testing utilities like `renderHook` wrap their callback in `component$()` internally, but the linter didn't know about that — so `renderHook(() => useSomeHook(args))` always errored.

Added `renderHook` to the allowed callee names in `useMethodUsage.ts`, so the arrow function passed to `renderHook` is treated the same way as one passed to `component$`.

Also added a test case (`valid-inside-render-hook.tsx`) that verifies the fix.

This affects at least two testing libraries:
- [`@noma.to/qwik-testing-library`](https://github.com/ianlet/qwik-testing-library)
- [`vitest-browser-qwik`](https://github.com/kunai-consulting/vitest-browser-qwik/)

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added new tests to cover the fix / functionality