### PR TITLE
fix(ci): include qwik-vite in build-qwik cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,8 @@ jobs:
           lookup-only: true
           path: packages/qwik/dist
           # Note that this includes the package.json of qwik
-          key: ${{ hashfiles('.github/workflows/ci.yml', 'pnpm-lock.yaml', 'scripts.json', 'scripts/**/*', 'packages/qwik/**/*', 'starters/features/**/*', 'starters/adapters/**/*', 'starters/templates/**/*', '!**/*.unit.*', '!**/*.rs', '!e2e/qwik-e2e/apps/e2e') }}
+          # qwik-vite source is bundled into packages/qwik/dist/optimizer.mjs by scripts/submodule-optimizer.ts, so its sources must invalidate this cache.
+          key: ${{ hashfiles('.github/workflows/ci.yml', 'pnpm-lock.yaml', 'scripts.json', 'scripts/**/*', 'packages/qwik/**/*', 'packages/qwik-vite/**/*', 'starters/features/**/*', 'starters/adapters/**/*', 'starters/templates/**/*', '!**/*.unit.*', '!**/*.rs', '!e2e/qwik-e2e/apps/e2e') }}
       - run: 'echo ${{ steps.cache-qwik.outputs.cache-primary-key }} > qwik-key.txt'
       - name: 'check cache: rust'
         id: cache-rust


### PR DESCRIPTION
# What is it?
- Bug

# Description
The `build-qwik` cache key on [ci.yml#L145](.github/workflows/ci.yml#L145) hashed `packages/qwik/**/*` but not `packages/qwik-vite/**/*`. Since [`scripts/submodule-optimizer.ts`](scripts/submodule-optimizer.ts) bundles `packages/qwik-vite/src` into `packages/qwik/dist/optimizer.mjs`, commits that touch only `qwik-vite` would hit the stale cache, skip the build, and re-upload an unchanged artifact — so pkg.pr.new previews (and the npm release) didn't include the qwik-vite changes. The `cache-others` key chains off `qwik-key.txt`, so it cascaded into stale router/eslint/create-qwik caches too.

Adding `packages/qwik-vite/**/*` to the hash inputs fixes the invalidation chain.