### PR TITLE
fix(core): preserve hidden slot projections after rerender

### DIFF
--- a/.changeset/tough-spies-wave.md
+++ b/.changeset/tough-spies-wave.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: ssr `q:template` projection handling so hidden slotted content can be restored correctly after component rerenders.

--- a/e2e/qwik-e2e/dev-server.ts
+++ b/e2e/qwik-e2e/dev-server.ts
@@ -208,7 +208,7 @@ export { router }
               clientManifest = manifest;
             },
           },
-          experimental: ['each', 'suspense', 'preventNavigate', 'enableRequestRewrite'],
+          experimental: ['each', 'suspense'],
         }),
       ],
     })
@@ -224,7 +224,7 @@ export { router }
       plugins: [
         ...plugins,
         optimizer.qwikVite({
-          experimental: ['each', 'suspense', 'preventNavigate', 'enableRequestRewrite'],
+          experimental: ['each', 'suspense'],
           ssr: {
             manifestInput: clientManifest,
           },

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -2005,7 +2005,7 @@ export function cleanup(
                   projectionChild = projectionChild.nextSibling as VNode | null;
                 }
 
-                cleanupStaleUnclaimedProjection(journal, projection);
+                cleanupStaleUnclaimedProjection(container, journal, projection);
               }
             }
           }
@@ -2031,18 +2031,10 @@ export function cleanup(
          */
         const vFirstChild = vnode_getFirstChild(vCursor);
         if (vFirstChild) {
-          vnode_walkVNode(vFirstChild, (vNode) => {
-            /**
-             * Instead of an ID, we store a direct reference to the VNode. This is necessary to
-             * locate the slot's parent in a detached subtree, as the ID would become invalid.
-             */
-            if (vNode.flags & VNodeFlags.Virtual) {
-              // The QSlotParent is used to find the slot parent during scheduling
-              vNode.slotParent;
-            }
-          });
+          vnode_walkVNode(vFirstChild);
           return;
         }
+        clearProjectionFromSlotParent(container, vCursor);
       }
     } else if (type & VNodeFlags.Text) {
       markVNodeAsDeleted(vCursor);
@@ -2080,7 +2072,21 @@ export function cleanup(
   } while (true as boolean);
 }
 
-function cleanupStaleUnclaimedProjection(journal: VNodeJournal, projection: VNode) {
+function clearProjectionFromSlotParent(container: ClientContainer, vNode: VNode) {
+  if (!vNode.slotParent) {
+    return;
+  }
+  const slotName = container.getHostProp<string>(vNode, QSlot);
+  if (slotName != null && container.getHostProp(vNode.slotParent, slotName) === vNode) {
+    vnode_setProp(vNode.slotParent, slotName, null);
+  }
+}
+
+function cleanupStaleUnclaimedProjection(
+  container: ClientContainer,
+  journal: VNodeJournal,
+  projection: VNode
+) {
   // we are removing a node where the projection would go after slot render.
   // This is not needed, so we need to cleanup still unclaimed projection
   const projectionParent = projection.parent;
@@ -2091,6 +2097,7 @@ function cleanupStaleUnclaimedProjection(journal: VNodeJournal, projection: VNod
       vnode_getElementName(projectionParent as ElementVNode) === QTemplate
     ) {
       // if parent is the q:template element then projection is still unclaimed - remove it
+      clearProjectionFromSlotParent(container, projection);
       vnode_remove(journal, projectionParent as ElementVNode | VirtualVNode, projection, true);
     }
   }

--- a/packages/qwik/src/core/client/vnode-utils.ts
+++ b/packages/qwik/src/core/client/vnode-utils.ts
@@ -1951,6 +1951,9 @@ export function vnode_toString(
             attrs.push(' ' + key + '=' + qwikDebugToString(value));
           }
         }
+        if (vnode.slotParent) {
+          attrs.push(' slotParent=(C)');
+        }
       }
       const name =
         (colorize ? NAME_COL_PREFIX : '') +

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -1819,6 +1819,151 @@ describe.each([
       expect(document.querySelector('q\\:template')).toBeUndefined();
     });
 
