### PR TITLE
fix: allow Temporal in valid-lexical-scope-lint

### DIFF
--- a/.changeset/bright-showers-taste.md
+++ b/.changeset/bright-showers-taste.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-qwik': patch
+---
+
+Allow `Temporal`-types in `valid-lexical-scope`-lint (as they can be serialized)

--- a/packages/eslint-plugin-qwik/src/validLexicalScope.ts
+++ b/packages/eslint-plugin-qwik/src/validLexicalScope.ts
@@ -542,6 +542,15 @@ const ALLOWED_CLASSES = {
   Set: true,
   Map: true,
   Uint8Array: true,
+  // Types in Temporal
+  Duration: true,
+  Instant: true,
+  PlainDate: true,
+  PlainDateTime: true,
+  PlainMonthDay: true,
+  PlainTime: true,
+  PlainYearMonth: true,
+  ZonedDateTime: true,
 };
 
 const referencesOutsideGood = `


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

Serialization-support for the types in `Temporal` was added in #8495.
However, the `valid-lexical-scope`-lint would still warn that they would not be allowed to be used in a different scope because they would not be serializable.
This PR adds the serializable types from `Temporal` to the allowlist of the lint.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [X] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [X] I performed a self-review of my own code
- [X] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
