### PR TITLE
ci: improve cache-hit workflow latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           lookup-only: true
-          path: packages/optimizer/bindings
+          path: packages/optimizer/
           key: ${{ hashfiles('.github/workflows/ci.yml', 'Makefile', 'rust-toolchain', '**/Cargo.toml', '**/Cargo.lock', '**/*.rs') }}
       - run: 'echo ${{ steps.cache-rust.outputs.cache-primary-key }} > rust-key.txt'
       - name: 'check cache: others'
@@ -190,7 +190,7 @@ jobs:
         with:
           lookup-only: true
           path: unit-tests-completed.txt
-          key: ${{ hashfiles('others-key.txt', 'packages/**/*.unit.*') }}
+          key: ${{ hashfiles('others-key.txt', 'packages/**/*.unit.*', 'packages/**/*.spec.*') }}
       - name: 'check cache: benchmarks'
         id: cache-bench
         uses: actions/cache/restore@v5
@@ -204,7 +204,7 @@ jobs:
         with:
           lookup-only: true
           path: e2e-tests-completed.txt
-          key: ${{ hashfiles('others-key.txt', 'starters/**/*') }}
+          key: ${{ hashfiles('others-key.txt', 'starters/**/*', 'e2e/qwik-e2e/tests/**/*', 'e2e/qwik-e2e/dev-server.ts', 'e2e/qwik-e2e/playwright.config.ts') }}
       - name: 'check cache: cli e2e tests'
         id: cache-cli-e2e
         uses: actions/cache/restore@v5
@@ -218,105 +218,8 @@ jobs:
         with:
           lookup-only: true
           path: docs-e2e-tests-completed.txt
-          key: ${{ hashfiles('others-key.txt', 'e2e/docs/**/*') }}
+          key: ${{ hashfiles('others-key.txt', 'e2e/docs-e2e/**/*') }}
 
-
-  ############ BUILD Qwik ############
-  build-qwik:
-    name: Build Qwik
-    needs:
-      - changes
-      - combined-optimizer
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify prerequisites
-        if: |
-          !(
-            needs.changes.result == 'success' &&
-            (
-              (
-                needs.changes.outputs.build-rust == 'true' &&
-                needs.combined-optimizer.result == 'success'
-              ) ||
-              (
-                needs.changes.outputs.build-rust != 'true' &&
-                needs.combined-optimizer.result == 'skipped'
-              )
-            )
-          )
-        run: exit 1
-
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v5
-        if: needs.changes.outputs.build-qwik == 'true'
-      - name: Setup Node
-        if: needs.changes.outputs.build-qwik == 'true'
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.CI_NODE_VERSION }}
-          cache: 'pnpm'
-          registry-url: https://registry.npmjs.org/
-
-      - name: Restore optimizer cache
-        if: |
-          needs.changes.outputs.build-qwik == 'true' &&
-          needs.changes.outputs.build-rust != 'true'
-        uses: actions/cache/restore@v4
-        with:
-          fail-on-cache-miss: true
-          path: packages/optimizer/
-          key: ${{ needs.changes.outputs.hash-rust }}
-
-      - name: Restore optimizer artifact
-        if: |
-          needs.changes.outputs.build-qwik == 'true' &&
-          needs.changes.outputs.build-rust == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: artifact-optimizer
-          path: packages/optimizer/
-
-      - name: Install NPM Dependencies
-        if: needs.changes.outputs.build-qwik == 'true'
-        run: |
-          # Ensure that the optimizer binary gets made
-          mkdir -p packages/optimizer/bindings/
-          pnpm install --frozen-lockfile
-
-      - name: 'build: qwik'
-        if: needs.changes.outputs.build-qwik == 'true'
-        # Also build optimizer for now
-        run: pnpm build --qwik --optimizer --insights --set-dist-tag="${{ needs.changes.outputs.disttag }}"
-
-      - name: Restore qwik cache
-        if: needs.changes.outputs.build-qwik != 'true'
-        uses: actions/cache/restore@v5
-        with:
-          fail-on-cache-miss: true
-          path: packages/qwik/dist
-          key: ${{ needs.changes.outputs.hash-qwik }}
-
-      - name: Print Qwik Dist Build
-        continue-on-error: true
-        run: tree -a packages/qwik/dist/
-
-      - name: Save qwik cache
-        if: needs.changes.outputs.build-qwik == 'true'
-        uses: actions/cache/save@v5
-        with:
-          key: ${{ needs.changes.outputs.hash-qwik }}
-          path: packages/qwik/dist
-
-      - name: Upload Qwik artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: artifact-qwik
-          include-hidden-files: true
-          path: packages/qwik/dist/
-          if-no-files-found: error
 
   ############ BUILD PLATFORM BINDINGS ############
   build-bindings:
@@ -400,8 +303,8 @@ jobs:
 
   ############ BUILD PACKAGE ############
   combined-optimizer:
-    name: Bundle Optimizer binaries
-    if: needs.changes.outputs.build-rust == 'true' && needs.build-bindings.result != 'skipped'
+    name: Prepare Optimizer binaries
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - build-bindings
@@ -409,10 +312,32 @@ jobs:
 
     steps:
       - name: Verify builds
