### PR TITLE
fix(preloader): dev-server preloading for absolute QRL chunk paths on Windows

### DIFF
--- a/.changeset/funny-boxes-happen.md
+++ b/.changeset/funny-boxes-happen.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: dev-server preloading for absolute QRL chunk paths on Windows

--- a/packages/qwik/src/core/bench/bench-results.json
+++ b/packages/qwik/src/core/bench/bench-results.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T13:33:16.277Z",
+  "generatedAt": "2026-05-02T12:40:09.768Z",
   "benchmarks": {
     "baseline.shared-workload": {
       "mean": 1.4272255158758433,
@@ -72,7 +72,7 @@
     "dom-table-10": 0,
     "dom-table-1k": 0,
     "serialize-state-1k": 96844,
-    "ssr-table-10": 2449,
-    "ssr-table-1k": 177675
+    "ssr-table-10": 2461,
+    "ssr-table-1k": 177687
   }
 }

--- a/packages/qwik/src/core/preloader/preloader.unit.ts
+++ b/packages/qwik/src/core/preloader/preloader.unit.ts
@@ -33,8 +33,8 @@ test('preloader script', async () => {
   const compressed = compress(Buffer.from(code), { mode: 1, quality: 11 });
   expect({ brotli: compressed.length, minified: code.length }).toMatchInlineSnapshot(`
     {
-      "brotli": 1357,
-      "minified": 2913,
+      "brotli": 1363,
+      "minified": 2923,
     }
   `);
 });

