### PR TITLE
refactor(qwik-router): loader/action failures on .error (drop fail())

### DIFF
--- a/.changeset/loader-action-error-state.md
+++ b/.changeset/loader-action-error-state.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': major
+---
+
+BREAKING: route loaders and actions now report failures via `loader.error` / `action.error` instead of `fail()` / `value.failed`. `throw error(status, data)` and failed validators surface on `.error` consistently on the server and the client, and `.value` is the success type only.

--- a/.changeset/rewrite-same-origin-absolute-url.md
+++ b/.changeset/rewrite-same-origin-absolute-url.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+`rewrite()` now accepts same-origin absolute URLs by normalizing them to a path (so they behave like a relative rewrite) instead of throwing a 400. Cross-origin URLs are still rejected.

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/(auth)/sign-in/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/(auth)/sign-in/index.tsx
@@ -18,14 +18,14 @@ export const onGet: RequestHandler = async ({ redirect, cookie }) => {
 };
 
 export const useSigninAction = globalAction$(
-  async (data, { cookie, redirect, status, fail }) => {
+  async (data, { cookie, redirect, error }) => {
     const result = await signIn(data, cookie);
 
     if (result.status === 'signed-in') {
       throw redirect(302, '/qwikrouter-test/dashboard/');
     }
 
-    return fail(403, {
+    throw error(403, {
       message: ['Invalid username or password'],
     });
   },
@@ -65,26 +65,26 @@ export default component$(() => {
       <h1>Sign In</h1>
 
       <Form action={signIn} spaReset>
-        {signIn.value?.message && <p style="color:red">{signIn.value.message}</p>}
+        {signIn.error?.message && <p style="color:red">{signIn.error.message}</p>}
         <label>
           <span>Username</span>
           <input name="username" type="text" autoComplete="username" required />
-          {signIn.value?.fieldErrors?.username && (
-            <p style="color:red">{signIn.value?.fieldErrors?.username}</p>
+          {signIn.error?.fieldErrors?.username && (
+            <p style="color:red">{signIn.error?.fieldErrors?.username}</p>
           )}
         </label>
         <label>
           <span>Password</span>
           <input name="password" type="password" autoComplete="current-password" required />
-          {signIn.value?.fieldErrors?.password && (
-            <p style="color:red">{signIn.value?.fieldErrors?.password}</p>
+          {signIn.error?.fieldErrors?.password && (
+            <p style="color:red">{signIn.error?.fieldErrors?.password}</p>
           )}
         </label>
         <label>
           <span>Confirm password</span>
           <input name="confirmPassword" type="password" autoComplete="current-password" required />
-          {signIn.value?.fieldErrors?.confirmPassword && (
-            <p style="color:red">{signIn.value?.fieldErrors?.confirmPassword}</p>
+          {signIn.error?.fieldErrors?.confirmPassword && (
+            <p style="color:red">{signIn.error?.fieldErrors?.confirmPassword}</p>
           )}
         </label>
         <button data-test-sign-in>Sign In</button>

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/actions/issue5065/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/actions/issue5065/index.tsx
@@ -22,12 +22,12 @@ export default component$(() => {
   fooValue satisfies MyObject;
 
   const zodAction = useZodObjectAction();
-  const zodValue = zodAction.value!;
-  if (zodValue.failed) {
-    zodValue satisfies { failed: true } & ValidatorErrorType<{
+  if (zodAction.error) {
+    zodAction.error.data satisfies ValidatorErrorType<{
       name: string;
     }>;
   } else {
+    const zodValue = zodAction.value!;
     zodValue satisfies MyObject;
   }
   return <>TEST</>;

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/actions/issue5463/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/actions/issue5463/index.tsx
@@ -34,7 +34,7 @@ export default component$(() => {
     >
   >;
 
-  const errors = dotNotation.value?.fieldErrors satisfies ConfirmType | undefined;
+  const errors = dotNotation.error?.fieldErrors satisfies ConfirmType | undefined;
 
   return (
     <>
@@ -45,7 +45,7 @@ export default component$(() => {
           name="credentials.username"
           value="user"
           class={{
-            error: dotNotation.value?.fieldErrors?.['credentials.username'],
+            error: dotNotation.error?.fieldErrors?.['credentials.username'],
           }}
         />
         <input
@@ -53,7 +53,7 @@ export default component$(() => {
           name="credentials.password"
           value="pass"
           class={{
-            error: dotNotation.value?.fieldErrors?.['credentials.password'],
+            error: dotNotation.error?.fieldErrors?.['credentials.password'],
           }}
         />
         <input
@@ -61,7 +61,7 @@ export default component$(() => {
           name="credentials.password"
           value="pass"
           class={{
-            error: dotNotation.value?.fieldErrors?.['evenMoreComplex.deep.firstName'],
+            error: dotNotation.error?.fieldErrors?.['evenMoreComplex.deep.firstName'],
           }}
         />
         {errors?.['credentials.password'] ?? 'no error'}
@@ -71,7 +71,7 @@ export default component$(() => {
           name="evenMoreComplex.deep.firstName"
           value="John"
           class={{
-            error: dotNotation.value?.fieldErrors?.['evenMoreComplex.deep.firstName'],
+            error: dotNotation.error?.fieldErrors?.['evenMoreComplex.deep.firstName'],
           }}
         />
 
@@ -80,7 +80,7 @@ export default component$(() => {
           name="persons.0.name"
           value="John"
           class={{
-            error: dotNotation.value?.fieldErrors?.['persons[].name']?.[0],
+            error: dotNotation.error?.fieldErrors?.['persons[].name']?.[0],
           }}
         />
 

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/actions/login.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/actions/login.tsx
@@ -9,7 +9,7 @@ export function delay(nu: number) {
 }
 
 export const useSecretAction = globalAction$(
-  async (payload, { fail, redirect }) => {
+  async (payload, { error, redirect }) => {
     if (payload.username === 'admin' && payload.code === 123) {
       await delay(2000);
       return {
@@ -19,7 +19,7 @@ export const useSecretAction = globalAction$(
     } else if (payload.username === 'redirect' && payload.code === 123) {
       throw redirect(302, '/qwikrouter-test/');
     }
-    return fail(400, {
+    throw error(400, {
       message: 'Invalid username or code',
     });
   },
@@ -51,8 +51,8 @@ export const SecretForm = component$(() => {
               placeholder="admin"
               value={action.formData?.get('username')}
             />
-            {action.value?.fieldErrors?.username && (
-              <p class={styles.error}>{action.value.fieldErrors.username}</p>
+            {action.error?.fieldErrors?.username && (
+              <p class={styles.error}>{action.error.fieldErrors.username}</p>
             )}
           </label>
         </div>
@@ -60,14 +60,14 @@ export const SecretForm = component$(() => {
           <label id="label-code">
             Code:
             <input type="text" name="code" placeholder="123" value={action.formData?.get('code')} />
-            {action.value?.fieldErrors?.code && (
-              <p class={styles.error}>{action.value.fieldErrors.code}</p>
+            {action.error?.fieldErrors?.code && (
+              <p class={styles.error}>{action.error.fieldErrors.code}</p>
             )}
           </label>
         </div>
-        {action.value?.message && (
+        {action.error?.message && (
           <p id="form-error" class={styles.error}>
-            {action.value.message}
+            {action.error.message}
           </p>
         )}
         {action.value?.secret && (

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/actions/validated/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/actions/validated/index.tsx
@@ -37,15 +37,11 @@ interface ActionSuccessObject {
   actionSuccess: string;
 }
 
-interface ActionFailedObject {
-  actionFail: string;
-}
-
-const actionQrl = (data: JSONObject, { fail }: RequestEventAction) => {
+const actionQrl = (data: JSONObject, { error }: RequestEventAction) => {
   if (Math.random() > 0.5) {
-    return fail(500, {
+    throw error(500, {
       actionFail: 'secret',
-    } as ActionFailedObject);
+    });
   }
 
   return {
@@ -79,99 +75,75 @@ export default component$(() => {
 
   // Use options object, use typed data validator, use data validator
   const action1 = useAction1();
-  if (action1.value) {
-    if (action1.value.failed) {
-      action1.value satisfies { failed: true } & (
-        | TypedDataValidatorError
-        | DataValidatorError
-        | ActionFailedObject
-      );
-    } else {
-      action1.value satisfies ActionSuccessObject;
-    }
+  if (action1.error) {
+    action1.error.data satisfies TypedDataValidatorError | DataValidatorError;
+  } else if (action1.value) {
+    action1.value satisfies ActionSuccessObject;
   }
 
   // Use options object, use typed data validator
   const action2 = useAction2();
-  if (action2.value) {
-    if (action2.value.failed) {
-      action2.value satisfies { failed: true } & (TypedDataValidatorError | ActionFailedObject);
-    } else {
-      action2.value satisfies ActionSuccessObject;
-    }
+  if (action2.error) {
+    action2.error.data satisfies TypedDataValidatorError;
+  } else if (action2.value) {
+    action2.value satisfies ActionSuccessObject;
   }
 
   // Use options object, use data validator
   const action3 = useAction3();
-  if (action3.value) {
-    if (action3.value.failed) {
-      action3.value satisfies { failed: true } & (DataValidatorError | ActionFailedObject);
-    } else {
-      action3.value satisfies ActionSuccessObject;
-    }
+  if (action3.error) {
+    action3.error.data satisfies DataValidatorError;
+  } else if (action3.value) {
+    action3.value satisfies ActionSuccessObject;
   }
 
   // Use typed data validator, use data validator
   const action4 = useAction4();
-  if (action4.value) {
-    if (action4.value.failed) {
-      action4.value satisfies { failed: true } & (
-        | TypedDataValidatorError
-        | DataValidatorError
-        | ActionFailedObject
-      );
-    } else {
-      action4.value satisfies ActionSuccessObject;
-    }
+  if (action4.error) {
+    action4.error.data satisfies TypedDataValidatorError | DataValidatorError;
+  } else if (action4.value) {
+    action4.value satisfies ActionSuccessObject;
   }
 
   // Use typed data validator
   const action5 = useAction5();
-  if (action5.value) {
-    if (action5.value.failed) {
-      action5.value satisfies { failed: true } & (TypedDataValidatorError | ActionFailedObject);
-    } else {
-      action5.value satisfies ActionSuccessObject;
-    }
+  if (action5.error) {
+    action5.error.data satisfies TypedDataValidatorError;
+  } else if (action5.value) {
+    action5.value satisfies ActionSuccessObject;
   }
 
   // Use data validator
   const action6 = useAction6();
-  if (action6.value) {
-    if (action6.value.failed) {
-      action6.value satisfies { failed: true } & (DataValidatorError | ActionFailedObject);
-    } else {
-      action6.value satisfies ActionSuccessObject;
-    }
+  if (action6.error) {
+    action6.error.data satisfies DataValidatorError;
+  } else if (action6.value) {
+    action6.value satisfies ActionSuccessObject;
   }
 
   // No validators
   const action7 = useAction7();
-  if (action7.value) {
-    if (action7.value.failed) {
-      action7.value satisfies { failed: true } & ActionFailedObject;
-    } else {
-      action7.value satisfies ActionSuccessObject;
-    }
+  if (action7.error) {
+    action7.error.data satisfies unknown;
+  } else if (action7.value) {
+    action7.value satisfies ActionSuccessObject;
   }
 
   // No validators, with action id
   const action8 = useAction7();
-  if (action8.value) {
-    if (action8.value.failed) {
-      action8.value satisfies { failed: true } & ActionFailedObject;
-    } else {
-      action8.value satisfies ActionSuccessObject;
-    }
+  if (action8.error) {
+    action8.error.data satisfies unknown;
+  } else if (action8.value) {
+    action8.value satisfies ActionSuccessObject;
   }
 
   return (
     <div>
       <h1>Validated</h1>
-      {loader.value.failed ? (
+      {loader.error ? (
         <div>
           <p>Failed</p>
-          <p>{loader.value.message}</p>
+          <p>{loader.error.message}</p>
         </div>
       ) : (
         <div>

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/[id]/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/[id]/index.tsx
@@ -156,9 +156,9 @@ export const useForm = routeAction$(
   })
 );
 
-export const useFormWithError = routeAction$(async (stuff, { fail }) => {
+export const useFormWithError = routeAction$(async (stuff, { error }) => {
   if (Math.random() > 2) {
-    return fail(500, {
+    throw error(500, {
       message: 'Random error',
     });
   }
@@ -171,14 +171,15 @@ export const head: DocumentHead = ({ resolveValue }) => {
   const date = resolveValue(useDateLoader);
   const dep = resolveValue(useDependencyLoader);
   const action = resolveValue(useForm);
-  const actionWithError = resolveValue(useFormWithError);
   let title = 'Loaders';
   if (action) {
     title += ` - ACTION: ${action.name}`;
   }
-  if (actionWithError) {
-    title += ` - Error: ${actionWithError.name} ${actionWithError.message}`;
-  }
+  // Note: `useFormWithError` now signals failure via `throw error(500, { message })` instead of
+  // a returned `fail()` value. A thrown action error never surfaces through `resolveValue`
+  // (which only yields the success value), and — as noted above — loaders/head refetched after
+  // an action submission run as standalone GETs without action context anyway. So there is no
+  // error message to read here; the former error branch is dropped.
   return {
     title,
     meta: [

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/issue3979/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/issue3979/index.tsx
@@ -65,34 +65,29 @@ export default component$(() => {
   const randomFailed = useRandomFailedLoader();
   const randomFailedWithValidator = useRandomFailedWithValidatorLoader();
 
+  // fail() / validation failures now surface as `loader.error` (a ServerError whose
+  // `.data` carries the payload), not as `loader.value.failed`. Guard on `.error`
+  // before reading `.value` — reading `.value` in error state re-throws.
   return (
     <div>
       <div>{pet.value.pet}</div>
       <div>
-        {petWithValidation.value.pet}
-        {petWithValidation.value.failed}
-        {petWithValidation.value.validationFailReason}
+        {petWithValidation.error ? petWithValidation.error.message : petWithValidation.value.pet}
       </div>
       <div>
         {dynamicPet.value.dog}
         {dynamicPet.value.rat}
       </div>
       <div>
-        {dynamicPetWithValidation.value.dog}
-        {dynamicPetWithValidation.value.rat}
-        {dynamicPetWithValidation.value.failed}
-        {dynamicPetWithValidation.value.validationFailReason}
+        {dynamicPetWithValidation.error
+          ? dynamicPetWithValidation.error.message
+          : `${dynamicPetWithValidation.value.dog ?? ''}${dynamicPetWithValidation.value.rat ?? ''}`}
       </div>
+      <div>{randomFailed.error ? randomFailed.error.message : randomFailed.value.pet}</div>
       <div>
-        {randomFailed.value.pet}
-        {randomFailed.value.failed}
-        {randomFailed.value.loaderFailedReason}
-      </div>
-      <div>
-        {randomFailedWithValidator.value.pet}
-        {randomFailedWithValidator.value.failed}
-        {randomFailedWithValidator.value.loaderFailedReason}
-        {randomFailedWithValidator.value.validationFailReason}
+        {randomFailedWithValidator.error
+          ? randomFailedWithValidator.error.message
+          : randomFailedWithValidator.value.pet}
       </div>
     </div>
   );

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/loader-error/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/loader-error/index.tsx
@@ -6,6 +6,10 @@ const useError = routeLoader$(async function ({ error }): Promise<string> {
 });
 
 export default component$(() => {
-  useError();
+  const loader = useError();
+  // A loader that throws `error()` enters error state — read it via `loader.error`.
+  if (loader.error) {
+    return <div id="loader-error">{loader.error.message}</div>;
+  }
   return <></>;
 });

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/loader-error/uncaught-server/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/loaders/loader-error/uncaught-server/index.tsx
@@ -11,6 +11,10 @@ const useCatchServerErrorInLoader = routeLoader$(async () => {
 });
 
 export default component$(() => {
-  useCatchServerErrorInLoader();
+  const loader = useCatchServerErrorInLoader();
+  // A ServerError thrown inside the loader (here, by a server$ call) enters error state.
+  if (loader.error) {
+    return <div id="loader-error">{loader.error.message}</div>;
+  }
   return <></>;
 });

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/products/[id]/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/products/[id]/index.tsx
@@ -12,8 +12,9 @@ export default component$(() => {
     <div>
       <h1>Product: {params.id}</h1>
 
-      {product.value == null && <p>Not Found</p>}
-      {product.value != null && (
+      {product.error && <p>Error: {product.error.message}</p>}
+      {!product.error && product.value == null && <p>Not Found</p>}
+      {!product.error && product.value != null && (
         <>
           <p>Price: {product.value.price}</p>
           <p>{product.value.description}</p>
@@ -144,7 +145,8 @@ export const useProductLoader = routeLoader$(
       throw rewrite('/qwikrouter-test/products/tshirt/');
     }
 
-    // Should throw an error
+    // Same-origin absolute URL — rewrite normalizes it to a path and re-routes like a
+    // relative rewrite (renders tshirt while keeping this URL).
     if (id === 'shirt-rewrite-absolute-url') {
       throw rewrite(`${url.origin}/qwikrouter-test/products/tshirt/`);
     }

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/plugin@errors.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/plugin@errors.tsx
@@ -6,16 +6,13 @@ export const onRequest: RequestHandler = async ({ next }) => {
   try {
     return await next();
   } catch (err) {
-    // Intercept and update ServerErrors to test middleware
+    // Intercept and update ServerErrors to test middleware.
+    // Note: loader failures (fail() / throw error()) no longer propagate here — they are
+    // captured per-loader and surfaced as `loader.error`, so middleware can't intercept them.
     if (err instanceof ServerError) {
       // Update for (common)/server-func/server-error
       if (isErrorReason(err.data)) {
         err.data.middleware = 'server-error-caught';
-      }
-
-      // Update for (common)/loaders/loader-error
-      if (err.data === 'loader-error-uncaught') {
-        err.data = 'loader-error-caught';
       }
     }
 

--- a/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
@@ -177,18 +177,23 @@ test.describe('loaders', () => {
       await expect(page.locator('#prop-unwrapped')).toHaveText('test');
     });
 
-    test('should modify ServerError in middleware', async ({ page }) => {
+    test('surfaces a thrown loader ServerError as loader.error', async ({ page }) => {
       const response = await page.goto('/qwikrouter-test/loaders/loader-error');
       const contentType = await response?.headerValue('Content-Type');
       const status = response?.status();
 
+      // The loader threw error(401, ...): the status propagates and the page renders the
+      // error through loader.error. Loader errors no longer escalate to a page-level error
+      // boundary, so middleware (plugin@errors) can't intercept/rename them.
       expect(status).toEqual(401);
       expect(contentType).toEqual('text/html; charset=utf-8');
       const body = page.locator('body');
-      await expect(body).toContainText('loader-error-caught');
+      await expect(body).toContainText('loader-error-uncaught');
     });
 
-    test('should return html with uncaught ServerErrors thrown in loaders', async ({ page }) => {
+    test('surfaces a ServerError thrown via server$ inside a loader as loader.error', async ({
+      page,
+    }) => {
       const response = await page.goto('/qwikrouter-test/loaders/loader-error/uncaught-server');
       const contentType = await response?.headerValue('Content-Type');
       const status = response?.status();

--- a/e2e/qwik-e2e/tests/qwikrouter/page.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/page.e2e.ts
@@ -128,13 +128,15 @@ function tests() {
         searchParams: { search: 'true' },
       });
 
-      /** Products: shirt (rewrite to /products/tshirt) ********** */
-      await linkNavigate(ctx, '[data-test-link="products-shirt-rewrite-absolute-url"]', 400);
+      /** Products: shirt (same-origin absolute rewrite → /products/tshirt) ********** */
+      await linkNavigate(ctx, '[data-test-link="products-shirt-rewrite-absolute-url"]');
       await assertPage(ctx, {
-        title: 'Error 400 - Qwik',
+        pathname: '/qwikrouter-test/products/shirt-rewrite-absolute-url/',
+        title: 'Product tshirt - Qwik',
+        layoutHierarchy: ['root'],
+        h1: 'Product: tshirt',
+        activeHeaderLink: 'Products',
       });
-      // Recover from error
-      await setPage(ctx, '/qwikrouter-test/products/hat/');
 
       /** Products: shirt (rewrite to /products/tshirt) ********** */
       await linkNavigate(ctx, '[data-test-link="products-shirt-rewrite-no-trailing-slash"]', 301);

--- a/packages/docs/src/routes/api/qwik-router-middleware-request-handler/api.json
+++ b/packages/docs/src/routes/api/qwik-router-middleware-request-handler/api.json
@@ -132,23 +132,6 @@
       "mdFile": "router.cookievalue.md"
     },
     {
-      "name": "data",
-      "id": "servererror-data",
-      "hierarchy": [
-        {
-          "name": "ServerError",
-          "id": "servererror-data"
-        },
-        {
-          "name": "data",
-          "id": "servererror-data"
-        }
-      ],
-      "kind": "Property",
-      "content": "```typescript\ndata: T;\n```",
-      "mdFile": "router.servererror.data.md"
-    },
-    {
       "name": "DeferReturn",
       "id": "deferreturn",
       "hierarchy": [
@@ -358,7 +341,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface RequestEventAction<PLATFORM = QwikRouterPlatform> extends RequestEventCommon<PLATFORM> \n```\n**Extends:** [RequestEventCommon](#requesteventcommon)<!-- -->&lt;PLATFORM&gt;\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfail\n\n\n</td><td>\n\n\n</td><td>\n\n&lt;T extends Record&lt;string, any&gt;&gt;(status: number, returnData: T) =&gt; FailReturn&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport interface RequestEventAction<PLATFORM = QwikRouterPlatform> extends RequestEventCommon<PLATFORM> \n```\n**Extends:** [RequestEventCommon](#requesteventcommon)<!-- -->&lt;PLATFORM&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/types.ts",
       "mdFile": "router.requesteventaction.md"
     },
@@ -386,7 +369,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface RequestEventCommon<PLATFORM = QwikRouterPlatform> extends RequestEventBase<PLATFORM> \n```\n**Extends:** [RequestEventBase](#requesteventbase)<!-- -->&lt;PLATFORM&gt;\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nerror\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n&lt;T = any&gt;(statusCode: ErrorCodes, message: T) =&gt; [ServerError](#servererror)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\nWhen called, the response will immediately end with the given status code. This could be useful to end a response with `404`<!-- -->, and use the 404 handler in the routes directory. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status for which status code should be used.\n\n\n</td></tr>\n<tr><td>\n\nexit\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n() =&gt; [AbortMessage](#abortmessage)\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nhtml\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode: StatusCodes, html: string) =&gt; [AbortMessage](#abortmessage)\n\n\n</td><td>\n\nConvenience method to send an HTML body response. The response will be automatically set the `Content-Type` header to`text/html; charset=utf-8`<!-- -->. An `html()` response can only be called once.\n\n\n</td></tr>\n<tr><td>\n\njson\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode: StatusCodes, data: any) =&gt; [AbortMessage](#abortmessage)\n\n\n</td><td>\n\nConvenience method to JSON stringify the data and send it in the response. The response will be automatically set the `Content-Type` header to `application/json; charset=utf-8`<!-- -->. A `json()` response can only be called once.\n\n\n</td></tr>\n<tr><td>\n\nlocale\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(local?: string) =&gt; string\n\n\n</td><td>\n\nWhich locale the content is in.\n\nThe locale value can be retrieved from selected methods using `getLocale()`<!-- -->:\n\n\n</td></tr>\n<tr><td>\n\nredirect\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode: RedirectCode, url: string) =&gt; [RedirectMessage](#redirectmessage)\n\n\n</td><td>\n\nURL to redirect to. When called, the response will immediately end with the correct redirect status and headers.\n\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections\n\n\n</td></tr>\n<tr><td>\n\nrewrite\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(pathname: string) =&gt; [RewriteMessage](#rewritemessage)\n\n\n</td><td>\n\nWhen called, qwik-router will execute the path's matching route flow.\n\nThe url in the browser will remain unchanged.\n\n\n</td></tr>\n<tr><td>\n\nsend\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nSendMethod\n\n\n</td><td>\n\nSend a body response. The `Content-Type` response header is not automatically set when using `send()` and must be set manually. A `send()` response can only be called once.\n\n\n</td></tr>\n<tr><td>\n\nstatus\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode?: StatusCodes) =&gt; number\n\n\n</td><td>\n\nHTTP response status code. Sets the status code when called with an argument. Always returns the status code, so calling `status()` without an argument will can be used to return the current status code.\n\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Status\n\n\n</td></tr>\n<tr><td>\n\ntext\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode: StatusCodes, text: string) =&gt; [AbortMessage](#abortmessage)\n\n\n</td><td>\n\nConvenience method to send an text body response. The response will be automatically set the `Content-Type` header to`text/plain; charset=utf-8`<!-- -->. An `text()` response can only be called once.\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport interface RequestEventCommon<PLATFORM = QwikRouterPlatform> extends RequestEventBase<PLATFORM> \n```\n**Extends:** [RequestEventBase](#requesteventbase)<!-- -->&lt;PLATFORM&gt;\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nerror\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n&lt;T = any&gt;(statusCode: ErrorCodes, message: T) =&gt; [ServerError](#servererror-variable)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\nWhen called, the response will immediately end with the given status code. This could be useful to end a response with `404`<!-- -->, and use the 404 handler in the routes directory. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status for which status code should be used.\n\n\n</td></tr>\n<tr><td>\n\nexit\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n() =&gt; [AbortMessage](#abortmessage)\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nhtml\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode: StatusCodes, html: string) =&gt; [AbortMessage](#abortmessage)\n\n\n</td><td>\n\nConvenience method to send an HTML body response. The response will be automatically set the `Content-Type` header to`text/html; charset=utf-8`<!-- -->. An `html()` response can only be called once.\n\n\n</td></tr>\n<tr><td>\n\njson\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode: StatusCodes, data: any) =&gt; [AbortMessage](#abortmessage)\n\n\n</td><td>\n\nConvenience method to JSON stringify the data and send it in the response. The response will be automatically set the `Content-Type` header to `application/json; charset=utf-8`<!-- -->. A `json()` response can only be called once.\n\n\n</td></tr>\n<tr><td>\n\nlocale\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(local?: string) =&gt; string\n\n\n</td><td>\n\nWhich locale the content is in.\n\nThe locale value can be retrieved from selected methods using `getLocale()`<!-- -->:\n\n\n</td></tr>\n<tr><td>\n\nredirect\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode: RedirectCode, url: string) =&gt; [RedirectMessage](#redirectmessage)\n\n\n</td><td>\n\nURL to redirect to. When called, the response will immediately end with the correct redirect status and headers.\n\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections\n\n\n</td></tr>\n<tr><td>\n\nrewrite\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(pathname: string) =&gt; [RewriteMessage](#rewritemessage)\n\n\n</td><td>\n\nWhen called, qwik-router will execute the path's matching route flow.\n\nThe url in the browser will remain unchanged.\n\n\n</td></tr>\n<tr><td>\n\nsend\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nSendMethod\n\n\n</td><td>\n\nSend a body response. The `Content-Type` response header is not automatically set when using `send()` and must be set manually. A `send()` response can only be called once.\n\n\n</td></tr>\n<tr><td>\n\nstatus\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode?: StatusCodes) =&gt; number\n\n\n</td><td>\n\nHTTP response status code. Sets the status code when called with an argument. Always returns the status code, so calling `status()` without an argument will can be used to return the current status code.\n\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Status\n\n\n</td></tr>\n<tr><td>\n\ntext\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\n(statusCode: StatusCodes, text: string) =&gt; [AbortMessage](#abortmessage)\n\n\n</td><td>\n\nConvenience method to send an text body response. The response will be automatically set the `Content-Type` header to`text/plain; charset=utf-8`<!-- -->. An `text()` response can only be called once.\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/types.ts",
       "mdFile": "router.requesteventcommon.md"
     },
@@ -483,8 +466,22 @@
           "id": "servererror"
         }
       ],
-      "kind": "Class",
-      "content": "```typescript\nexport declare class ServerError<T = any> extends Error \n```\n**Extends:** Error\n\n\n<table><thead><tr><th>\n\nConstructor\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n(constructor)(status, data)\n\n\n</td><td>\n\n\n</td><td>\n\nConstructs a new instance of the `ServerError` class\n\n\n</td></tr>\n</tbody></table>\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[data](#servererror-data)\n\n\n</td><td>\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\n[status](#servererror-status)\n\n\n</td><td>\n\n\n</td><td>\n\nnumber\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "kind": "TypeAlias",
+      "content": "```typescript\nServerError: {\n    new <T = unknown>(status: number, data: T): ServerError<T>;\n    readonly prototype: ServerErrorImpl;\n}\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/server-error.ts",
+      "mdFile": "router.servererror.md"
+    },
+    {
+      "name": "ServerError",
+      "id": "servererror",
+      "hierarchy": [
+        {
+          "name": "ServerError",
+          "id": "servererror"
+        }
+      ],
+      "kind": "Variable",
+      "content": "```typescript\nServerError: {\n    new <T = unknown>(status: number, data: T): ServerError<T>;\n    readonly prototype: ServerErrorImpl;\n}\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/server-error.ts",
       "mdFile": "router.servererror.md"
     },
@@ -560,23 +557,6 @@
       "kind": "MethodSignature",
       "content": "Sets a `Response` cookie header using the `Set-Cookie` header.\n\n\n```typescript\nset(name: string, value: string | number | Record<string, any>, options?: CookieOptions): void;\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nname\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nvalue\n\n\n</td><td>\n\nstring \\| number \\| Record&lt;string, any&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[CookieOptions](#cookieoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
       "mdFile": "router.cookie.set.md"
-    },
-    {
-      "name": "status",
-      "id": "servererror-status",
-      "hierarchy": [
-        {
-          "name": "ServerError",
-          "id": "servererror-status"
-        },
-        {
-          "name": "status",
-          "id": "servererror-status"
-        }
-      ],
-      "kind": "Property",
-      "content": "```typescript\nstatus: number;\n```",
-      "mdFile": "router.servererror.status.md"
     }
   ]
 }

--- a/packages/docs/src/routes/api/qwik-router-middleware-request-handler/index.mdx
+++ b/packages/docs/src/routes/api/qwik-router-middleware-request-handler/index.mdx
@@ -522,12 +522,6 @@ string
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/types.ts)
 
-<h2 id="servererror-data">data</h2>
-
-```typescript
-data: T;
-```
-
 <h2 id="deferreturn">DeferReturn</h2>
 
 ```typescript
@@ -944,38 +938,6 @@ export interface RequestEventAction<PLATFORM = QwikRouterPlatform> extends Reque
 
 **Extends:** [RequestEventCommon](#requesteventcommon)&lt;PLATFORM&gt;
 
-<table><thead><tr><th>
-
-Property
-
-</th><th>
-
-Modifiers
-
-</th><th>
-
-Type
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-fail
-
-</td><td>
-
-</td><td>
-
-&lt;T extends Record&lt;string, any&gt;&gt;(status: number, returnData: T) =&gt; FailReturn&lt;T&gt;
-
-</td><td>
-
-</td></tr>
-</tbody></table>
-
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/types.ts)
 
 <h2 id="requesteventbase">RequestEventBase</h2>
@@ -1368,7 +1330,7 @@ error
 
 </td><td>
 
-&lt;T = any&gt;(statusCode: ErrorCodes, message: T) =&gt; [ServerError](#servererror)&lt;T&gt;
+&lt;T = any&gt;(statusCode: ErrorCodes, message: T) =&gt; [ServerError](#servererror-variable)&lt;T&gt;
 
 </td><td>
 
@@ -1703,84 +1665,25 @@ string
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/rewrite-handler.ts)
 
-<h2 id="servererror">ServerError</h2>
+<h2 id="servererror-type-alias">ServerError</h2>
 
 ```typescript
-export declare class ServerError<T = any> extends Error
+ServerError: {
+    new <T = unknown>(status: number, data: T): ServerError<T>;
+    readonly prototype: ServerErrorImpl;
+}
 ```
 
-**Extends:** Error
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/server-error.ts)
 
-<table><thead><tr><th>
+<h2 id="servererror-variable">ServerError</h2>
 
-Constructor
-
-</th><th>
-
-Modifiers
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-(constructor)(status, data)
-
-</td><td>
-
-</td><td>
-
-Constructs a new instance of the `ServerError` class
-
-</td></tr>
-</tbody></table>
-
-<table><thead><tr><th>
-
-Property
-
-</th><th>
-
-Modifiers
-
-</th><th>
-
-Type
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-[data](#servererror-data)
-
-</td><td>
-
-</td><td>
-
-T
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-[status](#servererror-status)
-
-</td><td>
-
-</td><td>
-
-number
-
-</td><td>
-
-</td></tr>
-</tbody></table>
+```typescript
+ServerError: {
+    new <T = unknown>(status: number, data: T): ServerError<T>;
+    readonly prototype: ServerErrorImpl;
+}
+```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/server-error.ts)
 
@@ -2065,9 +1968,3 @@ _(Optional)_
 **Returns:**
 
 void
-
-<h2 id="servererror-status">status</h2>
-
-```typescript
-status: number;
-```

--- a/packages/docs/src/routes/api/qwik-router/api.json
+++ b/packages/docs/src/routes/api/qwik-router/api.json
@@ -12,7 +12,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type Action<RETURN, INPUT = Record<string, unknown>, OPTIONAL extends boolean = true> = {\n    (): ActionStore<RETURN, INPUT, OPTIONAL>;\n};\n```\n**References:** [ActionStore](#actionstore)",
+      "content": "```typescript\nexport type Action<RETURN, INPUT = Record<string, unknown>, OPTIONAL extends boolean = true, ERROR = unknown> = {\n    (): ActionStore<RETURN, INPUT, OPTIONAL, ERROR>;\n};\n```\n**References:** [ActionStore](#actionstore)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.action.md"
     },
@@ -26,7 +26,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type ActionConstructor = {\n    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {\n        readonly id?: string;\n        readonly validation: [VALIDATOR, ...REST];\n    }): Action<StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>> | FailReturn<FailOfRest<REST>>>, GetValidatorInputType<VALIDATOR>, false>;\n    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {\n        readonly id?: string;\n        readonly validation: [VALIDATOR];\n    }): Action<StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>>, GetValidatorInputType<VALIDATOR>, false>;\n    <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {\n        readonly id?: string;\n        readonly validation: REST;\n    }): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;\n    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR, ...rest: REST): Action<StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>> | FailReturn<FailOfRest<REST>>>, GetValidatorInputType<VALIDATOR>, false>;\n    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR): Action<StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>>, GetValidatorInputType<VALIDATOR>, false>;\n    <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, ...rest: REST): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;\n    <OBJ>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, options?: {\n        readonly id?: string;\n    }): Action<StrictUnion<OBJ>>;\n};\n```\n**References:** [TypedDataValidator](#typeddatavalidator)<!-- -->, [DataValidator](#datavalidator)<!-- -->, [GetValidatorOutputType](#getvalidatoroutputtype)<!-- -->, [Action](#action)<!-- -->, [StrictUnion](#strictunion)<!-- -->, [FailReturn](#failreturn)<!-- -->, [ValidatorErrorType](#validatorerrortype)<!-- -->, [GetValidatorInputType](#getvalidatorinputtype)<!-- -->, [FailOfRest](#failofrest)<!-- -->, [JSONObject](#jsonobject)",
+      "content": "```typescript\nexport type ActionConstructor = {\n    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {\n        readonly id?: string;\n        readonly validation: [VALIDATOR, ...REST];\n    }): Action<OBJ, GetValidatorInputType<VALIDATOR>, false, ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>>;\n    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {\n        readonly id?: string;\n        readonly validation: [VALIDATOR];\n    }): Action<OBJ, GetValidatorInputType<VALIDATOR>, false, ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>;\n    <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {\n        readonly id?: string;\n        readonly validation: REST;\n    }): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;\n    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR, ...rest: REST): Action<OBJ, GetValidatorInputType<VALIDATOR>, false, ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>>;\n    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR): Action<OBJ, GetValidatorInputType<VALIDATOR>, false, ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>;\n    <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, ...rest: REST): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;\n    <OBJ>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, options?: {\n        readonly id?: string;\n    }): Action<OBJ>;\n};\n```\n**References:** [TypedDataValidator](#typeddatavalidator)<!-- -->, [DataValidator](#datavalidator)<!-- -->, [GetValidatorOutputType](#getvalidatoroutputtype)<!-- -->, [Action](#action)<!-- -->, [GetValidatorInputType](#getvalidatorinputtype)<!-- -->, [ValidatorErrorType](#validatorerrortype)<!-- -->, [JSONObject](#jsonobject)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.actionconstructor.md"
     },
@@ -54,7 +54,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {\n    readonly actionPath: string;\n    readonly isRunning: boolean;\n    readonly status?: number;\n    readonly formData: FormData | undefined;\n    readonly value: RETURN | undefined;\n    readonly submit: QRL<OPTIONAL extends true ? (form?: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>> : (form: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>>>;\n    readonly submitted: boolean;\n};\n```\n**References:** [ActionReturn](#actionreturn)",
+      "content": "```typescript\nexport type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true, ERROR = unknown> = {\n    readonly actionPath: string;\n    readonly isRunning: boolean;\n    readonly status?: number;\n    readonly formData: FormData | undefined;\n    readonly value: RETURN | undefined;\n    readonly error: ServerError<ERROR> | undefined;\n    readonly submit: QRL<OPTIONAL extends true ? (form?: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>> : (form: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>>>;\n    readonly submitted: boolean;\n};\n```\n**References:** [ActionReturn](#actionreturn)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.actionstore.md"
     },
@@ -283,34 +283,6 @@
       "mdFile": "router.errorboundary.md"
     },
     {
-      "name": "FailOfRest",
-      "id": "failofrest",
-      "hierarchy": [
-        {
-          "name": "FailOfRest",
-          "id": "failofrest"
-        }
-      ],
-      "kind": "TypeAlias",
-      "content": "```typescript\nexport type FailOfRest<REST extends readonly DataValidator[]> = REST extends readonly DataValidator<infer ERROR>[] ? ERROR : never;\n```\n**References:** [DataValidator](#datavalidator)",
-      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
-      "mdFile": "router.failofrest.md"
-    },
-    {
-      "name": "FailReturn",
-      "id": "failreturn",
-      "hierarchy": [
-        {
-          "name": "FailReturn",
-          "id": "failreturn"
-        }
-      ],
-      "kind": "TypeAlias",
-      "content": "```typescript\nexport type FailReturn<T> = T & Failed;\n```",
-      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
-      "mdFile": "router.failreturn.md"
-    },
-    {
       "name": "Form",
       "id": "form",
       "hierarchy": [
@@ -488,7 +460,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type Loader<RETURN> = {\n    (): LoaderSignal<RETURN>;\n};\n```\n**References:** [LoaderSignal](#loadersignal)",
+      "content": "```typescript\nexport type Loader<RETURN, ERROR = unknown> = {\n    (): LoaderSignal<RETURN, ERROR>;\n};\n```\n**References:** [LoaderSignal](#loadersignal)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.loader_2.md"
     },
@@ -502,7 +474,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type LoaderSignal<TYPE> = (TYPE extends () => ValueOrPromise<infer VALIDATOR> ? Signal<ValueOrPromise<VALIDATOR>> : Signal<TYPE>) & Pick<AsyncSignal, 'promise' | 'loading' | 'error'>;\n```",
+      "content": "```typescript\nexport type LoaderSignal<TYPE, ERROR = unknown> = (TYPE extends () => ValueOrPromise<infer VALIDATOR> ? Signal<ValueOrPromise<VALIDATOR>> : Signal<TYPE>) & Pick<AsyncSignal, 'promise' | 'loading'> & {\n    error: ServerError<ERROR> | undefined;\n};\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.loadersignal.md"
     },

--- a/packages/docs/src/routes/api/qwik-router/index.mdx
+++ b/packages/docs/src/routes/api/qwik-router/index.mdx
@@ -11,8 +11,9 @@ export type Action<
   RETURN,
   INPUT = Record<string, unknown>,
   OPTIONAL extends boolean = true,
+  ERROR = unknown,
 > = {
-  (): ActionStore<RETURN, INPUT, OPTIONAL>;
+  (): ActionStore<RETURN, INPUT, OPTIONAL, ERROR>;
 };
 ```
 
@@ -38,13 +39,10 @@ export type ActionConstructor = {
       readonly validation: [VALIDATOR, ...REST];
     },
   ): Action<
-    StrictUnion<
-      | OBJ
-      | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>
-      | FailReturn<FailOfRest<REST>>
-    >,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>
   >;
   <
     OBJ extends Record<string, any> | void | null,
@@ -59,11 +57,10 @@ export type ActionConstructor = {
       readonly validation: [VALIDATOR];
     },
   ): Action<
-    StrictUnion<
-      OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>
-    >,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>>
   >;
   <
     OBJ extends Record<string, any> | void | null,
@@ -77,7 +74,7 @@ export type ActionConstructor = {
       readonly id?: string;
       readonly validation: REST;
     },
-  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+  ): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;
   <
     OBJ extends Record<string, any> | void | null,
     VALIDATOR extends TypedDataValidator,
@@ -90,13 +87,10 @@ export type ActionConstructor = {
     options: VALIDATOR,
     ...rest: REST
   ): Action<
-    StrictUnion<
-      | OBJ
-      | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>
-      | FailReturn<FailOfRest<REST>>
-    >,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>
   >;
   <
     OBJ extends Record<string, any> | void | null,
@@ -108,11 +102,10 @@ export type ActionConstructor = {
     ) => ValueOrPromise<OBJ>,
     options: VALIDATOR,
   ): Action<
-    StrictUnion<
-      OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>
-    >,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>>
   >;
   <
     OBJ extends Record<string, any> | void | null,
@@ -123,7 +116,7 @@ export type ActionConstructor = {
       event: RequestEventAction,
     ) => ValueOrPromise<OBJ>,
     ...rest: REST
-  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+  ): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;
   <OBJ>(
     actionQrl: (
       form: JSONObject,
@@ -132,11 +125,11 @@ export type ActionConstructor = {
     options?: {
       readonly id?: string;
     },
-  ): Action<StrictUnion<OBJ>>;
+  ): Action<OBJ>;
 };
 ```
 
-**References:** [TypedDataValidator](#typeddatavalidator), [DataValidator](#datavalidator), [GetValidatorOutputType](#getvalidatoroutputtype), [Action](#action), [StrictUnion](#strictunion), [FailReturn](#failreturn), [ValidatorErrorType](#validatorerrortype), [GetValidatorInputType](#getvalidatorinputtype), [FailOfRest](#failofrest), [JSONObject](#jsonobject)
+**References:** [TypedDataValidator](#typeddatavalidator), [DataValidator](#datavalidator), [GetValidatorOutputType](#getvalidatoroutputtype), [Action](#action), [GetValidatorInputType](#getvalidatorinputtype), [ValidatorErrorType](#validatorerrortype), [JSONObject](#jsonobject)
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 
@@ -154,12 +147,18 @@ export type ActionReturn<RETURN> = {
 <h2 id="actionstore">ActionStore</h2>
 
 ```typescript
-export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {
+export type ActionStore<
+  RETURN,
+  INPUT,
+  OPTIONAL extends boolean = true,
+  ERROR = unknown,
+> = {
   readonly actionPath: string;
   readonly isRunning: boolean;
   readonly status?: number;
   readonly formData: FormData | undefined;
   readonly value: RETURN | undefined;
+  readonly error: ServerError<ERROR> | undefined;
   readonly submit: QRL<
     OPTIONAL extends true
       ? (form?: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>>
@@ -783,25 +782,6 @@ ErrorBoundary: import("@qwik.dev/core").Component<ErrorBoundaryProps>;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/error-boundary.tsx)
 
-<h2 id="failofrest">FailOfRest</h2>
-
-```typescript
-export type FailOfRest<REST extends readonly DataValidator[]> =
-  REST extends readonly DataValidator<infer ERROR>[] ? ERROR : never;
-```
-
-**References:** [DataValidator](#datavalidator)
-
-[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
-
-<h2 id="failreturn">FailReturn</h2>
-
-```typescript
-export type FailReturn<T> = T & Failed;
-```
-
-[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
-
 <h2 id="form">Form</h2>
 
 ```typescript
@@ -1251,8 +1231,8 @@ _(Optional)_
 <h2 id="loader_2">Loader_2</h2>
 
 ```typescript
-export type Loader<RETURN> = {
-  (): LoaderSignal<RETURN>;
+export type Loader<RETURN, ERROR = unknown> = {
+  (): LoaderSignal<RETURN, ERROR>;
 };
 ```
 
@@ -1263,12 +1243,15 @@ export type Loader<RETURN> = {
 <h2 id="loadersignal">LoaderSignal</h2>
 
 ```typescript
-export type LoaderSignal<TYPE> = (TYPE extends () => ValueOrPromise<
-  infer VALIDATOR
->
+export type LoaderSignal<
+  TYPE,
+  ERROR = unknown,
+> = (TYPE extends () => ValueOrPromise<infer VALIDATOR>
   ? Signal<ValueOrPromise<VALIDATOR>>
   : Signal<TYPE>) &
-  Pick<AsyncSignal, "promise" | "loading" | "error">;
+  Pick<AsyncSignal, "promise" | "loading"> & {
+    error: ServerError<ERROR> | undefined;
+  };
 ```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)

--- a/packages/docs/src/routes/docs/(qwikrouter)/action/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/action/index.mdx
@@ -290,7 +290,7 @@ export default component$(() => {
         <input name="firstName" />
         <input name="lastName" />
 
-        {action.value?.failed && <p>{action.value.fieldErrors?.firstName}</p>}
+        {action.error && <p>{action.error.fieldErrors?.firstName}</p>}
         <button type="submit">Add user</button>
       </Form>
       {action.value?.success && (
@@ -301,7 +301,7 @@ export default component$(() => {
 });
 ```
 
-When submitting data to a `routeAction()`, the data is validated against the Zod schema. If the data is invalid, the action will put the validation error in the `routeAction.value` property.
+When submitting data to a `routeAction()`, the data is validated against the Zod schema. If the data is invalid, the action fails: the validation error surfaces on `action.error` (a `ServerError`), and the field-level messages are exposed directly on the error as `action.error.fieldErrors` (the validator error fields are spread onto the `ServerError`).
 
 Please refer to the [Zod documentation](https://zod.dev/) for more information on how to use Zod schemas.
 
@@ -366,17 +366,17 @@ export const useProductRecommendations = routeAction$(
 
 ## Action Failures
 
-In order to return non-success values, the action must use the `fail()` method.
+To signal a failure from an action, destructure `error` from the `RequestEvent` and `throw error(status, data)`. `error()` returns a `ServerError`, so throwing it puts the action into its error state.
 
-```tsx /fail/
+```tsx /error/
 import { routeAction$, zod$, z } from '@qwik.dev/router';
 
 export const useAddUser = routeAction$(
-  async (user, { fail }) => {
+  async (user, { error }) => {
     // `user` is typed { name: string }
     const userID = await db.users.add(user);
     if (!userID) {
-      return fail(500, {
+      throw error(500, {
         message: 'User could not be added',
       });
     }
@@ -390,7 +390,9 @@ export const useAddUser = routeAction$(
 );
 ```
 
-Failures are stored in the `action.value` property, just like the success value. However, the `action.value.failed` property is set to `true` when the action fails. Futhermore, failure messages can be found in the `fieldErrors` object according to properties defined in your Zod schema.
+Failures surface on the `action.error` property (a `ServerError`), separate from the success value on `action.value`. The `ServerError` carries `error.status` (the HTTP status) and `error.message` (the payload's string `message` when present). When you pass an object to `error()`, its fields are spread directly onto the error, so you read them flat: `error.<field>`. The original payload is also available as `error.data` (the canonical payload object).
+
+For validators, the validator error fields are exposed flat on the error: failure messages live in `action.error.fieldErrors` according to the properties defined in your Zod schema.
 
 The `fieldErrors` become a dot notation object. See [Complex forms](/docs/advanced/complex-forms) for more information.
 
@@ -404,14 +406,14 @@ export default component$(() => {
     <Form action={action}>
       <input name="name" />
       <button type="submit">Add user</button>
-      {action.value?.failed && <p>{action.value.fieldErrors.name}</p>}
+      {action.error && <p>{action.error.fieldErrors?.name}</p>}
       {action.value?.userID && <p>User added successfully</p>}
     </Form>
   );
 });
 ```
 
-Thanks to Typescript type discrimination, you can use the `action.value.failed` property to discriminate between success and failure.
+Branch on `action.error` to render failure UI, and on `action.value` for the success result — they are never both set at once.
 
 ## Previous form state
 

--- a/packages/docs/src/routes/docs/(qwikrouter)/route-loader/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/route-loader/index.mdx
@@ -66,10 +66,10 @@ Hooks return an `AsyncSignal<T>`. Branch on `.loading` and `.error` before readi
 import { component$ } from '@qwik.dev/core';
 import { routeLoader$ } from '@qwik.dev/router';
 
-export const useProductDetails = routeLoader$(async ({ params, fail }) => {
+export const useProductDetails = routeLoader$(async ({ params, error }) => {
   const product = await db.products.findById(params.productId);
   if (!product) {
-    return fail(404, { message: 'Product not found' });
+    throw error(404, { message: 'Product not found' });
   }
   return product;
 });
@@ -81,8 +81,8 @@ export default component$(() => {
     return <div>Loading…</div>;
   }
   if (product.error) {
-    // ServerError — read .status and .data
-    return <div>{product.error.status}: {product.error.data.message}</div>;
+    // ServerError — read .status, .data, and .message
+    return <div>{product.error.status}: {product.error.message}</div>;
   }
   return <div>Product name: {product.value.name}</div>;
 });
@@ -92,10 +92,20 @@ export default component$(() => {
 
 ### Signaling failure from a loader
 
-Loaders signal failure two ways. Both put the signal into error state with `signal.error` set to a `ServerError` carrying `.status` (HTTP status) and `.data` (the payload):
+To signal failure, destructure `error` from the `RequestEvent` and `throw error(status, data)`. This puts the signal into error state, with `signal.error` set to a `ServerError` carrying `.status` (the HTTP status), `.data` (the payload you passed to `error()`), and `.message` (`data.message` when the payload has a string `message`).
 
-- **`return requestEvent.fail(status, data)`** — return a tagged failure. `signal.error.data` is `{ failed: true, ...data }`.
-- **`throw requestEvent.error(status, data)`** — throw a `ServerError` directly. `signal.error.data` is `data`.
+```tsx
+export const useProduct = routeLoader$(async ({ params, error }) => {
+  const product = await db.products.findById(params.productId);
+  if (!product) {
+    // signal.error.status === 404, signal.error.data === { message: 'Product not found' }
+    throw error(404, { message: 'Product not found' });
+  }
+  return product;
+});
+```
+
+Read it back on `signal.error`, never on `signal.value` — `.value` holds the success value only.
 
 ## Multiple `routeLoader$`s
 
@@ -329,7 +339,7 @@ export default component$(() => {
 | Echo the just-submitted form value back to the page | Loader returns the URL-derived value; the component overlays `action.value` on top, e.g. `action.value?.name ?? loader.value.name`.                                                          |
 | Recompute derived data from the submission          | Put the inputs in the URL (search params, or `goto()` after the action) so the loader reads them like any other route input.                                                                |
 | Refresh authoritative data after a mutation         | The action writes to your store (DB, KV, etc.); the loader reads from that store. The action's `invalidate` list re-runs the loader and it picks up the new state — no action result needed. |
-| Show success / error feedback                       | Read the action signal directly: `action.value`, `action.isRunning`, `action.value?.failed`. Ephemeral UI feedback doesn't belong in a loader.                                              |
+| Show success / error feedback                       | Read the action signal directly: `action.value`, `action.isRunning`, `action.error`. Ephemeral UI feedback doesn't belong in a loader.                                              |
 
 ## Options reference
 

--- a/packages/docs/src/routes/docs/(qwikrouter)/validator/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/validator/index.mdx
@@ -37,20 +37,23 @@ export const useAction = routeAction$(
 );
 ```
 
-When submitting a request to a `routeAction()`, the request event and data undergo validation against the defined validator. If the validation fails, the action will place the validation error in the `routeAction.value` property.
+When submitting a request to a `routeAction()`, the request event and data undergo validation against the defined validator. If the validation fails, the action surfaces the validation error on the `routeAction.error` property (a `ServerError`), separate from the success value on `routeAction.value`.
 
 ```tsx
 export default component$(() => {
   const action = useAction();
 
-  // action value is undefined before submitting
-  if (action.value) {
-    if (action.value.failed) {
-      // action failed if query string has no secret
-      action.value satisfies { failed: true; message: string };
-    } else {
-      action.value satisfies { searchResult: string };
-    }
+  // both are undefined before submitting; only one is set after
+  if (action.error) {
+    // validation failed if query string has no secret
+    // action.error is a ServerError: .status is the HTTP status, and the
+    // validator error fields are spread directly onto the error, so you read
+    // them flat (e.g. action.error.message). The canonical payload object is
+    // still available as action.error.data.
+    action.error.message satisfies string;
+    action.error.data satisfies { message: string };
+  } else if (action.value) {
+    action.value satisfies { searchResult: string };
   }
 
   return (
@@ -144,21 +147,21 @@ interface Fail {
 }
 ```
 
-Validator behaves like using the `fail()` method in the action or loader when it returns a failed object.
+When a validator returns a failed object, the framework turns it into a `ServerError` — the same outcome as `throw error(status, data)` inside the action or loader. The error surfaces on `action.error`, with `action.error.status` set to the validator's `status`. The validator's `error` object fields are spread directly onto the error, so you read them flat (e.g. `action.error.message`); the canonical payload object is also available as `action.error.data`.
 
-```tsx /status/#a /errorObject/#b
+```tsx /status/#a /errorData/#b
 const status = 500;
-const errorObject = { message: "123" };
+const errorData = { message: "123" };
 
 export const useAction = routeAction$(
-  async (_, { fail }) => {
-    return fail(status, errorObject);
+  async (_, { error }) => {
+    throw error(status, errorData);
   },
   validator$(async () => {
     return {
       success: false,
       status,
-      errorObject,
+      error: errorData,
     };
   }),
 );

--- a/packages/qwik-router/src/middleware/request-handler/handlers/action-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/action-handler.ts
@@ -8,6 +8,7 @@ import type {
   ValidatorReturn,
 } from '../../../runtime/src/types';
 import { RequestEvSharedActionId, type RequestEventInternal } from '../request-event-core';
+import { ServerError } from '../server-error';
 import { IsQAction, QActionId } from '../request-path';
 import type { QRL } from '@qwik.dev/core';
 import type { RequestEventBase } from '../types';
@@ -83,10 +84,13 @@ export function actionHandler(routeActions: ActionInternal[]): RequestHandler {
     }
 
     let actionResult: unknown;
-    const result = await runValidators(requestEv, action.__validators, data, devMode);
-    if (!result.success) {
-      actionResult = requestEv.fail(result.status ?? 500, result.error);
-    } else {
+    let actionError: ServerError | undefined;
+    try {
+      const result = await runValidators(requestEv, action.__validators, data, devMode);
+      if (!result.success) {
+        // A failed validator surfaces as the action's error state.
+        throw new ServerError(result.status ?? 500, result.error);
+      }
       const actionResolved = devMode
         ? await measure(requestEv, action.__qrl.getHash(), () =>
             action!.__qrl.call(requestEv, result.data as JSONObject, requestEv)
@@ -96,12 +100,21 @@ export function actionHandler(routeActions: ActionInternal[]): RequestHandler {
         verifySerializable(actionResolved, action.__qrl);
       }
       actionResult = actionResolved;
+    } catch (err) {
+      // `throw error(...)` / failed validators surface as `action.error`. Other throws
+      // (redirects, unexpected errors) propagate to the middleware chain as before.
+      if (err instanceof ServerError) {
+        actionError = err;
+        requestEv.status(err.status);
+      } else {
+        throw err;
+      }
     }
-    const responseData: Record<string, unknown> = {
-      result: actionResult,
-    };
+    const responseData: Record<string, unknown> = actionError
+      ? { error: actionError }
+      : { result: actionResult };
     requestEv.sharedMap.set(RequestEvSharedActionId, actionId);
-    requestEv.sharedMap.set('@actionResult', actionResult);
+    requestEv.sharedMap.set('@actionResult', actionError ?? actionResult);
 
     if (action.__invalidate) {
       // Action specifies which loaders to invalidate — send only hashes, client re-fetches

--- a/packages/qwik-router/src/middleware/request-handler/handlers/action-handler.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/action-handler.unit.ts
@@ -2,6 +2,7 @@ import { _deserialize } from '@qwik.dev/core/internal';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RequestEvSharedActionId } from '../request-event-core';
 import { IsQAction, QActionId } from '../request-path';
+import { ServerError } from '../server-error';
 import { actionHandler } from './action-handler';
 
 const previousStrictLoaders = globalThis.__STRICT_LOADERS__;
@@ -46,9 +47,9 @@ const createActionRequest = () => {
     headersSent: false,
     exited: false,
     parseBody: vi.fn(async () => ({ name: 'Ada' })),
-    fail: vi.fn((statusCode: number, data: Record<string, unknown>) => {
+    error: vi.fn((statusCode: number, data: unknown) => {
       currentStatus = statusCode;
-      return { failed: true, status: statusCode, ...data };
+      return new ServerError(statusCode, data);
     }),
     status: vi.fn((statusCode?: number) => {
       if (typeof statusCode === 'number') {
@@ -132,11 +133,15 @@ describe('actionHandler', () => {
     await actionHandler([action])(requestEv as any);
 
     expect(sent.status).toBe(422);
-    const response = _deserialize<Record<string, unknown>>(sent.body!);
-    expect(response.result).toMatchObject({ failed: true, status: 422 });
+    const response = _deserialize<{ result?: unknown; error?: any }>(sent.body!);
+    expect(response.result).toBeUndefined();
+    expect(response.error).toMatchObject({
+      status: 422,
+      data: { field: 'name', message: 'too short' },
+    });
   });
 
-  it('reflects fail() status called from action QRL in HTTP response', async () => {
+  it('reflects thrown error() status from action QRL in HTTP response', async () => {
     globalThis.__STRICT_LOADERS__ = false;
     const { requestEv, sent } = createActionRequest();
 
@@ -147,15 +152,18 @@ describe('actionHandler', () => {
       __invalidate: undefined,
       __qrl: {
         getHash: () => 'action-a',
-        // First arg is requestEv, second is parsed body data
-        call: vi.fn(async (ev: any) => ev.fail(500, { msg: 'something went wrong' })),
+        // First arg is requestEv; the action throws error() to signal failure.
+        call: vi.fn(async (ev: any) => {
+          throw ev.error(500, { msg: 'something went wrong' });
+        }),
       },
     } as any;
 
     await actionHandler([action])(requestEv as any);
 
     expect(sent.status).toBe(500);
-    const response = _deserialize<Record<string, unknown>>(sent.body!);
-    expect(response.result).toMatchObject({ failed: true, msg: 'something went wrong' });
+    const response = _deserialize<{ result?: unknown; error?: any }>(sent.body!);
+    expect(response.result).toBeUndefined();
+    expect(response.error).toMatchObject({ status: 500, data: { msg: 'something went wrong' } });
   });
 });

--- a/packages/qwik-router/src/middleware/request-handler/middleware.request-handler.api.md
+++ b/packages/qwik-router/src/middleware/request-handler/middleware.request-handler.api.md
@@ -7,7 +7,6 @@
 import type { Action } from '@qwik.dev/router';
 import type { AsyncLocalStorage } from 'node:async_hooks';
 import type { EnvGetter as EnvGetter_2 } from '@qwik.dev/router/middleware/request-handler';
-import type { FailReturn } from '@qwik.dev/router';
 import type { JSXOutput } from '@qwik.dev/core';
 import type { Loader as Loader_2 } from '@qwik.dev/router';
 import type { QwikIntrinsicElements } from '@qwik.dev/core';
@@ -120,8 +119,6 @@ export interface RequestEvent<PLATFORM = QwikRouterPlatform> extends RequestEven
 
 // @public (undocumented)
 export interface RequestEventAction<PLATFORM = QwikRouterPlatform> extends RequestEventCommon<PLATFORM> {
-    // (undocumented)
-    fail: <T extends Record<string, any>>(status: number, returnData: T) => FailReturn<T>;
 }
 
 // @public (undocumented)
@@ -205,14 +202,16 @@ export class RewriteMessage extends AbortMessage {
     readonly pathname: string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "ServerErrorImpl" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type ServerError<T = unknown> = ServerErrorImpl<T> & (T extends object ? T : unknown);
+
 // @public (undocumented)
-export class ServerError<T = any> extends Error {
-    constructor(status: number, data: T);
-    // (undocumented)
-    data: T;
-    // (undocumented)
-    status: number;
-}
+export const ServerError: {
+    new <T = unknown>(status: number, data: T): ServerError<T>;
+    readonly prototype: ServerErrorImpl;
+};
 
 // @public (undocumented)
 export interface ServerRenderOptions extends RenderOptions {

--- a/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
@@ -1,7 +1,6 @@
 import { _deserialize, isDev } from '@qwik.dev/core/internal';
 import type {
   ActionInternal,
-  FailReturn,
   JSONValue,
   LoadedRoute,
   LoaderInternal,
@@ -288,10 +287,22 @@ export function createRequestEventWithDeps(
     rewrite: (pathname: string) => {
       check();
       if (pathname.startsWith('http')) {
-        throw new deps.ServerError(
-          400,
-          isDev ? 'Rewrite does not support absolute urls' : 'Bad Request'
-        );
+        // A rewrite is an internal, same-origin re-route. A same-origin absolute URL is just
+        // a path with the origin glued on, so normalize it to its path and treat it like a
+        // relative rewrite. A cross-origin URL can't be rewritten in place — that's a redirect.
+        let target: URL;
+        try {
+          target = new URL(pathname);
+        } catch {
+          throw new deps.ServerError(400, isDev ? 'Invalid rewrite url' : 'Bad Request');
+        }
+        if (target.origin !== url.origin) {
+          throw new deps.ServerError(
+            400,
+            isDev ? 'Rewrite does not support cross-origin urls' : 'Bad Request'
+          );
+        }
+        pathname = target.pathname + target.search + target.hash;
       }
       sharedMap.set(RequestEvIsRewrite, true);
       return exit(new deps.RewriteMessage(pathname.replace(/\/+/g, '/')));
@@ -299,16 +310,6 @@ export function createRequestEventWithDeps(
 
     defer: (returnData) => {
       return typeof returnData === 'function' ? returnData : () => returnData;
-    },
-
-    fail: <T extends Record<string, any>>(statusCode: number, data: T): FailReturn<T> => {
-      check();
-      status = statusCode;
-      headers.delete('Cache-Control');
-      return {
-        failed: true,
-        ...data,
-      };
     },
 
     text: (statusCode: number, text: string) => {

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../runtime/src/types';
 import {
   getRouteLoaderCtx,
+  getRouteLoaderErrors,
   getRouteLoaderValues,
   loadRouteLoader,
   setRouteLoaders,
@@ -293,11 +294,13 @@ export function createResolveRequestHandlers(deps: ResolveRequestHandlersDeps) {
                 `Expected request data for the action id ${selectedActionId} to be an object`
               );
             }
-            const result = await runValidators(requestEv, action.__validators, data);
             let actionResult: unknown;
-            if (!result.success) {
-              actionResult = requestEv.fail(result.status ?? 500, result.error);
-            } else {
+            try {
+              const result = await runValidators(requestEv, action.__validators, data);
+              if (!result.success) {
+                // A failed validator surfaces as the action's error state.
+                throw new deps.ServerError(result.status ?? 500, result.error);
+              }
               const actionResolved = isDev
                 ? await measure(requestEv, action.__qrl.getHash(), () =>
                     action.__qrl.call(requestEv, result.data as JSONObject, requestEv)
@@ -307,6 +310,15 @@ export function createResolveRequestHandlers(deps: ResolveRequestHandlersDeps) {
                 verifySerializable(actionResolved, action.__qrl);
               }
               actionResult = actionResolved;
+            } catch (err) {
+              // `throw error(...)` / failed validators become `action.error`. Other throws
+              // (redirects, unexpected errors) propagate to the middleware chain as before.
+              if (err instanceof deps.ServerError) {
+                requestEv.status(err.status);
+                actionResult = err;
+              } else {
+                throw err;
+              }
             }
             requestEv.sharedMap.set('@actionResult', actionResult);
           }
@@ -325,12 +337,27 @@ export function createResolveRequestHandlers(deps: ResolveRequestHandlersDeps) {
       if (routeLoaders.length > 0) {
         setLoaderData(requestEv, routeLoaders, route);
 
-        // Run loaders directly and store raw values.
-        // Errors/redirects propagate so middleware can catch them (e.g. plugin@errors).
+        // Run loaders directly and store raw values. A loader that signals failure
+        // (`fail()` / `throw error()`) throws a ServerError — captured per-loader so it
+        // surfaces as that loader's error state (`loader.error`) and the page still renders.
+        // Redirects and unexpected errors still propagate so middleware can catch them.
         const loaderValues = getRouteLoaderValues(requestEv);
+        const loaderErrors = getRouteLoaderErrors(requestEv);
         await Promise.all(
           routeLoaders.map(async (loader) => {
-            loaderValues[loader.__id] = await loadRouteLoader(loader, requestEv);
+            try {
+              loaderValues[loader.__id] = await loadRouteLoader(loader, requestEv);
+            } catch (err) {
+              if (err instanceof deps.ServerError) {
+                // Reflect the failure's status on the response. `throw error(status, ...)`
+                // already set it, but a directly-thrown `new ServerError(status, ...)`
+                // (e.g. from a server$ call) has not.
+                requestEv.status(err.status);
+                loaderErrors[loader.__id] = err;
+              } else {
+                throw err;
+              }
+            }
           })
         );
       }

--- a/packages/qwik-router/src/middleware/request-handler/server-error.ts
+++ b/packages/qwik-router/src/middleware/request-handler/server-error.ts
@@ -1,9 +1,40 @@
-/** @public */
-export class ServerError<T = any> extends Error {
-  constructor(
-    public status: number,
-    public data: T
-  ) {
-    super(typeof data === 'string' ? data : undefined);
+class ServerErrorImpl<T = unknown> extends Error {
+  status: number;
+  data: T;
+  constructor(status: number, data: T) {
+    // The error message is the string payload, or the payload's `message` field if it has one.
+    super(
+      typeof data === 'string'
+        ? data
+        : data &&
+            typeof data === 'object' &&
+            typeof (data as { message?: unknown }).message === 'string'
+          ? ((data as { message?: unknown }).message as string)
+          : undefined
+    );
+    // Expose object-payload fields directly on the error (`error.fieldErrors`) so callers don't
+    // have to reach through `.data`. `.data` remains the canonical payload (the exact value passed
+    // to `error()`, including string payloads) used for serializing error responses and re-throwing.
+    if (data && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+    this.status = status;
+    this.data = data;
   }
 }
+
+/**
+ * An error thrown from a loader/action (via `throw error(status, data)`) or produced by a failed
+ * validator. `status` is the HTTP status, `message` is the string payload (or the payload's
+ * `message` field), and an object payload's fields are exposed directly on the error (e.g.
+ * `error.fieldErrors`). `.data` is the canonical payload that was passed to `error()`.
+ *
+ * @public
+ */
+export type ServerError<T = unknown> = ServerErrorImpl<T> & (T extends object ? T : unknown);
+
+/** @public */
+export const ServerError = ServerErrorImpl as {
+  new <T = unknown>(status: number, data: T): ServerError<T>;
+  readonly prototype: ServerErrorImpl;
+};

--- a/packages/qwik-router/src/middleware/request-handler/types.ts
+++ b/packages/qwik-router/src/middleware/request-handler/types.ts
@@ -1,6 +1,6 @@
 import type { _deserialize, _serialize, _verifySerializable } from '@qwik.dev/core/internal';
 import type { Render, RenderOptions } from '@qwik.dev/core/server';
-import type { Action, FailReturn, Loader } from '@qwik.dev/router';
+import type { Action, Loader } from '@qwik.dev/router';
 import type { ServerError } from './server-error';
 import type { AbortMessage, RedirectMessage } from './redirect-handler';
 import type { RewriteMessage } from './rewrite-handler';
@@ -497,9 +497,7 @@ declare global {
 /** @public */
 export interface RequestEventAction<
   PLATFORM = QwikRouterPlatform,
-> extends RequestEventCommon<PLATFORM> {
-  fail: <T extends Record<string, any>>(status: number, returnData: T) => FailReturn<T>;
-}
+> extends RequestEventCommon<PLATFORM> {}
 
 /** @public */
 export type DeferReturn<T> = () => Promise<T>;

--- a/packages/qwik-router/src/runtime/src/index.ts
+++ b/packages/qwik-router/src/runtime/src/index.ts
@@ -21,7 +21,6 @@ export type {
   DocumentMeta,
   DocumentScript,
   DocumentStyle,
-  FailReturn,
   HttpStatus as HttpErrorProps,
   InternalRequest,
   JSONObject,
@@ -108,7 +107,6 @@ export { omitProps, untypedAppUrl } from './typed-routes';
 export type {
   ActionReturn,
   DataValidator,
-  FailOfRest,
   GetValidatorInputType,
   GetValidatorOutputType,
   GetValidatorType,

--- a/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
+++ b/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
@@ -115,6 +115,7 @@ import type {
   ScrollState,
 } from './types';
 import { submitAction } from './use-endpoint';
+import { ServerError } from '../../middleware/request-handler/server-error';
 import { useQwikRouterEnv } from './use-functions';
 import { isSameOrigin, isSamePath, toPath, toUrl } from './utils';
 import { startViewTransition, type ViewTransition } from './view-transition';
@@ -276,10 +277,12 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
       ? {
           id: currentActionId!,
           data: env.response.formData,
-          output: {
-            result: currentAction,
-            status: env.response.status,
-          },
+          // Runs during SSR where `currentAction` is the real value/instance, so a failed
+          // action (a `ServerError`) is routed to `output.error` and the rest to `output.result`.
+          output:
+            currentAction instanceof ServerError
+              ? { error: currentAction, status: env.response.status }
+              : { result: currentAction, status: env.response.status },
         }
       : undefined
   );
@@ -566,7 +569,7 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
           actionData = {
             status: result.status,
             action: action.id,
-            actionResult: result.result,
+            actionResult: result.error ?? result.result,
           };
 
           // Resolve the action promise and free the closure
@@ -574,6 +577,7 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
             action.resolve({
               status: result.status,
               result: result.result,
+              error: result.error,
             });
             action.resolve = undefined;
           }

--- a/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
+++ b/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
@@ -28,6 +28,7 @@ import { RequestEventLoader } from '@qwik.dev/router/middleware/request-handler'
 import { RequestHandler } from '@qwik.dev/router/middleware/request-handler';
 import type { ResolveSyncValue } from '@qwik.dev/router/middleware/request-handler';
 import type { SerializationStrategy } from '@qwik.dev/core/internal';
+import type { ServerError } from '@qwik.dev/router/middleware/request-handler';
 import type { Signal } from '@qwik.dev/core';
 import type * as v from 'valibot';
 import type { ValueOrPromise } from '@qwik.dev/core';
@@ -36,8 +37,8 @@ import { z } from 'zod';
 import type * as z_2 from 'zod';
 
 // @public (undocumented)
-export type Action<RETURN, INPUT = Record<string, unknown>, OPTIONAL extends boolean = true> = {
-    (): ActionStore<RETURN, INPUT, OPTIONAL>;
+export type Action<RETURN, INPUT = Record<string, unknown>, OPTIONAL extends boolean = true, ERROR = unknown> = {
+    (): ActionStore<RETURN, INPUT, OPTIONAL, ERROR>;
 };
 
 // @public (undocumented)
@@ -45,21 +46,21 @@ export type ActionConstructor = {
     <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {
         readonly id?: string;
         readonly validation: [VALIDATOR, ...REST];
-    }): Action<StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>> | FailReturn<FailOfRest<REST>>>, GetValidatorInputType<VALIDATOR>, false>;
+    }): Action<OBJ, GetValidatorInputType<VALIDATOR>, false, ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>>;
     <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {
         readonly id?: string;
         readonly validation: [VALIDATOR];
-    }): Action<StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>>, GetValidatorInputType<VALIDATOR>, false>;
+    }): Action<OBJ, GetValidatorInputType<VALIDATOR>, false, ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>;
     <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, options: {
         readonly id?: string;
         readonly validation: REST;
-    }): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
-    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR, ...rest: REST): Action<StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>> | FailReturn<FailOfRest<REST>>>, GetValidatorInputType<VALIDATOR>, false>;
-    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR): Action<StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>>, GetValidatorInputType<VALIDATOR>, false>;
-    <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, ...rest: REST): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+    }): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;
+    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR, ...rest: REST): Action<OBJ, GetValidatorInputType<VALIDATOR>, false, ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>>;
+    <OBJ extends Record<string, any> | void | null, VALIDATOR extends TypedDataValidator>(actionQrl: (data: GetValidatorOutputType<VALIDATOR>, event: RequestEventAction) => ValueOrPromise<OBJ>, options: VALIDATOR): Action<OBJ, GetValidatorInputType<VALIDATOR>, false, ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>;
+    <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, ...rest: REST): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;
     <OBJ>(actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>, options?: {
         readonly id?: string;
-    }): Action<StrictUnion<OBJ>>;
+    }): Action<OBJ>;
 };
 
 // @public (undocumented)
@@ -69,12 +70,13 @@ export type ActionReturn<RETURN> = {
 };
 
 // @public (undocumented)
-export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {
+export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true, ERROR = unknown> = {
     readonly actionPath: string;
     readonly isRunning: boolean;
     readonly status?: number;
     readonly formData: FormData | undefined;
     readonly value: RETURN | undefined;
+    readonly error: ServerError<ERROR> | undefined;
     readonly submit: QRL<OPTIONAL extends true ? (form?: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>> : (form: INPUT | FormData | SubmitEvent) => Promise<ActionReturn<RETURN>>>;
     readonly submitted: boolean;
 };
@@ -194,14 +196,6 @@ export type DocumentStyle = Readonly<((Omit<QwikIntrinsicElements['style'], 'dan
 export const ErrorBoundary: Component<ErrorBoundaryProps>;
 
 // @public (undocumented)
-export type FailOfRest<REST extends readonly DataValidator[]> = REST extends readonly DataValidator<infer ERROR>[] ? ERROR : never;
-
-// Warning: (ae-forgotten-export) The symbol "Failed" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export type FailReturn<T> = T & Failed;
-
-// @public (undocumented)
 export const Form: <O, I>(input: FormProps<O, I>, key: string | null) => JSXOutput;
 
 // @public (undocumented)
@@ -281,13 +275,15 @@ export interface LinkProps extends AnchorAttributes {
 }
 
 // @public (undocumented)
-type Loader_2<RETURN> = {
-    (): LoaderSignal<RETURN>;
+type Loader_2<RETURN, ERROR = unknown> = {
+    (): LoaderSignal<RETURN, ERROR>;
 };
 export { Loader_2 as Loader }
 
 // @public (undocumented)
-export type LoaderSignal<TYPE> = (TYPE extends () => ValueOrPromise<infer VALIDATOR> ? Signal<ValueOrPromise<VALIDATOR>> : Signal<TYPE>) & Pick<AsyncSignal, 'promise' | 'loading' | 'error'>;
+export type LoaderSignal<TYPE, ERROR = unknown> = (TYPE extends () => ValueOrPromise<infer VALIDATOR> ? Signal<ValueOrPromise<VALIDATOR>> : Signal<TYPE>) & Pick<AsyncSignal, 'promise' | 'loading'> & {
+    error: ServerError<ERROR> | undefined;
+};
 
 // @public (undocumented)
 type NavigationType_2 = 'initial' | 'form' | 'link' | 'popstate';
@@ -680,6 +676,10 @@ export type ZodConstructor = {
 //
 // @internal (undocumented)
 export const zodQrl: ZodConstructorQRL;
+
+// Warnings were encountered during analysis:
+//
+// /Users/maieul/dev/work/qwik-v2/dist-dev/dts-out/packages/qwik-router/src/runtime/src/types.d.ts:451:5 - (ae-forgotten-export) The symbol "FailOfRest" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -51,6 +51,7 @@ const REQUEST_ROUTE_LOADER_STATE = '@routeLoaderState';
 const REQUEST_LOADER_PATHS_STORE = '@loaderPathsStore';
 const REQUEST_ROUTE_LOADERS = '@routeLoaders';
 const REQUEST_ROUTE_LOADER_PROMISES = '@routeLoaderPromises';
+const REQUEST_ROUTE_LOADER_ERRORS = '@routeLoaderErrors';
 const REQUEST_ROUTE_LOADER_EVENTS = '@routeLoaderEvents';
 const REQUEST_ROUTE_LOADER_ROOT_EVENT = '@routeLoaderRootEvent';
 const ROUTE_LOADER_VALUE_PREFIX = '__qwik_route_loader_value__';
@@ -138,6 +139,13 @@ class ServerRouteLoaderCapture {
 
   load() {
     const requestEv = getRequestEvent();
+    // A loader that failed during loadersMiddleware (fail() / throw error()) was captured
+    // as a ServerError. Re-throw it so the AsyncSignal enters error state during render
+    // instead of re-running the loader.
+    const errors = getRouteLoaderErrors(requestEv);
+    if (this.hash in errors) {
+      throw errors[this.hash];
+    }
     // Use pre-computed value from loadersMiddleware if available,
     // to avoid re-running the loader after the response stream is open.
     const values = getRouteLoaderValues(requestEv);
@@ -510,6 +518,24 @@ export function getRouteLoaderValues(requestEv: RequestEventBase): Record<string
   return values;
 }
 
+/**
+ * Get/create the record of loader failures (`fail()` / `throw error()`) captured by
+ * loadersMiddleware. Keyed by loader id; values are the `ServerError` to surface as the signal's
+ * error state during render. Request-scoped and server-only.
+ */
+export function getRouteLoaderErrors(
+  requestEv: RequestEventBase
+): Record<string, InstanceType<typeof ServerError>> {
+  let errors = requestEv.sharedMap.get(REQUEST_ROUTE_LOADER_ERRORS) as
+    | Record<string, InstanceType<typeof ServerError>>
+    | undefined;
+  if (!errors) {
+    errors = {};
+    requestEv.sharedMap.set(REQUEST_ROUTE_LOADER_ERRORS, errors);
+  }
+  return errors;
+}
+
 function getRouteLoaderPromises(requestEv: RequestEventBase): Record<string, Promise<unknown>> {
   let promises = requestEv.sharedMap.get(REQUEST_ROUTE_LOADER_PROMISES) as
     | Record<string, Promise<unknown>>
@@ -638,7 +664,13 @@ export const getRouteLoaderData = async (
 
   const result = await runValidators(requestEv, validators, undefined);
   if (!result.success) {
-    return loaderRequestEv.fail(result.status ?? 500, result.error);
+    // A failed validator surfaces as the loader's error state (a ServerError), the same
+    // as `throw error(...)`. On the client, getRouteLoaderResponse serializes it into the
+    // error envelope and the AsyncSignal re-throws it for the component to read via
+    // `loader.error`.
+    const status = result.status ?? 500;
+    requestEv.status(status);
+    throw new ServerError(status, result.error);
   }
   const resolved = await loaderQrl.call(
     loaderRequestEv as unknown as ServerRequestEventLoader,
@@ -749,9 +781,7 @@ export const getRouteLoaderResponse = async (
 ): Promise<LoaderResponse> => {
   try {
     const value = await getRouteLoaderData(loaderQrl, validators, requestEv);
-    if (value && typeof value === 'object' && (value as any).failed) {
-      return { e: new ServerError(requestEv.status(), value) };
-    }
+    // fail() is thrown as a ServerError by getRouteLoaderData and handled in the catch below.
     return { d: value };
   } catch (err) {
     if (err instanceof RedirectMessage) {
@@ -782,7 +812,9 @@ export const routeLoaderQrl = ((
       signal = ensureRouteLoaderSignal(loader, state, routeLoaderCtx);
     }
     void signal.promise();
-    return signal;
+    // The runtime signal is an AsyncSignal (error: Error); loaders narrow `.error` to
+    // ServerError (failures are always ServerErrors), so assert the loader-facing type here.
+    return signal as unknown as ReturnType<LoaderInternal>;
   }
 
   loader.__brand = 'server_loader' as const;

--- a/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, expectTypeOf, it, test, vi } from 'vitest';
 import { _UNINITIALIZED, type SerializationStrategy } from '@qwik.dev/core/internal';
+import { ServerError } from '../../middleware/request-handler/server-error';
+import { RedirectMessage } from '../../middleware/request-handler/redirect-handler';
 import {
   ensureRouteLoaderSignal,
+  getRouteLoaderData,
+  getRouteLoaderResponse,
   loadRouteLoader,
+  routeLoader$,
   routeLoaderQrl,
   type RouteLoaderState,
 } from './route-loaders';
@@ -90,6 +95,157 @@ describe('route loader execution', () => {
     expect(loader.__expires).toBe(60_000);
   });
 });
+
+describe('loader failures surface as error state', () => {
+  // A loader failure (throw error() / failed validator) must surface as the signal's
+  // error state (a ServerError) on the server and the client — never as loader.value.
+  it('propagates the ServerError thrown by the loader', async () => {
+    const ev = makeRequestEv();
+    const qrl = createQrl('error-loader', (_thisArg, e) => {
+      throw e.error(400, { message: 'Product not found' });
+    });
+
+    const promise = getRouteLoaderData(qrl, undefined, ev);
+    await expect(promise).rejects.toBeInstanceOf(ServerError);
+    await promise.catch((err: ServerError) => {
+      expect(err.status).toBe(400);
+      expect(err.data).toEqual({ message: 'Product not found' });
+      // ServerError derives `.message` from object data's `message` field.
+      expect(err.message).toBe('Product not found');
+    });
+  });
+
+  it('propagates a directly-thrown ServerError', async () => {
+    const ev = makeRequestEv();
+    const thrown = new ServerError(404, { message: 'gone' });
+    const qrl = createQrl('error-loader', () => {
+      throw thrown;
+    });
+
+    await expect(getRouteLoaderData(qrl, undefined, ev)).rejects.toBe(thrown);
+  });
+
+  it('returns the raw value on success', async () => {
+    const ev = makeRequestEv();
+    const qrl = createQrl('ok-loader', () => ({ result: 'ok' }));
+
+    await expect(getRouteLoaderData(qrl, undefined, ev)).resolves.toEqual({ result: 'ok' });
+  });
+
+  it('rejects resolveValue when the resolved loader fails', async () => {
+    const requestEv = makeRequestEv();
+    const failing = createLoader('failing', (_thisArg, e) => {
+      throw e.error(400, { message: 'x' });
+    });
+    requestEv.resolveValue = (loader: LoaderInternal) => loadRouteLoader(loader, requestEv);
+
+    await expect(loadRouteLoader(failing, requestEv)).rejects.toBeInstanceOf(ServerError);
+  });
+
+  it('wraps a loader failure as an error envelope in getRouteLoaderResponse', async () => {
+    const ev = makeRequestEv();
+    const qrl = createQrl('fail-resp', (_thisArg, e) => {
+      throw e.error(400, { message: 'x' });
+    });
+
+    const res = await getRouteLoaderResponse(qrl, undefined, ev);
+    expect(res.e).toBeInstanceOf(ServerError);
+    expect(res.e?.data).toEqual({ message: 'x' });
+    expect(res.d).toBeUndefined();
+  });
+
+  it('returns a data envelope on success in getRouteLoaderResponse', async () => {
+    const ev = makeRequestEv();
+    const qrl = createQrl('ok-resp', () => ({ result: 'ok' }));
+
+    const res = await getRouteLoaderResponse(qrl, undefined, ev);
+    expect(res.d).toEqual({ result: 'ok' });
+    expect(res.e).toBeUndefined();
+  });
+
+  it('returns a redirect envelope on redirect', async () => {
+    const ev = makeRequestEv();
+    ev.headers.set('Location', '/login');
+    const qrl = createQrl('redir-resp', () => {
+      throw new RedirectMessage();
+    });
+
+    const res = await getRouteLoaderResponse(qrl, undefined, ev);
+    expect(res.r).toBe('/login');
+    expect(res.e).toBeUndefined();
+    expect(res.d).toBeUndefined();
+  });
+});
+
+describe('types', () => {
+  test('loader.value is the success type (failures surface on .error)', () => () => {
+    const useObj = routeLoader$(({ error, query }) => {
+      if (query.get('fail') === '1') {
+        throw error(400, { message: 'Product not found' });
+      }
+      return { result: 'ok' };
+    });
+    expectTypeOf(useObj().value).toEqualTypeOf<{ result: string }>();
+  });
+
+  test('primitive loader.value stays a primitive', () => () => {
+    const useStr = routeLoader$(({ error, query }) => {
+      if (query.get('fail') === '1') {
+        throw error(400, { message: 'Product not found' });
+      }
+      return 'hello';
+    });
+    expectTypeOf(useStr().value).toEqualTypeOf<string>();
+  });
+
+  test('reading value.failed is not valid', () => () => {
+    const useObj = routeLoader$(({ error, query }) => {
+      if (query.get('fail') === '1') {
+        throw error(400, { message: 'Product not found' });
+      }
+      return { result: 'ok' };
+    });
+    const value = useObj().value;
+    // @ts-expect-error failures surface on loader.error, never loader.value.failed
+    value.failed;
+  });
+
+  test('loader.error is a ServerError with status/data', () => () => {
+    const useObj = routeLoader$(({ error, query }) => {
+      if (query.get('fail') === '1') {
+        throw error(404, { message: 'Product not found' });
+      }
+      return { result: 'ok' };
+    });
+    const loader = useObj();
+    expectTypeOf(loader.error).toEqualTypeOf<ServerError | undefined>();
+    if (loader.error) {
+      expectTypeOf(loader.error.status).toEqualTypeOf<number>();
+      // `.message` is always typed (Error); the thrown payload type can't be inferred, so
+      // `.data` is `unknown` for a loader without validators.
+      expectTypeOf(loader.error.message).toEqualTypeOf<string>();
+    }
+  });
+});
+
+function makeRequestEv(): any {
+  let _status = 200;
+  return {
+    sharedMap: new Map(),
+    headers: new Map<string, string>(),
+    url: new URL('http://localhost/products/'),
+    status: (s?: number) => {
+      if (s !== undefined) {
+        _status = s;
+      }
+      return _status;
+    },
+    error: (status: number, data: unknown) => {
+      _status = status;
+      return new ServerError(status, data);
+    },
+  };
+}
 
 function createLoader(
   id: string,

--- a/packages/qwik-router/src/runtime/src/server-functions.ts
+++ b/packages/qwik-router/src/runtime/src/server-functions.ts
@@ -59,6 +59,7 @@ export const routeActionQrl = ((
       isRunning: false,
       status: undefined,
       value: undefined,
+      error: undefined,
       formData: undefined,
     };
     const state = useStore<Editable<ActionStore<unknown, unknown>>>(() => {
@@ -69,9 +70,13 @@ export const routeActionQrl = ((
           initialState.formData = data;
         }
         if (value.output) {
-          const { status, result } = value.output;
+          const { status, result, error } = value.output;
           initialState.status = status;
-          initialState.value = result;
+          if (error) {
+            initialState.error = error;
+          } else {
+            initialState.value = result;
+          }
         }
       }
       return initialState as ActionStore<unknown, unknown>;
@@ -111,10 +116,16 @@ Action.run() can only be called on the browser, for example when a user clicks a
           id,
           resolve: noSerialize(resolve),
         };
-      }).then(({ result, status }) => {
+      }).then(({ result, status, error }) => {
         state.isRunning = false;
         state.status = status;
-        state.value = result;
+        if (error) {
+          state.error = error;
+          state.value = undefined;
+        } else {
+          state.error = undefined;
+          state.value = result;
+        }
         if (form) {
           if (form.getAttribute('data-spa-reset') === 'true') {
             form.reset();

--- a/packages/qwik-router/src/runtime/src/server-functions.unit.ts
+++ b/packages/qwik-router/src/runtime/src/server-functions.unit.ts
@@ -1,9 +1,25 @@
 import { describe, expectTypeOf, test } from 'vitest';
 import * as z from 'zod';
-import { server$ } from './server-functions';
+import { routeAction$, server$, zod$ } from './server-functions';
 import type { RequestEventBase, ValidatorErrorType } from './types';
 
 describe('types', () => {
+  test('action.error is a ServerError with validator fields flattened on', () => () => {
+    const useLogin = routeAction$(
+      () => ({ ok: true }),
+      zod$({ username: z.string(), code: z.number() })
+    );
+    const action = useLogin();
+    expectTypeOf(action.value).toEqualTypeOf<{ ok: boolean } | undefined>();
+    if (action.error) {
+      expectTypeOf(action.error.status).toEqualTypeOf<number>();
+      // Validator errors are typed and read flat (no `.data` hop).
+      expectTypeOf(action.error.fieldErrors.username).toEqualTypeOf<string | undefined>();
+      expectTypeOf(action.error.fieldErrors.code).toEqualTypeOf<string | undefined>();
+      expectTypeOf(action.error.formErrors).toEqualTypeOf<string[]>();
+    }
+  });
+
   test('matching', () => () => {
     const foo = () => server$(() => 'hello');
 

--- a/packages/qwik-router/src/runtime/src/types.ts
+++ b/packages/qwik-router/src/runtime/src/types.ts
@@ -16,6 +16,7 @@ import type {
   RequestEventLoader,
   RequestHandler,
   ResolveSyncValue,
+  ServerError,
 } from '@qwik.dev/router/middleware/request-handler';
 import type * as v from 'valibot';
 import type * as z from 'zod';
@@ -143,7 +144,13 @@ export type RouteNavigate = QRL<
 
 export type RouteAction = Signal<RouteActionValue>;
 
-export type RouteActionResolver = { status: number; result: unknown };
+export type RouteActionResolver = {
+  status: number;
+  /** The action's successful return value. Unset when the action failed (see `error`). */
+  result?: unknown;
+  /** A `ServerError` from `throw error(...)`, a failed validator, or an uncaught server error. */
+  error?: ServerError;
+};
 export type RouteActionValue =
   | {
       id: string;
@@ -507,9 +514,16 @@ type StrictUnionHelper<T, TAll> = T extends any
 /** @public */
 export type StrictUnion<T> = Prettify<StrictUnionHelper<T, T>>;
 
-type Prettify<T> = {} & {
-  [K in keyof T]: T[K];
-};
+// Flatten an intersection for nicer tooltips, but leave primitives untouched.
+// Mapping a primitive (e.g. `string`) by its keys turns it into an object-shaped
+// type that's no longer assignable to the primitive itself — which breaks
+// StrictUnion arms whose value is a primitive (e.g. an action that returns a
+// string and can also `fail()`).
+type Prettify<T> = T extends string | number | boolean | bigint | symbol | null | undefined
+  ? T
+  : {} & {
+      [K in keyof T]: T[K];
+    };
 
 /** @public */
 export type JSONValue = string | number | boolean | { [x: string]: JSONValue } | Array<JSONValue>;
@@ -549,13 +563,6 @@ export type ActionOptions = {
   readonly invalidate?: Loader<any>[];
 };
 
-/** @public */
-export type FailOfRest<REST extends readonly DataValidator[]> = REST extends readonly DataValidator<
-  infer ERROR
->[]
-  ? ERROR
-  : never;
-
 type IsAny<Type> = 0 extends 1 & Type ? true : false;
 
 /** @public */
@@ -577,6 +584,13 @@ export type ValidatorErrorKeyDotNotation<T, Prefix extends string = ''> =
                 : `${Prefix}${K}`;
         }[keyof T & string]
       : never;
+
+/** @public */
+export type FailOfRest<REST extends readonly DataValidator[]> = REST extends readonly DataValidator<
+  infer ERROR
+>[]
+  ? ERROR
+  : never;
 
 /** @public */
 export type ValidatorErrorType<T, U = string> = {
@@ -605,13 +619,10 @@ export type ActionConstructor = {
       readonly validation: [VALIDATOR, ...REST];
     }
   ): Action<
-    StrictUnion<
-      | OBJ
-      | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>
-      | FailReturn<FailOfRest<REST>>
-    >,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>
   >;
 
   // Use options object, use typed data validator
@@ -625,9 +636,10 @@ export type ActionConstructor = {
       readonly validation: [VALIDATOR];
     }
   ): Action<
-    StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>>,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>>
   >;
 
   // Use options object, use data validator
@@ -637,7 +649,7 @@ export type ActionConstructor = {
       readonly id?: string;
       readonly validation: REST;
     }
-  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+  ): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;
 
   // Use typed data validator, use data validator
   <
@@ -652,13 +664,10 @@ export type ActionConstructor = {
     options: VALIDATOR,
     ...rest: REST
   ): Action<
-    StrictUnion<
-      | OBJ
-      | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>
-      | FailReturn<FailOfRest<REST>>
-    >,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>
   >;
 
   // Use typed data validator
@@ -669,16 +678,17 @@ export type ActionConstructor = {
     ) => ValueOrPromise<OBJ>,
     options: VALIDATOR
   ): Action<
-    StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>>,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>>
   >;
 
   // Use data validator
   <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
     actionQrl: (form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>,
     ...rest: REST
-  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+  ): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;
 
   // No validators
   <OBJ>(
@@ -686,7 +696,7 @@ export type ActionConstructor = {
     options?: {
       readonly id?: string;
     }
-  ): Action<StrictUnion<OBJ>>;
+  ): Action<OBJ>;
 };
 
 /** @public */
@@ -705,13 +715,10 @@ export type ActionConstructorQRL = {
       readonly validation: [VALIDATOR, ...REST];
     }
   ): Action<
-    StrictUnion<
-      | OBJ
-      | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>
-      | FailReturn<FailOfRest<REST>>
-    >,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>
   >;
 
   // Use options object, use typed data validator
@@ -724,9 +731,10 @@ export type ActionConstructorQRL = {
       readonly validation: [VALIDATOR];
     }
   ): Action<
-    StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>>,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>>
   >;
 
   // Use options object, use data validator
@@ -736,7 +744,7 @@ export type ActionConstructorQRL = {
       readonly id?: string;
       readonly validation: REST;
     }
-  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+  ): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;
 
   // Use typed data validator, use data validator
   <
@@ -750,13 +758,10 @@ export type ActionConstructorQRL = {
     options: VALIDATOR,
     ...rest: REST
   ): Action<
-    StrictUnion<
-      | OBJ
-      | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>
-      | FailReturn<FailOfRest<REST>>
-    >,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>> | FailOfRest<REST>
   >;
 
   // Use typed data validator
@@ -766,16 +771,17 @@ export type ActionConstructorQRL = {
     >,
     options: VALIDATOR
   ): Action<
-    StrictUnion<OBJ | FailReturn<ValidatorErrorType<GetValidatorInputType<VALIDATOR>>>>,
+    OBJ,
     GetValidatorInputType<VALIDATOR>,
-    false
+    false,
+    ValidatorErrorType<GetValidatorInputType<VALIDATOR>>
   >;
 
   // Use data validator
   <OBJ extends Record<string, any> | void | null, REST extends [DataValidator, ...DataValidator[]]>(
     actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<OBJ>>,
     ...rest: REST
-  ): Action<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+  ): Action<OBJ, Record<string, unknown>, true, FailOfRest<REST>>;
 
   // No validators
   <OBJ>(
@@ -783,7 +789,7 @@ export type ActionConstructorQRL = {
     options?: {
       readonly id?: string;
     }
-  ): Action<StrictUnion<OBJ>>;
+  ): Action<OBJ>;
 };
 
 /** @public */
@@ -869,13 +875,13 @@ export type LoaderConstructor = {
   <OBJ>(
     loaderFn: (event: RequestEventLoader) => ValueOrPromise<OBJ>,
     options?: LoaderOptions
-  ): Loader<[Extract<OBJ, Failed>] extends [never] ? OBJ : StrictUnion<OBJ>>;
+  ): Loader<OBJ>;
 
   // With validation
   <OBJ extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
     loaderFn: (event: RequestEventLoader) => ValueOrPromise<OBJ>,
     ...rest: REST
-  ): Loader<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+  ): Loader<OBJ, FailOfRest<REST>>;
 };
 
 /** @public */
@@ -884,13 +890,13 @@ export type LoaderConstructorQRL = {
   <OBJ>(
     loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<OBJ>>,
     options?: LoaderOptions
-  ): Loader<[Extract<OBJ, Failed>] extends [never] ? OBJ : StrictUnion<OBJ>>;
+  ): Loader<OBJ>;
 
   // With validation
   <OBJ extends Record<string, any> | void | null, REST extends readonly DataValidator[]>(
     loaderQrl: QRL<(event: RequestEventLoader) => ValueOrPromise<OBJ>>,
     ...rest: REST
-  ): Loader<StrictUnion<OBJ | FailReturn<FailOfRest<REST>>>>;
+  ): Loader<OBJ, FailOfRest<REST>>;
 };
 
 /** @public */
@@ -900,7 +906,7 @@ export type ActionReturn<RETURN> = {
 };
 
 /** @public */
-export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {
+export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true, ERROR = unknown> = {
   /**
    * It's the "action" path that a native `<form>` should have in order to call the action.
    *
@@ -960,9 +966,18 @@ export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {
    * Returned successful data of the action. This reactive property will contain the data returned
    * inside the `action$` function.
    *
-   * It's `undefined` before the action is first called.
+   * It's `undefined` before the action is first called, or when the action failed (see `error`).
    */
   readonly value: RETURN | undefined;
+
+  /**
+   * The `ServerError` thrown by the action's last execution (via `throw error(...)`, a failed
+   * validator, or an uncaught server error). `.status` is the HTTP status and `.data` is the
+   * payload.
+   *
+   * It's `undefined` before the action is first called and when the last execution succeeded.
+   */
+  readonly error: ServerError<ERROR> | undefined;
 
   /**
    * Method to execute the action programmatically from the browser. Ie, instead of using a
@@ -978,26 +993,23 @@ export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {
   readonly submitted: boolean;
 };
 
-type Failed = {
-  failed: true;
-};
-
 /** @public */
-export type FailReturn<T> = T & Failed;
-
-/** @public */
-export type LoaderSignal<TYPE> = (TYPE extends () => ValueOrPromise<infer VALIDATOR>
+export type LoaderSignal<TYPE, ERROR = unknown> = (TYPE extends () => ValueOrPromise<
+  infer VALIDATOR
+>
   ? Signal<ValueOrPromise<VALIDATOR>>
   : Signal<TYPE>) &
-  Pick<AsyncSignal, 'promise' | 'loading' | 'error'>;
+  Pick<AsyncSignal, 'promise' | 'loading'> & {
+    error: ServerError<ERROR> | undefined;
+  };
 
 /** @public */
-export type Loader<RETURN> = {
+export type Loader<RETURN, ERROR = unknown> = {
   /**
    * Returns the `Signal` containing the data returned by the `loader$` function. Like all `use-`
    * functions and methods, it can only be invoked within a `component$()`.
    */
-  (): LoaderSignal<RETURN>;
+  (): LoaderSignal<RETURN, ERROR>;
 };
 
 export interface LoaderInternal extends Loader<any> {
@@ -1016,13 +1028,18 @@ export interface LoaderInternal extends Loader<any> {
 }
 
 /** @public */
-export type Action<RETURN, INPUT = Record<string, unknown>, OPTIONAL extends boolean = true> = {
+export type Action<
+  RETURN,
+  INPUT = Record<string, unknown>,
+  OPTIONAL extends boolean = true,
+  ERROR = unknown,
+> = {
   /**
    * Returns the `ActionStore` containing the current action state and methods to invoke it from a
    * component$(). Like all `use-` functions and methods, it can only be invoked within a
    * `component$()`.
    */
-  (): ActionStore<RETURN, INPUT, OPTIONAL>;
+  (): ActionStore<RETURN, INPUT, OPTIONAL, ERROR>;
 };
 
 export interface ActionInternal extends Action<any, any> {

--- a/packages/qwik-router/src/runtime/src/use-endpoint.ts
+++ b/packages/qwik-router/src/runtime/src/use-endpoint.ts
@@ -1,4 +1,5 @@
 import type { RouteActionValue } from './types';
+import type { ServerError } from '../../middleware/request-handler/server-error';
 import { _deserialize } from '@qwik.dev/core/internal';
 import { ensureSlash } from '../../utils/pathname';
 import { QACTION_KEY } from './constants';
@@ -16,7 +17,8 @@ export async function submitAction(
 ): Promise<
   | {
       status: number;
-      result: unknown;
+      result?: unknown;
+      error?: ServerError;
       redirect?: string;
       loaderHashes?: string[];
     }
@@ -64,13 +66,15 @@ export async function submitAction(
   if ((response.headers.get('content-type') || '').includes('json')) {
     const text = await response.text();
     const data = _deserialize<{
-      result: unknown;
+      result?: unknown;
+      error?: ServerError;
       redirect?: string;
       loaderHashes?: string[];
     }>(text);
     return {
       status: response.status,
       result: data?.result,
+      error: data?.error,
       redirect: data?.redirect,
       loaderHashes: data?.loaderHashes,
     };

--- a/packages/qwik-router/src/runtime/src/use-endpoint.unit.ts
+++ b/packages/qwik-router/src/runtime/src/use-endpoint.unit.ts
@@ -57,20 +57,21 @@ describe('submitAction', () => {
     });
   });
 
-  it('reflects non-200 status from action response (fail/validator)', async () => {
+  it('reflects non-200 status and error envelope from a failed action response', async () => {
     vi.stubGlobal(
       'fetch',
       vi
         .fn()
         .mockResolvedValue(
-          await makeJsonResponse({ result: { failed: true, message: 'bad' } }, 422)
+          await makeJsonResponse({ error: { status: 422, data: { message: 'bad' } } }, 422)
         )
     );
 
     const result = await submitAction({ id: 'act-a', data: {} } as any, '/test/');
 
     expect(result?.status).toBe(422);
-    expect(result?.result).toMatchObject({ failed: true });
+    expect(result?.result).toBeUndefined();
+    expect(result?.error).toMatchObject({ status: 422, data: { message: 'bad' } });
   });
 });
 


### PR DESCRIPTION
# What is it?
- Feature / enhancement

# Description
Loaders and actions now surface failures on a typed `.error` (a `ServerError`) instead of `fail()` / `value.failed`, consistently on the server and the client. `throw error(...)` and failed validators land on `loader.error` / `action.error`; `.value` is the success type only, and `ServerError` exposes its payload fields flat and typed (e.g. `error.fieldErrors` from your zod$/valibot$ schema), with `.data` kept as the canonical payload.

`fail()` is removed — throw `error(status, data)` instead. Also: a same-origin absolute `rewrite()` now normalizes to a relative rewrite instead of erroring.