-        if: needs.build-bindings.result != 'success'
+        if: |
+          !(
+            needs.changes.result == 'success' &&
+            (
+              (
+                needs.changes.outputs.build-rust == 'true' &&
+                needs.build-bindings.result == 'success'
+              ) ||
+              (
+                needs.changes.outputs.build-rust != 'true' &&
+                needs.build-bindings.result == 'skipped'
+              )
+            )
+          )
         run: exit 1
 
+      - name: Restore optimizer cache
+        if: needs.changes.outputs.build-rust != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          fail-on-cache-miss: true
+          path: packages/optimizer/
+          key: ${{ needs.changes.outputs.hash-rust }}
+
       - name: Restore artifacts
+        if: needs.changes.outputs.build-rust == 'true'
         uses: actions/download-artifact@v8
 
       - name: Move Rust Artifacts
@@ -447,61 +372,79 @@ jobs:
           if-no-files-found: error
 
   build-other-packages:
-    name: Build Other Packages
+    name: Build Packages
     needs:
-      - build-qwik
       - changes
       - combined-optimizer
-    if: always() && needs.changes.outputs.build-others == 'true'
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Verify prerequisites
         if: |
           !(
             needs.changes.result == 'success' &&
-            needs.build-qwik.result == 'success' &&
-            (
-              (
-                needs.changes.outputs.build-rust == 'true' &&
-                needs.combined-optimizer.result == 'success'
-              ) ||
-              (
-                needs.changes.outputs.build-rust != 'true' &&
-                needs.combined-optimizer.result == 'skipped'
-              )
-            )
+            needs.combined-optimizer.result == 'success'
           )
         run: exit 1
 
       - name: Checkout
-        if: needs.changes.outputs.build-others == 'true'
         uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        if: needs.changes.outputs.build-others == 'true'
+        if: needs.changes.outputs.build-qwik == 'true' || needs.changes.outputs.build-others == 'true'
       - name: Setup Node
-        if: needs.changes.outputs.build-others == 'true'
+        if: needs.changes.outputs.build-qwik == 'true' || needs.changes.outputs.build-others == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.CI_NODE_VERSION }}
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Restore Qwik artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: artifact-qwik
-          path: packages/qwik/dist/
-
-      - name: Restore Optimizer artifact
+      - name: Restore optimizer artifact
+        if: needs.changes.outputs.build-qwik == 'true' || needs.changes.outputs.build-others == 'true'
         uses: actions/download-artifact@v8
         with:
           name: artifact-optimizer
           path: packages/optimizer/
 
       - name: Install NPM Dependencies
-        if: needs.changes.outputs.build-others == 'true'
-        run: pnpm install
+        if: needs.changes.outputs.build-qwik == 'true' || needs.changes.outputs.build-others == 'true'
+        run: |
+          # Ensure that the optimizer binary gets made
+          mkdir -p packages/optimizer/bindings/
+          pnpm install --frozen-lockfile
+
+      - name: 'build: qwik'
+        if: needs.changes.outputs.build-qwik == 'true'
+        # Also build optimizer for now
+        run: pnpm build --qwik --optimizer --insights --set-dist-tag="${{ needs.changes.outputs.disttag }}"
+
+      - name: Restore qwik cache
+        if: needs.changes.outputs.build-qwik != 'true'
+        uses: actions/cache/restore@v5
+        with:
+          fail-on-cache-miss: true
+          path: packages/qwik/dist
+          key: ${{ needs.changes.outputs.hash-qwik }}
+
+      - name: Print Qwik Dist Build
+        continue-on-error: true
+        run: tree -a packages/qwik/dist/
+
+      - name: Save qwik cache
+        if: needs.changes.outputs.build-qwik == 'true'
+        uses: actions/cache/save@v5
+        with:
+          key: ${{ needs.changes.outputs.hash-qwik }}
+          path: packages/qwik/dist
+
+      - name: Upload Qwik artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifact-qwik
+          include-hidden-files: true
+          path: packages/qwik/dist/
+          if-no-files-found: error
 
       - name: 'build: qwik-router & others'
         if: needs.changes.outputs.build-others == 'true'
@@ -674,16 +617,93 @@ jobs:
           key: ${{ needs.changes.outputs.hash-docs }}
           path: docs-build-completed.txt
 
