### PR TITLE
fix(core): don't HTML-escape SSR tag nesting errors

### DIFF
--- a/.changeset/ssr-tag-error-formatting.md
+++ b/.changeset/ssr-tag-error-formatting.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: don't HTML-escape SSR tag nesting errors so they're readable when logged

--- a/packages/qwik/src/core/tests/container.spec.tsx
+++ b/packages/qwik/src/core/tests/container.spec.tsx
@@ -535,15 +535,15 @@ describe('serializer v2', () => {
       ).rejects.toThrowError(
         [
           `Code(Q12): SsrError(tag): Error found in file: ${filePath}`,
-          `HTML rules do not allow &#39;&lt;div&gt;&#39; at this location.`,
+          `HTML rules do not allow '<div>' at this location.`,
           `  (The HTML parser will try to recover by auto-closing or inserting additional tags which will confuse Qwik when it resumes.)`,
-          `  Offending tag: &lt;div&gt;`,
+          `  Offending tag: <div>`,
           `  Existing tag context:`,
-          `    &lt;html&gt; [html content] -&gt; &lt;head&gt;, &lt;body&gt;`,
-          `     &lt;body&gt; [body content] -&gt; all tags allowed here`,
-          `      &lt;p&gt; [phrasing content] -&gt; &lt;a&gt;, &lt;b&gt;, &lt;img&gt;, &lt;input&gt; ... (no &lt;div&gt;, &lt;p&gt; ...)`,
-          `       &lt;b&gt;`,
-          `        &lt;div&gt; &lt;= is not allowed as a child of phrasing content.`,
+          `    <html> [html content] -> <head>, <body>`,
+          `     <body> [body content] -> all tags allowed here`,
+          `      <p> [phrasing content] -> <a>, <b>, <img>, <input> ... (no <div>, <p> ...)`,
+          `       <b>`,
+          `        <div> <= is not allowed as a child of phrasing content.`,
         ].join('\n')
       );
     });
@@ -558,13 +558,13 @@ describe('serializer v2', () => {
       ).rejects.toThrowError(
         [
           `Code(Q12): SsrError(tag): Error found in file: ${filePath}`,
-          `HTML rules do not allow &#39;&lt;div&gt;&#39; at this location.`,
+          `HTML rules do not allow '<div>' at this location.`,
           `  (The HTML parser will try to recover by auto-closing or inserting additional tags which will confuse Qwik when it resumes.)`,
-          `  Offending tag: &lt;div&gt;`,
+          `  Offending tag: <div>`,
           `  Existing tag context:`,
-          `    &lt;div&gt; [any content]`,
-          `     &lt;img&gt; [no-content element]`,
-          `      &lt;div&gt; &lt;= is not allowed as a child of no-content element.`,
+          `    <div> [any content]`,
+          `     <img> [no-content element]`,
+          `      <div> <= is not allowed as a child of no-content element.`,
         ].join('\n')
       );
     });

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -1193,7 +1193,7 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
               allowedContent(previousTagNesting)[0]
             }.`
           );
-          throw newTagError(text.map(escapeHTML).join('\n'));
+          throw newTagError(text.join('\n'));
         }
       }
     }


### PR DESCRIPTION
# What is it?
- Bug

# Description
SSR tag-nesting validation errors were run through `escapeHTML` before being thrown, so `<div>` showed up as `&lt;div&gt;` and `'` as `&#39;` in the logs. The error is logged as a plain JS `Error` and never written into HTML, so the escaping only made it unreadable. Dropped it and updated the two specs.