### PR TITLE
chore: revert "resolve relative rollup input paths against vite root"

### DIFF
--- a/.changeset/rollup-input-absolute.md
+++ b/.changeset/rollup-input-absolute.md
@@ -1,6 +1,0 @@
----
-'@qwik.dev/core': patch
----
-
-fix(vite): resolve relative SSR/client input paths to absolute before passing to rollup, preventing "[vite-plugin-qwik] Qwik input "src/entry.preview.tsx" not found" errors.
-

--- a/packages/qwik-vite/src/plugins/plugin.ts
+++ b/packages/qwik-vite/src/plugins/plugin.ts
@@ -381,38 +381,35 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
       }
     }
 
+    const out = { ...opts };
     // Make sure to know what the actual input is
     opts.input ||= updatedOpts.input as string[];
     if (opts.input && typeof opts.input === 'string') {
       opts.input = [opts.input];
     }
-    // Normalize relative input paths to absolute (consistent with rootDir/srcDir/outDir)
-    if (Array.isArray(opts.input)) {
-      opts.input = opts.input.map((inp) =>
-        inp.startsWith('@') || inp.startsWith('\0') || path.isAbsolute(inp)
-          ? inp
-          : normalizePath(path.resolve(opts.rootDir, inp))
-      );
-    }
-
-    const out = { ...opts };
     return out;
   };
 
+  let hasValidatedSource = false;
+
   const validateSource = async (resolver: (id: string) => Promise<unknown | undefined>) => {
-    const sys = getSys();
-    if (sys.env === 'node') {
-      const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
-      if (!fs.existsSync(opts.rootDir)) {
-        throw new Error(`Qwik rootDir "${opts.rootDir}" not found.`);
-      }
-      if (typeof opts.srcDir === 'string' && !fs.existsSync(opts.srcDir)) {
-        throw new Error(`Qwik srcDir "${opts.srcDir}" not found.`);
-      }
-      for (const [_, input] of Object.entries(opts.input || {})) {
-        const resolved = await resolver(input);
-        if (!resolved) {
-          throw new Error(`Qwik input "${input}" not found.`);
+    if (!hasValidatedSource) {
+      hasValidatedSource = true;
+
+      const sys = getSys();
+      if (sys.env === 'node') {
+        const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
+        if (!fs.existsSync(opts.rootDir)) {
+          throw new Error(`Qwik rootDir "${opts.rootDir}" not found.`);
+        }
+        if (typeof opts.srcDir === 'string' && !fs.existsSync(opts.srcDir)) {
+          throw new Error(`Qwik srcDir "${opts.srcDir}" not found.`);
+        }
+        for (const [_, input] of Object.entries(opts.input || {})) {
+          const resolved = await resolver(input);
+          if (!resolved) {
+            throw new Error(`Qwik input "${input}" not found.`);
+          }
         }
       }
     }

--- a/packages/qwik-vite/src/plugins/plugin.unit.ts
+++ b/packages/qwik-vite/src/plugins/plugin.unit.ts
@@ -165,8 +165,8 @@ test('tsconfigFileNames, empty array fallback to default', async () => {
 test('input string', async () => {
   const plugin = await mockPlugin();
   const opts = await plugin.normalizeOptions({ input: 'src/cmps/main.tsx' });
-  // relative inputs are resolved to absolute so rollup can find them
-  assert.deepEqual(opts.input, [normalizePath(resolve(cwd, 'src/cmps/main.tsx'))]);
+  // we don't provide input so that we don't override the vite input
+  assert.deepEqual(opts.input, undefined);
 });
 
 test('input array', async () => {
@@ -174,21 +174,8 @@ test('input array', async () => {
   const opts = await plugin.normalizeOptions({
     input: ['src/cmps/a.tsx', 'src/cmps/b.tsx'],
   });
-  // relative inputs are resolved to absolute so rollup can find them
-  assert.deepEqual(opts.input, [
-    normalizePath(resolve(cwd, 'src/cmps/a.tsx')),
-    normalizePath(resolve(cwd, 'src/cmps/b.tsx')),
-  ]);
-});
-
-test.runIf(process.platform === 'win32')('input array, win32', async () => {
-  const plugin = await mockPlugin();
-  const opts = await plugin.normalizeOptions({
-    rootDir: 'C:\\proj',
-    input: ['src\\cmps\\a.tsx', 'C:\\abs\\b.tsx'],
-  });
-  // relative paths are resolved against rootDir and normalized; absolute paths pass through
-  assert.deepEqual(opts.input, ['C:/proj/src/cmps/a.tsx', 'C:\\abs\\b.tsx']);
+  // we don't provide input so that we don't override the vite input
+  assert.deepEqual(opts.input, undefined);
 });
 
 test('outDir', async () => {

--- a/packages/qwik-vite/src/plugins/vite.ts
+++ b/packages/qwik-vite/src/plugins/vite.ts
@@ -227,7 +227,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
       };
 
       const opts = await qwikPlugin.normalizeOptions(pluginOpts);
-      input = opts.input;
+      input ||= opts.input;
 
       // Cache pluginOpts for use in configResolved()
       cachedPluginOpts = pluginOpts;

--- a/packages/qwik-vite/src/plugins/vite.unit.ts
+++ b/packages/qwik-vite/src/plugins/vite.unit.ts
@@ -310,24 +310,6 @@ test('command: build, --ssr entry.server.tsx', async () => {
   assert.deepEqual(c.publicDir, false);
 });
 
-test('command: build, --ssr with relative path resolves to absolute', async () => {
-  const initOpts = {
-    optimizerOptions: mockOptimizerOptions(),
-  };
-  const plugin = getPlugin(initOpts);
-  const c = (await plugin.config.call(
-    configHookPluginContext,
-    { build: { ssr: 'src/entry.server.tsx' } },
-    { command: 'build', mode: '' }
-  ))!;
-  const build = c.build!;
-  const rollupOptions = build!.rollupOptions!;
-
-  assert.deepEqual((rollupOptions.input as string[]).map(normalizePath), [
-    normalizePath(resolve(cwd, 'src', 'entry.server.tsx')),
-  ]);
-});
-
 test('command: serve, --mode ssr', async () => {
   const initOpts = {
     optimizerOptions: mockOptimizerOptions(),
@@ -597,9 +579,7 @@ describe('input config', () => {
       {},
       { command: 'build', mode: 'development' }
     ))!;
-    assert.deepEqual((c.build.rollupOptions.input as string[]).map(normalizePath), [
-      normalizePath(resolve(cwd, 'src', 'widget', 'counter.tsx')),
-    ]);
+    assert.deepEqual(c.build.rollupOptions.input, ['./src/widget/counter.tsx']);
   });
   test('should handle ssr target', async () => {
     const plugin = getPlugin(initOpts);
@@ -608,9 +588,7 @@ describe('input config', () => {
       {},
       { command: 'build', mode: 'ssr' }
     ))!;
-    assert.deepEqual((c.build.rollupOptions.input as string[]).map(normalizePath), [
-      normalizePath(resolve(cwd, 'src', 'widget', 'ssr.tsx')),
-    ]);
+    assert.deepEqual(c.build.rollupOptions.input, ['./src/widget/ssr.tsx']);
   });
 });
 


### PR DESCRIPTION
reverting https://github.com/QwikDev/qwik/pull/6903/changes/1d532e2e34cda06c0edde5a0609f5ab1f873b811