+  ############ PLAYWRIGHT BROWSER CACHE ############
+  prepare-playwright:
+    name: Prepare Playwright (${{ matrix.settings.host }}, ${{ matrix.settings.browser }})
+    if: |
+      always() && (
+        needs.changes.outputs.build-e2e == 'true' ||
+        needs.changes.outputs.build-cli-e2e == 'true' ||
+        needs.changes.outputs.build-docs-e2e == 'true'
+      )
+    needs:
+      - changes
+
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: ubuntu-latest
+            browser: chromium
+          - host: windows-latest
+            browser: chromium
+          - host: macos-latest
+            browser: webkit
+
+    runs-on: ${{ matrix.settings.host }}
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
+
+    steps:
+      - name: Verify prerequisites
+        if: needs.changes.result != 'success'
+        run: exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.CI_NODE_VERSION_E2E }}
+          cache: 'pnpm'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache/restore@v5
+        with:
+          key: playwright-${{ runner.os }}-${{ matrix.settings.browser }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: .cache/ms-playwright
+
+      - name: Install NPM Dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install ${{ matrix.settings.browser }}
+
+      - name: Save Playwright browser cache
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          key: playwright-${{ runner.os }}-${{ matrix.settings.browser }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: .cache/ms-playwright
+
   ############ DOCS E2E TEST ############
   test-e2e-docs:
     timeout-minutes: 15
-    name: Docs E2E Tests
-    if: always() && needs.build-docs.result == 'success'
+    name: Docs E2E Tests (shard ${{ matrix.shard.shard }}/${{ matrix.shard.shardTotal }})
+    if: always() && needs.build-docs.result == 'success' && needs.changes.outputs.build-docs-e2e == 'true'
     needs:
       - changes
       - build-docs
       - build-other-packages
+      - prepare-playwright
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - shard: 1
+            shardTotal: 2
+          - shard: 2
+            shardTotal: 2
     runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
     steps:
       - name: Verify prerequisites
@@ -691,7 +711,8 @@ jobs:
           !(
             needs.changes.result == 'success' &&
             needs.build-other-packages.result == 'success' &&
-            needs.build-docs.result == 'success'
+            needs.build-docs.result == 'success' &&
+            needs.prepare-playwright.result == 'success'
           )
         run: exit 1
 
@@ -714,25 +735,57 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright
-        run: npx playwright install chromium --with-deps
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache/restore@v5
+        with:
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('pnpm-lock.yaml') }}
+          path: .cache/ms-playwright
+
+      - name: Install Playwright System Dependencies
+        if: runner.os == 'Linux'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Install Playwright Browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
 
       - name: Docs E2E Tests
-        run: pnpm run test.e2e.docs && echo ok > docs-e2e-tests-completed.txt
-
-      - name: Save Docs E2E Tests Cache
-        uses: actions/cache/save@v5
-        with:
-          key: ${{ needs.changes.outputs.hash-docs-e2e }}
-          path: docs-e2e-tests-completed.txt
+        run: pnpm exec playwright test --config=e2e/docs-e2e/playwright.config.ts --project=chromium --shard=${{ matrix.shard.shard }}/${{ matrix.shard.shardTotal }}
 
       - name: Upload Playwright Trace
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: docs-playwright-report
+          name: docs-playwright-report-${{ matrix.shard.shard }}-${{ matrix.shard.shardTotal }}
           path: e2e/docs-e2e/test-results/
           retention-days: 30
+
+  save-docs-e2e-tests-cache:
+    name: Save Docs E2E Tests Cache
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - test-e2e-docs
+    if: always() && needs.changes.outputs.build-docs-e2e == 'true' && needs.test-e2e-docs.result == 'success'
+
+    steps:
+      - name: Verify prerequisites
+        if: |
+          !(
+            needs.changes.result == 'success' &&
+            needs.test-e2e-docs.result == 'success'
+          )
+        run: exit 1
+
+      - name: Mark docs e2e tests complete
+        run: echo ok > docs-e2e-tests-completed.txt
+
+      - name: Save docs e2e tests cache
+        uses: actions/cache/save@v5
+        with:
+          key: ${{ needs.changes.outputs.hash-docs-e2e }}
+          path: docs-e2e-tests-completed.txt
 
   ############ UNIT TEST ############
   test-unit:
@@ -884,34 +937,65 @@ jobs:
   test-e2e:
     # Sometimes the tests just hang
     timeout-minutes: 20
-    name: E2E Tests
+    name: E2E Tests (${{ matrix.settings.host }}, ${{ matrix.settings.browser }}, shard ${{ matrix.settings.shard }}/${{ matrix.settings.shardTotal }})
     if: always() && needs.changes.outputs.build-e2e == 'true'
 
     needs:
       - build-other-packages
       - changes
+      - prepare-playwright
 
     strategy:
+      fail-fast: false
       matrix:
         settings:
           - host: ubuntu-latest
             browser: chromium
+            shard: 1
+            shardTotal: 2
+          - host: ubuntu-latest
+            browser: chromium
+            shard: 2
+            shardTotal: 2
           # Some tests are failing on firefox, disable for now
           # - host: ubuntu-latest
           #   browser: firefox
           - host: windows-latest
             browser: chromium
+            shard: 1
+            shardTotal: 4
+          - host: windows-latest
+            browser: chromium
+            shard: 2
+            shardTotal: 4
+          - host: windows-latest
+            browser: chromium
+            shard: 3
+            shardTotal: 4
+          - host: windows-latest
+            browser: chromium
+            shard: 4
+            shardTotal: 4
           - host: macos-latest
             browser: webkit
+            shard: 1
+            shardTotal: 2
+          - host: macos-latest
+            browser: webkit
+            shard: 2
+            shardTotal: 2
 
     runs-on: ${{ matrix.settings.host }}
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
     steps:
       - name: Verify prerequisites
         if: |
           !(
             needs.changes.result == 'success' &&
-            needs.build-other-packages.result == 'success'
+            needs.build-other-packages.result == 'success' &&
+            needs.prepare-playwright.result == 'success'
           )
         run: exit 1
 
