### PR TITLE
fix: honor node streaming backpressure

### DIFF
--- a/.changeset/spicy-onions-jog.md
+++ b/.changeset/spicy-onions-jog.md
@@ -1,0 +1,6 @@
+---
+'@qwik.dev/router': patch
+'@qwik.dev/core': patch
+---
+
+fix: Node SSR streaming to honor downstream backpressure

--- a/packages/qwik-router/src/middleware/node/http.ts
+++ b/packages/qwik-router/src/middleware/node/http.ts
@@ -44,6 +44,88 @@ export function normalizeUrl(url: string, base: string) {
   return normalizeRequestUrl(url, base);
 }
 
+function createNodeResponseSink(res: ServerResponse) {
+  let closed = res.closed || res.destroyed;
+  const closedPromise = closed
+    ? Promise.resolve()
+    : new Promise<void>((resolve) => {
+        res.once('close', () => {
+          closed = true;
+          resolve();
+        });
+      });
+
+  const write = (chunk: Uint8Array) => {
+    if (closed || res.closed || res.destroyed) {
+      // If the response has already been closed or destroyed (for example the client has disconnected)
+      // then writing into it will cause an error. So just stop writing since no one
+      // is listening.
+      return;
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+
+        // Let Node process the completed write before SSR keeps emitting more chunks.
+        setImmediate(resolve);
+      };
+
+      const fail = (error: unknown) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        reject(error);
+      };
+
+      closedPromise.then(finish);
+
+      try {
+        res.write(chunk, (error) => {
+          if (error) {
+            if (isIgnoredError(error.message)) {
+              finish();
+              return;
+            }
+            fail(error);
+            return;
+          }
+          finish();
+        });
+      } catch (error) {
+        if (error instanceof Error && isIgnoredError(error.message)) {
+          finish();
+          return;
+        }
+        fail(error);
+      }
+    });
+  };
+
+  const close = () => {
+    if (closed || res.closed || res.destroyed) {
+      return;
+    }
+
+    return new Promise<void>((resolve) => {
+      res.end(() => {
+        resolve();
+      });
+    });
+  };
+
+  return {
+    write,
+    close,
+  };
+}
+
 export async function fromNodeHttp(
   url: URL,
   req: IncomingMessage | Http2ServerRequest,
@@ -100,6 +182,7 @@ export async function fromNodeHttp(
     },
     getWritableStream: (status, headers, cookies) => {
       res.statusCode = status;
+      const sink = createNodeResponseSink(res);
 
       try {
         for (const [key, value] of headers) {
@@ -118,20 +201,10 @@ export async function fromNodeHttp(
 
       return new WritableStream<Uint8Array>({
         write(chunk) {
-          if (res.closed || res.destroyed) {
-            // If the response has already been closed or destroyed (for example the client has disconnected)
-            // then writing into it will cause an error. So just stop writing since no one
-            // is listening.
-            return;
-          }
-          res.write(chunk, (error) => {
-            if (error && !isIgnoredError(error.message)) {
-              console.error(error);
-            }
-          });
+          return sink.write(chunk);
         },
         close() {
-          res.end();
+          return sink.close();
         },
       });
     },

--- a/packages/qwik-router/src/middleware/node/http.unit.ts
+++ b/packages/qwik-router/src/middleware/node/http.unit.ts
@@ -1,5 +1,16 @@
-import { assert, test } from 'vitest';
-import { normalizeUrl } from './http';
+import {
+  getPlatform,
+  setPlatform,
+  type JSXOutput,
+  type StreamWriter,
+} from '@qwik.dev/core/internal';
+import { renderToStream } from '@qwik.dev/core/server';
+import { EventEmitter } from 'node:events';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { connect } from 'node:net';
+import { performance } from 'node:perf_hooks';
+import { assert, describe, expect, test, vi } from 'vitest';
+import { fromNodeHttp, normalizeUrl } from './http';
 
 [
   {
@@ -40,5 +51,158 @@ import { normalizeUrl } from './http';
 ].forEach((t) => {
   test(`normalizeUrl(${t.url}, ${t.base})`, () => {
     assert.equal(normalizeUrl(t.url, t.base).href, t.expect);
+  });
+});
+
+describe('fromNodeHttp()', () => {
+  test('should resolve writes from the node write callback without waiting for drain', async () => {
+    const req = new EventEmitter() as IncomingMessage & EventEmitter;
+    req.method = 'GET';
+    req.url = '/';
+    req.headers = { host: 'localhost' };
+    (req as any).socket = {};
+
+    let writeCallback: ((error?: Error | null) => void) | undefined;
+    const res = new EventEmitter() as ServerResponse & EventEmitter;
+    Object.defineProperty(res, 'closed', { value: false, configurable: true });
+    Object.defineProperty(res, 'destroyed', { value: false, configurable: true });
+    res.setHeader = vi.fn();
+    res.write = vi.fn((_chunk: Uint8Array, cb?: (error?: Error | null) => void) => {
+      writeCallback = cb;
+      return false;
+    }) as any;
+    res.end = vi.fn((cb?: () => void) => {
+      cb?.();
+      return res;
+    }) as any;
+
+    const requestEv = await fromNodeHttp(new URL('http://localhost/'), req, res, 'server');
+    const writableStream = requestEv.getWritableStream(
+      200,
+      new Headers([['Content-Type', 'text/html; charset=utf-8']]),
+      { headers: () => [] } as any,
+      () => {},
+      undefined as any
+    );
+    const writer = writableStream.getWriter();
+
+    const writePromise = writer.write(new Uint8Array([1, 2, 3]));
+    await Promise.resolve();
+    expect(res.listenerCount('drain')).toBe(0);
+    expect(writeCallback).toBeDefined();
+
+    writeCallback?.(null);
+    await writePromise;
+    await writer.close();
+
+    expect(res.write).toHaveBeenCalledTimes(1);
+    expect(res.end).toHaveBeenCalledTimes(1);
+  });
+
+  // Verifies the Node adapter starts making response-write progress before a large SSR render fully completes.
+  test('should make Node response progress before render completes', async () => {
+    const timings = {
+      renderStarted: 0,
+      renderDone: 0,
+      firstSocketWrite: 0,
+    };
+    const jsx: JSXOutput = Array.from({ length: 4_000 }, (_, i) => `chunk-${i}-${'x'.repeat(96)}`);
+    const cookies = {
+      headers: () => [],
+    };
+
+    const server = createServer(async (req, res) => {
+      res.socket?.setNoDelay(true);
+      const socket = res.socket;
+      if (socket) {
+        const originalSocketWrite = socket.write.bind(socket);
+        socket.write = ((chunk: any, ...args: any[]) => {
+          if (timings.firstSocketWrite === 0) {
+            timings.firstSocketWrite = performance.now();
+          }
+          return originalSocketWrite(chunk, ...args);
+        }) as typeof socket.write;
+      }
+
+      const requestEv = await fromNodeHttp(
+        new URL(req.url || '/', 'http://127.0.0.1'),
+        req,
+        res,
+        'server'
+      );
+      const writableStream = requestEv.getWritableStream(
+        200,
+        new Headers([['Content-Type', 'text/html; charset=utf-8']]),
+        cookies as any,
+        () => {},
+        undefined as any
+      );
+      const writer = writableStream.getWriter();
+      const encoder = new TextEncoder();
+      const stream: StreamWriter = {
+        write(chunk: string) {
+          return writer.write(encoder.encode(chunk));
+        },
+      };
+      const platform = getPlatform();
+
+      try {
+        timings.renderStarted = performance.now();
+        await renderToStream(jsx, {
+          containerTagName: 'div',
+          qwikLoader: 'never',
+          stream,
+          streaming: {
+            inOrder: {
+              strategy: 'auto',
+              maximumInitialChunk: 128,
+              maximumChunk: 64,
+            },
+          },
+        });
+        timings.renderDone = performance.now();
+      } finally {
+        setPlatform(platform);
+        await writer.close();
+      }
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      server.close();
+      throw new Error('Failed to bind test server');
+    }
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const socket = connect(address.port, '127.0.0.1', () => {
+          socket.write('GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n');
+        });
+
+        socket.on('data', () => {
+          // Intentionally empty: the request must be consumed to let the server drain.
+        });
+        socket.on('end', resolve);
+        socket.on('error', reject);
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+    }
+
+    expect(timings.firstSocketWrite).toBeGreaterThan(0);
+    expect(timings.renderDone).toBeGreaterThan(timings.renderStarted);
+    expect(timings.firstSocketWrite).toBeLessThan(timings.renderDone);
   });
 });

--- a/packages/qwik-router/src/middleware/node/http.unit.ts
+++ b/packages/qwik-router/src/middleware/node/http.unit.ts
@@ -69,6 +69,8 @@ describe('fromNodeHttp()', () => {
     res.setHeader = vi.fn();
     res.write = vi.fn((_chunk: Uint8Array, cb?: (error?: Error | null) => void) => {
       writeCallback = cb;
+      // Returning false simulates backpressure. This adapter does not attach
+      // drain listeners because ServerResponse.write() provides a per-write callback.
       return false;
     }) as any;
     res.end = vi.fn((cb?: () => void) => {
@@ -88,6 +90,8 @@ describe('fromNodeHttp()', () => {
 
     const writePromise = writer.write(new Uint8Array([1, 2, 3]));
     await Promise.resolve();
+    // No drain listener should be attached in this path; Node calls the write
+    // callback once this chunk has flushed, even when write() returned false.
     expect(res.listenerCount('drain')).toBe(0);
     expect(writeCallback).toBeDefined();
 

--- a/packages/qwik-router/src/middleware/node/index.ts
+++ b/packages/qwik-router/src/middleware/node/index.ts
@@ -63,11 +63,11 @@ export function createQwikRouter(
       const handled = await requestHandler(serverRequestEv, opts);
       if (handled) {
         const err = await handled.completion;
-        if (err) {
-          throw err;
-        }
         if (handled.requestEv.headersSent) {
           return;
+        }
+        if (err) {
+          throw err;
         }
       }
       next();

--- a/packages/qwik-router/src/middleware/node/index.unit.ts
+++ b/packages/qwik-router/src/middleware/node/index.unit.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { QwikRouterNodeRequestOptions } from '.';
+
+const { mockRequestHandler, mockFromNodeHttp, mockComputeOrigin, mockGetUrl } = vi.hoisted(() => ({
+  mockRequestHandler: vi.fn(),
+  mockFromNodeHttp: vi.fn(),
+  mockComputeOrigin: vi.fn(() => 'http://localhost:3301'),
+  mockGetUrl: vi.fn((req: { url?: string }, origin: string) => new URL(req.url || '/', origin)),
+}));
+
+vi.mock('@qwik.dev/core', () => ({
+  isDev: false,
+}));
+
+vi.mock('@qwik.dev/core/server', () => ({
+  setServerPlatform: vi.fn(),
+}));
+
+vi.mock('@qwik.dev/router/middleware/request-handler', () => ({
+  isStaticPath: vi.fn(() => false),
+  requestHandler: mockRequestHandler,
+}));
+
+vi.mock('./http', () => ({
+  computeOrigin: mockComputeOrigin,
+  fromNodeHttp: mockFromNodeHttp,
+  getUrl: mockGetUrl,
+}));
+
+import { createQwikRouter } from './index';
+
+const createNodeOptions = (): QwikRouterNodeRequestOptions => ({
+  render: vi.fn() as any,
+});
+
+describe('createQwikRouter().router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should not forward handled completion errors after headers are sent', async () => {
+    const requestEv = {
+      headersSent: true,
+    };
+    mockFromNodeHttp.mockResolvedValue({
+      platform: {},
+    });
+    mockRequestHandler.mockResolvedValue({
+      completion: Promise.resolve(new Error('already handled')),
+      requestEv,
+    });
+
+    const next = vi.fn();
+    const middleware = createQwikRouter(createNodeOptions());
+
+    await middleware.router({ url: '/', headers: {} } as any, {} as any, next);
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should forward completion errors when headers are not sent', async () => {
+    const error = new Error('unhandled');
+    mockFromNodeHttp.mockResolvedValue({
+      platform: {},
+    });
+    mockRequestHandler.mockResolvedValue({
+      completion: Promise.resolve(error),
+      requestEv: {
+        headersSent: false,
+      },
+    });
+
+    const next = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const middleware = createQwikRouter(createNodeOptions());
+
+    await middleware.router({ url: '/', headers: {} } as any, {} as any, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+    consoleError.mockRestore();
+  });
+});

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -1196,7 +1196,9 @@ export interface SSRStreamWriter {
 // @internal (undocumented)
 export interface StreamWriter {
     // (undocumented)
-    write(chunk: string): void;
+    waitForDrain?(): ValueOrPromise<void>;
+    // (undocumented)
+    write(chunk: string): ValueOrPromise<void>;
 }
 
 // @internal (undocumented)

--- a/packages/qwik/src/core/shared/serdes/serialization-context.ts
+++ b/packages/qwik/src/core/shared/serdes/serialization-context.ts
@@ -251,7 +251,9 @@ export const createSerializationContext = (
   if (!writer) {
     const buffer: string[] = [];
     writer = {
-      write: (text: string) => buffer.push(text),
+      write: (text: string) => {
+        buffer.push(text);
+      },
       toString: () => buffer.join(''),
     } as StreamWriter;
   }

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -74,22 +74,29 @@ export async function _walkJSX(
   const enqueue = (value: StackValue) => stack.push(value);
   const drain = async (): Promise<void> => {
     while (stack.length) {
-      const value = stack.pop();
-      // Reference equality first (no prototype walk), then typeof
-      if (value === MaybeAsyncSignal) {
-        const trackFn = stack.pop() as () => StackValue;
-        await retryOnPromise(() => stack.push(trackFn()));
-        continue;
-      }
-      if (typeof value === 'function') {
-        if (value === Promise) {
-          stack.push(await (stack.pop() as Promise<JSXOutput>));
-        } else {
-          await (value as StackFn).apply(ssr);
+      try {
+        const value = stack.pop();
+        // Reference equality first (no prototype walk), then typeof
+        if (value === MaybeAsyncSignal) {
+          const trackFn = stack.pop() as () => StackValue;
+          await retryOnPromise(() => stack.push(trackFn()));
+          continue;
         }
-        continue;
+        if (typeof value === 'function') {
+          if (value === Promise) {
+            stack.push(await (stack.pop() as Promise<JSXOutput>));
+          } else {
+            await (value as StackFn).apply(ssr);
+          }
+          continue;
+        }
+        processJSXNode(ssr, enqueue, value as JSXOutput, options);
+      } finally {
+        const pendingFlush = ssr.streamHandler.waitForPendingFlush();
+        if (isPromise(pendingFlush)) {
+          await pendingFlush;
+        }
       }
-      processJSXNode(ssr, enqueue, value as JSXOutput, options);
     }
   };
   await drain();
@@ -138,7 +145,7 @@ function processJSXNode(
             currentStyleScoped: options.currentStyleScoped,
             parentComponentFrame: options.parentComponentFrame,
           });
-          ssr.streamHandler.flush();
+          await ssr.streamHandler.flush();
         }
       });
     } else {
@@ -250,7 +257,7 @@ function processJSXNode(
                   currentStyleScoped: options.currentStyleScoped,
                   parentComponentFrame: options.parentComponentFrame,
                 });
-                ssr.streamHandler.flush();
+                await ssr.streamHandler.flush();
               },
             });
           } else {

--- a/packages/qwik/src/core/ssr/ssr-types.ts
+++ b/packages/qwik/src/core/ssr/ssr-types.ts
@@ -18,7 +18,8 @@ import type { ResourceReturnInternal } from '../use/use-resource';
 
 /** @internal */
 export interface StreamWriter {
-  write(chunk: string): void;
+  write(chunk: string): ValueOrPromise<void>;
+  waitForDrain?(): ValueOrPromise<void>;
 }
 
 export interface ISsrNode {
@@ -125,9 +126,10 @@ export interface SSRContainer extends Container {
 
 /** @internal */
 export interface IStreamHandler {
-  flush(): void;
+  flush(): ValueOrPromise<void>;
+  waitForPendingFlush(): ValueOrPromise<void>;
   streamBlockStart(): void;
-  streamBlockEnd(): void;
+  streamBlockEnd(): ValueOrPromise<void>;
 }
 
 /** @public */

--- a/packages/qwik/src/core/tests/render-api.spec.tsx
+++ b/packages/qwik/src/core/tests/render-api.spec.tsx
@@ -139,6 +139,14 @@ const renderToStreamAndSetPlatform = async (jsx: JSXOutput, opts: RenderToStream
   return result;
 };
 
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
 describe('render api', () => {
   let document: Document;
   beforeEach(() => {
@@ -859,6 +867,50 @@ describe('render api', () => {
         });
         expect(write.mock.calls.length).toBeGreaterThan(100);
       });
+      it('should wait for an async direct write before emitting the next one', async () => {
+        const firstWrite = createDeferred();
+        let writeCount = 0;
+        const stream: StreamWriter = {
+          write() {
+            writeCount++;
+            if (writeCount === 1) {
+              return firstWrite.promise;
+            }
+            return Promise.resolve();
+          },
+        };
+        const streaming: StreamingOptions = {
+          inOrder: {
+            strategy: 'direct',
+          },
+        };
+        const LargeOutput = component$(() => (
+          <div>
+            {Array.from({ length: 40 }, (_, i) => (
+              <span key={i}>{`chunk-${i}-` + 'x'.repeat(20)}</span>
+            ))}
+          </div>
+        ));
+
+        const renderPromise = renderToStreamAndSetPlatform(<LargeOutput />, {
+          containerTagName: 'div',
+          stream,
+          streaming,
+        });
+
+        await vi.waitFor(() => expect(writeCount).toBeGreaterThan(0));
+        await Promise.resolve();
+        await Promise.resolve();
+        // Direct mode should also serialize async writes. If this becomes > 1
+        // before the first promise resolves, direct streaming is still
+        // ignoring downstream backpressure.
+        expect(writeCount).toBe(1);
+
+        firstWrite.resolve();
+        await renderPromise;
+
+        expect(writeCount).toBeGreaterThan(1);
+      });
       it('should render chunk by chunk with auto streaming', async () => {
         const stream: StreamWriter = {
           write: vi.fn(),
@@ -877,6 +929,53 @@ describe('render api', () => {
         });
         // This can change when the size of the output changes
         expect(stream.write).toHaveBeenCalledTimes(4);
+      });
+
+      it('should wait for an async flush before emitting the next chunk', async () => {
+        const firstWrite = createDeferred();
+        let writeCount = 0;
+        const stream: StreamWriter = {
+          write() {
+            writeCount++;
+            if (writeCount === 1) {
+              return firstWrite.promise;
+            }
+            return Promise.resolve();
+          },
+        };
+        const streaming: StreamingOptions = {
+          inOrder: {
+            strategy: 'auto',
+            maximumInitialChunk: 50,
+            maximumChunk: 50,
+          },
+        };
+        const LargeOutput = component$(() => (
+          <div>
+            {Array.from({ length: 40 }, (_, i) => (
+              <span key={i}>{`chunk-${i}-` + 'x'.repeat(20)}</span>
+            ))}
+          </div>
+        ));
+
+        const renderPromise = renderToStreamAndSetPlatform(<LargeOutput />, {
+          containerTagName: 'div',
+          stream,
+          streaming,
+        });
+
+        await vi.waitFor(() => expect(writeCount).toBeGreaterThan(0));
+        await Promise.resolve();
+        await Promise.resolve();
+        // The first async write is still unresolved here, so starting a second
+        // write would mean the renderer ignored downstream backpressure and let
+        // multiple flushes overlap in flight.
+        expect(writeCount).toBe(1);
+
+        firstWrite.resolve();
+        await renderPromise;
+
+        expect(writeCount).toBeGreaterThan(1);
       });
     });
   });

--- a/packages/qwik/src/server/ssr-render.ts
+++ b/packages/qwik/src/server/ssr-render.ts
@@ -81,7 +81,7 @@ export const renderToStream = async (
   await ssrContainer.$renderPromise$;
 
   // Flush remaining chunks in the buffer
-  streamHandler.flush();
+  await streamHandler.flush();
 
   const result: RenderToStreamResult = {
     flushes: streamHandler.networkFlushes,

--- a/packages/qwik/src/server/ssr-stream-handler.ts
+++ b/packages/qwik/src/server/ssr-stream-handler.ts
@@ -1,3 +1,4 @@
+import { isPromise } from './qwik-copy';
 import type { IStreamHandler } from './qwik-types';
 import type {
   InOrderStreaming,
@@ -17,6 +18,8 @@ export class StreamHandler implements IStreamHandler {
   private streamBlockBufferSize = 0;
   private nativeStream: StreamWriter;
   private firstFlushTimer = createTimer();
+  private pendingFlush: Promise<void> | undefined;
+  private flushQueued = false;
   public stream: StreamWriter;
 
   constructor(
@@ -44,6 +47,9 @@ export class StreamHandler implements IStreamHandler {
             }
             handler.enqueue(chunk);
           },
+          waitForDrain() {
+            return handler.waitForPendingFlush();
+          },
         };
         break;
       case 'direct': {
@@ -53,7 +59,14 @@ export class StreamHandler implements IStreamHandler {
             if (chunk === undefined || chunk === null) {
               return;
             }
-            originalStream.write(chunk);
+            if (handler.pendingFlush) {
+              const queued = handler.pendingFlush.then(() => originalStream.write(chunk));
+              return handler.trackPendingFlush(queued);
+            }
+            return handler.trackPendingFlush(originalStream.write(chunk));
+          },
+          waitForDrain() {
+            return handler.waitForPendingFlush();
           },
         };
         break;
@@ -75,9 +88,12 @@ export class StreamHandler implements IStreamHandler {
               const maxBufferSize =
                 handler.networkFlushes === 0 ? initialChunkSize : minimumChunkSize;
               if (handler.bufferSize >= maxBufferSize) {
-                handler.flush();
+                return handler.flush();
               }
             }
+          },
+          waitForDrain() {
+            return handler.waitForPendingFlush();
           },
         };
         break;
@@ -99,16 +115,59 @@ export class StreamHandler implements IStreamHandler {
     }
   }
 
-  flush() {
-    if (this.buffer) {
-      this.nativeStream.write(this.buffer);
-      this.buffer = '';
-      this.bufferSize = 0;
-      this.networkFlushes++;
-      if (this.networkFlushes === 1) {
-        this.timing.firstFlush = this.firstFlushTimer();
-      }
+  private trackPendingFlush(result: ReturnType<StreamWriter['write']>) {
+    if (!isPromise(result)) {
+      return;
     }
+
+    const pending = Promise.resolve(result).finally(() => {
+      if (this.pendingFlush === pending) {
+        this.pendingFlush = undefined;
+      }
+    });
+    this.pendingFlush = pending;
+    return pending;
+  }
+
+  private flushBuffer() {
+    const chunk = this.buffer;
+    this.buffer = '';
+    this.bufferSize = 0;
+    this.networkFlushes++;
+    if (this.networkFlushes === 1) {
+      this.timing.firstFlush = this.firstFlushTimer();
+    }
+
+    return this.trackPendingFlush(this.nativeStream.write(chunk));
+  }
+
+  flush(): Promise<void> | void {
+    if (!this.buffer) {
+      return this.waitForPendingFlush();
+    }
+
+    if (this.pendingFlush) {
+      if (!this.flushQueued) {
+        this.flushQueued = true;
+        const queued = this.pendingFlush.then(() => {
+          this.flushQueued = false;
+          this.pendingFlush = undefined;
+          return this.flush();
+        });
+        this.pendingFlush = queued.finally(() => {
+          if (this.pendingFlush === queued) {
+            this.pendingFlush = undefined;
+          }
+        });
+      }
+      return this.pendingFlush;
+    }
+
+    return this.flushBuffer();
+  }
+
+  waitForPendingFlush() {
+    return this.pendingFlush;
   }
 
   streamBlockStart() {
@@ -123,7 +182,7 @@ export class StreamHandler implements IStreamHandler {
       this.bufferSize += this.streamBlockBufferSize;
       this.streamBlockBuffer = '';
       this.streamBlockBufferSize = 0;
-      this.flush();
+      return this.flush();
     }
   }
 }

--- a/packages/qwik/src/server/ssr-stream-handler.unit.ts
+++ b/packages/qwik/src/server/ssr-stream-handler.unit.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { StreamHandler } from './ssr-stream-handler';
+import type { RenderToStreamOptions, StreamWriter } from './types';
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+describe('StreamHandler', () => {
+  it('should clear pendingFlush after a queued synchronous flush completes', async () => {
+    const firstWrite = createDeferred();
+    const chunks: string[] = [];
+    let writeCount = 0;
+    const stream: StreamWriter = {
+      write(chunk) {
+        chunks.push(chunk);
+        writeCount++;
+        if (writeCount === 1) {
+          return firstWrite.promise;
+        }
+      },
+    };
+    const handler = new StreamHandler(
+      {
+        stream,
+        streaming: {
+          inOrder: {
+            strategy: 'disabled',
+          },
+        },
+      } as RenderToStreamOptions,
+      {
+        firstFlush: 0,
+        render: 0,
+        snapshot: 0,
+      }
+    );
+
+    handler.stream.write('a');
+    const firstFlush = handler.flush();
+    expect(firstFlush).toBeInstanceOf(Promise);
+    expect(handler.waitForPendingFlush()).toBe(firstFlush);
+
+    handler.stream.write('b');
+    const queuedFlush = handler.flush();
+    expect(queuedFlush).toBeInstanceOf(Promise);
+
+    firstWrite.resolve();
+    await queuedFlush;
+
+    expect(chunks).toEqual(['a', 'b']);
+    expect(handler.waitForPendingFlush()).toBeUndefined();
+
+    handler.stream.write('c');
+    const thirdFlush = handler.flush();
+
+    expect(thirdFlush).toBeUndefined();
+    expect(chunks).toEqual(['a', 'b', 'c']);
+    expect(handler.waitForPendingFlush()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This PR makes Qwik SSR honor downstream backpressure during Node streaming. The core renderer now waits for pending async flushes before emitting the next chunk, and the Node middleware translates ServerResponse.write() / drain semantics into an awaitable stream signal instead of fire-and-forget writes.

It also adds a regression test in render-api.spec.tsx to ensure a second chunk is not emitted while the first async write is still pending, plus Node middleware regression coverage so handled errors are not rethrown after headers were already sent.

Performance testing shows time drops from ~250ms to ~40ms for response