### PR TITLE
fix(qwik): guard null/undefined vNode in markVNodeDirty

### DIFF
--- a/.changeset/guard-null-vnode-mark-dirty.md
+++ b/.changeset/guard-null-vnode-mark-dirty.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: guard null/undefined vNode in markVNodeDirty
+
+Prevent `TypeError: Cannot read properties of undefined (reading 'dirty')` crash in `markVNodeDirty` when callers pass an undefined vNode. This happens when `DomContainer.$destroy$()` is called during async qwikloader dispatch — `$getObjectById$` returns `undefined` for all pending deserialization, so `scheduleTask`, `scheduleEffects`, `_hmr`, `_val`, `_chk`, and `_res` all pass undefined vNodes to `markVNodeDirty`.

--- a/packages/qwik/src/core/shared/vnode/vnode-dirty.ts
+++ b/packages/qwik/src/core/shared/vnode/vnode-dirty.ts
@@ -111,6 +111,13 @@ export function markVNodeDirty(
   bits: ChoreBits,
   cursorRoot: VNode | null = null
 ): void {
+  if (!vNode) {
+    // vNode can be undefined when a container is destroyed during async qwikloader dispatch.
+    // DomContainer.$destroy$() replaces $getObjectById$ with () => undefined and truncates
+    // $stateData$, so deserializeCaptures returns [undefined] for pending event handlers.
+    // This affects scheduleTask, scheduleEffects, _hmr, _val, _chk, and _res.
+    return;
+  }
   const prevDirty = vNode.dirty;
   vNode.dirty |= bits;
   if (isSsrNodeGuard(vNode)) {

--- a/packages/qwik/src/core/shared/vnode/vnode-dirty.unit.ts
+++ b/packages/qwik/src/core/shared/vnode/vnode-dirty.unit.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { markVNodeDirty } from './vnode-dirty';
+import { ChoreBits } from './enums/chore-bits.enum';
+import type { Container } from '../types';
+
+describe('markVNodeDirty', () => {
+  it('does not throw when vNode is undefined (destroyed container)', () => {
+    // After DomContainer.$destroy$(), $getObjectById$ returns undefined for all IDs.
+    // Callers like scheduleTask, _hmr, _val, _chk pass the deserialized result
+    // directly to markVNodeDirty — which would be undefined.
+    const container = {} as Container;
+    expect(() => {
+      markVNodeDirty(container, undefined as any, ChoreBits.TASKS);
+    }).not.toThrow();
+  });
+
+  it('does not throw when vNode is null', () => {
+    const container = {} as Container;
+    expect(() => {
+      markVNodeDirty(container, null as any, ChoreBits.TASKS);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
# What is it?

- Bug fix

# Description

Fixes a runtime crash where `markVNodeDirty` receives an undefined/null vNode, causing:

```
TypeError: Cannot read properties of undefined (reading 'dirty')
  at markVNodeDirty (@qwik.dev/core/dist/core.mjs:6727:29)
```

This crash makes the entire application non-functional — no page renders, no login, all routes are dead.

## Root Cause

When `DomContainer.$destroy$()` is called during async qwikloader dispatch (e.g., SPA navigation destroys the container while queued event handlers are pending), it:

1. Truncates `$rawStateData$` and `$stateData$` to length 0
2. Replaces `$getObjectById$` with `() => undefined`

Pending event handlers then call `deserializeCaptures()` which invokes `container.$getObjectById$(id)` → returns `undefined`. The deserialized vNode references are `undefined`, and callers pass them directly to `markVNodeDirty`.

## Affected callers (all have the same vulnerability)

| Caller | File | What it passes |
|--------|------|---------------|
| `scheduleTask` | `use-task.ts` | `task.$el$` |
| `scheduleEffects` | `reactive-primitives/utils.ts` | `consumer.$el$` / `consumer` |
| `_hmr` | `use-hmr.ts` | `_captures![0]` |
| `_val` | `bind-handlers.ts` | `_captures![0]` |
| `_chk` | `bind-handlers.ts` | `_captures![0]` |
| `_res` | `bind-handlers.ts` | `_captures![0]` |

## Why fix in `markVNodeDirty` instead of each caller

- **Single fix point** — one guard protects all 20 callers, including the 6 vulnerable ones above
- **Zero API surface change** — no new fields, no interface changes, no coupling to `DomContainer`
- **Covers all edge cases** — not just full container destruction, but also partially-inflated `$stateData$` during lazy deserialization
- **Future-proof** — any new caller that passes an undefined vNode is automatically protected

### Alternative approaches considered

| Approach | Pros | Cons |
|----------|------|------|
| Guard at each call site (`!task?.$el$`) | Matches existing `WrappedSignalImpl` pattern | Decentralized — must be added to every caller; doesn't protect `_hmr`, `_val`, `_chk`, `_res` |
| `$destroyed$` flag on `DomContainer` | Semantically explicit | Requires `Container` interface change; doesn't cover partial inflation; more invasive |
| Fix in qwikloader (`element.closest()` re-check) | Fixes all handlers at once | Adds DOM traversal cost to every event dispatch; qwikloader is size-sensitive |
| Harden `markVNodeDirty` (this PR) | Single fix, all callers, zero API change | Silent return on undefined — mitigated by comment explaining when/why |

## Changes

### `packages/qwik/src/core/shared/vnode/vnode-dirty.ts`
- Added null/undefined guard at the top of `markVNodeDirty` with explanatory comment

### `packages/qwik/src/core/shared/vnode/vnode-dirty.unit.ts` (new)
- Test: does not throw when vNode is `undefined` (destroyed container scenario)
- Test: does not throw when vNode is `null`

### `.changeset/guard-null-vnode-mark-dirty.md`
- Patch changeset for `@qwik.dev/core`

# Docs

No user-facing documentation changes needed — `markVNodeDirty` is an internal API.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I made corresponding changes to the Qwik docs (N/A — internal API only)
- [x] I added new tests to cover the fix / functionality