### PR TITLE
fix(router): don't crash Vite dev when src/entry.ssr is missing

### DIFF
--- a/.changeset/router-dev-middleware-missing-entry-ssr.md
+++ b/.changeset/router-dev-middleware-missing-entry-ssr.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix(router): don't crash Vite dev when `src/entry.ssr` is missing
+
+The dev middleware called `ssrLoadModule('src/entry.ssr')` unconditionally, so hosts that embed the qwikRouter Vite plugin without an `entry.ssr` (Storybook, component test runners, etc.) crashed the dev server with an unhandled rejection. The load is now wrapped so missing-entry errors fall through to `next()`.

--- a/.changeset/router-dev-middleware-missing-entry-ssr.md
+++ b/.changeset/router-dev-middleware-missing-entry-ssr.md
@@ -2,6 +2,4 @@
 '@qwik.dev/router': patch
 ---
 
-fix(router): don't crash Vite dev when `src/entry.ssr` is missing
-
-The dev middleware called `ssrLoadModule('src/entry.ssr')` unconditionally, so hosts that embed the qwikRouter Vite plugin without an `entry.ssr` (Storybook, component test runners, etc.) crashed the dev server with an unhandled rejection. The load is now wrapped so missing-entry errors fall through to `next()`.
+fix(router): The Vite dev won't crash anymore when `src/entry.ssr` is missing (e.g. in monorepos)

--- a/packages/qwik-router/src/buildtime/vite/dev-middleware.ts
+++ b/packages/qwik-router/src/buildtime/vite/dev-middleware.ts
@@ -13,7 +13,17 @@ export const makeRouterDevMiddleware =
 
     // TODO more flexible entry points, like importing `render` from `src/server`
     // TODO pick a better name, entry.server-renderer perhaps?
-    const mod = (await server.ssrLoadModule('src/entry.ssr')) as { default: Render };
+    let mod: { default: Render };
+    try {
+      mod = (await server.ssrLoadModule('src/entry.ssr')) as { default: Render };
+    } catch (e) {
+      // Pass through so hosts without an entry.ssr (e.g. Storybook) can handle the request
+      // themselves instead of crashing the dev server with an unhandled rejection.
+      if (e instanceof Error) {
+        server.ssrFixStacktrace(e);
+      }
+      return next();
+    }
     if (!mod.default) {
       console.error('No default export found in src/entry.ssr');
       return next();


### PR DESCRIPTION
# What is it?
- Bug

# Description
The dev middleware in `qwik-router` calls `server.ssrLoadModule('src/entry.ssr')` unconditionally. When the qwikRouter Vite plugin is embedded in a host that doesn't ship an `entry.ssr` (Storybook, component test runners, etc.), the rejected promise becomes an unhandled rejection and crashes the dev server. Wrapping the load lets those hosts fall through to `next()` instead.

Reproduces today on `@qwik.dev/router@2.0.0-beta.34` when running Storybook over a Qwik library with `qwikRouter()` in the Vite config — workaround is `qwikRouter({ devSsrServer: false })`.