### PR TITLE
chore: force agents to use core.dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ Prefer `pnpm build build.core.dev` to build qwik and qwik-router faster.
 - **Install** — `pnpm install`
 - **Build (no Rust)** — `pnpm build.local` — for a fresh start
 - **Build (with Rust)** — `pnpm build.full` — only for optimizer changes
-- **Build core only** — `pnpm build.core` — fast, just Qwik + Router + types
-- **Dev rebuild** — `pnpm build.core.dev` — very fast iterative rebuild
+- **Build core** — `pnpm build.core` — fast, just Qwik + Router + types
+- **Build core only** — `pnpm build.core.dev` — very fast iterative rebuild
 - **Watch mode** — `pnpm build.watch` — rebuilds on change
 - **Unit tests** — `pnpm vitest run` — Vitest, runs `packages/**/*.unit.{ts,tsx}` and `*.spec.{ts,tsx}`, or specify a single file. Add `-u` to update snapshots. **NEVER use `pnpm test.unit`**
 - **E2E tests (Chromium)** — `pnpm test.e2e.chromium` — Playwright, always run the dev rebuild first!
@@ -219,7 +219,7 @@ This creates a `.changeset/*.md` file describing the change. The core packages (
 
 ### Before Pushing a PR
 
-1. `pnpm build.core`
+1. `pnpm build.core.dev`
 2. `pnpm test.unit` (run relevant tests)
 3. `pnpm lint`
 4. `pnpm api.update` (if you changed public API)


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
