### PR TITLE
fix(router): const assignment in route loaders

### DIFF
--- a/.changeset/swift-files-turn.md
+++ b/.changeset/swift-files-turn.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: fix "assignment to constant variable" errors when route loaders cache filtered search state across SPA navigations

--- a/e2e/qwik-e2e/apps/qwikrouter-ssg-snapshot/expected.state.txt
+++ b/e2e/qwik-e2e/apps/qwikrouter-ssg-snapshot/expected.state.txt
@@ -574,12 +574,13 @@
 78 RootRef [omitted]
 79 RootRef [omitted]
 80 RootRef [omitted]
-81 RootRef [omitted]
-82 Array []
-83 {string} "q-xxxxxxxx.js"
-84 {string} "s_0vpftJHSMyo"
-85 RootRef [omitted]
-86 Signal [
+81 Object 0
+82 RootRef [omitted]
+83 Array []
+84 {string} "q-xxxxxxxx.js"
+85 {string} "s_0vpftJHSMyo"
+86 RootRef [omitted]
+87 Signal [
   {number} 2
   EffectSubscription [
     RootRef [omitted]
@@ -588,7 +589,7 @@
   ]
   RootRef [omitted]
 ]
-87 Store [
+88 Store [
   Object [
     {string} "expanded"
     Constant true
@@ -623,28 +624,27 @@
     ]
   ]
 ]
-88 RootRef [omitted]
-89 {string} "q-xxxxxxxx.js"
-90 {string} "s_cgSl2l0RC14"
-91 RootRef [omitted]
+89 RootRef [omitted]
+90 {string} "q-xxxxxxxx.js"
+91 {string} "s_cgSl2l0RC14"
 92 RootRef [omitted]
-93 Map [
+93 RootRef [omitted]
+94 Map [
   {string} "."
   RootRef [omitted]
 ]
-94 {string} "s_QwONcWD5gIg"
-95 RootRef [omitted]
-96 {string} "q-xxxxxxxx.js"
-97 {string} "s_LqnNyU1Iy8c"
-98 RootRef [omitted]
-99 QRL "[omitted]"
-100 Object [
+95 {string} "s_QwONcWD5gIg"
+96 RootRef [omitted]
+97 {string} "q-xxxxxxxx.js"
+98 {string} "s_LqnNyU1Iy8c"
+99 RootRef [omitted]
+100 QRL "[omitted]"
+101 Object [
   {string} "r"
   RootRef [omitted]
 ]
-101 {string} "q-xxxxxxxx.js"
-102 {string} "_rsc"
-103 RootRef [omitted]
+102 {string} "q-xxxxxxxx.js"
+103 {string} "_rsc"
 104 RootRef [omitted]
 105 RootRef [omitted]
 106 RootRef [omitted]
@@ -664,12 +664,13 @@
 120 RootRef [omitted]
 121 RootRef [omitted]
 122 RootRef [omitted]
-123 {string} "s_lKDAUb7ao7U"
-124 RootRef [omitted]
-125 Promise [
+123 RootRef [omitted]
+124 {string} "s_lKDAUb7ao7U"
+125 RootRef [omitted]
+126 Promise [
   Constant true
   RootRef [omitted]
 ]
-126 ForwardRefs [
-  125
+127 ForwardRefs [
+  126
 ]

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/search-cache/[id]/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/search-cache/[id]/index.tsx
@@ -1,0 +1,42 @@
+import { component$ } from '@qwik.dev/core';
+import { Link, routeLoader$ } from '@qwik.dev/router';
+
+export const useSearchCacheLoader = routeLoader$(
+  ({ params, url }) => {
+    return {
+      id: params.id,
+      keep: url.searchParams.get('keep') ?? '',
+      noise: url.searchParams.get('noise') ?? 'none',
+      token: Math.random().toString(36).slice(2),
+    };
+  },
+  {
+    search: ['keep'],
+  }
+);
+
+export default component$(() => {
+  const data = useSearchCacheLoader();
+
+  return (
+    <main>
+      <p id="search-cache-route-path">routePath: {data.value.id}</p>
+      <p id="search-cache-keep">keep: {data.value.keep}</p>
+      <p id="search-cache-noise">noise: {data.value.noise}</p>
+      <p id="search-cache-token">token: {data.value.token}</p>
+
+      <Link
+        id="link-search-cache-alpha-second"
+        href="/qwikrouter-test/loaders/search-cache/alpha/?keep=one&noise=second"
+      >
+        Alpha second
+      </Link>
+      <Link
+        id="link-search-cache-beta"
+        href="/qwikrouter-test/loaders/search-cache/beta/?keep=one&noise=second"
+      >
+        Beta
+      </Link>
+    </main>
+  );
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/search-cache/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/search-cache/index.tsx
@@ -1,0 +1,15 @@
+import { component$ } from '@qwik.dev/core';
+import { Link } from '@qwik.dev/router';
+
+export default component$(() => {
+  return (
+    <main>
+      <Link
+        id="link-search-cache-alpha"
+        href="/qwikrouter-test/loaders/search-cache/alpha/?keep=one&noise=first"
+      >
+        Alpha
+      </Link>
+    </main>
+  );
+});

--- a/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
@@ -9,6 +9,52 @@ test.describe('loaders', () => {
   test.describe('spa', () => {
     test.use({ javaScriptEnabled: true });
     tests();
+
+    test('should reuse filtered search loaders only for the same SPA route path', async ({
+      page,
+    }) => {
+      const routePath = page.locator('#search-cache-route-path');
+      const keep = page.locator('#search-cache-keep');
+      const noise = page.locator('#search-cache-noise');
+      const token = page.locator('#search-cache-token');
+
+      await page.goto('/qwikrouter-test/loaders/search-cache/');
+      await page.locator('#link-search-cache-alpha').click();
+      await page.waitForURL(
+        (url) =>
+          url.pathname.endsWith('/loaders/search-cache/alpha/') &&
+          url.searchParams.get('keep') === 'one' &&
+          url.searchParams.get('noise') === 'first'
+      );
+      await expect(routePath).toHaveText('routePath: alpha');
+      await expect(keep).toHaveText('keep: one');
+      await expect(noise).toHaveText('noise: none');
+      const alphaToken = await token.innerText();
+
+      await page.locator('#link-search-cache-alpha-second').click();
+      await page.waitForURL(
+        (url) =>
+          url.pathname.endsWith('/loaders/search-cache/alpha/') &&
+          url.searchParams.get('keep') === 'one' &&
+          url.searchParams.get('noise') === 'second'
+      );
+      await expect(routePath).toHaveText('routePath: alpha');
+      await expect(keep).toHaveText('keep: one');
+      await expect(noise).toHaveText('noise: none');
+      await expect(token).toHaveText(alphaToken);
+
+      await page.locator('#link-search-cache-beta').click();
+      await page.waitForURL(
+        (url) =>
+          url.pathname.endsWith('/loaders/search-cache/beta/') &&
+          url.searchParams.get('keep') === 'one' &&
+          url.searchParams.get('noise') === 'second'
+      );
+      await expect(routePath).toHaveText('routePath: beta');
+      await expect(keep).toHaveText('keep: one');
+      await expect(noise).toHaveText('noise: none');
+      await expect(token).not.toHaveText(alphaToken);
+    });
   });
 
   function tests() {

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -288,8 +288,10 @@ const createRouteLoaderSignal = (
     ? new ServerRouteLoaderCapture(id, loader.__qrl, loader.__validators)
     : id;
   const searchFilter = loader.__search;
-  let lastFilteredSearch: string | undefined;
-  let lastRoutePath: string | undefined;
+  const lastFetch: {
+    filteredSearch?: string;
+    routePath?: string;
+  } = {};
   return createAsync$(
     async (ctx) => {
       const { track, info, previous, abortSignal } = ctx;
@@ -337,14 +339,14 @@ const createRouteLoaderSignal = (
         const filteredSearch = filterSearchParams(pageUrl.searchParams, searchFilter);
         if (
           previous !== undefined &&
-          filteredSearch === lastFilteredSearch &&
-          fetchRoutePath === lastRoutePath
+          filteredSearch === lastFetch.filteredSearch &&
+          fetchRoutePath === lastFetch.routePath
         ) {
           // Relevant search params didn't change and path didn't change — return previous value
           return previous;
         }
-        lastFilteredSearch = filteredSearch;
-        lastRoutePath = fetchRoutePath;
+        lastFetch.filteredSearch = filteredSearch;
+        lastFetch.routePath = fetchRoutePath;
         // Build a URL with only the allowed search params for the fetch
         fetchUrl = new URL(pageUrl.href);
         fetchUrl.search = filteredSearch;

--- a/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
@@ -9,19 +9,25 @@ import {
 import type { LoaderInternal } from './types';
 
 describe('search filter early-return logic', () => {
-  // Mirrors the closure variables and condition in createRouteLoaderSignal.
+  // Mirrors the captured lastFetch object and condition in createRouteLoaderSignal.
   // Before the fix, only filteredSearch was checked — path changes were silently suppressed.
   it('does not skip fetch when routePath changes even if filtered search is unchanged', () => {
-    let lastFilteredSearch: string | undefined;
-    let lastRoutePath: string | undefined;
+    const lastFetch: {
+      filteredSearch?: string;
+      routePath?: string;
+    } = {};
 
     const shouldSkipFetch = (routePath: string, filteredSearch: string) => {
-      const hasPrevious = lastFilteredSearch !== undefined;
-      if (hasPrevious && filteredSearch === lastFilteredSearch && routePath === lastRoutePath) {
+      const hasPrevious = lastFetch.filteredSearch !== undefined;
+      if (
+        hasPrevious &&
+        filteredSearch === lastFetch.filteredSearch &&
+        routePath === lastFetch.routePath
+      ) {
         return true;
       }
-      lastFilteredSearch = filteredSearch;
-      lastRoutePath = routePath;
+      lastFetch.filteredSearch = filteredSearch;
+      lastFetch.routePath = routePath;
       return false;
     };
 


### PR DESCRIPTION
Fixes routeLoader$ filtered search caching by storing the last filtered search and route path in a captured object, avoiding "assignment to constant variable" errors after QRL transform