### PR TITLE
fix(docs): prevent arcade font fallback flicker

### DIFF
--- a/packages/docs/src/global.css
+++ b/packages/docs/src/global.css
@@ -49,7 +49,7 @@
   src: url('./media/fonts/karmatic-arcade/karmatic-arcade.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -80,7 +80,7 @@
   --breakpoint-2xl: 90rem;
 
   /* Font families */
-  --font-display: 'Karmatic Arcade', cursive;
+  --font-display: 'Karmatic Arcade', sans-serif;
   --font-heading: 'Tomorrow', sans-serif;
   --font-body: 'Ubuntu Sans', sans-serif;
 

--- a/packages/docs/src/root.tsx
+++ b/packages/docs/src/root.tsx
@@ -3,6 +3,7 @@ import { Insights } from '@qwik.dev/core/insights';
 import { RouterOutlet, useQwikRouter } from '@qwik.dev/router';
 import { RouterHead } from './components/router-head/router-head';
 import { GlobalStore, type SiteStore } from './context';
+import karmaticArcadeFontUrl from './media/fonts/karmatic-arcade/karmatic-arcade.woff2?url';
 
 import styles from './global.css?inline';
 
@@ -35,6 +36,14 @@ export default component$(() => {
 
         <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
         <link rel="icon" href="/favicons/favicon.svg" type="image/svg+xml" />
+        <link
+          rel="preload"
+          href={karmaticArcadeFontUrl}
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+          fetchPriority="high"
+        />
 
         <RouterHead />
 


### PR DESCRIPTION
## Summary
- preload the Karmatic Arcade font from the docs root document
- block fallback painting for the arcade display face and use a neutral fallback

## Verification
- pnpm prettier --check packages/docs/src/root.tsx packages/docs/src/global.css
- git diff --check -- packages/docs/src/root.tsx packages/docs/src/global.css
- local headless Chrome check confirmed the font preload and font-display: block