### PR TITLE
docs(ruler): add rule forbidding hydration terminology for Qwik

### DIFF
--- a/.ruler/rules/no-hydration-terminology.md
+++ b/.ruler/rules/no-hydration-terminology.md
@@ -1,0 +1,31 @@
+# No Hydration Terminology Rule
+
+Never describe Qwik or any part of how Qwik works as hydration. Qwik does not hydrate. Qwik is
+resumable: the server serializes application state and listeners into the HTML, and the client
+resumes execution exactly where the server left off, without re-running component code or
+rebuilding the framework state.
+
+## Why This Rule Exists
+
+Generated documentation has repeatedly described Qwik using hydration terminology. This is
+factually wrong and undermines Qwik's core value proposition. Hydration means re-executing
+component code on the client to reconstruct framework state that the server already had.
+Qwik's entire design exists to avoid that work.
+
+## When Writing Documentation
+
+- Do not call any Qwik mechanism "hydration", "hydrating", "rehydration", "partial hydration",
+  "progressive hydration", "selective hydration", or "island hydration".
+- Do not describe Qwik components, containers, or apps as "hydrated" or "needing to hydrate".
+- Use the correct terms instead: "resumability", "resume", "resuming", "serialization",
+  "deserialization", and "lazy execution".
+- Describe client startup as Qwik resuming from serialized state, not as Qwik booting, mounting,
+  or hydrating the app.
+
+## Allowed Mentions
+
+The word "hydration" may appear only when explicitly contrasting Qwik with hydration-based
+frameworks, and the sentence must make clear that hydration is what other frameworks do and what
+Qwik avoids. For example: "Unlike frameworks that hydrate on the client, Qwik resumes from
+serialized state." Never use hydration vocabulary, even casually or by analogy, to explain what
+Qwik itself does.


### PR DESCRIPTION
## What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

## Description

Adds a new always-on Ruler rule (`.ruler/rules/no-hydration-terminology.md`) that forbids describing Qwik or any of its mechanisms as hydration when writing documentation.

AI-generated docs have repeatedly described Qwik's behavior using hydration terminology, which is factually wrong — Qwik resumes from serialized state instead of hydrating. The rule:

- bans all hydration vocabulary ("hydration", "rehydration", "partial/progressive/selective/island hydration", "hydrated") for describing Qwik itself
- points to the correct terms: resumability, resume, serialization, deserialization, lazy execution
- allows "hydration" only when explicitly contrasting Qwik with hydration-based frameworks

## Checklist

- [x] My code follows the developer guidelines of this project
- [ ] I performed a self-review of my own code
- [x] I made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)