### PR TITLE
fix(router): make server fn discovery deterministic in Deno builds

### DIFF
--- a/.changeset/lemon-flies-taste.md
+++ b/.changeset/lemon-flies-taste.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: intermittent Deno build failure in apps that use async tasks

--- a/packages/qwik-router/src/buildtime/vite/plugin.ts
+++ b/packages/qwik-router/src/buildtime/vite/plugin.ts
@@ -23,6 +23,7 @@ import { generateServiceWorkerRegister } from '../runtime-generation/generate-se
 import type { RoutingContext } from '../types';
 import { getRouteImports } from './get-route-imports';
 import { imagePlugin } from './image-jsx';
+import { collectServerFnModuleIds } from './server-fns';
 import type {
   QwikCityVitePluginOptions,
   QwikRouterPluginApi,
@@ -36,6 +37,7 @@ const QWIK_ROUTER_ENTRIES_ID = '@qwik-router-entries';
 const QWIK_ROUTER = '@qwik.dev/router';
 const QWIK_ROUTER_SW_REGISTER = '@qwik-router-sw-register';
 const VIRTUAL_SERVER_FNS = 'virtual:qwik-router-server-fns';
+type BuildContextRef = { current: RoutingContext | null };
 
 /**
  * @deprecated Use `qwikRouter` instead. Will be removed in V3
@@ -47,10 +49,18 @@ export function qwikCity(userOpts?: QwikCityVitePluginOptions): PluginOption[] {
 
 /** @public */
 export function qwikRouter(userOpts?: QwikRouterVitePluginOptions): PluginOption[] {
-  return [qwikRouterPlugin(userOpts), serverFnsPlugin(), ...imagePlugin(userOpts)];
+  const buildContextRef: BuildContextRef = { current: null };
+  return [
+    qwikRouterPlugin(userOpts, buildContextRef),
+    serverFnsPlugin(buildContextRef),
+    ...imagePlugin(userOpts),
+  ];
 }
 
-function qwikRouterPlugin(userOpts?: QwikRouterVitePluginOptions) {
+function qwikRouterPlugin(
+  userOpts: QwikRouterVitePluginOptions | undefined,
+  buildContextRef: BuildContextRef
+) {
   let ctx: RoutingContext | null = null;
   let mdxTransform: MdxTransform | null = null;
   let rootDir: string | null = null;
@@ -173,6 +183,7 @@ function qwikRouterPlugin(userOpts?: QwikRouterVitePluginOptions) {
         target,
         !userOpts?.staticImportRoutes
       );
+      buildContextRef.current = ctx;
 
       await validatePlugin(ctx.opts);
 
@@ -402,21 +413,36 @@ async function generateServerPackageJson(outDir: string) {
  * `virtual:qwik-router-server-fns` — a virtual module that statically imports all such modules so
  * their `_regSymbol` side effects run before any RPC request arrives.
  */
-function serverFnsPlugin(): Plugin {
+function serverFnsPlugin(buildContextRef: BuildContextRef): Plugin {
   const RESOLVED_ID = '\0' + VIRTUAL_SERVER_FNS;
   const serverFnModules = new Set<string>();
-  let pendingModules = 0;
-  let resolveServerFns: (() => void) | null = null;
-  let serverFnsReady: Promise<void>;
+  let serverFnsReady: Promise<void> | null = null;
 
   function reset() {
     serverFnModules.clear();
-    pendingModules = 0;
-    serverFnsReady = new Promise<void>((r) => {
-      resolveServerFns = r;
-    });
+    serverFnsReady = null;
   }
   reset();
+
+  async function collectServerFnModules(this: Rollup.PluginContext) {
+    if (serverFnsReady) {
+      await serverFnsReady;
+      return;
+    }
+
+    serverFnsReady = (async () => {
+      const ctx = buildContextRef.current;
+      if (!ctx) {
+        return;
+      }
+      const moduleIds = await collectServerFnModuleIds(ctx, RESOLVED_ID, (id) => this.load({ id }));
+      for (let i = 0; i < moduleIds.length; i++) {
+        serverFnModules.add(moduleIds[i]);
+      }
+    })();
+
+    await serverFnsReady;
+  }
 
   return {
     name: 'vite-plugin-qwik-router-server-fns',
@@ -439,39 +465,13 @@ function serverFnsPlugin(): Plugin {
 
         if (id === RESOLVED_ID) {
           if (isServerBuild) {
-            await serverFnsReady;
+            await collectServerFnModules.call(this);
           }
           if (!isServerBuild || serverFnModules.size === 0) {
             return '// No server$ functions';
           }
           return [...serverFnModules].map((mod) => `import ${JSON.stringify(mod)};`).join('\n');
         }
-
-        // Count module loads during SSR build for deferred resolution
-        if (isServerBuild && id !== RESOLVED_ID) {
-          pendingModules++;
-
-          this.load({ id })
-            .then((result) => {
-              if (typeof result.code === 'string' && result.code.includes('serverQrl(')) {
-                serverFnModules.add(id);
-              }
-            })
-            .finally(() => {
-              pendingModules--;
-              if (pendingModules <= 0 && resolveServerFns) {
-                // Rollup processes modules in batches — the count may briefly hit 0 between
-                // batches, so delay before resolving to let new loads get queued.
-                setTimeout(() => {
-                  if (pendingModules <= 0 && resolveServerFns) {
-                    resolveServerFns();
-                    resolveServerFns = null;
-                  }
-                }, 50);
-              }
-            });
-        }
-
         return null;
       },
     },

--- a/packages/qwik-router/src/buildtime/vite/server-fns.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.ts
@@ -7,7 +7,7 @@ type ServerFnModuleInfo = Pick<
 >;
 
 export async function collectServerFnModuleIds(
-  ctx: Pick<RoutingContext, 'entries' | 'layouts' | 'routes' | 'serverPlugins'>,
+  ctx: Pick<RoutingContext, 'layouts' | 'routes' | 'serverPlugins'>,
   resolvedVirtualId: string,
   loadModule: (id: string) => Promise<ServerFnModuleInfo>
 ) {
@@ -17,7 +17,6 @@ export async function collectServerFnModuleIds(
   const routes = ctx.routes;
   const layouts = ctx.layouts;
   const serverPlugins = ctx.serverPlugins;
-  const entries = ctx.entries;
 
   for (let i = 0; i < routes.length; i++) {
     const route = routes[i];
@@ -32,9 +31,6 @@ export async function collectServerFnModuleIds(
   }
   for (let i = 0; i < serverPlugins.length; i++) {
     queuedModuleIds.add(serverPlugins[i].filePath);
-  }
-  for (let i = 0; i < entries.length; i++) {
-    queuedModuleIds.add(entries[i].filePath);
   }
 
   while (queuedModuleIds.size > 0) {

--- a/packages/qwik-router/src/buildtime/vite/server-fns.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.ts
@@ -1,0 +1,66 @@
+import type { Rollup } from 'vite';
+import type { RoutingContext } from '../types';
+
+type ServerFnModuleInfo = Pick<
+  Rollup.ModuleInfo,
+  'code' | 'dynamicallyImportedIdResolutions' | 'id' | 'importedIdResolutions'
+>;
+
+export async function collectServerFnModuleIds(
+  ctx: Pick<RoutingContext, 'entries' | 'layouts' | 'routes' | 'serverPlugins'>,
+  resolvedVirtualId: string,
+  loadModule: (id: string) => Promise<ServerFnModuleInfo>
+) {
+  const serverFnModules = new Set<string>();
+  const queuedModuleIds = new Set<string>();
+  const seenModuleIds = new Set<string>();
+  const routes = ctx.routes;
+  const layouts = ctx.layouts;
+  const serverPlugins = ctx.serverPlugins;
+  const entries = ctx.entries;
+
+  for (let i = 0; i < routes.length; i++) {
+    const route = routes[i];
+    queuedModuleIds.add(route.filePath);
+    for (let j = 0; j < route.layouts.length; j++) {
+      const layout = route.layouts[j];
+      queuedModuleIds.add(layout.filePath);
+    }
+  }
+  for (let i = 0; i < layouts.length; i++) {
+    queuedModuleIds.add(layouts[i].filePath);
+  }
+  for (let i = 0; i < serverPlugins.length; i++) {
+    queuedModuleIds.add(serverPlugins[i].filePath);
+  }
+  for (let i = 0; i < entries.length; i++) {
+    queuedModuleIds.add(entries[i].filePath);
+  }
+
+  while (queuedModuleIds.size > 0) {
+    const [id] = queuedModuleIds;
+    queuedModuleIds.delete(id);
+
+    if (seenModuleIds.has(id) || id === resolvedVirtualId) {
+      continue;
+    }
+    seenModuleIds.add(id);
+
+    const moduleInfo = await loadModule(id);
+    if (moduleInfo.code?.includes('serverQrl(')) {
+      serverFnModules.add(moduleInfo.id);
+    }
+
+    const resolvedImports = moduleInfo.importedIdResolutions.concat(
+      moduleInfo.dynamicallyImportedIdResolutions
+    );
+    for (let i = 0; i < resolvedImports.length; i++) {
+      const resolvedImport = resolvedImports[i];
+      if (!resolvedImport.external && !seenModuleIds.has(resolvedImport.id)) {
+        queuedModuleIds.add(resolvedImport.id);
+      }
+    }
+  }
+
+  return [...serverFnModules];
+}

--- a/packages/qwik-router/src/buildtime/vite/server-fns.unit.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.unit.ts
@@ -92,11 +92,10 @@ describe('collectServerFnModuleIds', () => {
       filePath: '/app/plugin.ts',
       ext: 'ts',
     };
-    const ctx: Pick<RoutingContext, 'entries' | 'layouts' | 'routes' | 'serverPlugins'> = {
+    const ctx: Pick<RoutingContext, 'layouts' | 'routes' | 'serverPlugins'> = {
       routes: [route],
       layouts: [layout],
       serverPlugins: [serverPlugin],
-      entries: [],
     };
 
     const serverFnModules = await collectServerFnModuleIds(ctx, resolvedVirtualId, async (id) => {

--- a/packages/qwik-router/src/buildtime/vite/server-fns.unit.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.unit.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import type { BuiltLayout, BuiltRoute, BuiltServerPlugin, RoutingContext } from '../types';
+import { collectServerFnModuleIds } from './server-fns';
+
+describe('collectServerFnModuleIds', () => {
+  it('walks the reachable module graph and collects modules containing serverQrl', async () => {
+    const resolvedVirtualId = '\0virtual:qwik-router-server-fns';
+    const loads: string[] = [];
+    const modules = new Map([
+      [
+        '/app/routes/index.tsx',
+        {
+          id: '/app/routes/index.tsx',
+          code: 'export default component$(() => null);',
+          importedIdResolutions: [
+            { id: '/app/shared.ts', external: false },
+            { id: '/node_modules/@qwik.dev/core/index.mjs', external: false },
+          ],
+          dynamicallyImportedIdResolutions: [{ id: '/app/lazy.ts', external: false }],
+        },
+      ],
+      [
+        '/app/layout.tsx',
+        {
+          id: '/app/layout.tsx',
+          code: 'export default component$(() => null);',
+          importedIdResolutions: [{ id: '/app/shared.ts', external: false }],
+          dynamicallyImportedIdResolutions: [],
+        },
+      ],
+      [
+        '/app/shared.ts',
+        {
+          id: '/app/shared.ts',
+          code: 'export const shared = true;',
+          importedIdResolutions: [
+            { id: resolvedVirtualId, external: false },
+            { id: 'node:fs', external: true },
+          ],
+          dynamicallyImportedIdResolutions: [],
+        },
+      ],
+      [
+        '/app/lazy.ts',
+        {
+          id: '/app/lazy.ts',
+          code: 'export const fn = serverQrl(() => null);',
+          importedIdResolutions: [],
+          dynamicallyImportedIdResolutions: [],
+        },
+      ],
+      [
+        '/node_modules/@qwik.dev/core/index.mjs',
+        {
+          id: '/node_modules/@qwik.dev/core/index.mjs',
+          code: 'export {};',
+          importedIdResolutions: [],
+          dynamicallyImportedIdResolutions: [],
+        },
+      ],
+      [
+        '/app/plugin.ts',
+        {
+          id: '/app/plugin.ts',
+          code: 'export const pluginFn = serverQrl(() => null);',
+          importedIdResolutions: [],
+          dynamicallyImportedIdResolutions: [],
+        },
+      ],
+    ]);
+
+    const layout: BuiltLayout = {
+      filePath: '/app/layout.tsx',
+      dirPath: '/app',
+      id: 'layout',
+      layoutType: 'nested',
+      layoutName: '',
+    };
+    const route: BuiltRoute = {
+      id: 'index',
+      filePath: '/app/routes/index.tsx',
+      ext: 'tsx',
+      pathname: '/',
+      layouts: [layout],
+      routeName: 'index',
+      pattern: /^\/$/,
+      paramNames: [],
+      segments: [],
+    };
+    const serverPlugin: BuiltServerPlugin = {
+      id: 'plugin',
+      filePath: '/app/plugin.ts',
+      ext: 'ts',
+    };
+    const ctx: Pick<RoutingContext, 'entries' | 'layouts' | 'routes' | 'serverPlugins'> = {
+      routes: [route],
+      layouts: [layout],
+      serverPlugins: [serverPlugin],
+      entries: [],
+    };
+
+    const serverFnModules = await collectServerFnModuleIds(ctx, resolvedVirtualId, async (id) => {
+      loads.push(id);
+      const moduleInfo = modules.get(id);
+      if (!moduleInfo) {
+        throw new Error(`Unexpected module load: ${id}`);
+      }
+      return moduleInfo as any;
+    });
+
+    expect(serverFnModules.sort()).toEqual(['/app/lazy.ts', '/app/plugin.ts']);
+    expect(loads).toEqual([
+      '/app/routes/index.tsx',
+      '/app/layout.tsx',
+      '/app/plugin.ts',
+      '/app/shared.ts',
+      '/node_modules/@qwik.dev/core/index.mjs',
+      '/app/lazy.ts',
+    ]);
+  });
+});

--- a/scripts/docs-size-results.json
+++ b/scripts/docs-size-results.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-10T10:13:50.139Z",
+  "generatedAt": "2026-04-12T16:53:14.958Z",
   "routes": {
     "/": {
       "rawBytes": 217734,
-      "gzipBytes": 45398
+      "gzipBytes": 45406
     },
     "/docs": {
-      "rawBytes": 1063891,
-      "gzipBytes": 178196
+      "rawBytes": 1063907,
+      "gzipBytes": 178195
     }
   }
 }


### PR DESCRIPTION
Fix Deno build failure when routes using async tasks cause Rollup to exit early while loading `virtual:qwik-router-server-fns`.
The router Vite plugin now discovers server function modules deterministically instead of relying on background plugin loads, which avoids unresolved plugin promises during SSR builds.