### PR TITLE
fix(qwik-router): rewrite() accepts same-origin absolute URLs and handles query strings

### DIFF
--- a/.changeset/rewrite-same-origin-absolute-url.md
+++ b/.changeset/rewrite-same-origin-absolute-url.md
@@ -2,4 +2,4 @@
 '@qwik.dev/router': patch
 ---
 
-`rewrite()` now accepts same-origin absolute URLs by normalizing them to a path (so they behave like a relative rewrite) instead of throwing a 400. An explicit query on the rewrite target replaces the request's query, otherwise the original query is kept, and fragments are dropped. Cross-origin and invalid URLs are still rejected with a 400.
+`rewrite()` now accepts same-origin absolute URLs by normalizing them to a path, and handles query strings (an explicit query on the target replaces the request's query; fragments are dropped). Cross-origin and invalid URLs are still rejected with a 400.

--- a/.changeset/rewrite-same-origin-absolute-url.md
+++ b/.changeset/rewrite-same-origin-absolute-url.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+`rewrite()` now accepts same-origin absolute URLs by normalizing them to a path (so they behave like a relative rewrite) instead of throwing a 400. An explicit query on the rewrite target replaces the request's query, otherwise the original query is kept, and fragments are dropped. Cross-origin and invalid URLs are still rejected with a 400.

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/products/[id]/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/products/[id]/index.tsx
@@ -144,7 +144,8 @@ export const useProductLoader = routeLoader$(
       throw rewrite('/qwikrouter-test/products/tshirt/');
     }
 
-    // Should throw an error
+    // Same-origin absolute URL — rewrite normalizes it to a path and re-routes like a
+    // relative rewrite (renders tshirt while keeping this URL).
     if (id === 'shirt-rewrite-absolute-url') {
       throw rewrite(`${url.origin}/qwikrouter-test/products/tshirt/`);
     }

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/products/[id]/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/products/[id]/index.tsx
@@ -144,8 +144,6 @@ export const useProductLoader = routeLoader$(
       throw rewrite('/qwikrouter-test/products/tshirt/');
     }
 
-    // Same-origin absolute URL — rewrite normalizes it to a path and re-routes like a
-    // relative rewrite (renders tshirt while keeping this URL).
     if (id === 'shirt-rewrite-absolute-url') {
       throw rewrite(`${url.origin}/qwikrouter-test/products/tshirt/`);
     }

--- a/e2e/qwik-e2e/tests/qwikrouter/page.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/page.e2e.ts
@@ -128,13 +128,15 @@ function tests() {
         searchParams: { search: 'true' },
       });
 
-      /** Products: shirt (rewrite to /products/tshirt) ********** */
-      await linkNavigate(ctx, '[data-test-link="products-shirt-rewrite-absolute-url"]', 400);
+      /** Products: shirt (same-origin absolute rewrite → /products/tshirt) ********** */
+      await linkNavigate(ctx, '[data-test-link="products-shirt-rewrite-absolute-url"]');
       await assertPage(ctx, {
-        title: 'Error 400 - Qwik',
+        pathname: '/qwikrouter-test/products/shirt-rewrite-absolute-url/',
+        title: 'Product tshirt - Qwik',
+        layoutHierarchy: ['root'],
+        h1: 'Product: tshirt',
+        activeHeaderLink: 'Products',
       });
-      // Recover from error
-      await setPage(ctx, '/qwikrouter-test/products/hat/');
 
       /** Products: shirt (rewrite to /products/tshirt) ********** */
       await linkNavigate(ctx, '[data-test-link="products-shirt-rewrite-no-trailing-slash"]', 301);

--- a/packages/docs/src/routes/api/qwik-router-middleware-request-handler/api.json
+++ b/packages/docs/src/routes/api/qwik-router-middleware-request-handler/api.json
@@ -470,9 +470,26 @@
         }
       ],
       "kind": "Class",