--- a/packages/qwik/src/core/preloader/queue.ts
+++ b/packages/qwik/src/core/preloader/queue.ts
@@ -217,7 +217,8 @@ const preloadOne = (bundle: BundleImport) => {
 
   const link = doc.createElement('link');
   // Only bundles with state none are js bundles
-  link.href = new URL(`${base}${bundle.$name$}`, doc.baseURI).toString();
+  const name = bundle.$name$;
+  link.href = new URL(name[0] === '/' ? name : base + name, doc.baseURI).toString();
   link.rel = rel;
   // Needed when rel is 'preload'
   link.as = 'script';

--- a/packages/qwik/src/core/preloader/queue.unit.ts
+++ b/packages/qwik/src/core/preloader/queue.unit.ts
@@ -88,6 +88,27 @@ test('appends preloads directly to head within a trigger slice', async () => {
   expect(document.head.querySelectorAll('link').length).toBe(2);
 });
 
+test('does not turn absolute dev server paths into protocol-relative urls', async () => {
+  const document = installBrowserGlobals();
+  Object.assign(globalThis, {
+    MessageChannel: undefined,
+  });
+  vi.spyOn(performance, 'now').mockImplementation(() => 0);
+  vi.resetModules();
+  await installTestPlatform();
+
+  const { loadBundleGraph } = await import('./bundle-graph');
+  const { preload } = await import('./queue');
+
+  loadBundleGraph('/', undefined);
+  preload('/src/routes/index.tsx_component.js', 1);
+
+  vi.runAllTimers();
+
+  const link = document.head.querySelector('link') as HTMLLinkElement;
+  expect(link.href).toBe('http://document.qwik.dev/src/routes/index.tsx_component.js');
+});
+
 test('yields after the frame budget and resumes later', async () => {
   const document = installBrowserGlobals();
   Object.assign(globalThis, {

--- a/packages/qwik/src/core/tests/render-api.spec.tsx
+++ b/packages/qwik/src/core/tests/render-api.spec.tsx
@@ -561,6 +561,41 @@ describe('render api', () => {
         // expect(preloadScript[0]?.textContent).toContain(`bundle-graph`);
         expect(document.querySelectorAll('link')).toHaveLength(0);
       });
+      it('should not prefix absolute dev server preload paths', async () => {
+        const result = await renderToStringAndSetPlatform(<Counter />, {
+          base: '/',
+          containerTagName: 'div',
+          manifest: {
+            ...defaultManifest,
+            mapping: {
+              ...mapping,
+              s_click4: '/src/routes/index.tsx_s_click4.js',
+            },
+          },
+        });
+        const document = createDocument({ html: result.html });
+        const preloadScript = document.querySelector('script[q\\:type=preload]');
+        expect(preloadScript?.textContent).toContain('"/src/routes/index.tsx_s_click4.js"');
+        expect(preloadScript?.textContent).toContain(`e.href=l[0]=='/'?l:"/"+l`);
+        expect(preloadScript?.textContent).not.toContain('e.href="/"+');
+      });
+      it('should keep relative ssr preload paths relative', async () => {
+        const result = await renderToStringAndSetPlatform(<Counter />, {
+          containerTagName: 'div',
+          manifest: {
+            ...defaultManifest,
+            mapping: {
+              ...mapping,
+              s_click4: 's-click4.js',
+            },
+          },
+        });
+        const document = createDocument({ html: result.html });
+        const preloadScript = document.querySelector('script[q\\:type=preload]');
+        expect(preloadScript?.textContent).toContain('"s-click4.js"');
+        expect(preloadScript?.textContent).toContain('e.href="/build/"+l');
+        expect(preloadScript?.textContent).not.toContain('"/build/s-click4.js"');
+      });
     });
     describe('containerTagName/containerAttributes', () => {
       it('should render correct container tag name', async () => {

--- a/packages/qwik/src/server/preload-impl.ts
+++ b/packages/qwik/src/server/preload-impl.ts
@@ -7,6 +7,9 @@ const simplifyPath = (base: string, path: string | null | undefined) => {
   if (path == null) {
     return null;
   }
+  if (path[0] === '/') {
+    return path;
+  }
   const segments = `${base}${path}`.split('/');
   const simplified = [];
   for (let i = 0; i < segments.length; i++) {
@@ -40,7 +43,7 @@ export const preloaderPre = (
   const preloaderBundle = simplifyPath(base, resolvedManifest?.manifest?.preloader);
   let bundleGraphPath = resolvedManifest?.manifest.bundleGraphAsset;
   if (bundleGraphPath) {
-    bundleGraphPath = (import.meta.env.BASE_URL || '/') + bundleGraphPath;
+    bundleGraphPath = simplifyPath(import.meta.env.BASE_URL || '/', bundleGraphPath)!;
   }
   if (preloaderBundle && bundleGraphPath && options !== false) {
     const bundleGraph = container.resolvedManifest?.manifest.bundleGraph;
@@ -125,6 +128,7 @@ export const includePreloader = (
   const base = getBase(container);
 
   const links = [];
+  let hasAbsolutePreload = false;
 
   const { resolvedManifest } = container;
   if (allowedSsrPreloads) {
@@ -136,6 +140,9 @@ export const includePreloader = (
       if (href === preloaderBundle || href === coreBundle) {
         continue;
       }
+      if (href[0] === '/') {
+        hasAbsolutePreload = true;
+      }
       links.push(href);
       if (--allowedSsrPreloads === 0) {
         break;
@@ -143,6 +150,9 @@ export const includePreloader = (
     }
   }
   const preloaderBundle = simplifyPath(base, resolvedManifest?.manifest.preloader);
+  const setHref = hasAbsolutePreload
+    ? `e.href=l[0]=='/'?l:${JSON.stringify(base)}+l;`
+    : `e.href=${JSON.stringify(base)}+l;`;
   const insertLinks = links.length
     ? /**
        * We only use modulepreload links because they behave best. Older browsers can rely on the
@@ -152,7 +162,7 @@ export const includePreloader = (
       `${JSON.stringify(links)}.map((l,e)=>{` +
       `e=document.createElement('link');` +
       `e.rel='modulepreload';` +
-      `e.href=${JSON.stringify(base)}+l;` +
+      setHref +
       `document.head.appendChild(e)` +
       `});`
     : '';


### PR DESCRIPTION
Fix dev-server preloading for absolute QRL chunk paths.

The preloader now preserves absolute Vite dev-server paths like `/src/routes/...` instead of prefixing them with the build base, avoiding protocol-relative requests such as `//src/...` on Windows.