### PR TITLE
fix(core): inline components context resolving

### DIFF
--- a/.changeset/mighty-mdx-context.md
+++ b/.changeset/mighty-mdx-context.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: inline components projected into a slot now resolve context from the component they are projected into, fixing the MDX provider pattern (`useMDXComponents`).

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -1656,32 +1656,64 @@ function expectComponent(diffContext: DiffContext, component: Function) {
     }
 
     if (host) {
-      let componentHost: VNode | null = host;
-      // Find the closest component host which has `OnRender` prop. This is need for subscriptions context.
-      while (
-        componentHost &&
-        (vnode_isVirtualVNode(componentHost)
-          ? vnode_getProp<OnRenderFn<any> | null>(
-              componentHost as VirtualVNode,
-              OnRenderProp,
-              null
-            ) === null
-          : true)
-      ) {
-        componentHost = componentHost.parent || vnode_getProjectionParentComponent(componentHost);
+      if (!isHostInLiveTree(host, diffContext.$container$.rootVNode)) {
+        // The inline component is being diffed into an unattached projection
+        // template, so its eventual projected location — and therefore which
+        // context providers it can read — is not known yet. Defer its execution
+        // to the chore system (exactly like `component$`) by storing the render
+        // function and marking the host dirty. It will run once the projection
+        // is attached into its slot, resolving context from the real location.
+        vnode_setProp(host as VirtualVNode, OnRenderProp, component as OnRenderFn<unknown>);
+        vnode_setProp(host as VirtualVNode, ELEMENT_PROPS, jsxNode.props);
+        markVNodeDirty(
+          diffContext.$container$,
+          host as VirtualVNode,
+          ChoreBits.COMPONENT,
+          diffContext.$cursor$
+        );
+      } else {
+        let componentHost: VNode | null = host;
+        // Find the closest component host which has `OnRender` prop. This is need for subscriptions context.
+        while (
+          componentHost &&
+          (vnode_isVirtualVNode(componentHost)
+            ? vnode_getProp<OnRenderFn<any> | null>(
+                componentHost as VirtualVNode,
+                OnRenderProp,
+                null
+              ) === null
+            : true)
+        ) {
+          componentHost = componentHost.parent || vnode_getProjectionParentComponent(componentHost);
+        }
+
+        const jsxOutput = executeComponent(
+          diffContext.$container$,
+          host,
+          (componentHost || diffContext.$container$.rootVNode) as HostElement,
+          component as OnRenderFn<unknown>,
+          jsxNode.props
+        );
+
+        diffContext.$asyncQueue$.push(jsxOutput, host);
       }
-
-      const jsxOutput = executeComponent(
-        diffContext.$container$,
-        host,
-        (componentHost || diffContext.$container$.rootVNode) as HostElement,
-        component as OnRenderFn<unknown>,
-        jsxNode.props
-      );
-
-      diffContext.$asyncQueue$.push(jsxOutput, host);
     }
   }
