### PR TITLE
fix(qwik): guard undefined vNode in scheduleTask and scheduleEffects

### DIFF
--- a/.changeset/gentle-tasks-guard.md
+++ b/.changeset/gentle-tasks-guard.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: guard undefined vNode in scheduleTask and scheduleEffects
+
+Prevent `TypeError: Cannot read properties of undefined (reading 'dirty')` crash in `markVNodeDirty` when `task.$el$` or `consumer.$el$` is undefined during async event dispatch.

--- a/packages/qwik/src/core/reactive-primitives/utils.ts
+++ b/packages/qwik/src/core/reactive-primitives/utils.ts
@@ -95,6 +95,10 @@ export const scheduleEffects = (
       const property = effectSubscription.property;
       isDev && assertDefined(container, 'Container must be defined.');
       if (isTask(consumer)) {
+        if (!consumer.$el$) {
+          // Host element not available (container may have been destroyed)
+          return;
+        }
         consumer.$flags$ |= TaskFlags.DIRTY;
         markVNodeDirty(container!, consumer.$el$, ChoreBits.TASKS);
       } else if (consumer instanceof SignalImpl) {

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -270,6 +270,11 @@ export function scheduleTask(this: string, _event: Event, element: Element) {
     setCaptures(deserializeCaptures(container, this));
   }
   const task = _captures![0] as Task;
+  if (!task?.$el$) {
+    // Task or its host element was not properly deserialized
+    // (e.g., container destroyed during async dispatch)
+    return;
+  }
   task.$flags$ |= TaskFlags.DIRTY;
   markVNodeDirty(container, task.$el$, ChoreBits.TASKS);
 }

--- a/packages/qwik/src/core/use/use-task.unit.ts
+++ b/packages/qwik/src/core/use/use-task.unit.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it, test, vi } from 'vitest';
+import { describe, expect, expectTypeOf, it, test, vi, afterEach } from 'vitest';
 import { component$ } from '../shared/component.public';
 import type { QRLInternal } from '../shared/qrl/qrl-class';
 import type { Container, HostElement } from '../shared/types';
@@ -170,9 +170,32 @@ describe('runTask', () => {
   });
 });
 