@@ -934,17 +1018,29 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright
-        run: npx playwright install ${{ matrix.settings.browser }} --with-deps
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache/restore@v5
+        with:
+          key: playwright-${{ runner.os }}-${{ matrix.settings.browser }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: .cache/ms-playwright
+
+      - name: Install Playwright System Dependencies
+        if: runner.os == 'Linux'
+        run: pnpm exec playwright install-deps ${{ matrix.settings.browser }}
+
+      - name: Install Playwright Browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install ${{ matrix.settings.browser }}
 
       - name: Playwright E2E Tests
-        run: pnpm run test.e2e.${{ matrix.settings.browser }}
+        run: pnpm exec playwright test e2e/qwik-e2e/tests --browser=${{ matrix.settings.browser }} --config=e2e/qwik-e2e/playwright.config.ts --shard=${{ matrix.settings.shard }}/${{ matrix.settings.shardTotal }}
 
       - name: Upload Playwright Trace
         uses: actions/upload-artifact@v7
         if: failure() # only when tests fail
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.settings.host }}-${{ matrix.settings.browser }}-${{ matrix.settings.shard }}-${{ matrix.settings.shardTotal }}
           path: test-results/ # or test-results/ depending on your config
           retention-days: 30
  
@@ -953,55 +1049,138 @@ jobs:
         if: failure()
 
   test-cli-e2e:
-    name: E2E CLI Tests (${{ matrix.settings.runtime }}, ${{ matrix.settings.host }}, ${{ matrix.settings.browser }})
+    name: E2E CLI Tests (${{ matrix.settings.runtime }}, ${{ matrix.settings.host }}, ${{ matrix.settings.browser }}, shard ${{ matrix.settings.shard }}/${{ matrix.settings.shardTotal }})
     if: always() && needs.changes.outputs.build-cli-e2e == 'true'
 
     needs:
       - build-other-packages
       - changes
+      - prepare-playwright
 
     strategy:
+      fail-fast: false
       matrix:
         settings:
           - host: ubuntu-latest
             browser: chromium
             runtime: node
-            integration-script: test.e2e.integrations.chromium
+            integration-config: e2e/adapters-e2e/playwright.config.ts
             run-cli: true
             run-qwik-react: true
+            shard: 1
+            shardTotal: 2
+            cliShard: 1
+            cliShardTotal: 2
+          - host: ubuntu-latest
+            browser: chromium
+            runtime: node
+            integration-config: e2e/adapters-e2e/playwright.config.ts
+            run-cli: true
+            run-qwik-react: true
+            shard: 2
+            shardTotal: 2
+            cliShard: 2
+            cliShardTotal: 2
           - host: ubuntu-latest
             browser: chromium
             runtime: bun
-            integration-script: test.e2e.integrations.bun.chromium
+            integration-config: e2e/adapters-e2e/playwright.bun.config.ts
             run-cli: false
             run-qwik-react: false
+            shard: 1
+            shardTotal: 2
+          - host: ubuntu-latest
+            browser: chromium
+            runtime: bun
+            integration-config: e2e/adapters-e2e/playwright.bun.config.ts
+            run-cli: false
+            run-qwik-react: false
+            shard: 2
+            shardTotal: 2
           - host: ubuntu-latest
             browser: chromium
             runtime: deno
-            integration-script: test.e2e.integrations.deno.chromium
+            integration-config: e2e/adapters-e2e/playwright.deno.config.ts
             run-cli: false
             run-qwik-react: false
+            shard: 1
+            shardTotal: 2
+          - host: ubuntu-latest
+            browser: chromium
+            runtime: deno
+            integration-config: e2e/adapters-e2e/playwright.deno.config.ts
+            run-cli: false
+            run-qwik-react: false
+            shard: 2
+            shardTotal: 2
           - host: macos-latest
             browser: webkit
             runtime: node
-            integration-script: test.e2e.integrations.webkit
+            integration-config: e2e/adapters-e2e/playwright.config.ts
             run-cli: true
             run-qwik-react: true
+            shard: 1
+            shardTotal: 2
+            cliShard: 1
+            cliShardTotal: 2
+          - host: macos-latest
+            browser: webkit
+            runtime: node
+            integration-config: e2e/adapters-e2e/playwright.config.ts
+            run-cli: true
+            run-qwik-react: true
+            shard: 2
+            shardTotal: 2
+            cliShard: 2
+            cliShardTotal: 2
           - host: windows-latest
             browser: chromium
             runtime: node
-            integration-script: test.e2e.integrations.chromium
+            integration-config: e2e/adapters-e2e/playwright.config.ts
             run-cli: true
             run-qwik-react: true
+            shard: 1
+            shardTotal: 4
+            cliShard: 1
+            cliShardTotal: 2
+          - host: windows-latest
+            browser: chromium
+            runtime: node
+            integration-config: e2e/adapters-e2e/playwright.config.ts
+            run-cli: true
+            run-qwik-react: true
+            shard: 2
+            shardTotal: 4
+            cliShard: 2
+            cliShardTotal: 2
+          - host: windows-latest
+            browser: chromium
+            runtime: node
+            integration-config: e2e/adapters-e2e/playwright.config.ts
+            run-cli: false
+            run-qwik-react: true
+            shard: 3
+            shardTotal: 4
+          - host: windows-latest
+            browser: chromium
+            runtime: node
+            integration-config: e2e/adapters-e2e/playwright.config.ts
+            run-cli: false
+            run-qwik-react: true
+            shard: 4
+            shardTotal: 4
 
     runs-on: ${{ matrix.settings.host }}
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
     steps:
       - name: Verify prerequisites
         if: |
           !(
             needs.changes.result == 'success' &&
-            needs.build-other-packages.result == 'success'
+            needs.build-other-packages.result == 'success' &&
+            needs.prepare-playwright.result == 'success'
           )
         run: exit 1
 
