### PR TITLE
fix(optimizer): don't migrate transitive deps used by other segments

### DIFF
--- a/packages/optimizer/core/src/dependency_analysis.rs
+++ b/packages/optimizer/core/src/dependency_analysis.rs
@@ -433,7 +433,15 @@ pub fn find_migratable_vars(
 					return false;
 				}
 
+				// Don't migrate a variable that is used by another segment
+				// (it was pulled in as a transitive dependency, but other segments need it too)
 				let candidate_target = assignment.get(candidate_id).copied().unwrap_or(*seg_idx);
+				if let Some(usage) = root_var_usage.get(candidate_id) {
+					if usage.iter().any(|&seg| seg != candidate_target) {
+						return false;
+					}
+				}
+
 				if !shared_declarator_migrates_as_a_unit(
 					candidate_id,
 					candidate_target,

--- a/packages/optimizer/core/src/snapshots/qwik_core__test__variable_migration_transitive_dep_used_by_other_segment.snap
+++ b/packages/optimizer/core/src/snapshots/qwik_core__test__variable_migration_transitive_dep_used_by_other_segment.snap
@@ -1,0 +1,133 @@
+---
+source: packages/optimizer/core/src/test.rs
+assertion_line: 6030
+expression: output
+---
+==INPUT==
+
+
+import { component$, $ } from '@qwik.dev/core';
+
+// scrollState is used by both segments - must NOT be migrated
+const scrollState = (el) => ({ x: el.scrollLeft, y: el.scrollTop });
+
+// saveScroll is used by both segments - must NOT be migrated
+const saveScroll = (s) => history.replaceState(s, '');
+
+// bigHelper depends on scrollState and saveScroll, used only by App
+const bigHelper = (el) => {
+  const s = scrollState(el);
+  saveScroll(s);
+  return s;
+};
+
+export const App = component$(() => {
+  // Uses bigHelper (which transitively uses scrollState and saveScroll)
+  const s = bigHelper(document.body);
+  return <div>{s.x}</div>;
+});
+
+export const Other = component$(() => {
+  // Directly uses scrollState and saveScroll
+  const s = scrollState(document.body);
+  saveScroll(s);
+  return <div>{s.y}</div>;
+});
+
+============================= test.tsx_Other_component_C1my3EIdP1k.tsx (ENTRY POINT)==
+
+import { _auto_saveScroll as saveScroll } from "./test";
+import { _auto_scrollState as scrollState } from "./test";
+//
+export const Other_component_C1my3EIdP1k = ()=>{
+    // Directly uses scrollState and saveScroll
+    const s = scrollState(document.body);
+    saveScroll(s);
+    return <div>{s.y}</div>;
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;2CAsBgC;IAC9B,2CAA2C;IAC3C,MAAM,IAAI,YAAY,SAAS,IAAI;IACnC,WAAW;IACX,QAAQ,KAAK,EAAE,CAAC,GAAG;AACrB\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Other_component_C1my3EIdP1k",
+  "entry": null,
+  "displayName": "test.tsx_Other_component",
+  "hash": "C1my3EIdP1k",
+  "canonicalFilename": "test.tsx_Other_component_C1my3EIdP1k",
+  "path": "",
+  "extension": "tsx",
+  "parent": null,
+  "ctxKind": "function",
+  "ctxName": "component$",
+  "captures": false,
+  "loc": [
+    674,
+    813
+  ]
+}
+*/
+============================= test.tsx ==
+
+import { componentQrl } from "@qwik.dev/core";
+import { qrl } from "@qwik.dev/core";
+//
+const q_App_component_ckEPmXZlub0 = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_ckEPmXZlub0"), "App_component_ckEPmXZlub0");
+const q_Other_component_C1my3EIdP1k = /*#__PURE__*/ qrl(()=>import("./test.tsx_Other_component_C1my3EIdP1k"), "Other_component_C1my3EIdP1k");
+// scrollState is used by both segments - must NOT be migrated
+//
+const scrollState = (el)=>({
+        x: el.scrollLeft,
+        y: el.scrollTop
+    });
+// saveScroll is used by both segments - must NOT be migrated
+const saveScroll = (s)=>history.replaceState(s, '');
+export const App = /*#__PURE__*/ componentQrl(q_App_component_ckEPmXZlub0);
+export const Other = /*#__PURE__*/ componentQrl(q_Other_component_C1my3EIdP1k);
+export { saveScroll as _auto_saveScroll };
+export { scrollState as _auto_scrollState };
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AAGA,8DAA8D;;AAC9D,MAAM,cAAc,CAAC,KAAO,CAAC;QAAE,GAAG,GAAG,UAAU;QAAE,GAAG,GAAG,SAAS;IAAC,CAAC;AAElE,6DAA6D;AAC7D,MAAM,aAAa,CAAC,IAAM,QAAQ,YAAY,CAAC,GAAG;AASlD,OAAO,MAAM,oBAAM,0CAIhB;AAEH,OAAO,MAAM,sBAAQ,4CAKlB\"}")
+============================= test.tsx_App_component_ckEPmXZlub0.tsx (ENTRY POINT)==
+
+import { _auto_saveScroll as saveScroll } from "./test";
+import { _auto_scrollState as scrollState } from "./test";
+//
+const bigHelper = (el)=>{
+    const s = scrollState(el);
+    saveScroll(s);
+    return s;
+};
+export const App_component_ckEPmXZlub0 = ()=>{
+    // Uses bigHelper (which transitively uses scrollState and saveScroll)
+    const s = bigHelper(document.body);
+    return <div>{s.x}</div>;
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;MAUM,YAAY,CAAC;IACjB,MAAM,IAAI,YAAY;IACtB,WAAW;IACX,OAAO;AACT;yCAE8B;IAC5B,sEAAsE;IACtE,MAAM,IAAI,UAAU,SAAS,IAAI;IACjC,QAAQ,KAAK,EAAE,CAAC,GAAG;AACrB\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_ckEPmXZlub0",
+  "entry": null,
+  "displayName": "test.tsx_App_component",
+  "hash": "ckEPmXZlub0",
+  "canonicalFilename": "test.tsx_App_component_ckEPmXZlub0",
+  "path": "",
+  "extension": "tsx",
+  "parent": null,
+  "ctxKind": "function",
+  "ctxName": "component$",
+  "captures": false,
+  "loc": [
+    491,
+    638
+  ]
+}
+*/
+== DIAGNOSTICS ==
+
+[]