+// Module-level mocks — hoisted before imports by Vitest
+vi.mock('../client/dom-container', () => ({
+  getDomContainer: vi.fn(() => ({})),
+}));
+
+vi.mock('../shared/vnode/vnode-dirty', () => ({
+  markVNodeDirty: vi.fn(),
+}));
+
+vi.mock('../shared/qrl/qrl-class', async () => {
+  const actual =
+    await vi.importActual<typeof import('../shared/qrl/qrl-class')>('../shared/qrl/qrl-class');
+  return {
+    ...actual,
+    _captures: [undefined],
+    deserializeCaptures: vi.fn(),
+    setCaptures: vi.fn(),
+  };
+});
+
 describe('scheduleTask', () => {
-  it('does not throw when task.$el$ is undefined', () => {
-    // Simulate a task with undefined $el$ (e.g., container destroyed during async dispatch)
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw when task.$el$ is undefined', async () => {
     const task = new Task(
       TaskFlags.TASK,
       0,
@@ -182,54 +205,21 @@ describe('scheduleTask', () => {
       null
     );
 
-    // Mock _captures to return our task
-    vi.mock('../shared/qrl/qrl-class', async () => {
-      const actual =
-        await vi.importActual<typeof import('../shared/qrl/qrl-class')>('../shared/qrl/qrl-class');
-      return {
-        ...actual,
-        _captures: [task],
-        deserializeCaptures: vi.fn(),
-        setCaptures: vi.fn(),
-      };
-    });
-
-    vi.mock('../client/dom-container', () => ({
-      getDomContainer: vi.fn(() => ({})),
-    }));
-
-    vi.mock('../shared/vnode/vnode-dirty', () => ({
-      markVNodeDirty: vi.fn(),
-    }));
+    // Set _captures per-test via the mocked module
+    const qrlMod = await import('../shared/qrl/qrl-class');
+    Object.defineProperty(qrlMod, '_captures', { value: [task], writable: true });
 
     const mockElement = {} as Element;
     const mockEvent = new Event('qinit');
 
-    // Should not throw
     expect(() => {
       scheduleTask.call('', mockEvent, mockElement);
     }).not.toThrow();
   });
 
-  it('does not throw when _captures[0] is undefined', () => {
-    vi.mock('../shared/qrl/qrl-class', async () => {
-      const actual =
-        await vi.importActual<typeof import('../shared/qrl/qrl-class')>('../shared/qrl/qrl-class');
-      return {
-        ...actual,
-        _captures: [undefined],
-        deserializeCaptures: vi.fn(),
-        setCaptures: vi.fn(),
-      };
-    });
-
-    vi.mock('../client/dom-container', () => ({
-      getDomContainer: vi.fn(() => ({})),
-    }));
-
-    vi.mock('../shared/vnode/vnode-dirty', () => ({
-      markVNodeDirty: vi.fn(),
-    }));
+  it('does not throw when _captures[0] is undefined', async () => {
+    const qrlMod = await import('../shared/qrl/qrl-class');
+    Object.defineProperty(qrlMod, '_captures', { value: [undefined], writable: true });
 
     const mockElement = {} as Element;
     const mockEvent = new Event('qinit');
@@ -237,5 +227,29 @@ describe('scheduleTask', () => {
     expect(() => {
       scheduleTask.call('', mockEvent, mockElement);
     }).not.toThrow();
+  });
+
+  it('calls markVNodeDirty when task.$el$ is defined', async () => {
+    const host = {} as HostElement;
+    const task = new Task(
+      TaskFlags.TASK,
+      0,
+      host,
+      {} as QRLInternal<unknown>,
+      undefined,
+      null
+    );
+
+    const qrlMod = await import('../shared/qrl/qrl-class');
+    Object.defineProperty(qrlMod, '_captures', { value: [task], writable: true });
+
+    const { markVNodeDirty } = await import('../shared/vnode/vnode-dirty');
+
+    const mockElement = {} as Element;
+    const mockEvent = new Event('qinit');
+
+    scheduleTask.call('', mockEvent, mockElement);
+
+    expect(markVNodeDirty).toHaveBeenCalled();
   });
 });

--- a/packages/qwik/src/core/use/use-task.unit.ts
+++ b/packages/qwik/src/core/use/use-task.unit.ts
@@ -5,7 +5,7 @@ import type { Container, HostElement } from '../shared/types';
 import { useResource$ } from './use-resource-dollar';
 import { useSignal } from './use-signal';
 import { useStore } from './use-store.public';
-import { Task, TaskFlags, runTask } from './use-task';
+import { Task, TaskFlags, runTask, scheduleTask } from './use-task';
 import { useTask$ } from './use-task-dollar';
 import { useVisibleTask$ } from './use-visible-task-dollar';
 
@@ -167,5 +167,75 @@ describe('runTask', () => {
 
     expect(run).toBe(2);
     expect(cleanupCalls).toBe(1);
+  });
+});
+
+describe('scheduleTask', () => {
+  it('does not throw when task.$el$ is undefined', () => {
+    // Simulate a task with undefined $el$ (e.g., container destroyed during async dispatch)
+    const task = new Task(
+      TaskFlags.TASK,
+      0,
+      undefined as unknown as HostElement,
+      {} as QRLInternal<unknown>,
+      undefined,
+      null
+    );
+
+    // Mock _captures to return our task
+    vi.mock('../shared/qrl/qrl-class', async () => {
+      const actual =
+        await vi.importActual<typeof import('../shared/qrl/qrl-class')>('../shared/qrl/qrl-class');
+      return {
+        ...actual,
+        _captures: [task],
+        deserializeCaptures: vi.fn(),
+        setCaptures: vi.fn(),
+      };
+    });
+
+    vi.mock('../client/dom-container', () => ({
+      getDomContainer: vi.fn(() => ({})),
+    }));
+
+    vi.mock('../shared/vnode/vnode-dirty', () => ({
+      markVNodeDirty: vi.fn(),
+    }));
+
+    const mockElement = {} as Element;
+    const mockEvent = new Event('qinit');
+
+    // Should not throw
+    expect(() => {
+      scheduleTask.call('', mockEvent, mockElement);
+    }).not.toThrow();
+  });
+
+  it('does not throw when _captures[0] is undefined', () => {
+    vi.mock('../shared/qrl/qrl-class', async () => {
+      const actual =
+        await vi.importActual<typeof import('../shared/qrl/qrl-class')>('../shared/qrl/qrl-class');
+      return {
+        ...actual,
+        _captures: [undefined],
+        deserializeCaptures: vi.fn(),
+        setCaptures: vi.fn(),
+      };
+    });
+
+    vi.mock('../client/dom-container', () => ({
+      getDomContainer: vi.fn(() => ({})),
+    }));
+
+    vi.mock('../shared/vnode/vnode-dirty', () => ({
+      markVNodeDirty: vi.fn(),
+    }));
+
+    const mockElement = {} as Element;
+    const mockEvent = new Event('qinit');
+
+    expect(() => {
+      scheduleTask.call('', mockEvent, mockElement);
+    }).not.toThrow();
   });
 });

--- a/packages/qwik/src/core/use/use-task.unit.ts
+++ b/packages/qwik/src/core/use/use-task.unit.ts
@@ -170,66 +170,101 @@ describe('runTask', () => {
   });
 });
 
-// Module-level mocks — hoisted before imports by Vitest
+/**
+ * scheduleTask tests — simulate the real scenario where a container is destroyed
+ * during async qwikloader dispatch.
+ *
+ * Real-world flow:
+ *   1. qwikloader dispatches an event asynchronously (dispatch is now async)
+ *   2. During the await, a navigation/SPA transition destroys the container
+ *      via DomContainer.$destroy$(), which:
+ *        - truncates $rawStateData$ and $stateData$ to length 0
+ *        - replaces $getObjectById$ with () => undefined
+ *   3. The queued scheduleTask handler fires AFTER destruction
+ *   4. deserializeCaptures() calls container.$getObjectById$(id) → returns undefined
+ *   5. _captures[0] is undefined → crash on `task.$flags$ |= TaskFlags.DIRTY`
+ *
+ * The guard `if (!task?.$el$)` prevents this crash, matching the existing pattern
+ * in WrappedSignalImpl.invalidate() which checks `if (this.$container$ && this.$hostElement$)`.
+ */
+
+// Mock getDomContainer to return our controlled container
 vi.mock('../client/dom-container', () => ({
-  getDomContainer: vi.fn(() => ({})),
+  getDomContainer: vi.fn(),
 }));
 
 vi.mock('../shared/vnode/vnode-dirty', () => ({
   markVNodeDirty: vi.fn(),
 }));
 
-vi.mock('../shared/qrl/qrl-class', async () => {
-  const actual =
-    await vi.importActual<typeof import('../shared/qrl/qrl-class')>('../shared/qrl/qrl-class');
-  return {
-    ...actual,
-    _captures: [undefined],
-    deserializeCaptures: vi.fn(),
-    setCaptures: vi.fn(),
-  };
-});
-
 describe('scheduleTask', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('does not throw when task.$el$ is undefined', async () => {
+  it('does not throw when container was destroyed during async dispatch (_captures[0] is undefined)', async () => {
+    // Simulate DomContainer.$destroy$() — $getObjectById$ returns undefined for all IDs,
+    // exactly as the real $destroy$() method does:
+    //   this.$getObjectById$ = () => undefined;
+    //   this.$rawStateData$.length = 0;
+    //   this.$stateData$.length = 0;
+    const destroyedContainer = {
+      $getObjectById$: () => undefined,
+    };
+
+    const { getDomContainer } = await import('../client/dom-container');
+    vi.mocked(getDomContainer).mockReturnValue(destroyedContainer as any);
+
+    const mockElement = {} as Element;
+    const mockEvent = new Event('qinit');
+
+    // scheduleTask is called by qwikloader with `this` = serialized captures string (e.g. "42").
+    // Inside, it calls deserializeCaptures(container, "42") which does:
+    //   container.$getObjectById$("42") → undefined (container destroyed)
+    // So _captures becomes [undefined] and _captures[0] is undefined.
+    // Without the guard, this crashes:
+    //   TypeError: Cannot read properties of undefined (reading '$flags$')
+    expect(() => {
+      scheduleTask.call('42', mockEvent, mockElement);
+    }).not.toThrow();
+  });
+
+  it('does not throw when task.$el$ is undefined due to truncated $stateData$', async () => {
+    // Simulate a partially-destroyed container where the Task object itself was deserialized
+    // but its $el$ (host VNode) resolved to undefined.
+    //
+    // This happens during inflate.ts Task deserialization:
+    //   task.$el$ = v[3] as HostElement;
+    // where v[3] comes from $stateData$[someId]. After $destroy$() truncates $stateData$
+    // to length 0, any pending lazy deserialization of the VNode reference yields undefined.
     const task = new Task(
       TaskFlags.TASK,
       0,
-      undefined as unknown as HostElement,
+      undefined as unknown as HostElement, // $el$ is undefined — VNode ref was cleared
       {} as QRLInternal<unknown>,
       undefined,
       null
     );
 
-    // Set _captures per-test via the mocked module
-    const qrlMod = await import('../shared/qrl/qrl-class');
-    Object.defineProperty(qrlMod, '_captures', { value: [task], writable: true });
+    const partialContainer = {
+      $getObjectById$: () => task,
+    };
+
+    const { getDomContainer } = await import('../client/dom-container');
+    vi.mocked(getDomContainer).mockReturnValue(partialContainer as any);
 
     const mockElement = {} as Element;
     const mockEvent = new Event('qinit');
 
+    // The Task was deserialized but task.$el$ is undefined.
+    // Without the guard, markVNodeDirty receives undefined vNode → crash:
+    //   TypeError: Cannot read properties of undefined (reading 'dirty')
     expect(() => {
-      scheduleTask.call('', mockEvent, mockElement);
+      scheduleTask.call('42', mockEvent, mockElement);
     }).not.toThrow();
   });
 
-  it('does not throw when _captures[0] is undefined', async () => {
-    const qrlMod = await import('../shared/qrl/qrl-class');
-    Object.defineProperty(qrlMod, '_captures', { value: [undefined], writable: true });
-
-    const mockElement = {} as Element;
-    const mockEvent = new Event('qinit');
-
-    expect(() => {
-      scheduleTask.call('', mockEvent, mockElement);
-    }).not.toThrow();
-  });
-
-  it('calls markVNodeDirty when task.$el$ is defined', async () => {
+  it('calls markVNodeDirty when container is alive and task.$el$ is defined', async () => {
     const host = {} as HostElement;
     const task = new Task(
       TaskFlags.TASK,
@@ -240,16 +275,21 @@ describe('scheduleTask', () => {
       null
     );
 
-    const qrlMod = await import('../shared/qrl/qrl-class');
-    Object.defineProperty(qrlMod, '_captures', { value: [task], writable: true });
+    const liveContainer = {
+      $getObjectById$: () => task,
+    };
+
+    const { getDomContainer } = await import('../client/dom-container');
+    vi.mocked(getDomContainer).mockReturnValue(liveContainer as any);
 
     const { markVNodeDirty } = await import('../shared/vnode/vnode-dirty');
 
     const mockElement = {} as Element;
     const mockEvent = new Event('qinit');
 
-    scheduleTask.call('', mockEvent, mockElement);
+    scheduleTask.call('42', mockEvent, mockElement);
 
-    expect(markVNodeDirty).toHaveBeenCalled();
+    expect(markVNodeDirty).toHaveBeenCalledWith(liveContainer, host, expect.any(Number));
+    expect(task.$flags$ & TaskFlags.DIRTY).toBeTruthy();
   });
 });


### PR DESCRIPTION
# What is it?

- Bug fix

# Description

Fixes a runtime crash during hydration where `markVNodeDirty` receives an `undefined` vNode, causing:

```
TypeError: Cannot read properties of undefined (reading 'dirty')
  at markVNodeDirty (@qwik.dev/core/dist/core.mjs:6727:29)
  at String.scheduleTask (@qwik.dev/core/dist/core.mjs:8788:5)
```

This crash makes the entire application non-functional — no page renders, no login, all routes are dead.

## Root Cause

`scheduleTask` (in `use-task.ts`) and `scheduleEffects` (in `reactive-primitives/utils.ts`) pass `task.$el$` / `consumer.$el$` to `markVNodeDirty` without checking if the host element is defined.

`task.$el$` can be `undefined` when:
- The container is destroyed during async dispatch (the qwikloader's `dispatch` is now async, and if a navigation/destruction happens during an `await`, the container's `$stateData$` is truncated, causing subsequent deserialization to return `undefined` for VNode references)
- The serialized Task array has fewer elements than expected during inflation

Other callers of `markVNodeDirty` already have this guard — for example, `wrapped-signal-impl.ts` checks `if (this.$container$ && this.$hostElement$)` before calling `markVNodeDirty`. This PR adds the same defensive pattern to the two unguarded call sites.

## Changes

### `packages/qwik/src/core/use/use-task.ts`
- Added null check for `task?.$el$` in `scheduleTask` before calling `markVNodeDirty`

### `packages/qwik/src/core/reactive-primitives/utils.ts`
- Added null check for `consumer.$el$` in the `isTask(consumer)` branch of `scheduleEffects` before calling `markVNodeDirty`

### `packages/qwik/src/core/use/use-task.unit.ts`
- Added three test cases: two verifying `scheduleTask` does not throw when `task.$el$` or `_captures[0]` is `undefined`, and one positive test verifying `markVNodeDirty` IS called when `task.$el$` is defined
- Tests use module-level `vi.mock` with per-test `Object.defineProperty` to avoid the Vitest hoisting trap

### `.changeset/gentle-tasks-guard.md`
- Patch changeset for `@qwik.dev/core`

# Docs

No user-facing documentation changes needed — `scheduleTask`, `scheduleEffects`, and `markVNodeDirty` are internal APIs not exposed in the public docs or GLOSSARY.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I made corresponding changes to the Qwik docs (N/A — internal APIs only)
- [x] I added new tests to cover the fix / functionality