### PR TITLE
fix: resolve crash when inserting DOM nodes near an errored host

### DIFF
--- a/.changeset/ready-zebras-obey.md
+++ b/.changeset/ready-zebras-obey.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: crash when inserting dom nodes near an errored-host

--- a/packages/qwik/src/core/client/dom-container.ts
+++ b/packages/qwik/src/core/client/dom-container.ts
@@ -38,6 +38,9 @@ import {
   convertScopedStyleIdsToArray,
   convertStyleIdsToString,
 } from '../shared/utils/scoped-styles';
+import { setErrorPayload } from '../shared/cursor/chore-execution';
+import { ChoreBits } from '../shared/vnode/enums/chore-bits.enum';
+import { markVNodeDirty } from '../shared/vnode/vnode-dirty';
 import type { ElementVNode } from '../shared/vnode/element-vnode';
 import type { VirtualVNode } from '../shared/vnode/virtual-vnode';
 import type { VNode } from '../shared/vnode/vnode';
@@ -51,15 +54,11 @@ import {
 } from './types';
 import { mapArray_get, mapArray_has, mapArray_set } from './util-mapArray';
 import {
-  vnode_createErrorDiv,
   vnode_getProp,
-  vnode_insertElementBefore,
-  vnode_isElementVNode,
   vnode_isVirtualVNode,
   vnode_locate,
   vnode_newUnMaterializedElement,
   vnode_setProp,
-  type VNodeJournal,
 } from './vnode-utils';
 
 /** @public */
