### PR TITLE
test:  server-only-modules e2e -> reset qwik duplicate-import guard between in-process vite servers

### DIFF
--- a/e2e/qwik-e2e/tests/server-only-modules.e2e.ts
+++ b/e2e/qwik-e2e/tests/server-only-modules.e2e.ts
@@ -16,6 +16,12 @@ test.describe('server-only modules', () => {
 
   test.skip(({ browserName }) => browserName !== 'chromium', 'Runs once in Chromium e2e.');
 
+  test.beforeEach(() => {
+    // Core's duplicate-import guard (Q30) lives on globalThis and survives
+    // server.close(); reset it so each in-process Vite server can re-evaluate core.
+    (globalThis as any).__qwik = undefined;
+  });
+
   test('allows .server imports used only by routeLoader$', async () => {
     try {
       await cleanBuildOutput(allowedAppDir);


### PR DESCRIPTION
# What is it?

- Docs / tests / types / typos

# Description

The server-only-modules e2e spec creates multiple in-process Vite dev servers, and core's duplicate-import guard (`globalThis.__qwik`) survives `server.close()`, so the next server's module runner threw Q30 — "dev ssr mode allows server-only imports used only by routeLoader$" failed when run after the development-mode test. Reset the guard in a `beforeEach`. Only visible with `--retries=0` since a retry re-runs the serial group in a fresh worker.