### PR TITLE
fix: release paused cursors that are abandoned before they resume

### DIFF
--- a/.changeset/fifty-hats-look.md
+++ b/.changeset/fifty-hats-look.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: release paused cursors that are abandoned before they resume

--- a/packages/qwik/src/core/shared/cursor/cursor-queue.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-queue.ts
@@ -71,10 +71,10 @@ export function pauseCursor(cursor: Cursor, container: Container): void {
 }
 
 export function resumeCursor(cursor: Cursor, container: Container): void {
+  removeCursorFromPausedQueue(cursor, container);
   if (!(cursor.flags & VNodeFlags.Cursor)) {
     return;
   }
-  removeCursorFromPausedQueue(cursor, container);
   addCursorToQueue(container, cursor);
 }
 

--- a/packages/qwik/src/core/shared/cursor/cursor-walker.spec.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-walker.spec.ts
@@ -725,4 +725,20 @@ describe('abandonCursor', () => {
     expect(container.$pendingCount$).toBe(0);
     expect(getHighestPriorityCursor()).toBeNull();
   });
+
+  it('should release a paused cursor that lost its cursor flag before resuming', () => {
+    const container = createMockContainer();
+    const source = vnode_newVirtual() as Cursor;
+
+    createCursorData(container, source);
+    addCursorToQueue(container, source);
+    pauseCursor(source, container);
+    expect(container.$pendingCount$).toBe(1);
+
+    source.flags &= ~VNodeFlags.Cursor;
+    resumeCursor(source, container);
+
+    expect(container.$pendingCount$).toBe(0);
+    expect(getHighestPriorityCursor()).toBeNull();
+  });
 });


### PR DESCRIPTION
Fixes a SPA navigation timeout caused by abandoned paused cursors keeping the container pending count alive