### PR TITLE
fix(router - server-fns.ts): dynamicallyImportedIdResolutions don't exist in rolldown

### DIFF
--- a/packages/qwik-router/src/buildtime/vite/plugin.ts
+++ b/packages/qwik-router/src/buildtime/vite/plugin.ts
@@ -435,7 +435,7 @@ function serverFnsPlugin(buildContextRef: BuildContextRef): Plugin {
       if (!ctx) {
         return;
       }
-      const moduleIds = await collectServerFnModuleIds(ctx, RESOLVED_ID, (id) => this.load({ id }));
+      const moduleIds = await collectServerFnModuleIds(ctx, RESOLVED_ID, this);
       for (let i = 0; i < moduleIds.length; i++) {
         serverFnModules.add(moduleIds[i]);
       }

--- a/packages/qwik-router/src/buildtime/vite/server-fns.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.ts
@@ -1,22 +1,19 @@
 import type { Rollup } from 'vite';
 import type { RoutingContext } from '../types';
 
-type ServerFnModuleInfo = Pick<
-  Rollup.ModuleInfo,
-  'code' | 'dynamicallyImportedIdResolutions' | 'id' | 'importedIdResolutions'
->;
-
+export type ServerFnPluginContext = Pick<Rollup.PluginContext, 'resolve' | 'load'>;
+export type ServerFnRoutingContext = Pick<RoutingContext, 'layouts' | 'routes' | 'serverPlugins'>;
 export async function collectServerFnModuleIds(
-  ctx: Pick<RoutingContext, 'layouts' | 'routes' | 'serverPlugins'>,
+  routingContext: ServerFnRoutingContext,
   resolvedVirtualId: string,
-  loadModule: (id: string) => Promise<ServerFnModuleInfo>
+  pluginContext: ServerFnPluginContext
 ) {
   const serverFnModules = new Set<string>();
   const queuedModuleIds = new Set<string>();
   const seenModuleIds = new Set<string>();
-  const routes = ctx.routes;
-  const layouts = ctx.layouts;
-  const serverPlugins = ctx.serverPlugins;
+  const routes = routingContext.routes;
+  const layouts = routingContext.layouts;
+  const serverPlugins = routingContext.serverPlugins;
 
   for (let i = 0; i < routes.length; i++) {
     const route = routes[i];
@@ -42,18 +39,25 @@ export async function collectServerFnModuleIds(
     }
     seenModuleIds.add(id);
 
-    const moduleInfo = await loadModule(id);
-    if (moduleInfo.code?.includes('serverQrl(')) {
+    const resolved = await pluginContext.resolve(id, undefined, { skipSelf: true });
+    if (!resolved || resolved.external) {
+      continue;
+    }
+
+    const moduleInfo = await pluginContext.load({ id: resolved.id });
+    if (moduleInfo.code == null) {
+      continue;
+    }
+
+    if (moduleInfo.code.includes('serverQrl(')) {
       serverFnModules.add(moduleInfo.id);
     }
 
-    const resolvedImports = moduleInfo.importedIdResolutions.concat(
-      moduleInfo.dynamicallyImportedIdResolutions
-    );
+    const resolvedImports = moduleInfo.importedIds.concat(moduleInfo.dynamicallyImportedIds);
     for (let i = 0; i < resolvedImports.length; i++) {
       const resolvedImport = resolvedImports[i];
-      if (!resolvedImport.external && !seenModuleIds.has(resolvedImport.id)) {
-        queuedModuleIds.add(resolvedImport.id);
+      if (resolvedImport && !seenModuleIds.has(resolvedImport)) {
+        queuedModuleIds.add(resolvedImport);
       }
     }
   }

--- a/packages/qwik-router/src/buildtime/vite/server-fns.unit.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.unit.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { BuiltLayout, BuiltRoute, BuiltServerPlugin, RoutingContext } from '../types';
-import { collectServerFnModuleIds } from './server-fns';
+import type { BuiltLayout, BuiltRoute, BuiltServerPlugin } from '../types';
+import { collectServerFnModuleIds, type ServerFnRoutingContext } from './server-fns';
 
 describe('collectServerFnModuleIds', () => {
   it('walks the reachable module graph and collects modules containing serverQrl', async () => {
@@ -12,11 +12,8 @@ describe('collectServerFnModuleIds', () => {
         {
           id: '/app/routes/index.tsx',
           code: 'export default component$(() => null);',
-          importedIdResolutions: [
-            { id: '/app/shared.ts', external: false },
-            { id: '/node_modules/@qwik.dev/core/index.mjs', external: false },
-          ],
-          dynamicallyImportedIdResolutions: [{ id: '/app/lazy.ts', external: false }],
+          importedIds: ['/app/shared.ts', '/node_modules/@qwik.dev/core/index.mjs'],
+          dynamicallyImportedIds: ['/app/lazy.ts'],
         },
       ],
       [
@@ -24,8 +21,8 @@ describe('collectServerFnModuleIds', () => {
         {
           id: '/app/layout.tsx',
           code: 'export default component$(() => null);',
-          importedIdResolutions: [{ id: '/app/shared.ts', external: false }],
-          dynamicallyImportedIdResolutions: [],
+          importedIds: ['/app/shared.ts'],
+          dynamicallyImportedIds: [],
         },
       ],
       [
@@ -33,11 +30,8 @@ describe('collectServerFnModuleIds', () => {
         {
           id: '/app/shared.ts',
           code: 'export const shared = true;',
-          importedIdResolutions: [
-            { id: resolvedVirtualId, external: false },
-            { id: 'node:fs', external: true },
-          ],
-          dynamicallyImportedIdResolutions: [],
+          importedIds: [resolvedVirtualId],
+          dynamicallyImportedIds: [],
         },
       ],
       [
@@ -45,8 +39,8 @@ describe('collectServerFnModuleIds', () => {
         {
           id: '/app/lazy.ts',
           code: 'export const fn = serverQrl(() => null);',
-          importedIdResolutions: [],
-          dynamicallyImportedIdResolutions: [],
+          importedIds: [],
+          dynamicallyImportedIds: [],
         },
       ],
       [
@@ -54,8 +48,8 @@ describe('collectServerFnModuleIds', () => {
         {
           id: '/node_modules/@qwik.dev/core/index.mjs',
           code: 'export {};',
-          importedIdResolutions: [],
-          dynamicallyImportedIdResolutions: [],
+          importedIds: [],
+          dynamicallyImportedIds: [],
         },
       ],
       [
@@ -63,8 +57,8 @@ describe('collectServerFnModuleIds', () => {
         {
           id: '/app/plugin.ts',
           code: 'export const pluginFn = serverQrl(() => null);',
-          importedIdResolutions: [],
-          dynamicallyImportedIdResolutions: [],
+          importedIds: [],
+          dynamicallyImportedIds: [],
         },
       ],
     ]);
@@ -92,20 +86,25 @@ describe('collectServerFnModuleIds', () => {
       filePath: '/app/plugin.ts',
       ext: 'ts',
     };
-    const ctx: Pick<RoutingContext, 'layouts' | 'routes' | 'serverPlugins'> = {
+    const ctx: ServerFnRoutingContext = {
       routes: [route],
       layouts: [layout],
       serverPlugins: [serverPlugin],
     };
 
-    const serverFnModules = await collectServerFnModuleIds(ctx, resolvedVirtualId, async (id) => {
-      loads.push(id);
-      const moduleInfo = modules.get(id);
-      if (!moduleInfo) {
-        throw new Error(`Unexpected module load: ${id}`);
-      }
-      return moduleInfo as any;
-    });
+    const pluginContext = {
+      resolve: async (id: string) => ({ id, external: false }) as any,
+      load: async ({ id }: { id: string }) => {
+        loads.push(id);
+        const moduleInfo = modules.get(id);
+        if (!moduleInfo) {
+          throw new Error(`Unexpected module load: ${id}`);
+        }
+        return moduleInfo as any;
+      },
+    };
+
+    const serverFnModules = await collectServerFnModuleIds(ctx, resolvedVirtualId, pluginContext);
 
     expect(serverFnModules.sort()).toEqual(['/app/lazy.ts', '/app/plugin.ts']);
     expect(loads).toEqual([


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
