### PR TITLE
fix(vite): resolve relative rollup input paths against vite root

### DIFF
--- a/.changeset/rollup-input-absolute.md
+++ b/.changeset/rollup-input-absolute.md
@@ -1,0 +1,9 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix(vite): resolve relative SSR/client input paths to absolute before passing to rollup
+
+When a relative path was provided via `build.ssr` (string), `qwikVite({ ssr.input })`, or `qwikVite({ client.input })`, the raw relative string was forwarded to `rollupOptions.input`. Rollup then tried to resolve it from the current working directory rather than the Vite root, which caused `Could not resolve entry module` failures in monorepo / nx setups where CWD differs from the Vite root.
+
+Relative inputs are now normalized against the Vite root in `normalizeOptions`, matching how `rootDir`, `srcDir`, and `outDir` are handled.

--- a/.changeset/rollup-input-absolute.md
+++ b/.changeset/rollup-input-absolute.md
@@ -2,8 +2,5 @@
 '@qwik.dev/core': patch
 ---
 
-fix(vite): resolve relative SSR/client input paths to absolute before passing to rollup
+fix(vite): resolve relative SSR/client input paths to absolute before passing to rollup, preventing "[vite-plugin-qwik] Qwik input "src/entry.preview.tsx" not found" errors.
 
-When a relative path was provided via `build.ssr` (string), `qwikVite({ ssr.input })`, or `qwikVite({ client.input })`, the raw relative string was forwarded to `rollupOptions.input`. Rollup then tried to resolve it from the current working directory rather than the Vite root, which caused `Could not resolve entry module` failures in monorepo / nx setups where CWD differs from the Vite root.
-
-Relative inputs are now normalized against the Vite root in `normalizeOptions`, matching how `rootDir`, `srcDir`, and `outDir` are handled.

--- a/packages/qwik-vite/src/plugins/plugin.ts
+++ b/packages/qwik-vite/src/plugins/plugin.ts
@@ -378,35 +378,38 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
       }
     }
 
-    const out = { ...opts };
     // Make sure to know what the actual input is
     opts.input ||= updatedOpts.input as string[];
     if (opts.input && typeof opts.input === 'string') {
       opts.input = [opts.input];
     }
+    // Normalize relative input paths to absolute (consistent with rootDir/srcDir/outDir)
+    if (Array.isArray(opts.input)) {
+      opts.input = opts.input.map((inp) =>
+        inp.startsWith('@') || inp.startsWith('\0') || path.isAbsolute(inp)
+          ? inp
+          : normalizePath(path.resolve(opts.rootDir, inp))
+      );
+    }
+
+    const out = { ...opts };
     return out;
   };
 
