### PR TITLE
fix(devtools/ui): Preloads overflow, CodeBreak button placement, inline Qwik logo

### DIFF
--- a/.changeset/fix-devtools-ui-layout-polish.md
+++ b/.changeset/fix-devtools-ui-layout-polish.md
@@ -1,0 +1,9 @@
+---
+'@qwik.dev/devtools': patch
+---
+
+fix(devtools/ui): Preloads overflow, CodeBreak button placement, inline Qwik logo
+
+- Preloads panel: outer `overflow-hidden` clipped stat cards and prevented scroll when content exceeded the panel height. Switched to `overflow-auto` with `min-h-full` on the column stack so content scrolls on narrow or short panels.
+- CodeBreak StateParser: content container was missing the `flex` class, so the textarea pushed the Parse State button outside the card into the next grid row, overlapping the Parsed State header. Moved the button into the card header next to the title.
+- Inlined the Qwik logo as a local SVG component (`QwikLogo`) instead of fetching `https://qwik.dev/logos/qwik-logo.svg` via `<img src>`. Fixes the broken-image fallback in contexts where the remote fetch is blocked or unreachable.

--- a/packages/devtools/ui/src/components/DevtoolsButton/DevtoolsButton.tsx
+++ b/packages/devtools/ui/src/components/DevtoolsButton/DevtoolsButton.tsx
@@ -1,5 +1,6 @@
 import { component$, useSignal, $, useTask$ } from '@qwik.dev/core';
 import type { State } from '../../types/state';