-      "content": "```typescript\nexport declare class RewriteMessage extends AbortMessage \n```\n**Extends:** [AbortMessage](#abortmessage)\n\n\n<table><thead><tr><th>\n\nConstructor\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n(constructor)(pathname)\n\n\n</td><td>\n\n\n</td><td>\n\nConstructs a new instance of the `RewriteMessage` class\n\n\n</td></tr>\n</tbody></table>\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[pathname](#rewritemessage-pathname)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport declare class RewriteMessage extends AbortMessage \n```\n**Extends:** [AbortMessage](#abortmessage)\n\n\n<table><thead><tr><th>\n\nConstructor\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n(constructor)(pathname, search)\n\n\n</td><td>\n\n\n</td><td>\n\nConstructs a new instance of the `RewriteMessage` class\n\n\n</td></tr>\n</tbody></table>\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[pathname](#rewritemessage-pathname)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\n[search?](#rewritemessage-search)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring \\| undefined\n\n\n</td><td>\n\n_(Optional)_ When set, replaces the request's query string; otherwise the original query is kept.\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/rewrite-handler.ts",
       "mdFile": "router.rewritemessage.md"
+    },
+    {
+      "name": "search",
+      "id": "rewritemessage-search",
+      "hierarchy": [
+        {
+          "name": "RewriteMessage",
+          "id": "rewritemessage-search"
+        },
+        {
+          "name": "search",
+          "id": "rewritemessage-search"
+        }
+      ],
+      "kind": "Property",
+      "content": "When set, replaces the request's query string; otherwise the original query is kept.\n\n\n```typescript\nreadonly search?: string | undefined;\n```",
+      "mdFile": "router.rewritemessage.search.md"
     },
     {
       "name": "ServerError",

--- a/packages/docs/src/routes/api/qwik-router-middleware-request-handler/index.mdx
+++ b/packages/docs/src/routes/api/qwik-router-middleware-request-handler/index.mdx
@@ -1656,7 +1656,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-(constructor)(pathname)
+(constructor)(pathname, search)
 
 </td><td>
 
@@ -1699,9 +1699,34 @@ string
 </td><td>
 
 </td></tr>
+<tr><td>
+
+[search?](#rewritemessage-search)
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+string \| undefined
+
+</td><td>
+
+_(Optional)_ When set, replaces the request's query string; otherwise the original query is kept.
+
+</td></tr>
 </tbody></table>
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/middleware/request-handler/rewrite-handler.ts)
+
+<h2 id="rewritemessage-search">search</h2>
+
+When set, replaces the request's query string; otherwise the original query is kept.
+
+```typescript
+readonly search?: string | undefined;
+```
 
 <h2 id="servererror">ServerError</h2>
 

--- a/packages/qwik-router/src/middleware/request-handler/middleware.request-handler.api.md
+++ b/packages/qwik-router/src/middleware/request-handler/middleware.request-handler.api.md
@@ -200,9 +200,11 @@ export interface ResolveValue {
 
 // @public (undocumented)
 export class RewriteMessage extends AbortMessage {
-    constructor(pathname: string);
+    constructor(pathname: string,
+    search?: string | undefined);
     // (undocumented)
     readonly pathname: string;
+    readonly search?: string | undefined;
 }
 
 // @public (undocumented)

--- a/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
@@ -287,13 +287,8 @@ export function createRequestEventWithDeps(
 
     rewrite: (pathname: string) => {
       check();
-      // When the rewrite target carries an explicit query it replaces the request's query;
-      // otherwise the original query is kept. Fragments never reach the server — dropped.
       let search: string | undefined;
       if (/^https?:\/\//.test(pathname)) {
-        // A rewrite is an internal, same-origin re-route. A same-origin absolute URL is just
-        // a path with the origin glued on, so normalize it to its path and treat it like a
-        // relative rewrite. A cross-origin URL can't be rewritten in place — that's a redirect.
         let target: URL;
         try {
           target = new URL(pathname);

--- a/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
@@ -30,7 +30,7 @@ interface RequestEventDeps {
   Cookie: new (cookie?: string | null) => RequestCookie;
   AbortMessage: new () => AbortMessage;
   RedirectMessage: new () => RedirectMessage;
-  RewriteMessage: new (pathname: string) => RewriteMessage;
+  RewriteMessage: new (pathname: string, search?: string) => RewriteMessage;
   ServerError: new <T = any>(status: number, data: T) => ServerError<T>;
   recognizeRequest: typeof import('./request-path').recognizeRequest;
   trimRecognizedInternalPathname: typeof import('./request-path').trimRecognizedInternalPathname;
@@ -287,14 +287,42 @@ export function createRequestEventWithDeps(
 
     rewrite: (pathname: string) => {
       check();
-      if (pathname.startsWith('http')) {
-        throw new deps.ServerError(
-          400,
-          isDev ? 'Rewrite does not support absolute urls' : 'Bad Request'
-        );
+      // When the rewrite target carries an explicit query it replaces the request's query;
+      // otherwise the original query is kept. Fragments never reach the server — dropped.
+      let search: string | undefined;
+      if (/^https?:\/\//.test(pathname)) {
+        // A rewrite is an internal, same-origin re-route. A same-origin absolute URL is just
+        // a path with the origin glued on, so normalize it to its path and treat it like a
+        // relative rewrite. A cross-origin URL can't be rewritten in place — that's a redirect.
+        let target: URL;
+        try {
+          target = new URL(pathname);
+        } catch {
+          throw new deps.ServerError(400, isDev ? 'Invalid rewrite url' : 'Bad Request');
+        }
+        if (target.origin !== url.origin) {
+          throw new deps.ServerError(
+            400,
+            isDev ? 'Rewrite does not support cross-origin urls' : 'Bad Request'
+          );
+        }
+        pathname = target.pathname;
+        if (target.search) {
+          search = target.search;
+        }
+      } else {
+        const hashStart = pathname.indexOf('#');
+        if (hashStart !== -1) {
+          pathname = pathname.slice(0, hashStart);
+        }
+        const searchStart = pathname.indexOf('?');
+        if (searchStart !== -1) {
+          search = pathname.slice(searchStart);
+          pathname = pathname.slice(0, searchStart);
+        }
       }
       sharedMap.set(RequestEvIsRewrite, true);
-      return exit(new deps.RewriteMessage(pathname.replace(/\/+/g, '/')));
+      return exit(new deps.RewriteMessage(pathname.replace(/\/+/g, '/'), search));
     },
 
     defer: (returnData) => {

--- a/packages/qwik-router/src/middleware/request-handler/request-event.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-event.unit.ts
@@ -245,8 +245,6 @@ describe('request-event rewrite', () => {
 
     expect(result).toBeInstanceOf(RewriteMessage);
     expect(result.pathname).toBe('/x');
-    // No explicit query on the target: search stays undefined so the
-    // request's original query is kept by the rewrite handler.
     expect(result.search).toBeUndefined();
   });
 

--- a/packages/qwik-router/src/middleware/request-handler/request-event.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-event.unit.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createRequestEvent } from './request-event';
+import { RequestEvIsRewrite } from './request-event-core';
 import type { ServerRequestEvent } from './types';
 import type { LoadedRoute } from '../../runtime/src/types';
-import { RedirectMessage, ServerError } from '@qwik.dev/router/middleware/request-handler';
+import {
+  RedirectMessage,
+  RewriteMessage,
+  ServerError,
+} from '@qwik.dev/router/middleware/request-handler';
 
 function createMockServerRequestEvent(
   url = 'http://localhost:3000/test',
@@ -217,5 +222,98 @@ describe('request-event redirect', () => {
     expect(error).toBeInstanceOf(ServerError);
     expect(error.status).toBe(418);
     expect(error.data).toBe('teapot');
+  });
+});
+
+describe('request-event rewrite', () => {
+  it('splits an explicit query off a relative path and drops the fragment', () => {
+    const requestEv = createMockRequestEvent('http://localhost:3000/test?original=1');
+
+    const result = requestEv.rewrite('/x?q=1#h');
+
+    expect(result).toBeInstanceOf(RewriteMessage);
+    expect(result.pathname).toBe('/x');
+    expect(result.search).toBe('?q=1');
+    expect(requestEv.sharedMap.get(RequestEvIsRewrite)).toBe(true);
+    expect(requestEv.exited).toBe(true);
+  });
+
+  it('keeps the original query when the relative target has none', () => {
+    const requestEv = createMockRequestEvent('http://localhost:3000/test?original=1');
+
+    const result = requestEv.rewrite('/x');
+
+    expect(result).toBeInstanceOf(RewriteMessage);
+    expect(result.pathname).toBe('/x');
+    // No explicit query on the target: search stays undefined so the
+    // request's original query is kept by the rewrite handler.
+    expect(result.search).toBeUndefined();
+  });
+
+  it('drops a fragment-only suffix from a relative path', () => {
+    const requestEv = createMockRequestEvent();
+
+    const result = requestEv.rewrite('/x#h');
+
+    expect(result.pathname).toBe('/x');
+    expect(result.search).toBeUndefined();
+  });
+
+  it('normalizes a same-origin absolute URL to its path and query, dropping the fragment', () => {
+    const requestEv = createMockRequestEvent('http://localhost:3000/test');
+
+    const result = requestEv.rewrite('http://localhost:3000/x?q=1#h');
+
+    expect(result).toBeInstanceOf(RewriteMessage);
+    expect(result.pathname).toBe('/x');
+    expect(result.search).toBe('?q=1');
+  });
+
+  it('leaves search undefined for a same-origin absolute URL without a query', () => {
+    const requestEv = createMockRequestEvent('http://localhost:3000/test');
+
+    const result = requestEv.rewrite('http://localhost:3000/x');
+
+    expect(result.pathname).toBe('/x');
+    expect(result.search).toBeUndefined();
+  });
+
+  it('throws a 400 ServerError for cross-origin absolute URLs', () => {
+    const requestEv = createMockRequestEvent('http://localhost:3000/test');
+
+    let thrown: unknown;
+    try {
+      requestEv.rewrite('http://other-origin.com/x');
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(ServerError);
+    expect((thrown as InstanceType<typeof ServerError>).status).toBe(400);
+    expect(requestEv.sharedMap.get(RequestEvIsRewrite)).toBeUndefined();
+  });
+
+  it('throws a 400 ServerError when the URL is invalid after the protocol', () => {
+    const requestEv = createMockRequestEvent('http://localhost:3000/test');
+
+    let thrown: unknown;
+    try {
+      requestEv.rewrite('http://');
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(ServerError);
+    expect((thrown as InstanceType<typeof ServerError>).status).toBe(400);
+  });
+
+  it('does not treat a relative path starting with "http" as an absolute URL', () => {
+    const requestEv = createMockRequestEvent('http://localhost:3000/test');
+
+    const result = requestEv.rewrite('/http-docs/x');
+
+    expect(result).toBeInstanceOf(RewriteMessage);
+    expect(result.pathname).toBe('/http-docs/x');
+    expect(result.search).toBeUndefined();
   });
 });

--- a/packages/qwik-router/src/middleware/request-handler/rewrite-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/rewrite-handler.ts
@@ -2,7 +2,11 @@ import { AbortMessage } from './redirect-handler';
 
 /** @public */
 export class RewriteMessage extends AbortMessage {
-  constructor(readonly pathname: string) {
+  constructor(
+    readonly pathname: string,
+    /** When set, replaces the request's query string; otherwise the original query is kept. */
+    readonly search?: string
+  ) {
     super();
   }
 }

--- a/packages/qwik-router/src/middleware/request-handler/user-response-runner.ts
+++ b/packages/qwik-router/src/middleware/request-handler/user-response-runner.ts
@@ -18,7 +18,7 @@ export interface QwikRouterRun<T> {
 
 type RedirectMessageConstructor = new (...args: any[]) => object;
 type AbortMessageConstructor = new (...args: any[]) => object;
-type RewriteMessageConstructor = new (...args: any[]) => { pathname: string };
+type RewriteMessageConstructor = new (...args: any[]) => { pathname: string; search?: string };
 type ServerErrorConstructor = new (...args: any[]) => { status: StatusCodes; data: unknown };
 
 interface RequestEventInternalLike extends Readonly<RequestEvent> {
@@ -123,6 +123,9 @@ async function runNextWithDeps<TRequestEventInternal extends RequestEventInterna
         rewriteAttempt += 1;
         const url = new URL(requestEv.url);
         url.pathname = e.pathname;
+        if (e.search !== undefined) {
+          url.search = e.search;
+        }
         const { loadedRoute, requestHandlers } = await rebuildRouteInfo(url);
         requestEv.resetRoute(loadedRoute, requestHandlers, url);
         return await runOnce();


### PR DESCRIPTION
# What is it?

- Bug

# Description

`rewrite()` now accepts same-origin absolute URLs by normalizing them to a path (cross-origin and invalid URLs still 400), and carries the target's query separately so it can't be percent-encoded into the pathname — an explicit query replaces the request's query, otherwise the original is kept; fragments are dropped. Split out of #8717.