### PR TITLE
fix: rolldown-vite support (static paths + native import-analysis)

### DIFF
--- a/.changeset/rolldown-native-import-analysis.md
+++ b/.changeset/rolldown-native-import-analysis.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix(vite): strip rolldown-vite's native import-analysis plugin
+
+Under rolldown-vite (Vite 8) the import-analysis-build plugin has a native (Rust) counterpart, `native:import-analysis-build`, which still injects `__vitePreload` wrappers and `__VITE_PRELOAD__` markers into QRL chunks even though Qwik already removes the JS `vite:build-import-analysis` plugin. Add the native plugin name to the removal list so Qwik's own preloader manages dynamic imports as before.

--- a/.changeset/rolldown-static-paths-backticks.md
+++ b/.changeset/rolldown-static-paths-backticks.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix(router): match backtick-wrapped static-path placeholders in adapter post-build
+
+Rolldown can re-emit the `__QWIK_ROUTER_STATIC_PATHS_ARRAY__` / `__QWIK_ROUTER_NOT_FOUND_ARRAY__` placeholders as backtick template literals. The post-build replacement regex only matched single and double quotes, so the placeholders were left untouched and `isStaticPath` broke. The regex now also accepts backticks.

--- a/packages/qwik-router/src/adapters/shared/vite/post-build.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/post-build.ts
@@ -118,7 +118,7 @@ const injectStatics = async (
 
     let replaced = false;
     const newCode = code.replace(
-      /(['"])__QWIK_ROUTER_(STATIC_PATHS|NOT_FOUND)_ARRAY__\1/g,
+      /(["'`])__QWIK_ROUTER_(STATIC_PATHS|NOT_FOUND)_ARRAY__\1/g,
       (_, _quote, type) => {
         replaced = true;
         return type === 'STATIC_PATHS' ? staticPathsCode : notFoundPathsCode;

--- a/packages/qwik-vite/src/plugins/vite.ts
+++ b/packages/qwik-vite/src/plugins/vite.ts
@@ -482,7 +482,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         !qwikViteOpts.csr &&
         qwikPlugin.getOptions().target === 'client'
       ) {
-        const names = ['vite:build-import-analysis'];
+        const names = ['vite:build-import-analysis', 'native:import-analysis-build'];
         const plugins = config.plugins as VitePlugin[];
         for (const name of names) {
           const i = plugins.findIndex((p) => p?.name === name);


### PR DESCRIPTION
# What is it?

- Bug

# Description

Two small build-tooling fixes required to build a Qwik Router app with rolldown-vite (Vite 8). Both surfaced while testing the `rolldown-vite-support` branch with Vite 8, and both let me drop workarounds I'd been carrying in my app's root and adapter `vite.config.ts`.

**1. `fix(router)` - backtick-wrapped static-path placeholders**

Rolldown can re-emit the `__QWIK_ROUTER_STATIC_PATHS_ARRAY__` / `__QWIK_ROUTER_NOT_FOUND_ARRAY__` placeholders as backtick template literals. The adapter's `post-build.ts` injection regex only matched single/double quotes, so the placeholders were never substituted: `isStaticPath` always returned `false` and every static asset 404'd through the SSR fallthrough. The regex now also accepts backticks.

**2. `fix(vite)` - strip rolldown-vite's native import-analysis plugin**

Qwik already removes Vite's JS `vite:build-import-analysis` plugin (its `__vitePreload` machinery is redundant with Qwik's own preloader). Under rolldown-vite that plugin has a native Rust counterpart, `native:import-analysis-build`, which wasn't being removed, so it kept injecting `__vitePreload` wrappers and `__VITE_PRELOAD__` markers into QRL chunks, leaving orphaned identifiers. Added the native name to the existing removal list.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset (two `patch` changesets: `@qwik.dev/router`, `@qwik.dev/core`)
- [ ] I added new tests to cover the fix / functionality