+import { QwikLogo } from '../Icons/Icons';
 
 interface DevtoolsButtonProps {
   state: State;
@@ -114,12 +115,8 @@ export const DevtoolsButton = component$((props: DevtoolsButtonProps) => {
       onMouseDown$={handleMouseDown}
       onClick$={handleClick}
     >
-      <img
-        width={28}
-        height={28}
-        src="https://qwik.dev/logos/qwik-logo.svg"
-        alt="Qwik Logo"
-        draggable={false}
+      <QwikLogo
+        title="Qwik Logo"
         class="pointer-events-none h-7 w-7 opacity-90 drop-shadow-[0_2px_4px_rgba(0,0,0,0.2)]"
       />
     </div>

--- a/packages/devtools/ui/src/components/DevtoolsPanel/DevtoolsPanel.tsx
+++ b/packages/devtools/ui/src/components/DevtoolsPanel/DevtoolsPanel.tsx
@@ -9,7 +9,7 @@ import {
   useVisibleTask$,
 } from '@qwik.dev/core';
 import { State } from '../../types/state';
-import { IconArrowsPointingIn, IconArrowsPointingOut, IconXMark } from '../Icons/Icons';
+import { IconArrowsPointingIn, IconArrowsPointingOut, IconXMark, QwikLogo } from '../Icons/Icons';
 
 interface DevtoolsPanelProps {
   state: State;
@@ -467,14 +467,7 @@ export const DevtoolsPanel = component$((props: DevtoolsPanelProps) => {
             onDblClick$={handleToggleFullscreen}
           >
             <div class="flex min-w-0 items-center gap-3">
-              <img
-                width={20}
-                height={20}
-                src="https://qwik.dev/logos/qwik-logo.svg"
-                alt="Qwik Logo"
-                class="h-5 w-5 shrink-0"
-                draggable={false}
-              />
+              <QwikLogo title="Qwik Logo" class="h-5 w-5 shrink-0" />
               <div class="min-w-0">
                 <div class="truncate text-sm font-semibold">Qwik DevTools</div>
                 <div class="text-muted-foreground truncate text-xs">

--- a/packages/devtools/ui/src/components/Icons/Icons.tsx
+++ b/packages/devtools/ui/src/components/Icons/Icons.tsx
@@ -352,3 +352,31 @@ export const IconArrowsPointingIn = component$((props: IconProps) => {
     </svg>
   );
 });
+
+export const QwikLogo = component$((props: IconProps) => {
+  const { class: className, style, title } = props;
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 500 506"
+      class={className}
+      style={style}
+      aria-hidden={title ? undefined : true}
+      role={title ? 'img' : undefined}
+    >
+      {title ? <title>{title}</title> : null}
+      <path
+        fill="white"
+        d="M370.826 224.859 156.157 16.117l23.021 158.743-50.004 49.999 213.863 198.793-12.209-158.792 39.998-40.001Z"
+      />
+      <path
+        fill="#18b6f6"
+        d="m250 449.707 181.102 55.804-88.065-81.859-213.863-198.793 50.004-49.999-23.021-158.743L8.348 193.702a62.314 62.314 0 0 0 0 62.314l93.843 162.535a62.314 62.314 0 0 0 53.965 31.156H250Z"
+      />
+      <path
+        fill="#ac7ef4"
+        d="M343.843 0H156.157a62.312 62.312 0 0 0-53.965 31.157L8.348 193.702 156.157 16.117l214.669 208.742-39.998 40.001 12.209 158.792 88.065 81.859c5.078 1.564 9.533-3.756 7.102-8.48l-40.395-78.48 93.842-162.535a62.313 62.313 0 0 0 .001-62.314L397.808 31.157A62.312 62.312 0 0 0 343.843 0Z"
+      />
+    </svg>
+  );
+});

--- a/packages/devtools/ui/src/devtools/DevtoolsContent.tsx
+++ b/packages/devtools/ui/src/devtools/DevtoolsContent.tsx
@@ -1,6 +1,6 @@
 import { component$ } from '@qwik.dev/core';
 import type { AssetInfo } from '@qwik.dev/devtools/kit';
-import { IconMonitor } from '../components/Icons/Icons';
+import { IconMonitor, QwikLogo } from '../components/Icons/Icons';
 import { TabContent } from '../components/TabContent/TabContent';
 import { TabTitle } from '../components/TabTitle/TabTitle';
 import { Assets } from '../features/Assets/Assets';
@@ -56,13 +56,7 @@ export const DevtoolsContent = component$<DevtoolsContentProps>(({ state }) => {
       return (
         <TabContent>
           <div class="flex items-center gap-3" q:slot="title">
-            <img
-              width={32}
-              height={32}
-              src="https://qwik.dev/logos/qwik-logo.svg"
-              alt="Qwik Logo"
-              class="h-8 w-8"
-            />
+            <QwikLogo title="Qwik Logo" class="h-8 w-8" />
             <h1 class="text-2xl font-semibold">Qwik DevTools</h1>
           </div>
           <Overview state={state} q:slot="content" />

--- a/packages/devtools/ui/src/features/CodeBreak/StateParser.tsx
+++ b/packages/devtools/ui/src/features/CodeBreak/StateParser.tsx
@@ -108,31 +108,31 @@ export const StateParser = component$(() => {
   return (
     <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
       <div class="border-glass-border bg-card-item-bg flex h-[60vh] min-h-0 flex-col rounded-xl border">
-        <div class="border-glass-border flex items-center justify-between border-b p-3">
-          <div class="text-sm font-medium">Input State</div>
-          {parsingTime.value !== null && (
-            <span class="border-glass-border text-muted-foreground rounded-full border px-2 py-0.5 text-xs">
-              {parsingTime.value}ms
-            </span>
-          )}
+        <div class="border-glass-border flex items-center justify-between gap-3 border-b p-3">
+          <div class="flex items-center gap-3">
+            <div class="text-sm font-medium">Input State</div>
+            {parsingTime.value !== null && (
+              <span class="border-glass-border text-muted-foreground rounded-full border px-2 py-0.5 text-xs">
+                {parsingTime.value}ms
+              </span>
+            )}
+          </div>
+          <button
+            onClick$={onParseState$}
+            class="bg-accent rounded-md px-3 py-1.5 text-sm text-white hover:opacity-90"
+          >
+            Parse State
+          </button>
         </div>
-        <div class="min-h-0 flex-1 flex-col space-y-3 p-3">
+        <div class="flex min-h-0 flex-1 flex-col p-3">
           <textarea
             value={inputState.value}
             onInput$={(e: InputEvent, t: HTMLTextAreaElement) =>
               (inputState.value = (t as HTMLTextAreaElement).value)
             }
             placeholder="Paste Qwik state and click to parse/format."
-            class="border-glass-border bg-card-item-bg text-foreground placeholder:text-muted-foreground h-full min-h-0 w-full flex-1 resize-none rounded-md border p-3 font-mono text-sm"
+            class="border-glass-border bg-card-item-bg text-foreground placeholder:text-muted-foreground min-h-0 w-full flex-1 resize-none rounded-md border p-3 font-mono text-sm"
           />
-          <div class="flex items-center gap-3">
-            <button
-              onClick$={onParseState$}
-              class="bg-accent rounded-md px-3 py-1.5 text-sm text-white hover:opacity-90"
-            >
-              Parse State
-            </button>
-          </div>
         </div>
       </div>
 

--- a/packages/devtools/ui/src/features/Preloads/Preloads.tsx
+++ b/packages/devtools/ui/src/features/Preloads/Preloads.tsx
@@ -99,8 +99,8 @@ export const Preloads = component$(() => {
   });
 
   return (
-    <div class="h-full w-full flex-1 overflow-hidden">
-      <div class="flex h-full min-h-0 flex-col gap-4">
+    <div class="h-full w-full flex-1 overflow-auto">
+      <div class="flex min-h-full flex-col gap-4">
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
           <StatCard
             label="Visible QRLs"


### PR DESCRIPTION
## Summary

Three small UI fixes in `packages/devtools/ui` spotted while testing the in-app overlay (via the docs site) and the browser extension panel.

### Preloads — outer container clipped content

The Preloads panel root used `overflow-hidden` on an `h-full` flex container. When the stat-cards grid and filter header took most of the available vertical space (common in narrower devtools panels), the table below was pushed out of view with no way to scroll. On narrower widths, the stat cards were also clipped horizontally for the same reason.

Switched the outer container to `overflow-auto` and replaced `h-full min-h-0` on the column stack with `min-h-full` so the content can grow past the viewport and scroll naturally. The inner table keeps its own horizontal scroll wrapper for the `min-w-[1080px]` table, so the sticky header behaviour is preserved.

**File:** `packages/devtools/ui/src/features/Preloads/Preloads.tsx`

### CodeBreak (StateParser) — Parse State button overlapped the next card

The content container inside the Input State card had the classes `min-h-0 flex-1 flex-col space-y-3 p-3` — note the missing `flex`. Without `flex`, `flex-col` is a no-op and the textarea's `h-full` expanded to the full card height, pushing the `Parse State` button outside the card. On the mobile-stacked layout (single column), that button then landed directly on top of the `Parsed State` card's header, making it visually overlap and hard to click.

Rather than reintroducing the missing `flex` and hoping the stack stays balanced at all widths, moved the `Parse State` button into the Input State card header alongside the title. More robust across panel widths, easier to reach, and consistent with the rest of the UI where per-card actions live in the header.

**File:** `packages/devtools/ui/src/features/CodeBreak/StateParser.tsx`

### Inline Qwik logo (remove remote `<img>` dependency)

Three places referenced `https://qwik.dev/logos/qwik-logo.svg` via `<img src>` (DevtoolsButton, DevtoolsPanel title bar, DevtoolsContent overview header). In some contexts the remote fetch never resolves and the alt text is shown instead, leaving the panel/button looking broken.

Inlined the SVG as a new `QwikLogo` icon component and replaced all three usages. No more network dependency, renders identically on first paint.

**Files:**
- `packages/devtools/ui/src/components/Icons/Icons.tsx` (new `QwikLogo` export)
- `packages/devtools/ui/src/components/DevtoolsButton/DevtoolsButton.tsx`
- `packages/devtools/ui/src/components/DevtoolsPanel/DevtoolsPanel.tsx`
- `packages/devtools/ui/src/devtools/DevtoolsContent.tsx`

## Testing

- Built the devtools UI lib (`node --require ./scripts/runBefore.ts scripts/index.ts --devtools`) and ran the docs site with `qwikDevtools()` enabled.
- Visually verified the Preloads tab scrolls correctly at various devtools panel widths.
- Verified the Code Break Parse State button is rendered in the Input State card header, no overlap with the Parsed State card.
- Verified the Qwik logo renders inline in the button, title bar, and overview header without any network request.

## Notes

- Pure UI/CSS change in `@qwik.dev/devtools`, no public API surface affected.
- No changeset added — happy to add one if the maintainers prefer this trigger a patch bump.