### PR TITLE
fix(core): stabilize repeated HMR updates

### DIFF
--- a/.changeset/stale-hmr-hosts.md
+++ b/.changeset/stale-hmr-hosts.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: make repeated HMR JSX remove and restore updates reload QRLs before rerendering

--- a/packages/qwik/src/core/shared/qrl/qrl-class-dev.ts
+++ b/packages/qwik/src/core/shared/qrl/qrl-class-dev.ts
@@ -74,7 +74,7 @@ export const setupHmr = (
     return `${path}?${params.join('&')}`;
   };
 
-  document.addEventListener('qHmr' as any, (ev: CustomEvent<{ files: string[]; t: number }>) => {
+  const hmrHandler = (ev: CustomEvent<{ files: string[]; t: number }>) => {
     const files = ev.detail.files;
     const t = ev.detail.t || (document as any).__hmrT || Date.now();
     let didReload = false;
@@ -113,7 +113,6 @@ export const setupHmr = (
       }
       if (didReload) {
         lazy.$ref$ = undefined;
-        (document as any).__hmrDone = (document as any).__hmrT;
         if (lazy.qrls) {
           for (const qrlRef of lazy.qrls) {
             const qrl = qrlRef.deref();
@@ -128,5 +127,6 @@ export const setupHmr = (
         }
       }
     }
-  });
+  };
+  document.addEventListener('qHmr' as any, hmrHandler, true);
 };

--- a/packages/qwik/src/core/tests/hmr.spec.tsx
+++ b/packages/qwik/src/core/tests/hmr.spec.tsx
@@ -8,6 +8,7 @@ import {
 import { domRender, ssrRenderToDom, trigger, waitForDrain } from '@qwik.dev/core/testing';
 import { describe, expect, it } from 'vitest';
 import { _useHmr } from '../internal';
+import { VNodeFlags } from '../client/types';
 
 const debug = false; //true;
 Error.stackTraceLimit = 100;
@@ -19,8 +20,10 @@ Error.stackTraceLimit = 100;
  * set by `useOnDocument('qHmr', …)`.
  */
 async function triggerHmr(container: any, files: string[]) {
+  const t = Date.now();
+  container.document.__hmrT = t;
   await trigger(container.element, null, 'd:q-hmr', {
-    detail: { files, t: Date.now() },
+    detail: { files, t },
   });
   // markVNodeDirty schedules cursor work as a microtask. Ensure it runs.
   await true;
@@ -187,6 +190,88 @@ describe('domRender: HMR', () => {
 
     // No additional render
     expect(log.length).toBe(rendersBeforeHmr);
+  });
+
+  it('should re-render after HMR removes and restores a stateful component', async () => {
+    const log: string[] = [];
+    const state: {
+      phase: 'initial' | 'removed' | 'restored' | 'removed-again' | 'restored-again';
+    } = { phase: 'initial' };
+
+    const StatefulChild = component$(() => {
+      const store = useStore({ label: 'qwik-state' });
+      return (
+        <section data-testid={state.phase.startsWith('restored') ? 'hmr-restored' : 'hmr-initial'}>
+          {store.label}:{state.phase}
+        </section>
+      );
+    });
+
+    const Parent = component$(() => {
+      log.push(state.phase);
+      _useHmr('parent.tsx');
+      return (
+        <div data-qwik-inspector="parent.tsx:1:1">
+          {state.phase !== 'removed' && state.phase !== 'removed-again' && <StatefulChild />}
+        </div>
+      );
+    });
+
+    const { container } = await render(<Parent />, { debug });
+    expect(container.element.querySelector('[data-testid="hmr-initial"]')).toBeTruthy();
+
+    state.phase = 'removed';
+    await triggerHmr(container, ['parent.tsx']);
+
+    expect(log[log.length - 1]).toBe('removed');
+    expect(container.element.querySelector('[data-testid="hmr-initial"]')).toBeFalsy();
+    container.element.querySelector('[q-d\\:q-hmr]')?.removeAttribute('data-qwik-inspector');
+
+    state.phase = 'restored';
+    const rendersBeforeRestore = log.length;
+
+    await triggerHmr(container, ['parent.tsx']);
+
+    expect(log.length).toBeGreaterThan(rendersBeforeRestore);
+    expect(container.element.querySelector('[data-testid="hmr-restored"]')?.textContent).toBe(
+      'qwik-state:restored'
+    );
+
+    state.phase = 'removed-again';
+    const rendersBeforeSecondRemove = log.length;
+
+    await triggerHmr(container, ['parent.tsx']);
+
+    expect(log.length).toBeGreaterThan(rendersBeforeSecondRemove);
+    expect(log[log.length - 1]).toBe('removed-again');
+    expect(container.element.querySelector('[data-testid="hmr-restored"]')).toBeFalsy();
+
+    state.phase = 'restored-again';
+    const rendersBeforeSecondRestore = log.length;
+
+    await triggerHmr(container, ['parent.tsx']);
+
+    expect(log.length).toBeGreaterThan(rendersBeforeSecondRestore);
+    expect(container.element.querySelector('[data-testid="hmr-restored"]')?.textContent).toBe(
+      'qwik-state:restored-again'
+    );
+  });
+
+  it('should not ack HMR when the captured host has been deleted', async () => {
+    const Counter = component$(() => {
+      _useHmr('deleted-host.tsx');
+      return <div data-qwik-inspector="deleted-host.tsx:1:1">current</div>;
+    });
+
+    const { container, vNode } = await render(<Counter />, { debug });
+    if (!vNode) {
+      throw new Error('Expected rendered VNode');
+    }
+    vNode.flags |= VNodeFlags.Deleted;
+
+    await triggerHmr(container, ['deleted-host.tsx']);
+
+    expect((container.document as any).__hmrDone).not.toBe((container.document as any).__hmrT);
   });
 });
 