+    it('should render projection after hidden child rerenders', async () => {
+      const Child = component$((props: { counter: Signal<number> }) => {
+        return (
+          <>
+            {props.counter.value > 1 && (
+              <section>
+                <Slot />
+              </section>
+            )}
+          </>
+        );
+      });
+      const Parent = component$(() => {
+        const counter = useSignal(0);
+        const innerCounter = useSignal(0);
+        return (
+          <div>
+            <button id="counter" onClick$={() => counter.value++}>
+              Increment
+            </button>
+            <Child counter={counter}>
+              <span>
+                <button id="inner-counter" onClick$={() => innerCounter.value++}>
+                  Increment inner {innerCounter.value}
+                </button>
+              </span>
+            </Child>
+          </div>
+        );
+      });
+
+      const { document } = await render(<Parent />, { debug: DEBUG });
+      const content = (
+        <span>
+          <button id="inner-counter">Increment inner 0</button>
+        </span>
+      );
+
+      if (render === ssrRenderToDom) {
+        await expect(document.querySelector('q\\:template')).toMatchDOM(
+          <q:template hidden aria-hidden="true">
+            {content}
+          </q:template>
+        );
+      } else {
+        expect(document.querySelector('q\\:template')).toBeUndefined();
+      }
+
+      await trigger(document.body, '#counter', 'click');
+      await trigger(document.body, '#counter', 'click');
+      await trigger(document.body, '#inner-counter', 'click');
+      await trigger(document.body, '#inner-counter', 'click');
+      await expect(document.querySelector('button#inner-counter')).toMatchDOM(
+        <button id="inner-counter">Increment inner 2</button>
+      );
+    });
+
+    it('should render projection after child removes and restores slot', async () => {
+      const Child = component$(() => {
+        const show = useSignal(true);
+        return (
+          <section>
+            <button id="toggle-slot" onClick$={() => (show.value = !show.value)}>
+              Toggle slot
+            </button>
+            {show.value && <Slot />}
+          </section>
+        );
+      });
+      const Parent = component$(() => {
+        const counter = useSignal(0);
+        return (
+          <Child>
+            <button id="projected-counter" onClick$={() => counter.value++}>
+              Projected {counter.value}
+            </button>
+          </Child>
+        );
+      });
+
+      const { document } = await render(<Parent />, { debug: DEBUG });
+      await expect(document.querySelector('section')).toMatchDOM(
+        <section>
+          <button id="toggle-slot">Toggle slot</button>
+          <button id="projected-counter">Projected 0</button>
+        </section>
+      );
+
+      await trigger(document.body, '#toggle-slot', 'click');
+      await expect(document.querySelector('section')).toMatchDOM(
+        <section>
+          <button id="toggle-slot">Toggle slot</button>
+          {''}
+        </section>
+      );
+
+      await trigger(document.body, '#toggle-slot', 'click');
+      await trigger(document.body, '#projected-counter', 'click');
+      await trigger(document.body, '#projected-counter', 'click');
+      await expect(document.querySelector('#projected-counter')).toMatchDOM(
+        <button id="projected-counter">Projected 2</button>
+      );
+    });
+
+    it('should cleanup unclaimed projection q:template when component is removed', async () => {
+      const Child = component$(() => {
+        return <span>child</span>;
+      });
+      const Parent = component$(() => {
+        const show = useSignal(true);
+        return (
+          <div>
+            <button id="remove" onClick$={() => (show.value = false)}>
+              Remove
+            </button>
+            {show.value && (
+              <Child>
+                <span>projected</span>
+              </Child>
+            )}
+          </div>
+        );
+      });
+
+      const { document } = await render(<Parent />, { debug: DEBUG });
+      if (render === ssrRenderToDom) {
+        await expect(document.querySelector('q\\:template')).toMatchDOM(
+          <q:template hidden aria-hidden="true">
+            <span>projected</span>
+          </q:template>
+        );
+      } else {
+        expect(document.querySelector('q\\:template')).toBeUndefined();
+      }
+
+      await trigger(document.body, '#remove', 'click');
+      expect(document.querySelector('q\\:template')).toBeUndefined();
+      await expect(document.querySelector('div')).toMatchDOM(
+        <div>
+          <button id="remove">Remove</button>
+          {''}
+        </div>
+      );
+    });
+
     it('should add and delete projection content inside q:template for CSR rerender after SSR', async () => {
       const Child = component$(() => {
         const show = useSignal(false);

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -648,8 +648,12 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
 
       this.openFragment(
         isDev
-          ? { [DEBUG_TYPE]: VirtualType.Projection, [QSlotParent]: componentFrame.componentNode.id }
-          : { [QSlotParent]: componentFrame.componentNode.id }
+          ? {
+              [DEBUG_TYPE]: VirtualType.Projection,
+              [QSlotParent]: componentFrame.componentNode.id,
+              [QSlot]: slotName,
+            }
+          : { [QSlotParent]: componentFrame.componentNode.id, [QSlot]: slotName }
       );
       const lastNode = this.getOrCreateLastNode();
       if (lastNode.vnodeData) {


### PR DESCRIPTION
After rerender we shouldnt remove projection inside q:template