### PR TITLE
docs(ruler): add changeset conventions rule for agents

### DIFF
--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -106,6 +106,8 @@ by Ruler.
   intentionally.
 - `security-and-supply-chain`: run focused security reasoning for vulnerable surfaces, dependency
   changes, and GitHub Actions updates.
+- `changeset-conventions`: pick the bump level by change kind (patch/minor/major), write one
+  changeset per change, and keep each summary near 150 and under 300 characters.
 
 ## Engineering Rules
 
@@ -141,7 +143,8 @@ Follow that bias:
   verification from the optimizer skill and use `pnpm build.full` when a full JS/WASM rebuild is
   required.
 - If a change affects published packages, create a changeset with `pnpm change` unless the user or
-  maintainer explicitly says the change is non-release-affecting.
+  maintainer explicitly says the change is non-release-affecting. Follow the `changeset-conventions`
+  rule for bump level, one changeset per change, and summary length.
 - Base branch and release branch for v2 PRs: `build/v2`.
 
 ## Code Style

--- a/.ruler/README.md
+++ b/.ruler/README.md
@@ -18,6 +18,7 @@ should be loaded only when relevant.
 
 Current source rules:
 
+- `changeset-conventions`
 - `code-quality`
 - `generated-output-boundaries`
 - `guidance-source-of-truth`

--- a/.ruler/rules/changeset-conventions.md
+++ b/.ruler/rules/changeset-conventions.md
@@ -1,0 +1,27 @@
+# Changeset Conventions Rule
+
+When a change affects published packages, write changesets with `pnpm change` (or by adding files
+under `.changeset/`) using the bump level that matches the kind of change.
+
+## Bump Level
+
+- `patch`: bug fixes.
+- `minor`: new features.
+- `major`: API removal. A `major` may also include a new feature, but it must remove or break a
+  public API.
+
+## One Changeset Per Change
+
+Create a separate changeset for each `patch`, `minor`, or `major` change. Do not combine unrelated
+fixes and features into one changeset. If a single PR carries a bug fix and a new feature, write one
+`patch` changeset and one `minor` changeset.
+
+## Casing
+
+Write the changeset summary in lowercase, including any leading type prefix such as `fix:` or
+`feat:`. Do not uppercase the prefix or shout the summary.
+
+## Length
+
+Each changeset summary should aim for around 150 characters and must not exceed 300 characters.
+Describe the user-facing change in one tight sentence; move deeper detail to the PR description.


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
Adds a `.ruler/rules/changeset-conventions.md` rule so agents write changesets consistently: patch for bug fixes, minor for new features, major for API removal. One changeset per change, each summary ~150 chars and under 300. Registered it in `.ruler/AGENTS.md` and `.ruler/README.md`.