### PR TITLE
fix: handle callback-only response end in Vite HTML transform

### DIFF
--- a/.changeset/shy-knives-pay.md
+++ b/.changeset/shy-knives-pay.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: handle callback-only response end in Vite HTML transform

--- a/packages/qwik-router/src/buildtime/vite/html-transform-wrapper.spec.ts
+++ b/packages/qwik-router/src/buildtime/vite/html-transform-wrapper.spec.ts
@@ -16,7 +16,15 @@ class MockServerResponse extends EventEmitter {
     return true;
   });
 
-  private _origEnd = vi.fn((chunk?: any, cb?: () => void) => {
+  private _origEnd = vi.fn((chunk?: any, encoding?: any, cb?: () => void) => {
+    if (typeof chunk === 'function') {
+      cb = chunk;
+      chunk = undefined;
+      encoding = undefined;
+    } else if (typeof encoding === 'function') {
+      cb = encoding;
+      encoding = undefined;
+    }
     if (chunk && typeof chunk !== 'function') {
       this.output += chunk.toString();
     }
@@ -112,6 +120,23 @@ describe('wrapResponseForHtmlTransform', () => {
     await new Promise((resolve) => res.on('finish', resolve));
 
     expect(server.transformIndexHtml).toHaveBeenCalledOnce();
+    expect(res.output).toMatchInlineSnapshot(
+      `"<html><head><!-- head pre content --><!-- head post content --></head><body><!-- body pre content --><h1>Hello</h1><!-- body post content --></body></html>"`
+    );
+  });
+
+  it('should handle callback-only response end', async () => {
+    const callback = vi.fn();
+    wrapResponseForHtmlTransform(req, res as any, server);
+
+    res.setHeader('Content-Type', 'text/html');
+    res.write('<html><head></head><body><h1>Hello</h1></body></html>');
+    res.end(callback);
+
+    await new Promise((resolve) => res.on('finish', resolve));
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(res.origWrite).not.toHaveBeenCalledWith(callback, undefined, undefined);
     expect(res.output).toMatchInlineSnapshot(
       `"<html><head><!-- head pre content --><!-- head post content --></head><body><!-- body pre content --><h1>Hello</h1><!-- body post content --></body></html>"`
     );

--- a/packages/qwik-router/src/buildtime/vite/html-transform-wrapper.ts
+++ b/packages/qwik-router/src/buildtime/vite/html-transform-wrapper.ts
@@ -258,7 +258,11 @@ class HtmlTransformPatcher {
   }
 
   private async handleEnd(chunk?: any, encoding?: any, callback?: any): Promise<void> {
-    if (typeof encoding === 'function') {
+    if (typeof chunk === 'function') {
+      callback = chunk;
+      chunk = undefined;
+      encoding = undefined;
+    } else if (typeof encoding === 'function') {
       callback = encoding;
       encoding = undefined;
     }


### PR DESCRIPTION
Fixes dev mode error:
```
Error in handleEnd: TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received function
    at write_ (node:_http_outgoing:894:11)
    at ServerResponse.write (node:_http_outgoing:849:15)
    at HtmlTransformPatcher.handleWrite 
```