### PR TITLE
docs: add Qwik v2 beta docs banner

### DIFF
--- a/packages/docs/src/components/header/header.css
+++ b/packages/docs/src/components/header/header.css
@@ -8,6 +8,73 @@
   z-index: 100;
 }
 
+.v2-docs-super-header {
+  align-items: center;
+  background: #05070d;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.36);
+  color: #fff;
+  display: flex;
+  min-height: var(--super-header-height);
+  text-decoration: none;
+}
+
+.v2-docs-super-header:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+.v2-docs-super-header-inner {
+  align-items: center;
+  display: flex;
+  font-family: Poppins, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  gap: 0.625rem;
+  justify-content: center;
+  line-height: 1.2;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: var(--container-max-width);
+  padding: 0 1rem;
+  width: 100%;
+}
+
+.v2-docs-super-header-icon {
+  align-items: center;
+  color: #18b6f6;
+  display: inline-flex;
+  flex: 0 0 auto;
+  filter: drop-shadow(0 0 10px rgba(24, 182, 246, 0.55));
+}
+
+.v2-docs-super-header-copy {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.625rem;
+}
+
+.v2-docs-super-header-copy strong {
+  color: #fff;
+  font-weight: 700;
+}
+
+.v2-docs-super-header-copy span {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.v2-docs-super-header-arrow {
+  color: #fff;
+  display: inline-flex;
+  flex: 0 0 auto;
+  opacity: 0.9;
+  transition: transform 0.2s ease;
+}
+
+.v2-docs-super-header:hover .v2-docs-super-header-arrow {
+  transform: translateX(3px);
+}
+
 @media (min-width: 1024px) {
   .header-container {
     background: var(--bg-header-color);
@@ -65,7 +132,7 @@ header li a:hover svg {
 }
 
 header .mobile-menu {
-  height: var(--header-height);
+  height: var(--header-nav-height);
   position: absolute;
   right: 0;
   @apply p-5 lg:hidden;
@@ -92,7 +159,7 @@ header .header-inner {
   margin-left: auto;
   margin-right: auto;
   position: relative;
-  height: var(--header-height);
+  height: var(--header-nav-height);
 }
 
 .full-width header .header-inner {
@@ -103,7 +170,7 @@ header .header-logo {
   padding-left: 1rem;
   display: flex;
   align-items: center;
-  height: var(--header-height);
+  height: var(--header-nav-height);
 }
 
 .full-width header .header-logo {
@@ -123,6 +190,14 @@ header .header-logo {
 
   header .mobile-menu {
     padding: 0.5rem 1rem;
+  }
+
+  .v2-docs-super-header-inner {
+    font-size: 0.8125rem;
+  }
+
+  .v2-docs-super-header-copy span {
+    display: none;
   }
 
   .header-open header ul:not([role='listbox']) {

--- a/packages/docs/src/components/header/header.tsx
+++ b/packages/docs/src/components/header/header.tsx
@@ -73,6 +73,38 @@ export const Header = component$(() => {
           'home-page-header': pathname === '/',
         }}
       >
+        <a class="v2-docs-super-header" href="https://next.qwik.dev/">
+          <span class="v2-docs-super-header-inner">
+            <span class="v2-docs-super-header-icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M12 2.75 13.83 8.4 19.5 10.2l-5.67 1.8L12 17.65 10.17 12 4.5 10.2l5.67-1.8L12 2.75Z"
+                  fill="currentColor"
+                />
+                <path
+                  d="m18.5 15.25.65 2.1 2.1.65-2.1.65-.65 2.1-.65-2.1-2.1-.65 2.1-.65.65-2.1ZM5.5 3.25l.5 1.5 1.5.5-1.5.5-.5 1.5-.5-1.5-1.5-.5 1.5-.5.5-1.5Z"
+                  fill="white"
+                  fill-opacity=".9"
+                />
+              </svg>
+            </span>
+            <span class="v2-docs-super-header-copy">
+              <strong>Qwik v2 beta</strong>
+              <span>Lighter, faster, better.</span>
+            </span>
+            <span class="v2-docs-super-header-arrow" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <path
+                  d="M3.25 8h8.5m0 0L8.5 4.75M11.75 8 8.5 11.25"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.7"
+                />
+              </svg>
+            </span>
+          </span>
+        </a>
         <div class="header-inner">
           <div class="header-logo">
             <Link href="/">

--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -64,7 +64,9 @@
 
 :root {
   color-scheme: light;
-  --header-height: 80px;
+  --super-header-height: 40px;
+  --header-nav-height: 80px;
+  --header-height: calc(var(--header-nav-height) + var(--super-header-height));
   --aside-width: 300px;
   --container-max-width: 1400px;
   --builder-bar-height: 56px;
@@ -175,7 +177,9 @@
   :root {
     --panel-toggle-height: 56px;
     --builder-bar-height: 40px;
-    --header-height: 60px;
+    --super-header-height: 42px;
+    --header-nav-height: 60px;
+    --header-height: calc(var(--header-nav-height) + var(--super-header-height));
   }
 }
 

--- a/packages/docs/src/repl/ui/repl-version.ts
+++ b/packages/docs/src/repl/ui/repl-version.ts
@@ -21,10 +21,11 @@ export const getReplVersion = async (version: string | undefined, offline: boole
     if (!offline && isExpiredNpmData(npmData)) {
       // fetch most recent NPM version data
       console.debug(`Qwik REPL, fetch npm data: ${QWIK_NPM_V1_DATA}`);
-      npmData = await fetch(QWIK_NPM_V1_DATA).then((r) => r.json());
-      npmData.timestamp = Date.now();
+      const latestNpmData: NpmData = await fetch(QWIK_NPM_V1_DATA).then((r) => r.json());
+      latestNpmData.timestamp = Date.now();
       const v2Data = await fetch(QWIK_NPM_V2_DATA).then((r) => r.json());
-      npmData.versions.unshift(...v2Data.versions);
+      latestNpmData.versions.unshift(...v2Data.versions);
+      npmData = latestNpmData;
       localStorage.setItem(NPM_STORAGE_KEY, JSON.stringify(npmData));
     } else {
       console.debug(`Qwik REPL, using cached npm data`);


### PR DESCRIPTION
Adds a slim super-header link from v1 docs to the Qwik v2 beta docs at next.qwik.dev.

Also fixes the docs dev TypeScript nullability issue in REPL npm version refresh.

Checks:
- pnpm exec prettier --check packages/docs/src/components/header/header.tsx packages/docs/src/components/header/header.css packages/docs/src/global.css packages/docs/src/repl/ui/repl-version.ts
- pnpm exec tsc -p packages/docs/tsconfig.json
- pnpm vitest run packages/docs/src/repl/ui/repl-version.unit.ts