-  let hasValidatedSource = false;
-
   const validateSource = async (resolver: (id: string) => Promise<unknown | undefined>) => {
-    if (!hasValidatedSource) {
-      hasValidatedSource = true;
-
-      const sys = getSys();
-      if (sys.env === 'node') {
-        const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
-        if (!fs.existsSync(opts.rootDir)) {
-          throw new Error(`Qwik rootDir "${opts.rootDir}" not found.`);
-        }
-        if (typeof opts.srcDir === 'string' && !fs.existsSync(opts.srcDir)) {
-          throw new Error(`Qwik srcDir "${opts.srcDir}" not found.`);
-        }
-        for (const [_, input] of Object.entries(opts.input || {})) {
-          const resolved = await resolver(input);
-          if (!resolved) {
-            throw new Error(`Qwik input "${input}" not found.`);
-          }
+    const sys = getSys();
+    if (sys.env === 'node') {
+      const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
+      if (!fs.existsSync(opts.rootDir)) {
+        throw new Error(`Qwik rootDir "${opts.rootDir}" not found.`);
+      }
+      if (typeof opts.srcDir === 'string' && !fs.existsSync(opts.srcDir)) {
+        throw new Error(`Qwik srcDir "${opts.srcDir}" not found.`);
+      }
+      for (const [_, input] of Object.entries(opts.input || {})) {
+        const resolved = await resolver(input);
+        if (!resolved) {
+          throw new Error(`Qwik input "${input}" not found.`);
         }
       }
     }

--- a/packages/qwik-vite/src/plugins/plugin.unit.ts
+++ b/packages/qwik-vite/src/plugins/plugin.unit.ts
@@ -181,6 +181,16 @@ test('input array', async () => {
   ]);
 });
 
+test.runIf(process.platform === 'win32')('input array, win32', async () => {
+  const plugin = await mockPlugin();
+  const opts = await plugin.normalizeOptions({
+    rootDir: 'C:\\proj',
+    input: ['src\\cmps\\a.tsx', 'C:\\abs\\b.tsx'],
+  });
+  // relative paths are resolved against rootDir and normalized; absolute paths pass through
+  assert.deepEqual(opts.input, ['C:/proj/src/cmps/a.tsx', 'C:\\abs\\b.tsx']);
+});
+
 test('outDir', async () => {
   const plugin = await mockPlugin();
   const opts = await plugin.normalizeOptions({ outDir: 'out' });

--- a/packages/qwik-vite/src/plugins/plugin.unit.ts
+++ b/packages/qwik-vite/src/plugins/plugin.unit.ts
@@ -165,8 +165,8 @@ test('tsconfigFileNames, empty array fallback to default', async () => {
 test('input string', async () => {
   const plugin = await mockPlugin();
   const opts = await plugin.normalizeOptions({ input: 'src/cmps/main.tsx' });
-  // we don't provide input so that we don't override the vite input
-  assert.deepEqual(opts.input, undefined);
+  // relative inputs are resolved to absolute so rollup can find them
+  assert.deepEqual(opts.input, [normalizePath(resolve(cwd, 'src/cmps/main.tsx'))]);
 });
 
 test('input array', async () => {
@@ -174,8 +174,11 @@ test('input array', async () => {
   const opts = await plugin.normalizeOptions({
     input: ['src/cmps/a.tsx', 'src/cmps/b.tsx'],
   });
-  // we don't provide input so that we don't override the vite input
-  assert.deepEqual(opts.input, undefined);
+  // relative inputs are resolved to absolute so rollup can find them
+  assert.deepEqual(opts.input, [
+    normalizePath(resolve(cwd, 'src/cmps/a.tsx')),
+    normalizePath(resolve(cwd, 'src/cmps/b.tsx')),
+  ]);
 });
 
 test('outDir', async () => {

--- a/packages/qwik-vite/src/plugins/vite.ts
+++ b/packages/qwik-vite/src/plugins/vite.ts
@@ -227,7 +227,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
       };
 
       const opts = await qwikPlugin.normalizeOptions(pluginOpts);
-      input ||= opts.input;
+      input = opts.input;
 
       // Cache pluginOpts for use in configResolved()
       cachedPluginOpts = pluginOpts;

--- a/packages/qwik-vite/src/plugins/vite.unit.ts
+++ b/packages/qwik-vite/src/plugins/vite.unit.ts
@@ -310,6 +310,24 @@ test('command: build, --ssr entry.server.tsx', async () => {
   assert.deepEqual(c.publicDir, false);
 });
 
+test('command: build, --ssr with relative path resolves to absolute', async () => {
+  const initOpts = {
+    optimizerOptions: mockOptimizerOptions(),
+  };
+  const plugin = getPlugin(initOpts);
+  const c = (await plugin.config.call(
+    configHookPluginContext,
+    { build: { ssr: 'src/entry.server.tsx' } },
+    { command: 'build', mode: '' }
+  ))!;
+  const build = c.build!;
+  const rollupOptions = build!.rollupOptions!;
+
+  assert.deepEqual((rollupOptions.input as string[]).map(normalizePath), [
+    normalizePath(resolve(cwd, 'src', 'entry.server.tsx')),
+  ]);
+});
+
 test('command: serve, --mode ssr', async () => {
   const initOpts = {
     optimizerOptions: mockOptimizerOptions(),
@@ -579,7 +597,9 @@ describe('input config', () => {
       {},
       { command: 'build', mode: 'development' }
     ))!;
-    assert.deepEqual(c.build.rollupOptions.input, ['./src/widget/counter.tsx']);
+    assert.deepEqual((c.build.rollupOptions.input as string[]).map(normalizePath), [
+      normalizePath(resolve(cwd, 'src', 'widget', 'counter.tsx')),
+    ]);
   });
   test('should handle ssr target', async () => {
     const plugin = getPlugin(initOpts);
@@ -588,7 +608,9 @@ describe('input config', () => {
       {},
       { command: 'build', mode: 'ssr' }
     ))!;
-    assert.deepEqual(c.build.rollupOptions.input, ['./src/widget/ssr.tsx']);
+    assert.deepEqual((c.build.rollupOptions.input as string[]).map(normalizePath), [
+      normalizePath(resolve(cwd, 'src', 'widget', 'ssr.tsx')),
+    ]);
   });
 });
 


### PR DESCRIPTION
# What is it?
- Bug

# Description

Fixes

> ✗ Build failed in 5ms
[vite-plugin-qwik] Qwik input "src/entry.preview.tsx" not found.

When `build.ssr` is a string (or `qwikVite({ ssr.input, client.input })` is relative), the raw path was forwarded to `rollupOptions.input` unchanged. Rollup resolves from CWD, so in monorepo/nx setups where CWD ≠ Vite root this fails with `Could not resolve entry module`. Input is now normalized against the Vite root in `normalizeOptions`, like `rootDir`/`srcDir`/`outDir`.

Also fixes issues with rolldown with better input paths handling.