### PR TITLE
fix(vite): walk up to find Qwik deps in monorepo workspaces

### DIFF
--- a/.changeset/walk-up-monorepo-deps.md
+++ b/.changeset/walk-up-monorepo-deps.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+FIX: Qwik vite plugin's auto-detection of Qwik library dependencies now walks up the directory tree from Vite's `root` and unions deps from every `package.json` it finds. Previously it only read the `package.json` at `root`, which meant monorepo setups with the Vite root pointing at a sub-project (e.g. an Nx lib) missed Qwik libraries declared at the workspace root. Those libraries then fell through to Vite's pre-bundling, leaving raw `$()` calls in the bundled output and producing the runtime error "Optimizer should replace all usages of $()".

--- a/packages/qwik-vite/src/plugins/vite.ts
+++ b/packages/qwik-vite/src/plugins/vite.ts
@@ -729,18 +729,37 @@ async function checkExternals() {
   const core2 = '@qwik.dev/core';
   const core1 = '@builder.io/qwik';
   async function getInstalledDependencies(root: string): Promise<string[]> {
-    try {
-      const pkgPath = path.join(root, 'package.json');
-      const data = await fs.readFile(pkgPath, { encoding: 'utf-8' });
-      const json = JSON.parse(data);
-      return [
-        ...Object.keys(json.dependencies || {}),
-        ...Object.keys(json.devDependencies || {}),
-        ...Object.keys(json.optionalDependencies || {}),
-      ];
-    } catch {
-      return [];
+    // Walk up from `root` and union deps from every package.json we find, so
+    // monorepo setups where Vite's root points at a sub-project still pick up
+    // workspace-root deps (e.g. an Nx lib whose deps are declared at the
+    // repo root).
+    //
+    const deps = new Set<string>();
+    let dir = root;
+    while (dir) {
+      try {
+        const pkgPath = path.join(dir, 'package.json');
+        const data = await fs.readFile(pkgPath, { encoding: 'utf-8' });
+        const json = JSON.parse(data);
+        for (const name of Object.keys(json.dependencies || {})) {
+          deps.add(name);
+        }
+        for (const name of Object.keys(json.devDependencies || {})) {
+          deps.add(name);
+        }
+        for (const name of Object.keys(json.optionalDependencies || {})) {
+          deps.add(name);
+        }
+      } catch {
+        // No package.json at this level, or unreadable — keep walking.
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) {
+        break;
+      }
+      dir = parent;
     }
+    return [...deps];
   }
 
   async function isQwikDep(dep: string, dir: string) {


### PR DESCRIPTION
# What is it?

- Bug

# Description

The `checkQwikExternals` Vite sub-plugin discovers Qwik libraries by reading `package.json` so it can keep them out of esbuild's pre-bundling (otherwise the optimizer never sees them and their `$()` calls survive into the bundle). Today it only reads `package.json` at Vite's `config.root`. In monorepo setups where the Vite root is a sub-project — Nx libs, pnpm workspaces with lib-level vite configs, etc. — that directory often has no `package.json` at all, so any Qwik library declared at the workspace root is missed, gets pre-bundled, and triggers the runtime error `Optimizer should replace all usages of $() with some special syntax` when the unprocessed `$()` calls run.

This PR makes the discovery walk up from `config.root` and union deps from every `package.json` it finds, all the way to filesystem root. No workspace-marker detection (`pnpm-workspace.yaml`, `workspaces` field, `nx.json`, `rush.json`, ...) — every package manager has its own marker and the list keeps growing. The `isQwikDep` check that follows already validates each candidate against `node_modules` and the package's own `package.json` (`qwik` field, or `@qwik.dev/core`/`@builder.io/qwik` in deps/peerDeps), so false positives from unrelated `package.json` files higher up the tree are filtered out.

## On performance

This is much cheaper than the v1 approach of recursively scanning `node_modules`. That scan was bounded by the **total installed package count** — typically 2k-10k package directories in a real app, each requiring `readFile + parse`. Here the bound is the **declared deps** in the walked-up `package.json` files (50-300 names), each checked with a single `node_modules/<name>/package.json` read. The walk-up itself is ~5-10 `package.json` reads at most, all hash lookups on the directory's name index — single-digit milliseconds on local SSD, run once during Vite's `config` hook. Roughly 10-30× fewer file reads than the v1 recursive scan, and no directory enumeration, which means no special-casing for pnpm's `.pnpm/` flat layout vs npm's nested tree.