### PR TITLE
fix(core): repair OOOS Suspense state patch root serialization

### DIFF
--- a/.changeset/tame-worms-argue.md
+++ b/.changeset/tame-worms-argue.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: event handlers in out-of-order Suspense content so they resume correctly after streamed state patches

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "vitest.include": [
+    "**/*.spec.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
     "**/*.unit.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"
   ],
   "vitest.exclude": [
@@ -9,6 +10,8 @@
     "**/cypress/**",
     "**/.{idea,git,cache,output,temp}/**"
   ],
+  "vitest.shellType": "terminal",
+  "vitest.runtime": "node",
   "cSpell.words": [
     "bucketize",
     "Stringifiable"

--- a/packages/qwik/src/core/client/process-vnode-data.unit.tsx
+++ b/packages/qwik/src/core/client/process-vnode-data.unit.tsx
@@ -307,6 +307,21 @@ describe('processVnodeData', () => {
         </Fragment>
       </div>
     );
+
+    const directSegmentSectionVNode = container.vNodeLocate(section);
+    expect(directSegmentSectionVNode.parent).not.toBeNull();
+
+    const segmentSectionVNode = container.vNodeLocate(`${getSegmentVNodeRefId('1', 1)}`);
+    let parent = segmentSectionVNode.parent;
+    let foundRootHost = false;
+    while (parent) {
+      if (parent === rootHostVNode) {
+        foundRootHost = true;
+        break;
+      }
+      parent = parent.parent;
+    }
+    expect(foundRootHost).toBe(true);
   });
   it('should not cache empty children for a suspense placeholder-only result parent', () => {
     const [container] = process(`

--- a/packages/qwik/src/core/client/vnode-utils.ts
+++ b/packages/qwik/src/core/client/vnode-utils.ts
@@ -786,7 +786,7 @@ export const vnode_ensureTextInflated = (journal: VNodeJournal, vnode: TextVNode
 
 export const vnode_locate = (rootVNode: ElementVNode, id: string | Element): VNode => {
   ensureElementVNode(rootVNode);
-  let vNode: VNode | Element = rootVNode;
+  let vNode: VNode = rootVNode;
   const containerElement = rootVNode.node as ContainerElement;
   const qVNodeRefs = containerElement.qVNodeRefs;
   let elementOffset: number = -1;

--- a/packages/qwik/src/core/shared/serdes/serialization-context.ts
+++ b/packages/qwik/src/core/shared/serdes/serialization-context.ts
@@ -37,7 +37,8 @@ export interface SerializationContext {
   $serializePatch$: (
     rootStart: number,
     rootIds: number[],
-    extraRootId?: number | string | number[]
+    extraRootId?: number | string | number[],
+    streamedRootLimit?: number
   ) => ValueOrPromise<void>;
 
   $symbolToChunkResolver$: SymbolToChunkResolver;
@@ -153,9 +154,10 @@ class SerializationContextImpl implements SerializationContext {
   async $serializePatch$(
     rootStart: number,
     rootIds: number[],
-    extraRootId?: number | string | number[]
+    extraRootId?: number | string | number[],
+    streamedRootLimit?: number
   ): Promise<void> {
-    await this.$serializer$.serializePatch(rootStart, rootIds, extraRootId);
+    await this.$serializer$.serializePatch(rootStart, rootIds, extraRootId, streamedRootLimit);
   }
 
   $setWriter$(writer: SSRInternalStreamWriter): void {

--- a/packages/qwik/src/core/shared/serdes/serialize.ts
+++ b/packages/qwik/src/core/shared/serdes/serialize.ts
@@ -90,10 +90,11 @@ export class Serializer {
   async serializePatch(
     rootStart: number,
     rootIds: number[],
-    extraRootId?: number | string | number[]
+    extraRootId?: number | string | number[],
+    streamedRootLimit = rootStart
   ): Promise<void> {
     const previousStreamedRootLimit = this.$streamedRootLimit$;
-    this.$streamedRootLimit$ = rootStart;
+    this.$streamedRootLimit$ = streamedRootLimit;
     this.$writer$.write(BRACKET_OPEN);
     this.$serializationContext$.$serializedForwardRefCount$ = 0;
     try {

--- a/packages/qwik/src/core/tests/suspense.spec.tsx
+++ b/packages/qwik/src/core/tests/suspense.spec.tsx
@@ -17,6 +17,7 @@ import {
   component$,
   getDomContainer,
   type JSXOutput,
+  useAsync$,
   useErrorBoundary,
   Slot,
   useTask$,
@@ -1945,6 +1946,117 @@ describe('ssrRenderToDom: out-of-order Suspense', () => {
       resolveSlow(<span id="ooos-unit-resume-after-qo-ready">Resume after qO ready</span>);
       await renderPromise;
       delete (globalThis as any).__ooosUnitResumeAfterQOValue;
+    }
+  });
+
+  it('should keep hoisted loop event params on their own buttons in resolved segments', async () => {
+    (globalThis as any).__ooosUnitLoopNavValue = 0;
+    (globalThis as any).__ooosUnitLoopItemValue = '';
+    (globalThis as any).__ooosUnitLoopRequests = [];
+    (globalThis as any).__ooosUnitLoopResolvers = [];
+
+    type Story = { id: string; label: string };
+    const storiesForPage = (page: number): Story[] =>
+      Array.from({ length: 30 }, (_, index) => ({
+        id: `${page}-${index}`,
+        label: `Story ${page}-${index}`,
+      }));
+    const resolveNextPage = async (page: number) => {
+      await vi.waitFor(() =>
+        expect((globalThis as any).__ooosUnitLoopResolvers.length).toBeGreaterThan(0)
+      );
+      const resolve = (globalThis as any).__ooosUnitLoopResolvers.shift() as (
+        value: Story[]
+      ) => void;
+      resolve(storiesForPage(page));
+    };
+
+    const Stories = component$(
+      ({ stories, 'bind:page': page }: { stories?: Story[]; 'bind:page': { value: number } }) => (
+        <>
+          <button
+            id="ooos-unit-loop-next"
+            onClick$={() => {
+              page.value += 1;
+              (globalThis as any).__ooosUnitLoopNavValue = page.value;
+            }}
+          >
+            Next
+          </button>
+          <ul>
+            {stories?.map((story) => (
+              <button
+                id={`ooos-unit-loop-item-${story.id}`}
+                onClick$={() => {
+                  (globalThis as any).__ooosUnitLoopItemValue = story.id;
+                }}
+              >
+                {story.label}
+              </button>
+            ))}
+          </ul>
+        </>
+      )
+    );
+    const App = component$(() => {
+      const page = useSignal(0);
+      const stories = useAsync$<Story[]>(async ({ track }) => {
+        const pageNum = track(page);
+        (globalThis as any).__ooosUnitLoopRequests.push(pageNum);
+        return new Promise<Story[]>((resolve) => {
+          (globalThis as any).__ooosUnitLoopResolvers.push(resolve);
+        });
+      });
+      return (
+        <main>
+          <span id="ooos-unit-loop-page">{page.value}</span>
+          <Suspense fallback={<p>Waiting loop params</p>}>
+            <Stories stories={stories.value} bind:page={page} />
+          </Suspense>
+        </main>
+      );
+    });
+    const chunks: string[] = [];
+
+    const renderPromise = ssrRenderSuspenseStream(<App />, chunks, { debug });
+
+    try {
+      await vi.waitFor(() => expect(chunks.join('')).toContain('Waiting loop params'));
+      await resolveNextPage(0);
+      const { document, container } = await renderPromise;
+
+      expect(chunks.join('')).toContain('type="qwik/vnode" q:patch');
+      const segmentStateScript = document.querySelector('script[type="qwik/state"][q\\:patch]');
+      const [rootStart, segmentRoots] = JSON.parse(segmentStateScript!.textContent!) as [
+        number,
+        unknown[],
+      ];
+      for (let i = 0; i < segmentRoots.length; i += 2) {
+        expect([segmentRoots[i], segmentRoots[i + 1]]).not.toEqual([
+          TypeIds.RootRef,
+          rootStart + i / 2,
+        ]);
+      }
+
+      await trigger(container.element, '#ooos-unit-loop-item-0-1', 'click');
+      await waitForDrain(container);
+      expect((globalThis as any).__ooosUnitLoopItemValue).toBe('0-1');
+
+      await trigger(container.element, '#ooos-unit-loop-next', 'click');
+      await waitForDrain(container);
+      expect((globalThis as any).__ooosUnitLoopNavValue).toBe(1);
+      await vi.waitFor(() => expect((globalThis as any).__ooosUnitLoopRequests).toEqual([0, 1]));
+      expect(document.querySelector('#ooos-unit-loop-page')?.textContent).toBe('1');
+    } finally {
+      const resolvers = (globalThis as any).__ooosUnitLoopResolvers;
+      for (let i = 0; i < resolvers.length; i++) {
+        resolvers[i](storiesForPage(-1));
+      }
+      await renderPromise;
+      delete (globalThis as any).__ooosUnitLoopNavValue;
+      delete (globalThis as any).__ooosUnitLoopItemValue;
+      delete (globalThis as any).__ooosUnitLoopRequests;
+      delete (globalThis as any).__ooosUnitLoopResolvers;
     }
   });
 

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -2164,7 +2164,7 @@ export class SSRSegmentContainer extends SSRContainer implements ISSRSegmentCont
     this.serializationCtx.$markSsrNodeForSerialization$ =
       this.markVNodeDataForSerialization.bind(this);
     return maybeThen(
-      this.serializationCtx.$serializePatch$(rootStart, rootIds, subscriptionPatchRootId),
+      this.serializationCtx.$serializePatch$(rootStart, rootIds, subscriptionPatchRootId, 0),
       () => {
         this.closeScript();
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,33 +1,35 @@
 import { qwikVite } from '@qwik.dev/core/optimizer';
+import { fileURLToPath } from 'node:url';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
+
+const fromRoot = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
 export default defineConfig({
   // temporary fix to allow tests to run without the kit package, remove this once we have a proper kit package
   resolve: {
     alias: {
-      '@qwik.dev/devtools/kit': new URL('./packages/devtools/kit/src/index.ts', import.meta.url)
-        .pathname,
+      '@qwik.dev/devtools/kit': fromRoot('./packages/devtools/kit/src/index.ts'),
     },
   },
   plugins: [
     qwikVite({
       debug: !true,
-      srcDir: `./packages/qwik/src`,
+      srcDir: fromRoot('./packages/qwik/src'),
       devTools: { hmr: false },
       experimental: ['each', 'suspense'],
     }),
     tsconfigPaths({ ignoreConfigErrors: true }),
   ],
   test: {
-    root: 'packages',
+    root: fromRoot('./packages'),
     include: [
       '**/*.spec.*',
       '**/*.unit.*',
       '!*/(lib|dist|build|server|target)/**',
       '!**/node_modules/**',
     ],
-    setupFiles: ['../vitest-setup.ts'],
+    setupFiles: [fromRoot('./vitest-setup.ts')],
     projects: ['..'],
     testTimeout: 10000,
   },


### PR DESCRIPTION
Fixes out-of-order Suspense state patch serialization so segment-local roots no longer get treated as already-streamed root-container roots. This keeps resumed event handlers working correctly for streamed Suspense content, including hoisted QRL params inside loops.