### PR TITLE
fix: node crash after not handled aborted connections

### DIFF
--- a/.changeset/dry-rabbits-hang.md
+++ b/.changeset/dry-rabbits-hang.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: handle aborted Node response streams without crashing and resolve the Node response stream contract

--- a/packages/qwik-router/src/middleware/node/http.ts
+++ b/packages/qwik-router/src/middleware/node/http.ts
@@ -31,10 +31,23 @@ export function getUrl(req: IncomingMessage | Http2ServerRequest, origin: string
   return normalizeUrl((req as any).originalUrl || req.url || '/', origin);
 }
 
-// when the user refreshes or cancels the stream there will be an error
-function isIgnoredError(message = '') {
-  const ignoredErrors = ['The stream has been destroyed', 'write after end'];
-  return ignoredErrors.some((ignored) => message.includes(ignored));
+// Client disconnects are expected during streaming SSR: the socket is gone,
+// so the adapter should stop writing instead of surfacing them as app errors.
+function isClientAbortWriteError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const code = (error as Error & { code?: string }).code;
+  if (
+    code === 'EPIPE' ||
+    code === 'ECONNRESET' ||
+    code === 'ERR_STREAM_DESTROYED' ||
+    code === 'ERR_STREAM_WRITE_AFTER_END'
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 // ensure no HTTP/2-specific headers are being set
@@ -46,20 +59,39 @@ export function normalizeUrl(url: string, base: string) {
 
 function createNodeResponseSink(res: ServerResponse) {
   let closed = res.closed || res.destroyed;
-  const closedPromise = closed
-    ? Promise.resolve()
-    : new Promise<void>((resolve) => {
-        res.once('close', () => {
-          closed = true;
-          resolve();
-        });
-      });
+  let responseError: unknown;
+  let resolveClosed = () => {};
+  const closedPromise = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+    if (closed) {
+      resolve();
+      return;
+    }
+    res.once('close', () => {
+      closed = true;
+      resolve();
+    });
+  });
+
+  res.on('error', (error) => {
+    if (responseError === undefined) {
+      responseError = error;
+    }
+    closed = true;
+    resolveClosed();
+  });
+
+  const shouldPropagateResponseError = () =>
+    responseError !== undefined && !isClientAbortWriteError(responseError);
 
   const write = (chunk: Uint8Array) => {
     if (closed || res.closed || res.destroyed) {
       // If the response has already been closed or destroyed (for example the client has disconnected)
       // then writing into it will cause an error. So just stop writing since no one
       // is listening.
+      if (shouldPropagateResponseError()) {
+        return Promise.reject(responseError);
+      }
       return;
     }
 
@@ -76,21 +108,33 @@ function createNodeResponseSink(res: ServerResponse) {
         setImmediate(resolve);
       };
 
+      const finishClosed = () => {
+        closed = true;
+        finish();
+      };
+
       const fail = (error: unknown) => {
         if (settled) {
           return;
         }
         settled = true;
+        closed = true;
         reject(error);
       };
 
-      closedPromise.then(finish);
+      closedPromise.then(() => {
+        if (shouldPropagateResponseError()) {
+          fail(responseError);
+          return;
+        }
+        finish();
+      });
 
       try {
         res.write(chunk, (error) => {
           if (error) {
-            if (isIgnoredError(error.message)) {
-              finish();
+            if (isClientAbortWriteError(error)) {
+              finishClosed();
               return;
             }
             fail(error);
@@ -99,8 +143,8 @@ function createNodeResponseSink(res: ServerResponse) {
           finish();
         });
       } catch (error) {
-        if (error instanceof Error && isIgnoredError(error.message)) {
-          finish();
+        if (isClientAbortWriteError(error)) {
+          finishClosed();
           return;
         }
         fail(error);
@@ -110,13 +154,52 @@ function createNodeResponseSink(res: ServerResponse) {
 
   const close = () => {
     if (closed || res.closed || res.destroyed) {
+      if (shouldPropagateResponseError()) {
+        return Promise.reject(responseError);
+      }
       return;
     }
 
-    return new Promise<void>((resolve) => {
-      res.end(() => {
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        closed = true;
         resolve();
+      };
+
+      const fail = (error: unknown) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        closed = true;
+        reject(error);
+      };
+
+      closedPromise.then(() => {
+        if (shouldPropagateResponseError()) {
+          fail(responseError);
+          return;
+        }
+        finish();
       });
+
+      try {
+        res.end(() => {
+          finish();
+        });
+      } catch (error) {
+        if (isClientAbortWriteError(error)) {
+          finish();
+          return;
+        }
+        fail(error);
+      }
     });
   };
 
@@ -161,6 +244,9 @@ export async function fromNodeHttp(
 
   const body = req.method === 'HEAD' || req.method === 'GET' ? undefined : getRequestBody();
   const controller = new AbortController();
+  const abort = () => {
+    controller.abort();
+  };
   const options = {
     method: req.method,
     headers: requestHeaders,
@@ -168,9 +254,10 @@ export async function fromNodeHttp(
     signal: controller.signal,
     duplex: 'half' as any,
   };
-  res.on('close', () => {
-    controller.abort();
-  });
+  req.on('aborted', abort);
+  req.on('error', abort);
+  res.on('close', abort);
+  res.on('error', abort);
   const serverRequestEv: ServerRequestEvent<boolean> = {
     mode,
     url,
@@ -180,7 +267,7 @@ export async function fromNodeHttp(
         return process.env[key];
       },
     },
-    getWritableStream: (status, headers, cookies) => {
+    getWritableStream: (status, headers, cookies, resolve) => {
       res.statusCode = status;
       const sink = createNodeResponseSink(res);
 
@@ -198,6 +285,8 @@ export async function fromNodeHttp(
       } catch (err) {
         console.error(err);
       }
+
+      resolve(true);
 
       return new WritableStream<Uint8Array>({
         write(chunk) {

--- a/packages/qwik-router/src/middleware/node/http.ts
+++ b/packages/qwik-router/src/middleware/node/http.ts
@@ -60,25 +60,25 @@ export function normalizeUrl(url: string, base: string) {
 function createNodeResponseSink(res: ServerResponse) {
   let closed = res.closed || res.destroyed;
   let responseError: unknown;
-  let resolveClosed = () => {};
-  const closedPromise = new Promise<void>((resolve) => {
-    resolveClosed = resolve;
-    if (closed) {
-      resolve();
-      return;
-    }
-    res.once('close', () => {
-      closed = true;
-      resolve();
-    });
-  });
+  let resolveClosed: () => void;
+  const closedPromise = closed
+    ? Promise.resolve()
+    : new Promise<void>((resolve) => {
+        resolveClosed = resolve;
+        res.once('close', () => {
+          closed = true;
+          resolve();
+        });
+      });
 
   res.on('error', (error) => {
     if (responseError === undefined) {
       responseError = error;
     }
-    closed = true;
-    resolveClosed();
+    if (!closed) {
+      closed = true;
+      resolveClosed();
+    }
   });
 
   const shouldPropagateResponseError = () =>

--- a/packages/qwik-router/src/middleware/node/http.unit.ts
+++ b/packages/qwik-router/src/middleware/node/http.unit.ts
@@ -103,6 +103,219 @@ describe('fromNodeHttp()', () => {
     expect(res.end).toHaveBeenCalledTimes(1);
   });
 
+  test('should resolve the response when the writable stream is created', async () => {
+    const req = new EventEmitter() as IncomingMessage & EventEmitter;
+    req.method = 'GET';
+    req.url = '/';
+    req.headers = { host: 'localhost' };
+    (req as any).socket = {};
+
+    const res = new EventEmitter() as ServerResponse & EventEmitter;
+    Object.defineProperty(res, 'closed', { value: false, configurable: true });
+    Object.defineProperty(res, 'destroyed', { value: false, configurable: true });
+    res.setHeader = vi.fn();
+    res.write = vi.fn((_chunk: Uint8Array, cb?: (error?: Error | null) => void) => {
+      cb?.(null);
+      return true;
+    }) as any;
+    res.end = vi.fn((cb?: () => void) => {
+      cb?.();
+      return res;
+    }) as any;
+
+    const requestEv = await fromNodeHttp(new URL('http://localhost/'), req, res, 'server');
+    const resolve = vi.fn();
+    const writableStream = requestEv.getWritableStream(
+      201,
+      new Headers([['Content-Type', 'text/html; charset=utf-8']]),
+      { headers: () => [] } as any,
+      resolve,
+      undefined as any
+    );
+
+    expect(resolve).toHaveBeenCalledWith(true);
+    await writableStream.close();
+
+    expect(res.statusCode).toBe(201);
+    expect(res.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('should abort the request signal on node request errors', async () => {
+    const req = new EventEmitter() as IncomingMessage & EventEmitter;
+    req.method = 'GET';
+    req.url = '/';
+    req.headers = { host: 'localhost' };
+    (req as any).socket = {};
+
+    const res = new EventEmitter() as ServerResponse & EventEmitter;
+    Object.defineProperty(res, 'closed', { value: false, configurable: true });
+    Object.defineProperty(res, 'destroyed', { value: false, configurable: true });
+
+    const requestEv = await fromNodeHttp(new URL('http://localhost/'), req, res, 'server');
+
+    req.emit('error', new Error('request socket reset'));
+
+    expect(requestEv.request.signal.aborted).toBe(true);
+  });
+
+  test('should catch EPIPE write errors from aborted clients', async () => {
+    const req = new EventEmitter() as IncomingMessage & EventEmitter;
+    req.method = 'GET';
+    req.url = '/';
+    req.headers = { host: 'localhost' };
+    (req as any).socket = {};
+
+    const error = Object.assign(new Error('write EPIPE'), {
+      code: 'EPIPE',
+      errno: -32,
+      syscall: 'write',
+    });
+    const res = new EventEmitter() as ServerResponse & EventEmitter;
+    Object.defineProperty(res, 'closed', { value: false, configurable: true });
+    Object.defineProperty(res, 'destroyed', { value: false, configurable: true });
+    res.setHeader = vi.fn();
+    res.write = vi.fn((_chunk: Uint8Array, cb?: (error?: Error | null) => void) => {
+      cb?.(error);
+      return false;
+    }) as any;
+    res.end = vi.fn((cb?: () => void) => {
+      cb?.();
+      return res;
+    }) as any;
+
+    const requestEv = await fromNodeHttp(new URL('http://localhost/'), req, res, 'server');
+    const writableStream = requestEv.getWritableStream(
+      200,
+      new Headers([['Content-Type', 'text/html; charset=utf-8']]),
+      { headers: () => [] } as any,
+      () => {},
+      undefined as any
+    );
+    const writer = writableStream.getWriter();
+
+    await expect(writer.write(new Uint8Array([1, 2, 3]))).resolves.toBeUndefined();
+    await writer.close();
+
+    expect(res.write).toHaveBeenCalledTimes(1);
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
+  test('should catch emitted EPIPE write errors from aborted clients', async () => {
+    const req = new EventEmitter() as IncomingMessage & EventEmitter;
+    req.method = 'GET';
+    req.url = '/';
+    req.headers = { host: 'localhost' };
+    (req as any).socket = {};
+
+    const error = Object.assign(new Error('write EPIPE'), {
+      code: 'EPIPE',
+      errno: -32,
+      syscall: 'write',
+    });
+    const res = new EventEmitter() as ServerResponse & EventEmitter;
+    Object.defineProperty(res, 'closed', { value: false, configurable: true });
+    Object.defineProperty(res, 'destroyed', { value: false, configurable: true });
+    res.setHeader = vi.fn();
+    res.write = vi.fn(() => {
+      res.emit('error', error);
+      return false;
+    }) as any;
+    res.end = vi.fn((cb?: () => void) => {
+      cb?.();
+      return res;
+    }) as any;
+
+    const requestEv = await fromNodeHttp(new URL('http://localhost/'), req, res, 'server');
+    const writableStream = requestEv.getWritableStream(
+      200,
+      new Headers([['Content-Type', 'text/html; charset=utf-8']]),
+      { headers: () => [] } as any,
+      () => {},
+      undefined as any
+    );
+    const writer = writableStream.getWriter();
+
+    await expect(writer.write(new Uint8Array([1, 2, 3]))).resolves.toBeUndefined();
+    await writer.close();
+
+    expect(res.write).toHaveBeenCalledTimes(1);
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
+  test('should reject non-abort write errors', async () => {
+    const req = new EventEmitter() as IncomingMessage & EventEmitter;
+    req.method = 'GET';
+    req.url = '/';
+    req.headers = { host: 'localhost' };
+    (req as any).socket = {};
+
+    const res = new EventEmitter() as ServerResponse & EventEmitter;
+    Object.defineProperty(res, 'closed', { value: false, configurable: true });
+    Object.defineProperty(res, 'destroyed', { value: false, configurable: true });
+    res.setHeader = vi.fn();
+    res.write = vi.fn((_chunk: Uint8Array, cb?: (error?: Error | null) => void) => {
+      cb?.(new Error('unexpected write failure'));
+      return false;
+    }) as any;
+    res.end = vi.fn((cb?: () => void) => {
+      cb?.();
+      return res;
+    }) as any;
+
+    const requestEv = await fromNodeHttp(new URL('http://localhost/'), req, res, 'server');
+    const writableStream = requestEv.getWritableStream(
+      200,
+      new Headers([['Content-Type', 'text/html; charset=utf-8']]),
+      { headers: () => [] } as any,
+      () => {},
+      undefined as any
+    );
+    const writer = writableStream.getWriter();
+
+    await expect(writer.write(new Uint8Array([1, 2, 3]))).rejects.toThrow(
+      'unexpected write failure'
+    );
+
+    expect(res.write).toHaveBeenCalledTimes(1);
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
+  test('should reject emitted non-abort write errors', async () => {
+    const req = new EventEmitter() as IncomingMessage & EventEmitter;
+    req.method = 'GET';
+    req.url = '/';
+    req.headers = { host: 'localhost' };
+    (req as any).socket = {};
+
+    const res = new EventEmitter() as ServerResponse & EventEmitter;
+    Object.defineProperty(res, 'closed', { value: false, configurable: true });
+    Object.defineProperty(res, 'destroyed', { value: false, configurable: true });
+    res.setHeader = vi.fn();
+    res.write = vi.fn(() => {
+      res.emit('error', new Error('emitted write failure'));
+      return false;
+    }) as any;
+    res.end = vi.fn((cb?: () => void) => {
+      cb?.();
+      return res;
+    }) as any;
+
+    const requestEv = await fromNodeHttp(new URL('http://localhost/'), req, res, 'server');
+    const writableStream = requestEv.getWritableStream(
+      200,
+      new Headers([['Content-Type', 'text/html; charset=utf-8']]),
+      { headers: () => [] } as any,
+      () => {},
+      undefined as any
+    );
+    const writer = writableStream.getWriter();
+
+    await expect(writer.write(new Uint8Array([1, 2, 3]))).rejects.toThrow('emitted write failure');
+
+    expect(res.write).toHaveBeenCalledTimes(1);
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
   // Verifies the Node adapter starts making response-write progress before a large SSR render fully completes.
   test('should make Node response progress before render completes', async () => {
     const timings = {

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -635,7 +635,10 @@ The request origin "${inputOrigin}" does not match the server origin "${origin}"
         pipeSource = readable.pipeThrough(capture);
       }
 
-      const pipe = pipeSource.pipeTo(writableStream, { preventClose: true });
+      let pipeError: unknown;
+      const pipe = pipeSource.pipeTo(writableStream, { preventClose: true }).catch((error) => {
+        pipeError = error;
+      });
       const stream = writable.getWriter();
       const status = requestEv.status();
       try {
@@ -664,6 +667,9 @@ The request origin "${inputOrigin}" does not match the server origin "${origin}"
         await stream.ready;
         await stream.close();
         await pipe;
+      }
+      if (pipeError) {
+        throw pipeError;
       }
 
       if (eTagCacheKey && cacheChunks && cacheChunks.length > 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4050,6 +4050,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unpic/core@0.0.42':
     resolution: {integrity: sha512-K5Di+P8Bijl7doGDBGU+5VqX44e2iXMEm7G/AVla+9Hgxb5rOm/OXZoOjCUNjx5BOnjsVyegP6vlgsTfBtymkQ==}


### PR DESCRIPTION
There were three problems:
- EPIPE / ECONNRESET were not treated as normal client disconnects.
The old code only handled messages like write after end and The stream has been destroyed.
- ServerResponse / request socket error events were not listened to.
In Node, an emitted error event without a listener can crash the process.
- The Node adapter dropped the getWritableStream(..., resolve) callback.
Other adapters resolve the response promise when the response stream is created. Node was not doing that, so handled.response could hang.