### PR TITLE
refactor(devtools): single source of truth for shared protocol types

### DIFF
--- a/.changeset/shared-protocol-types.md
+++ b/.changeset/shared-protocol-types.md
@@ -1,0 +1,11 @@
+---
+'@qwik.dev/devtools': patch
+---
+
+refactor(devtools): single source of truth for shared protocol types
+
+The VNode tree node, component detail entry, and render event shapes were declared
+three times: in the browser extension, in the devtools UI, and in the kit client
+bridge. They now live once in @qwik.dev/devtools/kit (protocol module) as
+DevtoolsVNodeTreeNode, DevtoolsComponentDetailEntry, and DevtoolsRenderEvent, and
+every consumer imports them from there.

--- a/packages/browser-extension/src/shared/types.ts
+++ b/packages/browser-extension/src/shared/types.ts
@@ -1,9 +1,16 @@
 import type {
+  DevtoolsVNodeTreeNode as VNodeTreeNode,
+  DevtoolsComponentDetailEntry as ComponentDetailEntry,
+  DevtoolsRenderEvent as RenderEvent,
   QwikDevtoolsComponentSnapshot,
   QwikDevtoolsSignalsSnapshot,
   QwikPerfStoreRemembered,
   QwikPreloadStoreRemembered,
 } from '@qwik.dev/devtools/kit';
