### PR TITLE
chore: update-action-pins script

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Check account age (skip accounts < 30 days)
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const user = await github.rest.users.getByUsername({
@@ -27,7 +27,7 @@ jobs:
 
       - name: AI triage and apply labels
         if: steps.check.outputs.result == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:

--- a/.github/workflows/auto-assign-core-team.yml
+++ b/.github/workflows/auto-assign-core-team.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Add PR to Qwik Development project
         id: add-project
         if: steps.team.outputs.isCore == 'true'
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/QwikDev/projects/1
           github-token: ${{ secrets.QWIK_AUTO_ASSIGN_PR_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: echo event_name=${{ github.event_name }}
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set Dist Tag
         id: set_dist_tag
@@ -210,11 +210,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
@@ -240,7 +240,7 @@ jobs:
           path: packages/qwik/dist
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-qwik-no-optimizer
           include-hidden-files: true
@@ -270,16 +270,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           components: clippy,rustfmt
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
@@ -309,7 +309,7 @@ jobs:
         run: ls -lR packages/qwik/bindings/
 
       - name: Upload Platform Binding Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-bindings-${{ matrix.settings.target }}
           include-hidden-files: true
@@ -337,7 +337,7 @@ jobs:
 
       - name: Restore artifacts
         if: needs.changes.outputs.build-rust == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Restore Qwik from cache
         uses: actions/cache/restore@v4
@@ -366,7 +366,7 @@ jobs:
           path: packages/qwik/bindings
 
       - name: Upload Qwik artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-qwik
           include-hidden-files: true
@@ -389,20 +389,20 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.build-others == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         if: needs.changes.outputs.build-others == 'true'
       - name: Setup Node
         if: needs.changes.outputs.build-others == 'true'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
       - name: Restore Qwik artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: artifact-qwik
           path: packages/qwik/
@@ -444,7 +444,7 @@ jobs:
         run: tree -a packages/qwik-city/lib/
 
       - name: Upload QwikCity Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-qwikcity
           include-hidden-files: true
@@ -455,7 +455,7 @@ jobs:
         run: tree -a packages/qwik-labs/lib/ packages/qwik-labs/vite/
 
       - name: Upload QwikLabs+React Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-qwiklabs
           include-hidden-files: true
@@ -469,7 +469,7 @@ jobs:
         run: tree -a packages/qwik-react/lib/
 
       - name: Upload qwik-react Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-qwikreact
           include-hidden-files: true
@@ -482,7 +482,7 @@ jobs:
         run: tree -a packages/create-qwik/dist/
 
       - name: Upload Create Qwik CLI Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-create-qwik
           include-hidden-files: true
@@ -493,7 +493,7 @@ jobs:
         run: tree -a packages/eslint-plugin-qwik/dist/
 
       - name: Upload Eslint rules Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-eslint-plugin-qwik
           include-hidden-files: true
@@ -515,10 +515,10 @@ jobs:
         run: exit 1
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Move Distribution Artifacts
         run: |
@@ -532,9 +532,9 @@ jobs:
           mv artifact-qwiklabs/lib packages/qwik-labs/lib
           mv artifact-qwiklabs/vite packages/qwik-labs/vite
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
@@ -567,18 +567,18 @@ jobs:
         run: exit 1
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Move Distribution Artifacts
         run: |
@@ -598,7 +598,7 @@ jobs:
         run: pnpm run build.packages.docs && echo ok > docs-build-completed.txt
 
       - name: Save Docs Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-docs
           include-hidden-files: true
@@ -627,18 +627,18 @@ jobs:
         run: exit 1
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Move Distribution Artifacts
         run: |
@@ -690,18 +690,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Move Distribution Artifacts
         run: |
@@ -754,18 +754,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Move Distribution Artifacts
         run: |
@@ -788,11 +788,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
@@ -873,18 +873,18 @@ jobs:
           path: cli-e2e-tests-completed.txt
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Move Distribution Artifacts
         run: |
@@ -907,7 +907,7 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         if: github.ref == 'refs/heads/upcoming'
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           publish: pnpm release
         env:
@@ -940,7 +940,7 @@ jobs:
 
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.QWIK_API_TOKEN_GITHUB }}
           repository: builderIO/qwik-city-e2e

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Check for docs artifact
         id: check-artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           retries: 3
           script: |
@@ -43,11 +43,11 @@ jobs:
 
       - name: Checkout code
         if: ${{ steps.check-artifact.outputs.has-docs == 'true' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download docs artifact
         if: ${{ steps.check-artifact.outputs.has-docs == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: artifact-docs
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
   "packageManager": "pnpm@10.14.0",
   "private": true,
   "scripts": {
+    "actions.update-pins": "node --experimental-strip-types scripts/update-action-pins.ts",
     "api.update": "node --require ./scripts/runBefore.ts scripts/index.ts --tsc --api --dev",
     "build": "node --require ./scripts/runBefore.ts scripts/index.ts",
     "build.changelog-formatter": "tsc .changeset/changelog-github-custom.ts && mv .changeset/changelog-github-custom.js .changeset/changelog-github-custom.cjs",

--- a/scripts/update-action-pins.ts
+++ b/scripts/update-action-pins.ts
@@ -1,0 +1,199 @@
+/**
+ * Update GitHub Action pins in .github workflow files.
+ *
+ * Handles two formats:
+ *
+ * 1. Tag-based: uses: owner/repo@v4 → pinned to SHA
+ * 2. SHA-pinned: uses: owner/repo@<sha> # v4 → updated to latest SHA+tag
+ *
+ * Requires the `gh` CLI to be authenticated.
+ *
+ * Usage: node --experimental-strip-types scripts/update-action-pins.ts node
+ * --experimental-strip-types scripts/update-action-pins.ts --dry-run
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// uses: owner/repo@<40-char sha> # tag
+const PINNED_RE =
+  /(?<=uses:\s{1,10})([a-zA-Z0-9_.\-]+\/[a-zA-Z0-9_.\-]+)@([0-9a-f]{40})\s*#\s*(\S+)/g;
+
+// uses: owner/repo@vX or @vX.Y.Z (tag-based, not pinned)
+const TAG_RE = /(?<=uses:\s{1,10})([a-zA-Z0-9_.\-]+\/[a-zA-Z0-9_.\-]+)@(v[0-9][^\s]*)/g;
+
+function ghApi(path: string): unknown {
+  return JSON.parse(
+    execFileSync('gh', ['api', path], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] })
+  );
+}
+
+function getLatestTag(repo: string): string {
+  try {
+    return (ghApi(`repos/${repo}/releases/latest`) as { tag_name: string }).tag_name;
+  } catch {
+    return (ghApi(`repos/${repo}/tags`) as { name: string }[])[0]?.name;
+  }
+}
+
+function getCommitSha(repo: string, ref: string): string {
+  return (ghApi(`repos/${repo}/commits/${encodeURIComponent(ref)}`) as { sha: string }).sha;
+}
+
+function findWorkflowFiles(): string[] {
+  const workflowDir = join(ROOT, '.github', 'workflows');
+  const actionsDir = join(ROOT, '.github', 'actions');
+  const files: string[] = [];
+
+  const collect = (dir: string, pattern: RegExp) => {
+    try {
+      for (const f of readdirSync(dir, { recursive: true, encoding: 'utf8' })) {
+        if (pattern.test(f)) files.push(join(dir, f as string));
+      }
+    } catch {
+      // directory may not exist
+    }
+  };
+
+  collect(workflowDir, /\.ya?ml$/);
+  collect(actionsDir, /\.ya?ml$/);
+  return files;
+}
+
+interface PinInfo {
+  repo: string;
+  currentRef: string; // sha or tag
+  currentTag: string;
+}
+
+const files = findWorkflowFiles();
+console.log(`Found ${files.length} workflow file(s).\n`);
+
+// Collect unique actions (keyed by repo@currentRef)
+const pinnedActions = new Map<string, PinInfo>();
+const tagActions = new Map<string, PinInfo>();
+
+for (const file of files) {
+  const content = readFileSync(file, 'utf-8');
+
+  for (const [, repo, sha, tag] of content.matchAll(PINNED_RE)) {
+    if (!repo.startsWith('.')) {
+      pinnedActions.set(`${repo}@${sha}`, { repo, currentRef: sha, currentTag: tag });
+    }
+  }
+
+  for (const [, repo, tag] of content.matchAll(TAG_RE)) {
+    if (!repo.startsWith('.')) {
+      const key = `${repo}@${tag}`;
+      if (!pinnedActions.has(key)) {
+        tagActions.set(key, { repo, currentRef: tag, currentTag: tag });
+      }
+    }
+  }
+}
+
+console.log(
+  `  ${pinnedActions.size} SHA-pinned action(s), ${tagActions.size} tag-based action(s)\n`
+);
+
+type UpdateInfo = {
+  repo: string;
+  oldRef: string;
+  oldTag: string;
+  newSha: string;
+  newTag: string;
+};
+
+const updates = new Map<string, UpdateInfo>();
+
+// Process SHA-pinned — check if a newer version exists
+for (const [key, { repo, currentRef: sha, currentTag: tag }] of pinnedActions) {
+  process.stdout.write(`  [pinned] ${repo} (${tag}) → `);
+  let latestTag: string;
+  let latestSha: string;
+  try {
+    latestTag = getLatestTag(repo);
+    latestSha = getCommitSha(repo, latestTag);
+  } catch (e) {
+    console.log(`ERROR: ${(e as Error).message}`);
+    continue;
+  }
+
+  if (latestSha === sha) {
+    console.log('up to date');
+  } else {
+    console.log(`${latestTag} (${latestSha.slice(0, 7)})`);
+    updates.set(key, { repo, oldRef: sha, oldTag: tag, newSha: latestSha, newTag: latestTag });
+  }
+}
+
+// Process tag-based — pin to SHA
+for (const [key, { repo, currentRef: tag }] of tagActions) {
+  process.stdout.write(`  [tag]    ${repo}@${tag} → `);
+  let sha: string;
+  try {
+    sha = getCommitSha(repo, tag);
+  } catch (e) {
+    console.log(`ERROR: ${(e as Error).message}`);
+    continue;
+  }
+
+  console.log(`${sha.slice(0, 7)} (pin)`);
+  updates.set(key, { repo, oldRef: tag, oldTag: tag, newSha: sha, newTag: tag });
+}
+
+if (updates.size === 0) {
+  console.log('\nAll actions up to date.');
+  process.exit(0);
+}
+
+if (DRY_RUN) {
+  console.log(`\n[dry-run] Would update ${updates.size} action(s). No files written.`);
+  process.exit(0);
+}
+
+let filesChanged = 0;
+
+for (const file of files) {
+  let content = readFileSync(file, 'utf-8');
+  let changed = false;
+
+  for (const { repo, oldRef, oldTag, newSha, newTag } of updates.values()) {
+    // Replace SHA-pinned format
+    const beforePinned = `${repo}@${oldRef} # ${oldTag}`;
+    const afterPinned = `${repo}@${newSha} # ${newTag}`;
+    if (content.includes(beforePinned)) {
+      content = content.replaceAll(beforePinned, afterPinned);
+      changed = true;
+    }
+
+    // Replace tag-based format (pin it)
+    const beforeTag = `${repo}@${oldRef}`;
+    const afterTag = `${repo}@${newSha} # ${newTag}`;
+    // Only replace exact tag refs (not already-pinned sha refs)
+    if (oldRef === oldTag && content.includes(beforeTag)) {
+      // Make sure we're not replacing inside a sha-pinned line
+      const tagLineRe = new RegExp(
+        `(uses:\\s{1,10})${repo.replace(/\//g, '\\/')}@${oldRef}(?!\\s*#)`,
+        'g'
+      );
+      const newContent = content.replace(tagLineRe, `$1${afterTag}`);
+      if (newContent !== content) {
+        content = newContent;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) {
+    writeFileSync(file, content, 'utf-8');
+    filesChanged++;
+    console.log(`  updated: ${file.replace(ROOT, '')}`);
+  }
+}
+
+console.log(`\nUpdated ${updates.size} action(s) across ${filesChanged} file(s).`);

--- a/scripts/update-action-pins.ts
+++ b/scripts/update-action-pins.ts
@@ -17,6 +17,10 @@ import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const ROOT = new URL('..', import.meta.url).pathname;
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 const DRY_RUN = process.argv.includes('--dry-run');
 
 // uses: owner/repo@<40-char sha> # tag
@@ -178,7 +182,7 @@ for (const file of files) {
     if (oldRef === oldTag && content.includes(beforeTag)) {
       // Make sure we're not replacing inside a sha-pinned line
       const tagLineRe = new RegExp(
-        `(uses:\\s{1,10})${repo.replace(/\//g, '\\/')}@${oldRef}(?!\\s*#)`,
+        `(uses:\\s{1,10})${escapeRegex(repo)}@${escapeRegex(oldRef)}(?!\\s*#)`,
         'g'
       );
       const newContent = content.replace(tagLineRe, `$1${afterTag}`);


### PR DESCRIPTION
Add a pnpm script to replace action tags with fixed commit hashes, as well as update existing hashes.