### PR TITLE
test: fix non-asserting e2e checks (missing awaits, no-op assertions)

### DIFF
--- a/e2e/docs-e2e/tests/Docs/navBarOnMobile.spec.ts
+++ b/e2e/docs-e2e/tests/Docs/navBarOnMobile.spec.ts
@@ -11,10 +11,10 @@ test('navbar on mobile', async ({ page }) => {
   const navToolKit = page.locator('.menu-toolkit');
   const body = page.locator('body');
 
-  expect(body).not.toHaveClass('header-open');
+  await expect(body).not.toHaveClass('header-open');
   await expect(openIcon).toBeVisible();
   await openIcon.click();
-  expect(body).toHaveClass('header-open');
+  await expect(body).toHaveClass('header-open');
   await expect(closeIcon).toBeVisible();
 
   await expect(navToolKit).toBeVisible();
@@ -33,7 +33,7 @@ test('navbar on mobile', async ({ page }) => {
   expect(menuItems).toStrictEqual(expectedMenuLinks);
 
   await closeIcon.click();
-  expect(body).not.toHaveClass('header-open');
+  await expect(body).not.toHaveClass('header-open');
   await expect(closeIcon).not.toBeVisible();
   await expect(openIcon).toBeVisible();
   await expect(navToolKit).not.toBeVisible();

--- a/starters/e2e/e2e.sync-qrl.spec.ts
+++ b/starters/e2e/e2e.sync-qrl.spec.ts
@@ -26,6 +26,6 @@ test.describe("resuming", () => {
     // clicking checkbox does not toggles the checked state, because default is prevented.
     await input.click();
     await expect(input).toBeChecked();
-    await expect(await input.getAttribute("prevented")).toBeDefined();
+    await expect(input).hasAttribute("prevented");
   });
 });

--- a/starters/e2e/e2e.use-id.spec.ts
+++ b/starters/e2e/e2e.use-id.spec.ts
@@ -15,7 +15,7 @@ test.describe("use-id", () => {
 
   test("Creates unique ids and ensure no collisions", async ({ page }) => {
     const totalIdsLocator = page.locator("#totalIds");
-    await totalIdsLocator.isVisible();
+    await expect(totalIdsLocator).toBeVisible();
     const totalIdsText = await totalIdsLocator.textContent();
     const totalIds = parseInt(totalIdsText || "-1");
     await expect(totalIds).toBeGreaterThan(0); // MAKE SURE WE HAVE SOME IDS

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -55,7 +55,7 @@ test.describe("actions", () => {
       });
       test("should scroll on hash change", async ({ page }) => {
         await page.goto("/qwikcity-test/scroll-restoration/hash/");
-        expect(page).toHaveURL("/qwikcity-test/scroll-restoration/hash/");
+        await expect(page).toHaveURL("/qwikcity-test/scroll-restoration/hash/");
 
         const link = page.locator("#hash-1");
         await link.click();
@@ -112,7 +112,7 @@ test.describe("actions", () => {
 
         await scrollDetector1;
         await expect(page.locator("h1")).toHaveText("Page Short");
-        expect(page).toHaveURL("/qwikcity-test/scroll-restoration/page-short/");
+        await expect(page).toHaveURL("/qwikcity-test/scroll-restoration/page-short/");
         expect(await getWindowScrollXY(page)).toStrictEqual([0, 0]);
 
         const scrollHeightShort = await getScrollHeight(page);
@@ -129,7 +129,7 @@ test.describe("actions", () => {
 
         await scrollDetector2;
         await expect(page.locator("h1")).toHaveText("Page Long");
-        expect(page).toHaveURL("/qwikcity-test/scroll-restoration/page-long/");
+        await expect(page).toHaveURL("/qwikcity-test/scroll-restoration/page-long/");
         expect(await getWindowScrollXY(page)).toStrictEqual([
           0,
           scrollHeightLong,
@@ -140,7 +140,7 @@ test.describe("actions", () => {
 
         await scrollDetector3;
         await expect(page.locator("h1")).toHaveText("Page Short");
-        expect(page).toHaveURL("/qwikcity-test/scroll-restoration/page-short/");
+        await expect(page).toHaveURL("/qwikcity-test/scroll-restoration/page-short/");
         expect(await getWindowScrollXY(page)).toStrictEqual([
           0,
           scrollHeightShort,

--- a/starters/e2e/qwikcity/resource.spec.ts
+++ b/starters/e2e/qwikcity/resource.spec.ts
@@ -4,7 +4,7 @@ test.describe("Resource", () => {
   test("should handle the resource correctly", async ({ page }) => {
     await page.goto("/qwikcity-test/issue7254/");
 
-    await page.getByText("Data: hello Bar");
+    await expect(page.getByText("Data: hello Bar")).toBeVisible();
 
     await page.getByRole("button", { name: "Reset" }).click();
 


### PR DESCRIPTION
# What is it?

- Docs / tests / types / typos

# Description

This PR strengthens existing Playwright checks in the Qwik starter and docs E2E suites. It does not add product behavior or rename tests.

The fixes are focused on assertions that currently do not enforce the behavior they describe:

- Prefix `await` on 7 web-first assertions whose promises were previously discarded (`toHaveURL` and `toHaveClass`).
- Replace `expect(await input.getAttribute("prevented")).toBeDefined()` with the repo's existing custom matcher idiom, `await expect(input).hasAttribute("prevented")`. The old form passes for `null`, so it did not verify that the attribute exists.
- Replace a discarded `isVisible()` boolean and a bare `getByText()` locator statement with `await expect(...).toBeVisible()`.

Blame check:

- The docs mobile menu class checks trace to 1230712613 from 2025-07-15.
- The docs resource locator check traces to dd80d5e6ca from 2025-01-17.
- The affected starter checks trace at least as far back as 7e742eb3a from 2024-06-25.

Verification:

- Re-fetched `origin/main` on 2026-06-13.
- Applied commit 4d25770799accf43eb409dc4c845b46acf7eeaed to a temp worktree based on current `origin/main` and ran:
  `bash scripts/pr-preflight.sh tmp/preflight-qwik e2e/docs-e2e/tests/Docs/navBarOnMobile.spec.ts starters/e2e/e2e.sync-qrl.spec.ts starters/e2e/e2e.use-id.spec.ts starters/e2e/qwikcity/nav.spec.ts starters/e2e/qwikcity/resource.spec.ts`
- Result: `PREFLIGHT 0 fail(s)` with scanner delta `total from 16 to 9, p0 from 9 to 2, ast from 5 to 0`; AST artifacts clean; diff hygiene clean; authoring clean with 0 added comments and no test renames.
- Not run locally: repo TypeScript, lint, or Playwright E2E. This clone has no `node_modules`, and the Qwik E2E path requires the repo dependency and app setup. The preflight therefore skipped tsc, eslint, and Playwright because local repo binaries were absent.

Checklist:

- [x] My code follows the developer guidelines of this project
- [x] I performed a self-review of my own code
- [x] Changeset not needed: test-only assertion fixes, no package release note
- [x] Docs not needed: no public docs behavior changes
- [x] Existing tests updated by strengthening their assertions

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