@@ -1036,18 +1215,32 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Install Playwright
-        run: npx playwright install ${{ matrix.settings.browser }} --with-deps
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache/restore@v5
+        with:
+          key: playwright-${{ runner.os }}-${{ matrix.settings.browser }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: .cache/ms-playwright
+
+      - name: Install Playwright System Dependencies
+        if: runner.os == 'Linux'
+        run: pnpm exec playwright install-deps ${{ matrix.settings.browser }}
+
+      - name: Install Playwright Browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install ${{ matrix.settings.browser }}
 
       - name: Playwright E2E Integration Tests
-        run: pnpm run ${{ matrix.settings.integration-script }}
+        run: pnpm exec playwright test e2e/adapters-e2e/tests --project=${{ matrix.settings.browser }} --config=${{ matrix.settings.integration-config }} --shard=${{ matrix.settings.shard }}/${{ matrix.settings.shardTotal }}
 
       - name: Playwright E2E Qwik React Tests
         if: matrix.settings.run-qwik-react
-        run: pnpm run test.e2e.qwik-react.${{ matrix.settings.browser }}
+        run: pnpm exec playwright test e2e/qwik-react-e2e/tests --project=${{ matrix.settings.browser }} --config=e2e/qwik-react-e2e/playwright.config.ts --shard=${{ matrix.settings.shard }}/${{ matrix.settings.shardTotal }}
       - name: CLI E2E Tests
         if: matrix.settings.run-cli
-        run: pnpm run test.e2e.cli.${{ matrix.settings.browser }}
+        run: pnpm --filter qwik-cli-e2e exec vitest run --config=vite.config.ts --shard=${{ matrix.settings.cliShard }}/${{ matrix.settings.cliShardTotal }}
+        env:
+          PW_BROWSER: ${{ matrix.settings.browser }}
 
   save-e2e-tests-cache:
     name: Save E2E Tests Cache
@@ -1121,7 +1314,7 @@ jobs:
 
       - name: "Verify pnpm dedupe"
         if: always()
-        run: pnpm dedupe --check
+        run: NPM_CONFIG_USERCONFIG=/dev/null pnpm --config.platform=linux --config.arch=x64 dedupe --check
 
       - name: SyncPack Check
         if: always()
@@ -1158,6 +1351,7 @@ jobs:
     # don't run on forks
     if: |
       always() && 
+      github.event_name != 'pull_request' &&
       github.repository == 'QwikDev/qwik' && (
         github.ref == 'refs/heads/build/v2' ||
         needs.test-unit.result == 'success' || 
@@ -1245,19 +1439,16 @@ jobs:
 
     needs:
       - changes
-      - build-qwik
       - combined-optimizer
       - build-other-packages
 
     # Publish previews as soon as the build is ready, regardless of test status.
-    # Accept `skipped` because build jobs are skipped on cache hits.
     if: |
       always() &&
       github.repository == 'QwikDev/qwik' &&
       github.event_name != 'workflow_dispatch' &&
-      (needs.build-qwik.result == 'success' || needs.build-qwik.result == 'skipped') &&
       (needs.combined-optimizer.result == 'success' || needs.combined-optimizer.result == 'skipped') &&
-      (needs.build-other-packages.result == 'success' || needs.build-other-packages.result == 'skipped')
+      needs.build-other-packages.result == 'success'
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,9 @@ jobs:
       - name: Restore artifacts
         if: needs.changes.outputs.build-rust == 'true'
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-bindings-*'
+          merge-multiple: false
 
       - name: Move Rust Artifacts
         if: needs.changes.outputs.build-rust == 'true'
@@ -545,11 +548,21 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
 
       - run: pnpm install --frozen-lockfile
       - name: Build Qwik Insights
@@ -592,11 +605,21 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
 
       - run: pnpm install --frozen-lockfile
       - name: Build Qwik Docs
@@ -727,11 +750,28 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
+
+      - name: Download Docs Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: artifact-docs
+          path: artifact-docs
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
+          artifact-docs
 
       - run: pnpm install --frozen-lockfile
 
@@ -822,11 +862,21 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
 
       - run: pnpm install --frozen-lockfile
 
@@ -867,18 +917,13 @@ jobs:
     needs:
       - changes
       - build-other-packages
-      - build-docs
 
     steps:
       - name: Verify prerequisites
         if: |
           !(
             needs.changes.result == 'success' &&
-            needs.build-other-packages.result == 'success' &&
-            (
-              needs.build-docs.result == 'success' ||
-              needs.build-docs.result == 'skipped'
-            )
+            needs.build-other-packages.result == 'success'
           )
         run: exit 1
 
@@ -893,11 +938,21 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
 
       - run: pnpm install --frozen-lockfile
 
@@ -979,11 +1034,19 @@ jobs:
           - host: macos-latest
             browser: webkit
             shard: 1
-            shardTotal: 2
+            shardTotal: 4
           - host: macos-latest
             browser: webkit
             shard: 2
-            shardTotal: 2
+            shardTotal: 4
+          - host: macos-latest
+            browser: webkit
+            shard: 3
+            shardTotal: 4
+          - host: macos-latest
+            browser: webkit
+            shard: 4
+            shardTotal: 4
 
     runs-on: ${{ matrix.settings.host }}
     env:
@@ -1010,11 +1073,21 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
 
       - run: pnpm install --frozen-lockfile
 
@@ -1195,11 +1268,21 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
 
       - run: pnpm install --frozen-lockfile
 
@@ -1389,11 +1472,21 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v8
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
 
       - run: pnpm install --frozen-lockfile
 
@@ -1462,11 +1555,21 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - name: Download Build Artifacts
+      - name: Download Package Artifacts
         uses: actions/download-artifact@v4
+        with:
+          pattern: 'artifact-{optimizer,qwik,qwikrouter,qwikreact,create-qwik,eslint-plugin-qwik}'
+          merge-multiple: false
 
       - name: Move Distribution Artifacts
-        run: pnpm ci.restore-artifacts
+        run: >
+          pnpm ci.restore-artifacts
+          artifact-optimizer
+          artifact-qwik
+          artifact-qwikrouter
+          artifact-qwikreact
+          artifact-create-qwik
+          artifact-eslint-plugin-qwik
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,8 +418,12 @@ jobs:
           mkdir -p packages/optimizer/bindings/
           pnpm install --frozen-lockfile
 
+      - name: 'build: qwik and packages'
+        if: needs.changes.outputs.build-qwik == 'true' && needs.changes.outputs.build-others == 'true'
+        run: pnpm build --qwik --optimizer --insights --tsc --api --qwikrouter --cli --qwikreact --eslint --set-dist-tag="${{ needs.changes.outputs.disttag }}"
+
       - name: 'build: qwik'
-        if: needs.changes.outputs.build-qwik == 'true'
+        if: needs.changes.outputs.build-qwik == 'true' && needs.changes.outputs.build-others != 'true'
         # Also build optimizer for now
         run: pnpm build --qwik --optimizer --insights --set-dist-tag="${{ needs.changes.outputs.disttag }}"
 
@@ -451,7 +455,7 @@ jobs:
           if-no-files-found: error
 
       - name: 'build: qwik-router & others'
-        if: needs.changes.outputs.build-others == 'true'
+        if: needs.changes.outputs.build-others == 'true' && needs.changes.outputs.build-qwik != 'true'
         run: pnpm build --tsc --api --qwikrouter --cli --qwikreact --eslint --set-dist-tag="${{ needs.changes.outputs.disttag }}"
       - name: Save others cache
         if: needs.changes.outputs.build-others == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,8 @@ jobs:
           path: packages/qwik/dist
           # Note that this includes the package.json of qwik
           # qwik-vite source is bundled into packages/qwik/dist/optimizer.mjs by scripts/submodule-optimizer.ts, so its sources must invalidate this cache.
-          key: ${{ hashfiles('.github/workflows/ci.yml', 'pnpm-lock.yaml', 'scripts.json', 'scripts/**/*', 'packages/qwik/**/*', 'packages/qwik-vite/**/*', 'starters/features/**/*', 'starters/adapters/**/*', 'starters/templates/**/*', '!**/*.unit.*', '!**/*.rs', '!e2e/qwik-e2e/apps/e2e') }}
+          # CI-only helpers should not invalidate compiled package output caches.
+          key: ${{ hashfiles('pnpm-lock.yaml', 'scripts.json', 'scripts/**/*', '!scripts/ci-restore-artifacts.ts', 'packages/qwik/**/*', 'packages/qwik-vite/**/*', 'starters/features/**/*', 'starters/adapters/**/*', 'starters/templates/**/*', '!**/*.unit.*', '!**/*.rs', '!e2e/qwik-e2e/apps/e2e') }}
       - run: 'echo ${{ steps.cache-qwik.outputs.cache-primary-key }} > qwik-key.txt'
       - name: 'check cache: rust'
         id: cache-rust
@@ -153,7 +154,7 @@ jobs:
         with:
           lookup-only: true
           path: packages/optimizer/
-          key: ${{ hashfiles('.github/workflows/ci.yml', 'Makefile', 'rust-toolchain', '**/Cargo.toml', '**/Cargo.lock', '**/*.rs') }}
+          key: ${{ hashfiles('Makefile', 'rust-toolchain', '**/Cargo.toml', '**/Cargo.lock', '**/*.rs') }}
       - run: 'echo ${{ steps.cache-rust.outputs.cache-primary-key }} > rust-key.txt'
       - name: 'check cache: others'
         id: cache-others
@@ -197,7 +198,7 @@ jobs:
         with:
           lookup-only: true
           path: bench-tests-completed.txt
-          key: ${{ hashfiles('others-key.txt', 'packages/**/*.bench.*', 'scripts/validate-bench*', 'packages/docs/**/*') }}
+          key: ${{ hashfiles('others-key.txt', 'packages/**/*.bench.*', 'scripts/validate-bench*') }}
       - name: 'check cache: e2e tests'
         id: cache-e2e
         uses: actions/cache/restore@v5

--- a/e2e/qwik-e2e/playwright.config.ts
+++ b/e2e/qwik-e2e/playwright.config.ts
@@ -18,9 +18,7 @@ expect.extend({
 
 const config: PlaywrightTestConfig = {
   use: {
-    launchOptions: {
-      slowMo: 100,
-    },
+    ...(inGithubCI ? {} : { launchOptions: { slowMo: 100 } }),
     viewport: {
       width: 520,
       height: 600,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8696,9 +8696,6 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nan@2.26.2:
-    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
-
   nano-spawn@2.1.0:
     resolution: {integrity: sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==}
     engines: {node: '>=20.17'}
@@ -10868,10 +10865,6 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unix-dgram@2.0.7:
-    resolution: {integrity: sha512-pWaQorcdxEUBFIKjCqqIlQaOoNVmchyoaNAJ/1LwyyfK2XSxcBhgJNiSE8ZRhR0xkNGyk4xInt1G03QPoKXY5A==}
-    engines: {node: '>=0.10.48'}
-
   unixify@1.0.0:
     resolution: {integrity: sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==}
     engines: {node: '>=0.10.0'}
@@ -11521,6 +11514,9 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+ignoredOptionalDependencies:
+  - unix-dgram
 
 snapshots:
 
@@ -18288,9 +18284,7 @@ snapshots:
     dependencies:
       lru-cache: 11.3.3
 
-  hot-shots@11.4.0:
-    optionalDependencies:
-      unix-dgram: 2.0.7
+  hot-shots@11.4.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -20078,9 +20072,6 @@ snapshots:
   mute-stream@0.0.8: {}
 
   mute-stream@3.0.0: {}
-
-  nan@2.26.2:
-    optional: true
 
   nano-spawn@2.1.0: {}
 
@@ -22750,12 +22741,6 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
-
-  unix-dgram@2.0.7:
-    dependencies:
-      bindings: 1.5.0
-      nan: 2.26.2
-    optional: true
 
   unixify@1.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,8 +15,10 @@ onlyBuiltDependencies:
   - puppeteer
   - sharp
   - simple-git-hooks
-  - unix-dgram
   - workerd
+
+ignoredOptionalDependencies:
+  - unix-dgram
 
 overrides:
   '@builder.io/qwik': link:./packages/qwik

--- a/scripts/ci-restore-artifacts.ts
+++ b/scripts/ci-restore-artifacts.ts
@@ -11,24 +11,53 @@ import { join, resolve } from 'node:path';
 const root = resolve(import.meta.dirname, '..');
 
 /** Each entry maps an artifact source to its package destination. */
-const artifacts: Array<{ src: string; dest: string }> = [
-  { src: 'artifact-qwik', dest: 'packages/qwik/dist' },
-  { src: 'artifact-optimizer', dest: 'packages/optimizer' },
-  { src: 'artifact-qwikrouter', dest: 'packages/qwik-router/lib' },
-  { src: 'artifact-create-qwik', dest: 'packages/create-qwik/dist' },
-  { src: 'artifact-eslint-plugin-qwik', dest: 'packages/eslint-plugin-qwik/dist' },
+const artifacts: Array<{ artifact: string; src: string; dest: string }> = [
+  { artifact: 'artifact-qwik', src: 'artifact-qwik', dest: 'packages/qwik/dist' },
+  { artifact: 'artifact-optimizer', src: 'artifact-optimizer', dest: 'packages/optimizer' },
+  {
+    artifact: 'artifact-qwikrouter',
+    src: 'artifact-qwikrouter',
+    dest: 'packages/qwik-router/lib',
+  },
+  {
+    artifact: 'artifact-create-qwik',
+    src: 'artifact-create-qwik',
+    dest: 'packages/create-qwik/dist',
+  },
+  {
+    artifact: 'artifact-eslint-plugin-qwik',
+    src: 'artifact-eslint-plugin-qwik',
+    dest: 'packages/eslint-plugin-qwik/dist',
+  },
   // qwik-react artifact nests its output in a `lib` subdirectory
-  { src: 'artifact-qwikreact', dest: 'packages/qwik-react/lib' },
+  { artifact: 'artifact-qwikreact', src: 'artifact-qwikreact', dest: 'packages/qwik-react/lib' },
   // docs build output (upload LCA is packages/docs/, so paths are relative to that)
-  { src: 'artifact-docs/dist', dest: 'packages/docs/dist' },
-  { src: 'artifact-docs/server', dest: 'packages/docs/server' },
+  { artifact: 'artifact-docs', src: 'artifact-docs/dist', dest: 'packages/docs/dist' },
+  { artifact: 'artifact-docs', src: 'artifact-docs/server', dest: 'packages/docs/server' },
 ];
+
+const requestedArtifacts = new Set(process.argv.slice(2));
+const knownArtifacts = new Set(artifacts.map(({ artifact }) => artifact));
+
+for (const artifact of requestedArtifacts) {
+  if (!knownArtifacts.has(artifact)) {
+    throw new Error(`Unknown artifact allowlist entry: ${artifact}`);
+  }
+}
 
 let restored = 0;
 
-for (const { src, dest } of artifacts) {
+for (const { artifact, src, dest } of artifacts) {
+  const required = requestedArtifacts.has(artifact);
+  if (requestedArtifacts.size > 0 && !required) {
+    continue;
+  }
+
   const srcPath = join(root, src);
   if (!existsSync(srcPath)) {
+    if (required) {
+      throw new Error(`Required artifact source not found: ${src}`);
+    }
     console.log(`  skip: ${src} (not found)`);
     continue;
   }
@@ -46,4 +75,4 @@ for (const entry of readdirSync(root)) {
   }
 }
 
-console.log(`Restored ${restored} artifact(s).`);
+console.log(`Restored ${restored} artifact path(s).`);


### PR DESCRIPTION
## Summary

- restore/save the optimizer cache using the same `packages/optimizer/` path
- make `combined-optimizer` always upload `artifact-optimizer`, from either cache or a fresh native build
- merge the Qwik and dependent package builds into one `pnpm build` invocation when both caches miss
- scope artifact downloads so jobs fetch only the package/docs artifacts they need
- add an artifact allowlist to `pnpm ci.restore-artifacts`
- restore/upload package artifacts on package cache hits
- start E2E, unit, benchmark, docs, insights, and `pkg.pr.new` jobs as soon as build artifacts are ready
- keep `pkg.pr.new` previews publishing for draft PRs; only the npm release job is skipped on PRs
- cache Playwright browser installs separately from per-job `pnpm install`
- shard main E2E: Ubuntu 2 shards, Windows 4 shards, macOS WebKit 4 shards
- shard CLI E2E by runtime/host, with Windows node shards split across 4 shards
- shard docs E2E into 2 shards
- decouple benchmarks from the docs build path
- keep Playwright `slowMo` for local debugging only, not GitHub CI
- avoid invalidating compiled package caches for CI-only workflow/helper changes
- skip the optional `unix-dgram` native dependency; it is pulled through Netlify telemetry tooling and was dominating Windows install time without being used by these CI paths
- rebased onto `build/v2` after #8700, which includes the flaky `use-visible-task` test fix

## CI speedups

Baseline is comparable pre-change GitHub Actions run `27032427822`. Latest measured run is `27073909583` at `938b1e736`, and the full Qwik CI passed.

| Scenario | Before | After | Faster | Main fix |
| --- | ---: | ---: | ---: | --- |
| Full workflow terminal time | 15m 28s | 7m 31s | 51.4% | Earlier fan-out, scoped artifacts, Playwright cache, sharded E2E, Windows install fix |
| Requirements gate time | 14m 58s | 7m 28s | 50.1% | Faster critical path into E2E/docs/benchmark jobs |
| Time to test fan-out | 5m 24s | 2m 31s | 53.4% | Tests start after build artifacts, not after unit tests |
| Main E2E path complete | 15m 00s | 6m 16s | 58.2% | Ubuntu 2-way, Windows 4-way, macOS WebKit 4-way sharding |
| CLI E2E path complete | 13m 41s | 6m 59s | 49.0% | Runtime/host sharding plus Windows optional-native install fix |
| Docs E2E path complete | 10m 29s | 7m 31s | 28.3% | 2-way docs sharding plus docs-only artifact downloads |
| Benchmark path complete | 10m 55s | 4m 26s | 59.4% | Benchmarks no longer wait for Build Docs |
| Build Docs path complete | 9m 19s | 6m 14s | 33.1% | Scoped package artifact restore/download path |

| E2E job group | Before | After slowest shard | Faster | Main fix |
| --- | ---: | ---: | ---: | --- |
| Windows main E2E | 9m 29s | 2m 24s | 74.7% | 4 shards, cached Playwright browser install, skipped unused `unix-dgram` build |
| macOS WebKit main E2E | 7m 25s | 3m 02s | 59.1% | WebKit moved from 2 to 4 shards |
| Ubuntu main E2E | 3m 52s | 2m 29s | 35.8% | 2 shards and cached Playwright browser install |
| Windows CLI E2E | 8m 06s | 2m 53s | 64.4% | Windows node CLI split across 4 shards and skipped unused `unix-dgram` build |
| macOS CLI E2E | 3m 23s | 1m 56s | 42.9% | CLI runtime/host split |
| Ubuntu node CLI E2E | 2m 18s | 2m 18s | 0.0% | Not a current bottleneck; run-to-run variance dominates |

| Windows install hotspot | Before | After | Faster | Why |
| --- | ---: | ---: | ---: | --- |
| Main E2E `pnpm install` slowest shard | 2m 15s | 24s | 82.2% | Avoids compiling optional `unix-dgram` native module |
| CLI E2E `pnpm install` slowest shard | 3m 03s | 25s | 86.3% | Avoids compiling optional `unix-dgram` native module |

`unix-dgram` is optional under `hot-shots`, pulled in by Netlify-related tooling. It was building a native module on Windows via `node-gyp` even though these Qwik CI jobs do not use Unix datagram socket telemetry. If a future CI path actually needs that optional module, the failure should be deterministic rather than flaky.

## Validation

- `/private/tmp/actionlint-1.7.12/actionlint -color=false .github/workflows/ci.yml`
- `/Users/jacksm5pro/dev/open-source/qwik/node_modules/.bin/prettier --no-config --single-quote --trailing-comma es5 --print-width 100 --tab-width 2 --check .github/workflows/ci.yml scripts/ci-restore-artifacts.ts e2e/qwik-e2e/playwright.config.ts`
- `/Users/jacksm5pro/dev/open-source/qwik/node_modules/.bin/prettier --no-config --single-quote --trailing-comma es5 --print-width 100 --tab-width 2 --check pnpm-workspace.yaml pnpm-lock.yaml`
- `CI=true NPM_CONFIG_USERCONFIG=/dev/null pnpm install --frozen-lockfile --reporter append-only`
- `git diff --check`
- `NPM_CONFIG_USERCONFIG=/dev/null pnpm --config.platform=linux --config.arch=x64 dedupe --check`
- GitHub Actions run `27073909583`: full Qwik CI passed

## Security notes

- cache restores use exact content-derived keys without `restore-keys`
- optimizer cache restores require `fail-on-cache-miss`
- no new secrets or elevated permissions were added
- cached optimizer output is re-uploaded as a same-run artifact only after cache/build prerequisite checks pass
