### PR TITLE
fix(router): SPA routing issue with back/forward navigation after manual refresh

### DIFF
--- a/.changeset/long-cooks-joke.md
+++ b/.changeset/long-cooks-joke.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: fix an SPA routing bug where using browser back/forward after a manual refresh could change the URL without rerendering the page

--- a/e2e/qwik-e2e/tests/qwikrouter/nav.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/nav.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Locator } from '@playwright/test';
 import {
   assertPage,
   getScrollHeight,
@@ -11,6 +11,31 @@ import {
 } from './util.js';
 
 test.describe('nav', () => {
+  // Firefox can lag a bit before exposing image DOM properties on the MPA/SSR path,
+  // so wait for a fully loaded image state instead of reading natural* eagerly.
+  async function expectLoadedImage(locator: Locator, naturalWidth: number, naturalHeight: number) {
+    await expect
+      .poll(async () => {
+        return locator.evaluate((node) => {
+          if (!(node instanceof HTMLImageElement)) {
+            return null;
+          }
+          return {
+            complete: node.complete,
+            currentSrc: !!node.currentSrc,
+            naturalHeight: node.naturalHeight,
+            naturalWidth: node.naturalWidth,
+          };
+        });
+      })
+      .toEqual({
+        complete: true,
+        currentSrc: true,
+        naturalHeight,
+        naturalWidth,
+      });
+  }
+
   test.describe('mpa', () => {
     test.use({ javaScriptEnabled: false });
     tests();
@@ -58,20 +83,40 @@ test.describe('nav', () => {
 
     test.describe('scroll-restoration', () => {
       test('should not refresh again on popstate after manual refresh', async ({ page }) => {
+        const documentLoadsKey = '__qwik_router_document_loads__';
+        await page.addInitScript((storageKey) => {
+          const documentLoads = Number(sessionStorage.getItem(storageKey) || '0') + 1;
+          sessionStorage.setItem(storageKey, String(documentLoads));
+        }, documentLoadsKey);
+        const getDocumentLoads = () =>
+          page.evaluate(
+            (storageKey) => Number(sessionStorage.getItem(storageKey) || '0'),
+            documentLoadsKey
+          );
+
         await page.goto('/qwikrouter-test/scroll-restoration/page-long/');
         const link = page.locator('#to-page-short');
         await link.click();
 
         await expect(page).toHaveURL('/qwikrouter-test/scroll-restoration/page-short/');
         await expect(page.locator('h1')).toHaveText('Page Short');
+        await expect.poll(getDocumentLoads).toBe(1);
 
         await page.reload();
         await expect(page.locator('h1')).toHaveText('Page Short');
+        await expect.poll(getDocumentLoads).toBe(2);
 
         await page.goBack();
 
         await expect(page).toHaveURL('/qwikrouter-test/scroll-restoration/page-long/');
         await expect(page.locator('h1')).toHaveText('Page Long');
+        await expect.poll(getDocumentLoads).toBe(2);
+
+        await page.goForward();
+
+        await expect(page).toHaveURL('/qwikrouter-test/scroll-restoration/page-short/');
+        await expect(page.locator('h1')).toHaveText('Page Short');
+        await expect.poll(getDocumentLoads).toBe(2);
       });
       test('should scroll on hash change', async ({ page }) => {
         await page.goto('/qwikrouter-test/scroll-restoration/hash/');
@@ -444,16 +489,14 @@ test.describe('nav', () => {
     test('media in home page', async ({ page }) => {
       await page.goto('/qwikrouter-test/');
 
-      await expect(page.locator('#image-jpeg')).toHaveJSProperty('naturalWidth', 520);
-      await expect(page.locator('#image-jpeg')).toHaveJSProperty('naturalHeight', 520);
+      await expectLoadedImage(page.locator('#image-jpeg'), 520, 520);
 
-      await expect(page.locator('#image-jpeg')).toHaveJSProperty('loading', 'eager');
-      await expect(page.locator('#image-jpeg')).toHaveJSProperty('decoding', 'auto');
+      await expect(page.locator('#image-jpeg')).toHaveAttribute('loading', 'eager');
+      await expect(page.locator('#image-jpeg')).toHaveAttribute('decoding', 'auto');
 
-      await expect(page.locator('#image-avif')).toHaveJSProperty('width', 100);
-      await expect(page.locator('#image-avif')).toHaveJSProperty('height', 100);
-      await expect(page.locator('#image-avif')).toHaveJSProperty('naturalWidth', 520);
-      await expect(page.locator('#image-avif')).toHaveJSProperty('naturalHeight', 520);
+      await expect(page.locator('#image-avif')).toHaveAttribute('width', '100');
+      await expect(page.locator('#image-avif')).toHaveAttribute('height', '100');
+      await expectLoadedImage(page.locator('#image-avif'), 520, 520);
     });
 
     test('redirects, re-runs loaders and changes the url within the same page when search params changed', async ({

--- a/packages/qwik-router/src/runtime/src/router-outlet-component.tsx
+++ b/packages/qwik-router/src/runtime/src/router-outlet-component.tsx
@@ -10,7 +10,20 @@ import {
 import { ContentInternalContext } from './contexts';
 import type { ClientSPAWindow } from './qwik-router-component';
 import type { ScrollHistoryState } from './scroll-restoration';
+import { type RouterPopstateEventDetail } from './spa-init';
 import spaInit from './spa-init';
+import type { RouteNavigate } from './types';
+import { useNavigate } from './use-functions';
+
+export const handleRouterPopstate = (
+  nav: RouteNavigate,
+  event: Event | CustomEvent<RouterPopstateEventDetail>
+) => {
+  const href = (event as CustomEvent<RouterPopstateEventDetail>).detail?.href;
+  if (href) {
+    return nav(href, { type: 'popstate' });
+  }
+};
 
 /** @public */
 export const RouterOutlet = component$(() => {
@@ -20,6 +33,7 @@ export const RouterOutlet = component$(() => {
   }
 
   const internalContext = useContext(ContentInternalContext);
+  const nav = useNavigate();
 
   const contents = internalContext.value;
 
@@ -39,17 +53,19 @@ export const RouterOutlet = component$(() => {
         {!__EXPERIMENTAL__.noSPA && (
           <script
             document:onQCInit$={spaInit}
+            document:onQRouterPopstate$={(event) => handleRouterPopstate(nav, event)}
             document:onQInit$={sync$(() => {
               // Minify window and history
               // Write this as minified as possible, the optimizer does not really minify this code.
               ((w: ClientSPAWindow, h: History & { state?: ScrollHistoryState }) => {
-                if (!w._qcs && h.scrollRestoration === 'manual') {
+                if (!w._qcs) {
                   // true
                   w._qcs = !0;
 
                   // scrollState
                   const s = h.state?._qRouterScroll;
                   if (s) {
+                    h.scrollRestoration = 'manual';
                     w.scrollTo(s.x, s.y);
                   }
                   // Tell qwikloader to run the spaInit code

--- a/packages/qwik-router/src/runtime/src/router-outlet-component.unit.ts
+++ b/packages/qwik-router/src/runtime/src/router-outlet-component.unit.ts
@@ -1,0 +1,29 @@
+import { assert, test, vi, type Mock } from 'vitest';
+import { handleRouterPopstate } from './router-outlet-component';
+import type { RouteNavigate } from './types';
+import { Q_ROUTER_POPSTATE_EVENT } from './spa-init';
+
+test('handleRouterPopstate forwards the bridged href to goto as popstate navigation', async () => {
+  const nav = vi.fn(async () => undefined) as unknown as RouteNavigate;
+
+  await handleRouterPopstate(
+    nav,
+    new CustomEvent(Q_ROUTER_POPSTATE_EVENT, {
+      detail: {
+        href: 'http://localhost/scroll-restoration/page-short/',
+      },
+    })
+  );
+
+  assert.deepEqual((nav as unknown as Mock).mock.calls, [
+    ['http://localhost/scroll-restoration/page-short/', { type: 'popstate' }],
+  ]);
+});
+
+test('handleRouterPopstate ignores bridge events without an href', async () => {
+  const nav = vi.fn(async () => undefined) as unknown as RouteNavigate;
+
+  await handleRouterPopstate(nav, new CustomEvent(Q_ROUTER_POPSTATE_EVENT, { detail: {} }));
+
+  assert.deepEqual((nav as unknown as Mock).mock.calls, []);
+});

--- a/packages/qwik-router/src/runtime/src/spa-init.ts
+++ b/packages/qwik-router/src/runtime/src/spa-init.ts
@@ -1,11 +1,36 @@
-import type { ContextId, DomContainer, _ContainerElement } from 'packages/qwik/core-internal';
 import type { ClientSPAWindow } from './qwik-router-component';
 import type { ScrollHistoryState } from './scroll-restoration';
-import type { RouteNavigate, ScrollState } from './types';
+import type { ScrollState } from './types';
 
 import { event$, isDev } from '@qwik.dev/core';
 
 declare const window: ClientSPAWindow;
+
+export const Q_ROUTER_POPSTATE_EVENT = 'qrouterpopstate';
+export interface RouterPopstateEventDetail {
+  href: string;
+}
+
+export const createCurrentPathTracker = (initialPath: string) => {
+  let currentPath = initialPath;
+
+  return (nextPath: string) => {
+    if (currentPath !== nextPath) {
+      currentPath = nextPath;
+      return true;
+    }
+
+    return false;
+  };
+};
+
+export const dispatchRouterPopstate = (document: Document, href: string) => {
+  document.dispatchEvent(
+    new CustomEvent<RouterPopstateEventDetail>(Q_ROUTER_POPSTATE_EVENT, {
+      detail: { href },
+    })
+  );
+};
 
 // TODO Dedupe handler code from here and QwikRouterProvider?
 // TODO Navigation API; check for support & simplify.
@@ -20,7 +45,7 @@ export default event$((_: Event, el: Element) => {
   // This complements qwik-router-component.ts
   // only run once, when router didn't init yet
   if (!window._qRouterSPA && !window._qRouterInitPopstate) {
-    const currentPath = location.pathname + location.search;
+    const hasPathChanged = createCurrentPathTracker(location.pathname + location.search);
 
     const checkAndScroll = (scrollState: ScrollState | undefined) => {
       if (scrollState) {
@@ -55,24 +80,8 @@ export default event$((_: Event, el: Element) => {
       window._qRouterScrollEnabled = false;
       clearTimeout(window._qRouterScrollDebounce);
 
-      if (currentPath !== location.pathname + location.search) {
-        const getContainer = (el: Element) =>
-          el.closest('[q\\:container]:not([q\\:container=html]):not([q\\:container=text])');
-
-        const container = getContainer(el);
-        const domContainer = (container as _ContainerElement).qContainer as DomContainer;
-        const hostElement = domContainer.vNodeLocate(el);
-
-        const nav = domContainer?.resolveContext(hostElement, {
-          id: 'qr-n',
-        } as ContextId<RouteNavigate>);
-
-        if (nav) {
-          nav(location.href, { type: 'popstate' });
-        } else {
-          // No useNavigate ctx available, fallback to reload.
-          location.reload();
-        }
+      if (hasPathChanged(location.pathname + location.search)) {
+        dispatchRouterPopstate(document, location.href);
       } else {
         if (history.scrollRestoration === 'manual') {
           const scrollState = (history.state as ScrollHistoryState)?._qRouterScroll;

--- a/packages/qwik-router/src/runtime/src/spa-init.unit.ts
+++ b/packages/qwik-router/src/runtime/src/spa-init.unit.ts
@@ -1,0 +1,38 @@
+import { assert, test } from 'vitest';
+import {
+  createCurrentPathTracker,
+  dispatchRouterPopstate,
+  Q_ROUTER_POPSTATE_EVENT,
+} from './spa-init';
+
+test('createCurrentPathTracker treats back then forward as two path changes', () => {
+  const hasPathChanged = createCurrentPathTracker('/scroll-restoration/page-short');
+
+  assert.equal(hasPathChanged('/scroll-restoration/page-short'), false);
+  assert.equal(hasPathChanged('/scroll-restoration/page-long'), true);
+  assert.equal(hasPathChanged('/scroll-restoration/page-short'), true);
+});
+
+test('createCurrentPathTracker ignores repeated visits to the same path', () => {
+  const hasPathChanged = createCurrentPathTracker('/scroll-restoration/page-short');
+
+  assert.equal(hasPathChanged('/scroll-restoration/page-long'), true);
+  assert.equal(hasPathChanged('/scroll-restoration/page-long'), false);
+});
+
+test('dispatchRouterPopstate sends the current href through the recovery bridge', () => {
+  let dispatchedEvent: Event | undefined;
+  const document = {
+    dispatchEvent: (event: Event) => {
+      dispatchedEvent = event;
+      return true;
+    },
+  } as Document;
+
+  dispatchRouterPopstate(document, 'http://localhost/scroll-restoration/page-short/');
+
+  assert.equal(dispatchedEvent?.type, Q_ROUTER_POPSTATE_EVENT);
+  assert.deepEqual((dispatchedEvent as CustomEvent).detail, {
+    href: 'http://localhost/scroll-restoration/page-short/',
+  });
+});

--- a/scripts/docs-size-results.json
+++ b/scripts/docs-size-results.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-09T09:51:56.089Z",
+  "generatedAt": "2026-04-09T20:58:38.674Z",
   "routes": {
     "/": {
-      "rawBytes": 217511,
-      "gzipBytes": 45014
+      "rawBytes": 217750,
+      "gzipBytes": 45413
     },
     "/docs": {
-      "rawBytes": 1064084,
-      "gzipBytes": 179689
+      "rawBytes": 1063923,
+      "gzipBytes": 178259
     }
   }
 }


### PR DESCRIPTION
Fix browser  back/forward navigation after manual refresh.
Before this change, if a page was manually refreshed and the user then used browser history navigation, the URL could change without rerendering the page, or the router could fall back to an extra document reload during pre-resume recovery.