--- a/packages/optimizer/core/src/test.rs
+++ b/packages/optimizer/core/src/test.rs
@@ -6020,6 +6020,73 @@ export const Other = component$(() => {
 	});
 }
 
+/// Regression test: when a root variable is pulled in as a transitive dependency
+/// for migration to segment A, but is also directly used by segment B, it must NOT
+/// be migrated. Otherwise segment B loses access to it (the export is removed).
+/// This reproduces the qwik-router bug where `currentScrollState` and `saveScrollHistory`
+/// were migrated to the useTask segment but also needed by the goto segment.
+#[test]
+fn variable_migration_transitive_dep_used_by_other_segment() {
+	let res = test_input!(TestInput {
+		code: r#"
+import { component$, $ } from '@qwik.dev/core';
+
+// scrollState is used by both segments - must NOT be migrated
+const scrollState = (el) => ({ x: el.scrollLeft, y: el.scrollTop });
+
+// saveScroll is used by both segments - must NOT be migrated
+const saveScroll = (s) => history.replaceState(s, '');
+
+// bigHelper depends on scrollState and saveScroll, used only by App
+const bigHelper = (el) => {
+  const s = scrollState(el);
+  saveScroll(s);
+  return s;
+};
+
+export const App = component$(() => {
+  // Uses bigHelper (which transitively uses scrollState and saveScroll)
+  const s = bigHelper(document.body);
+  return <div>{s.x}</div>;
+});
+
+export const Other = component$(() => {
+  // Directly uses scrollState and saveScroll
+  const s = scrollState(document.body);
+  saveScroll(s);
+  return <div>{s.y}</div>;
+});
+"#
+		.to_string(),
+		snapshot: true,
+		..TestInput::default()
+	});
+
+	// Verify the fix: scrollState and saveScroll must be importable by both segments
+	let output = res.unwrap();
+	let other_segment = output
+		.modules
+		.iter()
+		.find(|m| m.path.contains("Other_component"))
+		.expect("Other_component segment should exist");
+
+	// scrollState must be imported (not missing) in the Other segment
+	assert!(
+		other_segment.code.contains("scrollState")
+			&& (other_segment.code.contains("import")
+				|| other_segment.code.contains("const scrollState")),
+		"scrollState must be available in Other segment (imported or inlined), got:\n{}",
+		other_segment.code
+	);
+	assert!(
+		other_segment.code.contains("saveScroll")
+			&& (other_segment.code.contains("import")
+				|| other_segment.code.contains("const saveScroll")),
+		"saveScroll must be available in Other segment (imported or inlined), got:\n{}",
+		other_segment.code
+	);
+}
+
 #[test]
 fn root_level_self_referential_qrl() {
 	test_input!(TestInput {


### PR DESCRIPTION
When variable migration collected transitive dependencies for a root variable being migrated to a single segment, it didn't check whether those transitive deps were also directly used by other segments. This caused the deps to be migrated (inlined) into one segment and their exports removed from the parent module, leaving other segments with dangling references.

In qwik-router, this manifested as `currentScrollState` and `saveScrollHistory` being migrated to the useTask segment (as transitive deps of other helpers) while the goto segment also needed them, causing ReferenceErrors at runtime during SPA navigation.

The fix adds a check in the safety filter of `find_migratable_vars`: if a candidate variable appears in `root_var_usage` for any segment other than the migration target, it is excluded from migration.