@@ -186,24 +185,8 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
   handleError(err: any, host: VNode | null): void {
     if (qDev && host) {
       if (typeof document !== 'undefined') {
-        const createErrorWrapper = () => {
-          const vHost = host;
-          const vHostParent = vHost.parent;
-          const vHostNextSibling = vHost.nextSibling as VNode | null;
-          const journal: VNodeJournal = [];
-          const vErrorDiv = vnode_createErrorDiv(journal, document, vHost, err);
-          // If the host is an element node, we need to insert the error div into its parent.
-          const insertHost = vnode_isElementVNode(vHost) ? vHostParent || vHost : vHost;
-          // If the host is different then we need to insert errored-host in the same position as the host.
-          const insertBefore = insertHost === vHost ? null : vHostNextSibling;
-          vnode_insertElementBefore(
-            journal,
-            insertHost as ElementVNode | VirtualVNode,
-            vErrorDiv,
-            insertBefore
-          );
-        };
-        this.$renderPromise$ ? this.$renderPromise$.then(createErrorWrapper) : createErrorWrapper();
+        setErrorPayload(host, err);
+        markVNodeDirty(this, host, ChoreBits.ERROR_WRAP);
       }
 
       if (err && err instanceof Error) {

--- a/packages/qwik/src/core/shared/cursor/chore-execution.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.ts
@@ -1,4 +1,9 @@
-import { type VNodeJournal } from '../../client/vnode-utils';
+import {
+  type VNodeJournal,
+  vnode_createErrorDiv,
+  vnode_insertElementBefore,
+  vnode_isElementVNode,
+} from '../../client/vnode-utils';
 import { vnode_diff } from '../../client/vnode-diff';
 import { Task, TaskFlags, runTask, type TaskFn } from '../../use/use-task';
 import { executeComponent } from '../component-execution';
@@ -17,10 +22,12 @@ import type { NodeProp } from '../../reactive-primitives/subscription-data';
 import { isSignal, scheduleEffects } from '../../reactive-primitives/utils';
 import type { Signal } from '../../reactive-primitives/signal.public';
 import type { ElementVNode } from '../vnode/element-vnode';
+import type { VirtualVNode } from '../vnode/virtual-vnode';
 import { createSetAttributeOperation } from '../vnode/types/dom-vnode-operation';
 import type { JSXOutput } from '../jsx/types/jsx-node';
 import {
   HOST_SIGNAL,
+  ERROR_DATA_KEY,
   NODE_DIFF_DATA_KEY,
   NODE_PROPS_DATA_KEY,
   type CursorData,
@@ -110,6 +117,49 @@ function getNodeDiffPayload(vNode: VNode): JSXOutput | null {
 export function setNodeDiffPayload(vNode: VNode, payload: JSXOutput | Signal<JSXOutput>): void {
   const props = (vNode.props ||= {}) as Props;
   props[NODE_DIFF_DATA_KEY] = payload;
+}
+
+function getErrorPayload(vNode: VNode): Error | null {
+  const props = vNode.props as Props;
+  return (props?.[ERROR_DATA_KEY] as Error) ?? null;
+}
+
+export function setErrorPayload(vNode: VNode, error: Error | null): void {
+  const props = (vNode.props ||= {}) as Props;
+  props[ERROR_DATA_KEY] = error;
+}
+
+export function executeErrorWrap(vNode: VNode, journal: VNodeJournal): void {
+  vNode.dirty &= ~ChoreBits.ERROR_WRAP;
+
+  const err = getErrorPayload(vNode);
+  if (!err) {
+    return;
+  }
+  // cleanup payload
+  setErrorPayload(vNode, null);
+
+  const vHost = vNode;
+  const vHostParent = vHost.parent;
+  const vHostNextSibling = vHost.nextSibling as VNode | null;
+  const vErrorDiv = vnode_createErrorDiv(journal, document, vHost, err);
+  // If the host is an element node, we need to insert the error div into its parent.
+  const insertHost = vnode_isElementVNode(vHost) ? vHostParent || vHost : vHost;
+  // If the host is different then we need to insert errored-host in the same position as the host.
+  const insertBefore = insertHost === vHost ? null : vHostNextSibling;
+  vnode_insertElementBefore(
+    journal,
+    insertHost as ElementVNode | VirtualVNode,
+    vErrorDiv,
+    insertBefore
+  );
+  // vnode_createErrorDiv moves children into the errored-host element, which can
+  // mark the host with CHILDREN dirty bit. Clear it along with dirtyChildren to
+  // avoid an infinite loop — those children are now under errored-host, not this host.
+  // This is safe because CHILDREN is always processed before ERROR_WRAP in the walker,
+  // so any pre-existing child work has already completed.
+  vNode.dirty &= ~ChoreBits.CHILDREN;
+  vNode.dirtyChildren = null;
 }
 
 export function executeNodeDiff(

--- a/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
@@ -34,6 +34,26 @@ import type { Signal } from '../../reactive-primitives/signal.public';
 import type { QRLInternal } from '../qrl/qrl-class';
 import type { JSXOutput } from '../jsx/types/jsx-node';
 
+vi.mock('../../client/vnode-utils', () => ({
+  vnode_createErrorDiv: vi.fn(() => {
+    // Return a mock ElementVNode
+    const node = { tagName: 'ERRORED-HOST' } as any;
+    return {
+      flags: 1, // VNodeFlags.Element
+      dirty: 0,
+      parent: null,
+      previousSibling: null,
+      nextSibling: null,
+      lastChild: null,
+      firstChild: null,
+      node,
+      props: {},
+    };
+  }),
+  vnode_insertElementBefore: vi.fn(),
+  vnode_isElementVNode: vi.fn((vNode: any) => !!(vNode?.flags & 1)),
+}));
+
 vi.mock('../../use/use-task', async () => {
   const actual = await vi.importActual<typeof import('../../use/use-task')>('../../use/use-task');
   return {

--- a/packages/qwik/src/core/shared/cursor/cursor-props.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-props.ts
@@ -10,6 +10,7 @@ export const cursorDatas = new WeakMap<Cursor, CursorData>();
 /** Key used to store pending node prop updates in vNode props. */
 export const NODE_PROPS_DATA_KEY = ':nodeProps';
 export const NODE_DIFF_DATA_KEY = ':nodeDiff';
+export const ERROR_DATA_KEY = ':errorData';
 export const HOST_SIGNAL = ':signal';
 
 export interface CursorData {

--- a/packages/qwik/src/core/shared/cursor/cursor-walker.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-walker.ts
@@ -11,6 +11,7 @@ import {
   executeCleanup,
   executeComponentChore,
   executeCompute,
+  executeErrorWrap,
   executeNodeDiff,
   executeNodeProps,
   executeReconcile,
@@ -181,6 +182,11 @@ export function walkCursor(cursor: Cursor, options: WalkOptions): void {
           currentVNode = next;
           continue;
         }
+      } else if (currentVNode.dirty & ChoreBits.ERROR_WRAP) {
+        // Must run after CHILDREN so that all descendant chores (e.g. signal text
+        // NODE_DIFF updates) are flushed before we reparent children into the
+        // errored-host wrapper element.
+        executeErrorWrap(currentVNode, journal);
       }
     } catch (error) {
       container.handleError(error, currentVNode);

--- a/packages/qwik/src/core/shared/vnode/enums/chore-bits.enum.ts
+++ b/packages/qwik/src/core/shared/vnode/enums/chore-bits.enum.ts
@@ -8,6 +8,7 @@ export const enum ChoreBits {
   CHILDREN = 1 << 5,
   CLEANUP = 1 << 6,
   RECONCILE = 1 << 7,
+  ERROR_WRAP = 1 << 8,
   DIRTY_MASK = TASKS |
     NODE_DIFF |
     COMPONENT |
@@ -15,5 +16,6 @@ export const enum ChoreBits {
     COMPUTE |
     CHILDREN |
     CLEANUP |
-    RECONCILE,
+    RECONCILE |
+    ERROR_WRAP,
 }

--- a/packages/qwik/src/core/tests/error-handling.spec.tsx
+++ b/packages/qwik/src/core/tests/error-handling.spec.tsx
@@ -102,6 +102,71 @@ describe.each([
     );
   });
 
+  it('should insert a node before an errored-host', async () => {
+    const ErrorCmp = component$(() => {
+      const counter = useSignal(0);
+      if (counter.value !== 0) {
+        throw new Error('error');
+      }
+      return (
+        <main>
+          <button id="error-btn" onClick$={() => counter.value++}>
+            {counter.value}
+          </button>
+        </main>
+      );
+    });
+
+    const Parent = component$(() => {
+      const show = useSignal(false);
+      return (
+        <>
+          <button id="show-btn" onClick$={() => (show.value = true)}>
+            toggle
+          </button>
+          {show.value && <div id="inserted">inserted</div>}
+          <ErrorCmp />
+        </>
+      );
+    });
+
+    const { vNode, document } = await render(
+      <ErrorProvider>
+        <Parent />
+      </ErrorProvider>,
+      { debug }
+    );
+    globalThis.document = document;
+
+    // Trigger the error first
+    await trigger(document.body, '#error-btn', 'click');
+
+    // Now insert a node before the errored-host
+    await trigger(document.body, '#show-btn', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Projection ssr-required>
+          <Component ssr-required>
+            <Fragment ssr-required>
+              <button id="show-btn">toggle</button>
+              <div id="inserted">inserted</div>
+              <Component ssr-required>
+                <errored-host>
+                  <main>
+                    <button id="error-btn">
+                      <Signal ssr-required>1</Signal>
+                    </button>
+                  </main>
+                </errored-host>
+              </Component>
+            </Fragment>
+          </Component>
+        </Projection>
+      </Component>
+    );
+  });
+
   it('should handle error in event handler', async () => {
     const Cmp = component$(() => {
       const counter = useSignal(0);


### PR DESCRIPTION
Errored-host wasnt applied to DOM. Moved logic to cursor for correct errored-host handling