--- a/packages/qwik/src/core/use/use-hmr.ts
+++ b/packages/qwik/src/core/use/use-hmr.ts
@@ -9,6 +9,7 @@ import { inlinedQrl } from '../shared/qrl/qrl';
 import { ChoreBits } from '../shared/vnode/enums/chore-bits.enum';
 import type { VNode } from '../shared/vnode/vnode';
 import { markVNodeDirty } from '../shared/vnode/vnode-dirty';
+import { VNodeFlags } from '../client/types';
 import { tryGetInvokeContext } from './use-core';
 import { useOnDocument } from './use-on';
 import type { QRL } from '../shared/qrl/qrl.public';
@@ -27,20 +28,20 @@ export const _hmr = function (
   event: CustomEvent<{ files: string[]; t: number }>,
   element: Element
 ) {
-  if (
-    !event.detail.files.some((file) =>
-      element.getAttribute('data-qwik-inspector')?.startsWith(file)
-    )
-  ) {
-    return;
-  }
   // Deserialize captures from `this` when called via qwikloader/attribute dispatch
+  const container = getDomContainer(element);
   if (typeof this === 'string') {
-    const container = getDomContainer(element);
     setCaptures(deserializeCaptures(container, this));
   }
-  const host = _captures![0] as VNode;
-  const container = getDomContainer(element);
+  const devPath = _captures?.[1] as string | undefined;
+  const hmrPath = devPath ?? element.getAttribute('data-qwik-inspector');
+  if (!hmrPath || !event.detail.files.some((file) => hmrPath.startsWith(file))) {
+    return;
+  }
+  const host = _captures?.[0] as VNode | undefined;
+  if (!host || host.flags & VNodeFlags.Deleted) {
+    return;
+  }
   markVNodeDirty(container, host, ChoreBits.COMPONENT);
   // Mark HMR as handled
   const doc: any = element.ownerDocument;
@@ -62,6 +63,6 @@ export function _useHmr(devPath: string): void {
   hmrQrl ||= inlinedQrl(_hmr, '_hmr');
   const hostElement = iCtx.$hostElement$;
   // We must capture the vnode to be able to re-render
-  const qrl = (hmrQrl as QRLInternal).w([hostElement]) as typeof hmrQrl;
+  const qrl = (hmrQrl as QRLInternal).w([hostElement, devPath]) as typeof hmrQrl;
   useOnDocument('qHmr', qrl);
 }


### PR DESCRIPTION
## Summary
- match Qwik HMR updates using captured optimizer dev paths instead of relying on current data-qwik-inspector attributes
- skip acknowledging deleted/stale captured hosts
- invalidate lazy QRL refs before component HMR handlers run, without treating lazy invalidation as a handled update
- add regression coverage for repeated remove/restore of a stateful component

## Verification
- pnpm build.core.dev
- pnpm vitest run packages/qwik/src/core/tests/hmr.spec.tsx
- pnpm tsc.check
- Kunai browser QA: remove/add/remove/add layout shell repro passes with local Qwik + qwik-bundler