### PR TITLE
fix(router): avoid top-level await in generated SSG entry

### DIFF
--- a/.changeset/edge-ssg-top-level-await.md
+++ b/.changeset/edge-ssg-top-level-await.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix(router): SSG builds with edge/worker adapters no longer crash on Rollup

--- a/packages/qwik-router/src/adapters/shared/vite/index.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/index.ts
@@ -127,16 +127,22 @@ export function viteAdapter(opts: ViteAdapterPluginOptions) {
         `if (args.includes('--quiet')) ssgOpts.log = 'quiet';`,
         `if (args.includes('--debug')) ssgOpts.log = 'debug';`,
         ``,
-        `if (isMainThread) {`,
-        `  await runSsg({`,
-        `    render,`,
-        `    qwikRouterConfig,`,
-        `    workerFilePath: new URL(import.meta.url).href,`,
-        `    ...ssgOpts,`,
-        `  });`,
-        `} else {`,
-        `  await startWorker({ render, qwikRouterConfig });`,
-        `}`,
+        // Fire-and-forget instead of top-level await. On the worker/edge SSR target Vite
+        // inlines dynamic imports, and Rollup then reads the inlined `./system` namespace
+        // before it is initialized across a top-level await. See rollup/rollup#4166.
+        // runSsg/startWorker keep the process alive (worker handles) and call process.exit.
+        `const ssgRun = isMainThread`,
+        `  ? runSsg({`,
+        `      render,`,
+        `      qwikRouterConfig,`,
+        `      workerFilePath: new URL(import.meta.url).href,`,
+        `      ...ssgOpts,`,
+        `    })`,
+        `  : startWorker({ render, qwikRouterConfig });`,
+        `ssgRun.catch((err) => {`,
+        `  console.error(err);`,
+        `  process.exit(1);`,
+        `});`,
       ].join('\n');
     },
 


### PR DESCRIPTION
# What is it?
- Bug

# Description
SSG builds with the edge/worker adapters (vercel-edge, netlify-edge, cloudflare-pages) crash on Rollup-vite. The generated SSG entry used a top-level `await`; on the worker/edge SSR target Vite inlines dynamic imports, and Rollup then reads the inlined `./system` namespace before it's initialized across that top-level await ([rollup/rollup#4166](https://github.com/rollup/rollup/issues/4166)). The entry now starts the SSG/worker promise without awaiting at the top level (it still keeps the process alive via worker handles and calls `process.exit`). rolldown-vite and node-target adapters were unaffected; this also keeps them correct.