### PR TITLE
fix(core): hide node:async_hooks import from non-Qwik bundlers

### DIFF
--- a/.changeset/core-locale-node-builtin-import.md
+++ b/.changeset/core-locale-node-builtin-import.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix(core): hide `node:async_hooks` import from non-Qwik bundlers
+
+`use-locale.ts` does `import('node:async_hooks')` inside an `if (isServer)` branch to set up `AsyncLocalStorage`. Consumers that bundle `@qwik.dev/core` for the browser without the Qwik Vite plugin (e.g. Cypress's webpack-preprocessor) can't tree-shake the dead branch and fail at build time with `UnhandledSchemeError: Reading from "node:async_hooks" is not handled`. The dynamic-import target is now built at runtime so the literal isn't preserved through Rollup's constant folding, and `/* webpackIgnore */` / `/* @vite-ignore */` comments cover consumer bundlers.

--- a/.changeset/core-locale-node-builtin-import.md
+++ b/.changeset/core-locale-node-builtin-import.md
@@ -2,6 +2,4 @@
 '@qwik.dev/core': patch
 ---
 
-fix(core): hide `node:async_hooks` import from non-Qwik bundlers
-
-`use-locale.ts` does `import('node:async_hooks')` inside an `if (isServer)` branch to set up `AsyncLocalStorage`. Consumers that bundle `@qwik.dev/core` for the browser without the Qwik Vite plugin (e.g. Cypress's webpack-preprocessor) can't tree-shake the dead branch and fail at build time with `UnhandledSchemeError: Reading from "node:async_hooks" is not handled`. The dynamic-import target is now built at runtime so the literal isn't preserved through Rollup's constant folding, and `/* webpackIgnore */` / `/* @vite-ignore */` comments cover consumer bundlers.
+fix(core): hide `node:async_hooks` import from non-Qwik bundlers (e.g. cypress E2E)

--- a/packages/qwik/src/core/shared/platform/async-local-storage.ts
+++ b/packages/qwik/src/core/shared/platform/async-local-storage.ts
@@ -1,0 +1,15 @@
+import type { AsyncLocalStorage } from 'node:async_hooks';
+
+type ProcessWithBuiltins = {
+  getBuiltinModule?: (id: string) => unknown;
+};
+
+/** @internal */
+export const getAsyncLocalStorage = () => {
+  const process = (globalThis as { process?: ProcessWithBuiltins }).process;
+  return (
+    process?.getBuiltinModule?.('node:async_hooks') as
+      | { AsyncLocalStorage?: new <T>() => AsyncLocalStorage<T> }
+      | undefined
+  )?.AsyncLocalStorage;
+};

--- a/packages/qwik/src/core/use/use-locale.ts
+++ b/packages/qwik/src/core/use/use-locale.ts
@@ -1,4 +1,5 @@
 import { tryGetInvokeContext } from './use-core';
+import { getAsyncLocalStorage } from '../shared/platform/async-local-storage';
 import { isServer } from '@qwik.dev/core/build';
 import type { AsyncLocalStorage } from 'node:async_hooks';
 
@@ -7,20 +8,10 @@ let _locale: string | undefined = undefined;
 let localAsyncStore: AsyncLocalStorage<string> | undefined;
 
 if (isServer) {
-  // Hide the `node:` specifier from static analysis so consumers bundling the
-  // published core for the browser without the Qwik Vite plugin (e.g. raw
-  // webpack used by Cypress's webpack-preprocessor) don't fail with
-  // "UnhandledSchemeError" on this dead-code branch. The `.join` defeats
-  // Rollup's constant folding so the literal isn't restored at qwik build
-  // time, and the magic comments cover Vite/webpack at consumer build time.
-  const moduleName = ['node', 'async_hooks'].join(':');
-  import(/* @vite-ignore */ /* webpackIgnore: true */ moduleName)
-    .then((module: typeof import('node:async_hooks')) => {
-      localAsyncStore = new module.AsyncLocalStorage();
-    })
-    .catch(() => {
-      // ignore if AsyncLocalStorage is not available
-    });
+  const AsyncLocalStorage = getAsyncLocalStorage();
+  if (AsyncLocalStorage) {
+    localAsyncStore = new AsyncLocalStorage();
+  }
 }
 
 /**

--- a/packages/qwik/src/core/use/use-locale.ts
+++ b/packages/qwik/src/core/use/use-locale.ts
@@ -7,8 +7,15 @@ let _locale: string | undefined = undefined;
 let localAsyncStore: AsyncLocalStorage<string> | undefined;
 
 if (isServer) {
-  import('node:async_hooks')
-    .then((module) => {
+  // Hide the `node:` specifier from static analysis so consumers bundling the
+  // published core for the browser without the Qwik Vite plugin (e.g. raw
+  // webpack used by Cypress's webpack-preprocessor) don't fail with
+  // "UnhandledSchemeError" on this dead-code branch. The `.join` defeats
+  // Rollup's constant folding so the literal isn't restored at qwik build
+  // time, and the magic comments cover Vite/webpack at consumer build time.
+  const moduleName = ['node', 'async_hooks'].join(':');
+  import(/* @vite-ignore */ /* webpackIgnore: true */ moduleName)
+    .then((module: typeof import('node:async_hooks')) => {
       localAsyncStore = new module.AsyncLocalStorage();
     })
     .catch(() => {


### PR DESCRIPTION
# What is it?
- Bug

# Description
\`packages/qwik/src/core/use/use-locale.ts\` does \`import('node:async_hooks')\` inside an \`if (isServer)\` branch (added in [#9116](https://github.com/QwikDev/qwik/pull/9116) — \`bdc690ddf\` _feat(core): use AsyncLocalStorage for locale_) to set up \`AsyncLocalStorage\` server-side.

The \`isServer\` flag is a runtime check (\`!isBrowser\` from \`@qwik.dev/core/build\`), not a bundler define. Consumers bundling \`@qwik.dev/core\` for the browser **without** the Qwik Vite plugin can't tree-shake this branch and fail at build time:

\`\`\`
Module build failed: UnhandledSchemeError: Reading from "node:async_hooks" is not handled by plugins (Unhandled scheme).
\`\`\`

I hit this with Cypress's default webpack-preprocessor in a Qwik 2 monorepo migration. Any spec file whose import graph touches \`@qwik.dev/core\` blows up. Same class of issue would hit raw webpack/esbuild/Parcel setups that don't run the Qwik optimizer.

## Fix

- Build the dynamic-import target at runtime via \`['node', 'async_hooks'].join(':')\` so Rollup's constant folding doesn't restore the \`node:\` literal in the published \`core.mjs\` (currently it's preserved as-is because \`node:async_hooks\` is in the rollup externals — see [scripts/submodule-core.ts:42](https://github.com/QwikDev/qwik/blob/build/v2/scripts/submodule-core.ts#L42)).
- Add \`/* webpackIgnore: true */\` and \`/* @vite-ignore */\` magic comments so consumer bundlers leave the dynamic import alone. The \`if (isServer)\` guard ensures the runtime call only happens in Node, where \`node:async_hooks\` resolves; the existing \`.catch()\` already swallows resolution failures elsewhere.
- Public API unchanged.