### PR TITLE
fix(core): reset creation mode when diffing into an existing projection

### DIFF
--- a/.changeset/lucky-spiders-wonder.md
+++ b/.changeset/lucky-spiders-wonder.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: duplicate projected element children when a component throws a promise on first render

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -406,12 +406,9 @@ function diff(
               } else if (type === Projection) {
                 expectProjection(diffContext);
                 if (diffContext.$vNewNode$ === null) {
-                  // An existing projection keeps its children across re-renders, so they
-                  // must be diffed against, never blindly re-created. Creation mode can be
-                  // inherited from the component host level when the host was re-diffed
-                  // before its own render populated any children (e.g. a component that
-                  // threw a promise on first render and was re-executed), which would
-                  // otherwise duplicate the projected element children.
+                  // An existing projection keeps its children, so diff against them.
+                  // Creation mode inherited from a not-yet-rendered host would
+                  // duplicate them instead.
                   diffContext.$isCreationMode$ = false;
                 }
                 descend(

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -405,19 +405,11 @@ function diff(
                 }
               } else if (type === Projection) {
                 expectProjection(diffContext);
-                if (diffContext.$vNewNode$ === null) {
-                  // An existing projection keeps its children, so diff against them.
-                  // Creation mode inherited from a not-yet-rendered host would
-                  // duplicate them instead.
-                  diffContext.$isCreationMode$ = false;
-                }
                 descend(
                   diffContext,
                   diffContext.$jsxValue$.children,
                   true,
-                  // special case for projection, we don't want to expect no children
-                  // because the projection's children are not removed
-                  false
+                  /* isProjection */ true
                 );
               } else if (type === SSRComment) {
                 expectNoMore(diffContext);
@@ -544,15 +536,17 @@ function advance(diffContext: DiffContext) {
  *
  *   In the above example all nodes are on same level so we don't `descendVNode` even thought there is
  *   an array produced by the `map` function.
+ * @param isProjection - True when descending into a Projection, whose children survive re-renders:
+ *   they are diffed against (never re-created) and kept when the new JSX has no children.
  */
 function descend(
   diffContext: DiffContext,
   children: JSXChildren,
   descendVNode: boolean,
-  shouldExpectNoChildren: boolean = true
+  isProjection: boolean = false
 ) {
   if (
-    shouldExpectNoChildren &&
+    !isProjection &&
     (children == null || (descendVNode && isArray(children) && children.length === 0))
   ) {
     expectNoChildren(diffContext);
@@ -566,7 +560,9 @@ function descend(
         'Expecting vCurrent to be defined.'
       );
     const creationMode =
-      diffContext.$isCreationMode$ ||
+      // a projection keeps its children across re-renders, so it never inherits
+      // creation mode from a not-yet-rendered host; create only if new or empty
+      (!isProjection && diffContext.$isCreationMode$) ||
       !!diffContext.$vNewNode$ ||
       !vnode_getFirstChild(diffContext.$vCurrent$!);
 

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -405,6 +405,15 @@ function diff(
                 }
               } else if (type === Projection) {
                 expectProjection(diffContext);
+                if (diffContext.$vNewNode$ === null) {
+                  // An existing projection keeps its children across re-renders, so they
+                  // must be diffed against, never blindly re-created. Creation mode can be
+                  // inherited from the component host level when the host was re-diffed
+                  // before its own render populated any children (e.g. a component that
+                  // threw a promise on first render and was re-executed), which would
+                  // otherwise duplicate the projected element children.
+                  diffContext.$isCreationMode$ = false;
+                }
                 descend(
                   diffContext,
                   diffContext.$jsxValue$.children,

--- a/packages/qwik/src/core/tests/render-promise.spec.tsx
+++ b/packages/qwik/src/core/tests/render-promise.spec.tsx
@@ -1,4 +1,4 @@
-import { Fragment as Component, Fragment, component$, useSignal } from '@qwik.dev/core';
+import { Fragment as Component, Fragment, Slot, component$, useSignal } from '@qwik.dev/core';
 import { domRender, ssrRenderToDom } from '@qwik.dev/core/testing';
 import { describe, expect, it } from 'vitest';
 
@@ -42,5 +42,77 @@ describe.each([
     });
     const { document } = await render(<Cmp />, { debug });
     expect(document.querySelector('div')).toHaveProperty('textContent', 'child');
+  });
+
+  it('should not duplicate projected element children when component throws a promise on first render', async () => {
+    const Wrapper = component$(() => (
+      <form>
+        <Slot />
+      </form>
+    ));
+    const Title = component$(() => <header>title</header>);
+    const Footer = component$(() => <footer>footer</footer>);
+    const Cmp = component$(() => {
+      // The signal is read before the throw, so the component subscribes to it.
+      // The thrown promise sets the signal, which marks the component dirty again
+      // and triggers a second diff pass before <Wrapper> has rendered its <Slot>.
+      // The second pass used to inherit creation mode (the host has no children
+      // yet) and blindly re-create the projected element children. The trailing
+      // <Footer /> is required: matching it by component hash jumps the cursor
+      // past the stale <div>, so expectNoMore() would not clean it up.
+      const store = useSignal<string>();
+      if (!store.value) {
+        throw Promise.resolve().then(() => {
+          store.value = 'resolved';
+        });
+      }
+      return (
+        <Wrapper>
+          <Title />
+          <div class="fields">{store.value}</div>
+          <Footer />
+        </Wrapper>
+      );
+    });
+    const { document } = await render(<Cmp />, { debug });
+    expect(document.querySelectorAll('div.fields')).toHaveLength(1);
+    expect(document.querySelectorAll('header')).toHaveLength(1);
+    expect(document.querySelectorAll('footer')).toHaveLength(1);
+  });
+
+  it('should not duplicate named slot content when component throws a promise on first render', async () => {
+    const Wrapper = component$(() => (
+      <form>
+        <section>
+          <Slot name="top" />
+        </section>
+        <Slot />
+      </form>
+    ));
+    const Title = component$(() => <header>title</header>);
+    const Footer = component$(() => <footer>footer</footer>);
+    const Cmp = component$(() => {
+      const store = useSignal<string>();
+      if (!store.value) {
+        throw Promise.resolve().then(() => {
+          store.value = 'resolved';
+        });
+      }
+      return (
+        <Wrapper>
+          <div q:slot="top" class="banner">
+            banner
+          </div>
+          <Title />
+          <div class="fields">{store.value}</div>
+          <Footer />
+        </Wrapper>
+      );
+    });
+    const { document } = await render(<Cmp />, { debug });
+    expect(document.querySelectorAll('div.banner')).toHaveLength(1);
+    expect(document.querySelectorAll('div.fields')).toHaveLength(1);
+    expect(document.querySelectorAll('header')).toHaveLength(1);
+    expect(document.querySelectorAll('footer')).toHaveLength(1);
   });
 });

--- a/packages/qwik/src/core/tests/render-promise.spec.tsx
+++ b/packages/qwik/src/core/tests/render-promise.spec.tsx
@@ -53,13 +53,10 @@ describe.each([
     const Title = component$(() => <header>title</header>);
     const Footer = component$(() => <footer>footer</footer>);
     const Cmp = component$(() => {
-      // The signal is read before the throw, so the component subscribes to it.
-      // The thrown promise sets the signal, which marks the component dirty again
-      // and triggers a second diff pass before <Wrapper> has rendered its <Slot>.
-      // The second pass used to inherit creation mode (the host has no children
-      // yet) and blindly re-create the projected element children. The trailing
-      // <Footer /> is required: matching it by component hash jumps the cursor
-      // past the stale <div>, so expectNoMore() would not clean it up.
+      // The thrown promise writes a tracked signal, scheduling a second diff
+      // pass before <Wrapper> has rendered its <Slot>. The trailing <Footer />
+      // is required: matching it moves the cursor past the stale <div>, so
+      // expectNoMore() would not clean it up.
       const store = useSignal<string>();
       if (!store.value) {
         throw Promise.resolve().then(() => {


### PR DESCRIPTION
# What is it?

- Bug

# Description

When a component throws a promise on first client render (e.g. a library resolving QRLs by throwing, like formisch's `useResolvedQrl`) and the promise resolution writes a signal the component already subscribed to, the component is diffed a second time before its child component has rendered its `<Slot />`. At that point the child host has no children yet, so `descend()` flips `$isCreationMode$` on, and the sticky flag leaks into the *existing* projection from the first pass. `expectElement` then blindly re-creates plain element children instead of matching them (components survive because `expectComponent` matches by hash), and a trailing component sibling jumps the cursor past the stale element so `expectNoMore` never cleans it up — leaving duplicated DOM.

Symptom in an app: form fields rendered twice on every first SPA navigation to a route, correct again when revisiting (cached QRLs resolve synchronously, so nothing throws).

The fix: a projection never inherits creation mode from the surrounding level — an existing projection keeps its children across re-renders, so they must be diffed against, never re-created; it is in creation mode only when new or empty. Handled in `descend()` via an `isProjection` param (replacing `shouldExpectNoChildren`, which was already projection-only). Regression tests cover default and named slots; both fail without the behavior change.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I added new tests to cover the fix / functionality