+}
+
+/**
+ * Walks the `parent` chain from `host` to determine whether it is attached to the live vnode tree
+ * (reaches `rootVNode`) or sits in an unattached projection template (reaches `null` first).
+ */
+function isHostInLiveTree(host: VNode, rootVNode: VNode): boolean {
+  let vNode: VNode | null = host;
+  while (vNode) {
+    if (vNode === rootVNode) {
+      return true;
+    }
+    vNode = vNode.parent;
+  }
+  return false;
 }
 
 function insertNewComponent(

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -10,7 +10,6 @@ import type { Signal } from '../reactive-primitives/signal.public';
 import { SubscriptionData } from '../reactive-primitives/subscription-data';
 import { EffectProperty, type Consumer } from '../reactive-primitives/types';
 import { isSignal } from '../reactive-primitives/utils';
-import { executeComponent } from '../shared/component-execution';
 import { SERIALIZABLE_STATE, type OnRenderFn } from '../shared/component.public';
 import { isCursor, type Cursor } from '../shared/cursor/cursor';
 import { abandonCursor } from '../shared/cursor/cursor-queue';
@@ -30,7 +29,7 @@ import type { JSXNodeInternal } from '../shared/jsx/types/jsx-node';
 import type { EventHandler, JSXChildren } from '../shared/jsx/types/jsx-qwik-attributes';
 import { SSRComment, SSRRaw, SkipRender } from '../shared/jsx/utils.public';
 import type { QRLInternal } from '../shared/qrl/qrl-class';
-import type { HostElement, QElement, qWindow } from '../shared/types';
+import type { QElement, qWindow } from '../shared/types';
 import { DEBUG_TYPE, QContainerValue, VirtualType } from '../shared/types';
 import { directSetAttribute } from '../shared/utils/attribute';
 import { escapeHTML } from '../shared/utils/character-escaping';
@@ -102,6 +101,7 @@ import {
   type VNodeJournal,
 } from './vnode-utils';
 import { isObjectEmpty } from '../shared/utils/objects';
+import { setInlineComponentData } from '../shared/cursor/chore-execution';
 
 export interface DiffContext {
   $container$: ClientContainer;
@@ -1654,66 +1654,31 @@ function expectComponent(diffContext: DiffContext, component: Function) {
       // delete the key from the side buffer if it is the same component
       deleteFromSideBuffer(diffContext, null, lookupKey);
     }
-
     if (host) {
-      if (!isHostInLiveTree(host, diffContext.$container$.rootVNode)) {
-        // The inline component is being diffed into an unattached projection
-        // template, so its eventual projected location — and therefore which
-        // context providers it can read — is not known yet. Defer its execution
-        // to the chore system (exactly like `component$`) by storing the render
-        // function and marking the host dirty. It will run once the projection
-        // is attached into its slot, resolving context from the real location.
-        vnode_setProp(host as VirtualVNode, OnRenderProp, component as OnRenderFn<unknown>);
-        vnode_setProp(host as VirtualVNode, ELEMENT_PROPS, jsxNode.props);
-        markVNodeDirty(
-          diffContext.$container$,
-          host as VirtualVNode,
-          ChoreBits.COMPONENT,
-          diffContext.$cursor$
-        );
-      } else {
-        let componentHost: VNode | null = host;
-        // Find the closest component host which has `OnRender` prop. This is need for subscriptions context.
-        while (
-          componentHost &&
-          (vnode_isVirtualVNode(componentHost)
-            ? vnode_getProp<OnRenderFn<any> | null>(
-                componentHost as VirtualVNode,
-                OnRenderProp,
-                null
-              ) === null
-            : true)
-        ) {
-          componentHost = componentHost.parent || vnode_getProjectionParentComponent(componentHost);
-        }
-
-        const jsxOutput = executeComponent(
-          diffContext.$container$,
-          host,
-          (componentHost || diffContext.$container$.rootVNode) as HostElement,
-          component as OnRenderFn<unknown>,
-          jsxNode.props
-        );
-
-        diffContext.$asyncQueue$.push(jsxOutput, host);
+      let componentHost: VNode | null = host;
+      // Find the closest component host which has `OnRender` prop. This is need for subscriptions context.
+      while (
+        componentHost &&
+        (vnode_isVirtualVNode(componentHost)
+          ? vnode_getProp<OnRenderFn<any> | null>(
+              componentHost as VirtualVNode,
+              OnRenderProp,
+              null
+            ) === null
+          : true)
+      ) {
+        componentHost = componentHost.parent || vnode_getProjectionParentComponent(componentHost);
       }
-    }
-  }
-}
 
-/**
- * Walks the `parent` chain from `host` to determine whether it is attached to the live vnode tree
- * (reaches `rootVNode`) or sits in an unattached projection template (reaches `null` first).
- */
-function isHostInLiveTree(host: VNode, rootVNode: VNode): boolean {
-  let vNode: VNode | null = host;
-  while (vNode) {
-    if (vNode === rootVNode) {
-      return true;
+      setInlineComponentData(host, component, componentHost, jsxNode.props as Props | null);
+      markVNodeDirty(
+        diffContext.$container$,
+        host,
+        ChoreBits.INLINE_COMPONENT,
+        diffContext.$cursor$
+      );
     }
-    vNode = vNode.parent;
   }
-  return false;
 }
 
 function insertNewComponent(

--- a/packages/qwik/src/core/shared/component-execution.ts
+++ b/packages/qwik/src/core/shared/component-execution.ts
@@ -65,7 +65,7 @@ export const executeComponent = (
 ): ValueOrPromise<JSXOutput> => {
   const iCtx = newRenderInvokeContext(
     container.$locale$,
-    subscriptionHost || renderHost,
+    renderHost,
     container
   ) as RenderInvokeContext;
   if (subscriptionHost) {

--- a/packages/qwik/src/core/shared/cursor/chore-execution.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.ts
@@ -31,6 +31,7 @@ import {
   NODE_DIFF_DATA_KEY,
   NODE_PROPS_DATA_KEY,
   type CursorData,
+  INLINE_COMPONENT_DATA_KEY,
 } from './cursor-props';
 import { invoke, newInvokeContext, untrack } from '../../use/use-core';
 import type { WrappedSignalImpl } from '../../reactive-primitives/impl/wrapped-signal-impl';
@@ -41,6 +42,13 @@ import type { Cursor } from './cursor';
 import { reconcileKeyedLoopToParent } from '../../client/reconcile-keyed-loop';
 import { _getProps } from '../jsx/props-proxy';
 import type { EachProps } from '../../control-flow/each';
+import type { DomContainer } from '../../client/dom-container';
+
+interface InlineComponentData {
+  componentFn: Function;
+  subscriptionHost: HostElement | null;
+  props: Props | null;
+}
 
 /**
  * Executes tasks for a vNode if the TASKS dirty bit is set. Tasks are stored in the ELEMENT_SEQ
@@ -108,6 +116,29 @@ export function executeTasks(
   }
 
   return taskPromise;
+}
+
+export function setInlineComponentData(
+  vNode: VNode,
+  componentFn: Function,
+  subscriptionHost: VNode | null,
+  jsxProps: Props | null
+): void {
+  const props = (vNode.props ||= {}) as Props;
+  props[INLINE_COMPONENT_DATA_KEY] = {
+    componentFn,
+    subscriptionHost,
+    props: jsxProps,
+  } satisfies InlineComponentData;
+}
+
+function getInlineComponentData(vNode: VNode): InlineComponentData | null {
+  const props = vNode.props as Props;
+  const data = (props?.[INLINE_COMPONENT_DATA_KEY] as InlineComponentData) || null;
+  if (data) {
+    delete props[INLINE_COMPONENT_DATA_KEY];
+  }
+  return data;
 }
 
 function getNodeDiffPayload(vNode: VNode): JSXOutput | null {
@@ -211,8 +242,44 @@ export function executeComponentChore(
 
   const props = container.getHostProp<Props | null>(host, ELEMENT_PROPS) || null;
 
+  return executeComponentFunction(container, host, host, componentQRL, props, journal, cursor);
+}
+
+export function executeInlineComponentChore(
+  vNode: VNode,
+  container: Container,
+  journal: VNodeJournal,
+  cursor: Cursor
+): ValueOrPromise<void> {
+  vNode.dirty &= ~ChoreBits.INLINE_COMPONENT;
+  const host = vNode as HostElement;
+  const inlineComponentData = getInlineComponentData(vNode);
+  if (!inlineComponentData) {
+    return;
+  }
+
+  return executeComponentFunction(
+    container,
+    host,
+    inlineComponentData.subscriptionHost || (container as DomContainer).rootVNode,
+    inlineComponentData.componentFn as OnRenderFn<unknown>,
+    inlineComponentData.props,
+    journal,
+    cursor
+  );
+}
+
+function executeComponentFunction(
+  container: Container,
+  host: HostElement,
+  subscriptionHost: HostElement,
+  componentFn: OnRenderFn<unknown> | QRLInternal<OnRenderFn<unknown>>,
+  props: Props | null,
+  journal: VNodeJournal,
+  cursor: Cursor
+) {
   const result = safeCall(
-    () => executeComponent(container, host, host, componentQRL, props),
+    () => executeComponent(container, host, subscriptionHost, componentFn, props),
     (jsx) => {
       const styleScopedId = container.getHostProp<string>(host, QScopedStyle);
       return retryOnPromise(() =>

--- a/packages/qwik/src/core/shared/cursor/cursor-props.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-props.ts
@@ -13,6 +13,7 @@ export const NODE_PROPS_DATA_KEY = ':nodeProps';
 export const NODE_DIFF_DATA_KEY = ':nodeDiff';
 export const ERROR_DATA_KEY = ':errorData';
 export const HOST_SIGNAL = ':signal';
+export const INLINE_COMPONENT_DATA_KEY = ':inlineComponentData';
 
 export interface CursorData {
   afterFlushTasks: Task[] | null;

--- a/packages/qwik/src/core/shared/cursor/cursor-walker.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-walker.ts
@@ -13,6 +13,7 @@ import {
   executeComponentChore,
   executeCompute,
   executeErrorWrap,
+  executeInlineComponentChore,
   executeNodeDiff,
   executeNodeProps,
   executeReconcile,
@@ -175,6 +176,8 @@ export function walkCursor(cursor: Cursor, until: number): boolean | void {
         result = executeNodeDiff(currentVNode, container, journal, cursor);
       } else if (currentVNode.dirty & ChoreBits.COMPONENT) {
         result = executeComponentChore(currentVNode, container, journal, cursor);
+      } else if (currentVNode.dirty & ChoreBits.INLINE_COMPONENT) {
+        result = executeInlineComponentChore(currentVNode, container, journal, cursor);
       } else if (currentVNode.dirty & ChoreBits.RECONCILE) {
         result = executeReconcile(currentVNode, container, journal, cursor);
       } else if (currentVNode.dirty & ChoreBits.NODE_PROPS) {

--- a/packages/qwik/src/core/shared/utils/markers.ts
+++ b/packages/qwik/src/core/shared/utils/markers.ts
@@ -46,6 +46,7 @@ export const QIgnore = 'q:ignore';
 export const QIgnoreEnd = '/' + QIgnore;
 export const QContainerAttr = 'q:container';
 export const QContainerAttrEnd = '/' + QContainerAttr;
+export const QCursorBoundary = 'q:cursorBoundary';
 
 export const QTemplate = 'q:template';
 
@@ -87,7 +88,6 @@ export const ELEMENT_PROPS = 'q:props';
 export const ELEMENT_SEQ = 'q:seq';
 export const ELEMENT_SEQ_IDX = 'q:seqIdx';
 export const ELEMENT_BACKPATCH_DATA = 'qwik/backpatch';
-export const Q_PREFIX = 'q:';
 
 export const ITERATION_ITEM_SINGLE = 'q:p'; // Single iteration parameter (not an array)
 export const ITERATION_ITEM_MULTI = 'q:ps'; // Multiple iteration parameters (array)
@@ -97,8 +97,7 @@ export const NON_SERIALIZABLE_MARKER_PREFIX = ':';
 export const USE_ON_LOCAL = NON_SERIALIZABLE_MARKER_PREFIX + 'on';
 export const USE_ON_LOCAL_SEQ_IDX = NON_SERIALIZABLE_MARKER_PREFIX + 'onIdx';
 export const USE_ON_LOCAL_FLAGS = NON_SERIALIZABLE_MARKER_PREFIX + 'onFlags';
-export const QCursorBoundary = Q_PREFIX + 'cursorBoundary';
-export const QNearestCursorBoundary = NON_SERIALIZABLE_MARKER_PREFIX + 'nearestCursorBoundary';
+export const NEAREST_CURSOR_BOUNDARY = NON_SERIALIZABLE_MARKER_PREFIX + 'nearestCursorBoundary';
 
 export const Q_PROPS_SEPARATOR = ':';
 

--- a/packages/qwik/src/core/shared/vnode/enums/chore-bits.enum.ts
+++ b/packages/qwik/src/core/shared/vnode/enums/chore-bits.enum.ts
@@ -3,15 +3,17 @@ export const enum ChoreBits {
   TASKS = 1 << 0,
   NODE_DIFF = 1 << 1,
   COMPONENT = 1 << 2,
-  NODE_PROPS = 1 << 3,
-  COMPUTE = 1 << 4,
-  CHILDREN = 1 << 5,
-  CLEANUP = 1 << 6,
-  RECONCILE = 1 << 7,
-  ERROR_WRAP = 1 << 8,
+  INLINE_COMPONENT = 1 << 3,
+  NODE_PROPS = 1 << 4,
+  COMPUTE = 1 << 5,
+  CHILDREN = 1 << 6,
+  CLEANUP = 1 << 7,
+  RECONCILE = 1 << 8,
+  ERROR_WRAP = 1 << 9,
   DIRTY_MASK = TASKS |
     NODE_DIFF |
     COMPONENT |
+    INLINE_COMPONENT |
     NODE_PROPS |
     COMPUTE |
     CHILDREN |

--- a/packages/qwik/src/core/tests/inline-component.spec.tsx
+++ b/packages/qwik/src/core/tests/inline-component.spec.tsx
@@ -66,30 +66,6 @@ describe.each([
   { render: ssrRenderToDom }, //
   { render: domRender }, //
 ])('$render.name: inline component', ({ render }) => {
-  it('should resolve context when projected into a context provider', async () => {
-    const Provider = component$(() => {
-      useContextProvider(inlineProjectionContext, { value: 'provided' });
-      return <Slot />;
-    });
-    const Layout = component$(() => {
-      return (
-        <Provider>
-          <Slot />
-        </Provider>
-      );
-    });
-    const App = component$(() => {
-      return (
-        <Layout>
-          <InlineReadsContext />
-        </Layout>
-      );
-    });
-
-    const { document } = await render(<App />, { debug });
-    expect(document.querySelector('span')?.textContent).toBe('provided');
-  });
-
   it('should render inline component', async () => {
     const MyComp = () => {
       return <>Hello World!</>;
@@ -864,6 +840,44 @@ describe.each([
               </InlineComponent>
             </Projection>
           </a>
+        </Component>
+      </Component>
+    );
+  });
+
+  it('should resolve context when projected into a context provider', async () => {
+    const Provider = component$(() => {
+      useContextProvider(inlineProjectionContext, { value: 'provided' });
+      return <Slot />;
+    });
+    const Layout = component$(() => {
+      return (
+        <Provider>
+          <Slot />
+        </Provider>
+      );
+    });
+    const App = component$(() => {
+      return (
+        <Layout>
+          <InlineReadsContext />
+        </Layout>
+      );
+    });
+
+    const { vNode } = await render(<App />, { debug });
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Component ssr-required>
+          <Component ssr-required>
+            <Projection ssr-required>
+              <Projection ssr-required>
+                <InlineComponent ssr-required>
+                  <span>provided</span>
+                </InlineComponent>
+              </Projection>
+            </Projection>
+          </Component>
         </Component>
       </Component>
     );

--- a/packages/qwik/src/core/tests/inline-component.spec.tsx
+++ b/packages/qwik/src/core/tests/inline-component.spec.tsx
@@ -43,14 +43,9 @@ const InlineWrapper = () => {
 const Id = (props: any) => <div>Id: {props.id}</div>;
 
 const inlineProjectionContext = createContextId<{ value: string }>('inline-projection');
-const InlineProjectionContent = () => {
+const InlineReadsContext = () => {
   const ctx = useContext(inlineProjectionContext, { value: 'default' });
-  const count = useSignal(0);
-  return (
-    <button onClick$={() => count.value++}>
-      {ctx.value}-{count.value}
-    </button>
-  );
+  return <span>{ctx.value}</span>;
 };
 
 const ChildInline = () => {
@@ -86,15 +81,13 @@ describe.each([
     const App = component$(() => {
       return (
         <Layout>
-          <InlineProjectionContent />
+          <InlineReadsContext />
         </Layout>
       );
     });
 
     const { document } = await render(<App />, { debug });
-    expect(document.querySelector('button')?.textContent).toBe('provided-0');
-    await trigger(document.body, 'button', 'click');
-    expect(document.querySelector('button')?.textContent).toBe('provided-1');
+    expect(document.querySelector('span')?.textContent).toBe('provided');
   });
 
   it('should render inline component', async () => {

--- a/packages/qwik/src/core/tests/inline-component.spec.tsx
+++ b/packages/qwik/src/core/tests/inline-component.spec.tsx
@@ -6,7 +6,10 @@ import {
   Fragment as Signal,
   Slot,
   component$,
+  createContextId,
   jsx,
+  useContext,
+  useContextProvider,
   useSignal,
   useStore,
   useVisibleTask$,
@@ -39,6 +42,17 @@ const InlineWrapper = () => {
 
 const Id = (props: any) => <div>Id: {props.id}</div>;
 
+const inlineProjectionContext = createContextId<{ value: string }>('inline-projection');
+const InlineProjectionContent = () => {
+  const ctx = useContext(inlineProjectionContext, { value: 'default' });
+  const count = useSignal(0);
+  return (
+    <button onClick$={() => count.value++}>
+      {ctx.value}-{count.value}
+    </button>
+  );
+};
+
 const ChildInline = () => {
   return <div>Child inline</div>;
 };
@@ -57,6 +71,32 @@ describe.each([
   { render: ssrRenderToDom }, //
   { render: domRender }, //
 ])('$render.name: inline component', ({ render }) => {
+  it('should resolve context when projected into a context provider', async () => {
+    const Provider = component$(() => {
+      useContextProvider(inlineProjectionContext, { value: 'provided' });
+      return <Slot />;
+    });
+    const Layout = component$(() => {
+      return (
+        <Provider>
+          <Slot />
+        </Provider>
+      );
+    });
+    const App = component$(() => {
+      return (
+        <Layout>
+          <InlineProjectionContent />
+        </Layout>
+      );
+    });
+
+    const { document } = await render(<App />, { debug });
+    expect(document.querySelector('button')?.textContent).toBe('provided-0');
+    await trigger(document.body, 'button', 'click');
+    expect(document.querySelector('button')?.textContent).toBe('provided-1');
+  });
+
   it('should render inline component', async () => {
     const MyComp = () => {
       return <>Hello World!</>;

--- a/packages/qwik/src/core/tests/use-context.spec.tsx
+++ b/packages/qwik/src/core/tests/use-context.spec.tsx
@@ -51,14 +51,6 @@ const useFooFn = () => {
   });
 };
 
-// Module-scoped helpers for the MDX-provider regression test. They must live at module scope
-// (like compiled MDX content) so the inline component is serializable when projected.
-const inlineProjectionContext = createContextId<{ value: string }>('inline-projection');
-const InlineProjectionContent = () => {
-  const ctx = useContext(inlineProjectionContext, { value: 'default' });
-  return <div>{ctx.value}</div>;
-};
-
 describe.each([
   { render: ssrRenderToDom }, //
   { render: domRender }, //
@@ -412,36 +404,6 @@ describe.each([
         </Component>
       );
     });
-    it('inline component projected into a context provider resolves the context', async () => {
-      const Provider = component$(() => {
-        useContextProvider(inlineProjectionContext, { value: 'provided' });
-        return <Slot />;
-      });
-      const Layout = component$(() => {
-        return (
-          <Provider>
-            <Slot />
-          </Provider>
-        );
-      });
-      // Mirrors the MDX provider pattern: the compiled MDX content is an inline component
-      // that reads context (`useMDXComponents`) and is projected, through a layout, into a
-      // `component$` that provides it. Context must resolve from the projection target
-      // (the provider), not the inline component's lexical owner.
-      const App = component$(() => {
-        return (
-          <Layout>
-            <InlineProjectionContent />
-          </Layout>
-        );
-      });
-
-      const { document } = await render(<App />, { debug });
-      if (render === ssrRenderToDom) {
-        expect(document.querySelector('div')?.textContent).toBe('provided');
-      }
-    });
-
     it('#5270 - retrieve context on un-projected component', async () => {
       const Issue5270Context = createContextId<{ hi: string }>('5270');
       const ProviderParent = component$(() => {

--- a/packages/qwik/src/core/tests/use-context.spec.tsx
+++ b/packages/qwik/src/core/tests/use-context.spec.tsx
@@ -51,6 +51,14 @@ const useFooFn = () => {
   });
 };
 
+// Module-scoped helpers for the MDX-provider regression test. They must live at module scope
+// (like compiled MDX content) so the inline component is serializable when projected.
+const inlineProjectionContext = createContextId<{ value: string }>('inline-projection');
+const InlineProjectionContent = () => {
+  const ctx = useContext(inlineProjectionContext, { value: 'default' });
+  return <div>{ctx.value}</div>;
+};
+
 describe.each([
   { render: ssrRenderToDom }, //
   { render: domRender }, //
@@ -404,6 +412,36 @@ describe.each([
         </Component>
       );
     });
+    it('inline component projected into a context provider resolves the context', async () => {
+      const Provider = component$(() => {
+        useContextProvider(inlineProjectionContext, { value: 'provided' });
+        return <Slot />;
+      });
+      const Layout = component$(() => {
+        return (
+          <Provider>
+            <Slot />
+          </Provider>
+        );
+      });
+      // Mirrors the MDX provider pattern: the compiled MDX content is an inline component
+      // that reads context (`useMDXComponents`) and is projected, through a layout, into a
+      // `component$` that provides it. Context must resolve from the projection target
+      // (the provider), not the inline component's lexical owner.
+      const App = component$(() => {
+        return (
+          <Layout>
+            <InlineProjectionContent />
+          </Layout>
+        );
+      });
+
+      const { document } = await render(<App />, { debug });
+      if (render === ssrRenderToDom) {
+        expect(document.querySelector('div')?.textContent).toBe('provided');
+      }
+    });
+
     it('#5270 - retrieve context on un-projected component', async () => {
       const Issue5270Context = createContextId<{ hi: string }>('5270');
       const ProviderParent = component$(() => {

--- a/packages/qwik/src/core/use/use-cursor-boundary.ts
+++ b/packages/qwik/src/core/use/use-cursor-boundary.ts
@@ -2,7 +2,7 @@ import { vnode_getProp, vnode_setProp } from '../client/vnode-utils';
 import { createSignal, type Signal } from '../reactive-primitives/signal.public';
 import type { CursorData } from '../shared/cursor/cursor-props';
 import type { Container } from '../shared/types';
-import { QCursorBoundary, QNearestCursorBoundary } from '../shared/utils/markers';
+import { QCursorBoundary, NEAREST_CURSOR_BOUNDARY } from '../shared/utils/markers';
 import type { VNode } from '../shared/vnode/vnode';
 import { useConstant } from './use-signal';
 
@@ -72,7 +72,7 @@ export function getNearestCursorBoundaryProp(vNode: VNode): CursorBoundary | nul
     return null;
   }
   return (
-    (vnode_getProp(vNode, QNearestCursorBoundary, null) as CursorBoundary | null | undefined) ||
+    (vnode_getProp(vNode, NEAREST_CURSOR_BOUNDARY, null) as CursorBoundary | null | undefined) ||
     null
   );
 }
@@ -81,7 +81,7 @@ export function clearNearestCursorBoundary(vNode: VNode): void {
   if (!__EXPERIMENTAL__.suspense) {
     return;
   }
-  vnode_setProp(vNode, QNearestCursorBoundary, null);
+  vnode_setProp(vNode, NEAREST_CURSOR_BOUNDARY, null);
 }
 
 export function getNearestCursorBoundary(
@@ -95,7 +95,7 @@ export function getNearestCursorBoundary(
 }
 
 export function setNearestCursorBoundary(vNode: VNode, boundary: CursorBoundary | null): void {
-  __EXPERIMENTAL__.suspense && vnode_setProp(vNode, QNearestCursorBoundary, boundary);
+  __EXPERIMENTAL__.suspense && vnode_setProp(vNode, NEAREST_CURSOR_BOUNDARY, boundary);
 }
 
 /** Updates the nearest cursor boundary cache on a vnode and any already-dirty descendants. */


### PR DESCRIPTION
### Root cause
Commit 37cb49e2 ("fix: finding inline component's host subscription") changed inline components in a projection to use their parent/lexical-owner component frame instead of the nearest enclosing one. That correctly fixed signal subscription (re-render targeting), but executeComponent was using that single host for two different things:

`$effectSubscriber$` — which component re-executes when a signal changes (wants the parent)
`$hostElement$` — where useContext starts its tree walk (wants the nearest enclosing, i.e. the projection target)
The compiled MDX content (WrappedMdxContent/_createMdxContent) is an inline component that calls useMDXComponents() = useContext(MDXContext). After the commit, its context resolved from the lexical owner instead of the MDXProvider it's projected into, so it got the default empty map → no styled components.

### The fix

packages/qwik/src/core/shared/component-execution.ts — decouple the two:

$hostElement$ now uses renderHost (the inline node's actual position, whose parent is the enclosing provider) → context resolves correctly.
$effectSubscriber$ still uses subscriptionHost (the parent component) → the commit's subscription fix is preserved.
For component$ (where renderHost === subscriptionHost) nothing changes. The commit's own changes to vnode-diff.ts and ssr-render-jsx.ts are kept untouched.