+
+// The VNode/detail/render shapes are the shared data contract, owned by @qwik.dev/devtools/kit.
+// Re-export under the local names so consumers keep one import source and cannot drift.
+export type { VNodeTreeNode, ComponentDetailEntry, RenderEvent };
 
 export interface QwikContainerInfo {
   detected: boolean;
@@ -14,27 +21,6 @@ export interface QwikContainerInfo {
   manifestHash: string | null;
   containerCount: number;
   runtime: string | null;
-}
-
-export interface VNodeTreeNode {
-  name?: string;
-  id: string;
-  label?: string;
-  props?: Record<string, unknown>;
-  children?: VNodeTreeNode[];
-}
-
-export interface ComponentDetailEntry {
-  hookType: string;
-  variableName: string;
-  data: unknown;
-}
-
-export interface RenderEvent {
-  component: string;
-  phase: string;
-  duration: number;
-  timestamp: number;
 }
 
 export type ExtensionMessage =

--- a/packages/devtools/kit/src/client-bridge.ts
+++ b/packages/devtools/kit/src/client-bridge.ts
@@ -7,30 +7,12 @@ import type { QwikPerfStoreRemembered, QwikPreloadStoreRemembered } from './glob
 import { getQwikDevtoolsGlobal } from './global-store';
 import { QWIK_DEVTOOLS_GLOBAL } from './protocol/globals';
 import { DEVTOOLS_MESSAGES, type QwikDevtoolsPageMessage } from './protocol/messages';
+import type { DevtoolsVNodeTreeNode } from './protocol/vnode';
+import type { DevtoolsRenderEvent } from './protocol/perf';
+import type { DevtoolsComponentDetailEntry } from './protocol/hooks';
 
 export interface InPageBridgeOptions {
   isBrowser: boolean;
-}
-
-export interface DevtoolsRenderEvent {
-  component: string;
-  phase: string;
-  duration: number;
-  timestamp: number;
-}
-
-export interface DevtoolsComponentDetailEntry {
-  hookType: string;
-  variableName: string;
-  data: unknown;
-}
-
-export interface DevtoolsVNodeTreeNode {
-  name?: string;
-  id: string;
-  label?: string;
-  props?: Record<string, unknown>;
-  children?: DevtoolsVNodeTreeNode[];
 }
 
 export interface InPageBridge {

--- a/packages/devtools/kit/src/protocol/hooks.ts
+++ b/packages/devtools/kit/src/protocol/hooks.ts
@@ -45,6 +45,17 @@ export const SIGNAL_HOOK_TYPES = [
   'useContext',
 ] as const;
 
+/**
+ * A single component hook entry with deeply serialized data, returned by the devtools hook's
+ * component detail lookup. Shared data contract: do not redeclare in consumers, import it from
+ * here.
+ */
+export interface DevtoolsComponentDetailEntry {
+  hookType: string;
+  variableName: string;
+  data: unknown;
+}
+
 export const INNER_USE_HOOK = 'useCollectHooks';
 export const VIRTUAL_QWIK_DEVTOOLS_KEY = 'virtual-qwik-devtools.ts';
 export const QWIK_DEVTOOLS_HOOK_VERSION = 1;

--- a/packages/devtools/kit/src/protocol/perf.ts
+++ b/packages/devtools/kit/src/protocol/perf.ts
@@ -6,3 +6,14 @@ export const PERF_PHASE_CSR = 'csr';
 export const DEFAULT_PERF_STORE_EXPRESSION = '{ ssr: [], csr: [] }';
 
 export type QwikDevtoolsPerfPhase = typeof PERF_PHASE_SSR | typeof PERF_PHASE_CSR;
+
+/**
+ * A single render event emitted by the performance runtime (CSR render with timing). Shared data
+ * contract: do not redeclare in consumers, import it from here.
+ */
+export interface DevtoolsRenderEvent {
+  component: string;
+  phase: string;
+  duration: number;
+  timestamp: number;
+}

--- a/packages/devtools/kit/src/protocol/vnode.ts
+++ b/packages/devtools/kit/src/protocol/vnode.ts
@@ -18,3 +18,15 @@ export const QWIK_VNODE_PROTOCOL = {
   },
   bridgeVirtualModuleId: 'virtual:qwik-devtools-bridge',
 } as const;
+
+/**
+ * Serializable VNode tree node exchanged between the page hook and the devtools UI/extension.
+ * Shared data contract: do not redeclare in consumers, import it from here.
+ */
+export interface DevtoolsVNodeTreeNode {
+  name?: string;
+  id: string;
+  label?: string;
+  props?: Record<string, unknown>;
+  children?: DevtoolsVNodeTreeNode[];
+}

--- a/packages/devtools/ui/src/devtools/page-data-source.ts
+++ b/packages/devtools/ui/src/devtools/page-data-source.ts
@@ -6,8 +6,15 @@ import {
   type QwikPreloadStoreRemembered,
   type QwikDevtoolsComponentSnapshot,
   type QwikDevtoolsSignalsSnapshot,
+  type DevtoolsVNodeTreeNode as VNodeTreeNode,
+  type DevtoolsComponentDetailEntry as ComponentDetailEntry,
+  type DevtoolsRenderEvent as RenderEvent,
 } from '@qwik.dev/devtools/kit';
 import { isBrowser } from '@qwik.dev/core';
+
+// The VNode/detail/render shapes are the shared data contract, owned by @qwik.dev/devtools/kit.
+// Re-export under the local names so feature components keep one import source and cannot drift.
+export type { VNodeTreeNode, ComponentDetailEntry, RenderEvent };
 
 /**
  * Abstraction for accessing page-level data from different contexts.
@@ -76,30 +83,6 @@ export interface PageDataSource {
 
   /** Subscribe to live render events (CSR component renders with timing). */
   subscribeRenderEvents(cb: (event: RenderEvent) => void): (() => void) | null;
-}
-
-/** A single render event emitted by the performance runtime. */
-export interface RenderEvent {
-  component: string;
-  phase: string;
-  duration: number;
-  timestamp: number;
-}
-
-/** A single hook entry with deeply serialized data. */
-export interface ComponentDetailEntry {
-  hookType: string;
-  variableName: string;
-  data: unknown;
-}
-
-/** Serializable VNode tree node (matches overlay's TreeNode shape). */
-export interface VNodeTreeNode {
-  name?: string;
-  id: string;
-  label?: string;
-  props?: Record<string, unknown>;
-  children?: VNodeTreeNode[];
 }
 
 /**


### PR DESCRIPTION
## Problem

The VNode tree node, component detail entry, and render event shapes were declared three times with identical fields:

- `packages/browser-extension/src/shared/types.ts` (`VNodeTreeNode`, `ComponentDetailEntry`, `RenderEvent`)
- `packages/devtools/ui/src/devtools/page-data-source.ts` (same names)
- `packages/devtools/kit/src/client-bridge.ts` (`DevtoolsVNodeTreeNode`, `DevtoolsComponentDetailEntry`, `DevtoolsRenderEvent`)

Three copies of the same data contract had to be kept in sync by hand.

## Solution

Make `@qwik.dev/devtools/kit` the single source of truth.

- The three interfaces now live once in the kit protocol module: `DevtoolsVNodeTreeNode` in `protocol/vnode.ts`, `DevtoolsRenderEvent` in `protocol/perf.ts`, `DevtoolsComponentDetailEntry` in `protocol/hooks.ts`.
- `kit/client-bridge.ts` imports them from the protocol module instead of declaring its own copies, so it becomes a consumer of the shared types too.
- The browser extension and the devtools UI drop their local declarations and re-export the kit types under their existing local names, so every consumer keeps a single import source and cannot drift.
- The `Devtools` prefix is kept on purpose: a bare `RenderEvent` would collide with the DOM lib global.

No public API change: the same type names are still exported from `@qwik.dev/devtools/kit`, just from the protocol module rather than the client bridge.

## Verification

- `@qwik.dev/devtools/kit` builds and its generated `.d.mts` exports all three types.
- `tsc` on the devtools UI passes with zero errors.
- `tsc` on the browser extension reports only two preexisting wxt `TS2742` errors, unrelated to this change.
- eslint passes on every touched file.

## References

QwikDev project board, card "p1 Shared Type Duplication": https://github.com/orgs/QwikDev/projects/6/views/1