### PR TITLE
fix(docs): enable iframe CORS headers

### DIFF
--- a/packages/docs/src/routes/layout.tsx
+++ b/packages/docs/src/routes/layout.tsx
@@ -1,14 +1,16 @@
 import type { RequestHandler } from '@qwik.dev/router';
 import { component$, Slot } from '@qwik.dev/core';
+import { setReplCorsHeaders } from '~/utils/utils';
 
 export default component$(() => {
   return <Slot />;
 });
 
-export const onGet: RequestHandler = ({ cacheControl }) => {
+export const onGet: RequestHandler = ({ cacheControl, headers }) => {
   // cache for pages using this layout
   cacheControl({
     public: true,
     maxAge: 3600,
   });
+  setReplCorsHeaders(headers);
 };


### PR DESCRIPTION
## Summary
- Ports only the iframe docs fix from #8596.
- Applies REPL CORS headers in the docs root layout so embedded docs iframes can load correctly.

## Testing
- pnpm exec prettier --check packages/docs/src/routes/layout.tsx