### PR TITLE
chore(ruler): remind to re-run ruler when .ruler changes on pull

### DIFF
--- a/.ruler/README.md
+++ b/.ruler/README.md
@@ -110,6 +110,14 @@ rg -n 'Source: .ruler/rules' AGENTS.md
 find .codex/skills -name SKILL.md
 ```
 
+## Stale Guidance Reminder
+
+A `post-merge` git hook (`scripts/ruler-postmerge-check.mjs`, wired through `simple-git-hooks`)
+prints a reminder whenever a pull changes anything under `.ruler/`. It only notifies — it never
+writes files — so generated assistant outputs are never scaffolded behind your back. When you see
+it, re-run `ruler apply --agents <your-tool>` to refresh your local files. The hook installs on
+`pnpm install` via the `prepare` script.
+
 ## Generate Local Assistant Files
 
 Install Ruler if you do not already have it:

--- a/package.json
+++ b/package.json
@@ -289,7 +289,8 @@
     "worktree": "node --require ./scripts/runBefore.ts scripts/worktrees.ts"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm pretty-quick --staged"
+    "pre-commit": "pnpm pretty-quick --staged",
+    "post-merge": "node ./scripts/ruler-postmerge-check.mjs"
   },
   "type": "module"
 }

--- a/scripts/ruler-postmerge-check.mjs
+++ b/scripts/ruler-postmerge-check.mjs
@@ -1,0 +1,32 @@
+// post-merge git hook: notify when shared AI guidance under `.ruler/` changed in a pull.
+//
+// Generated assistant files (`.claude/`, `.codex/`, `.cursor/`, ...) are local, gitignored Ruler
+// outputs. When `.ruler/` source changes upstream, a developer's generated files go stale until
+// they re-run Ruler. This hook only prints a reminder — it never writes files — so there are no
+// surprise scaffolds, no CI noise (post-merge does not fire on fetch/checkout), and no trust cost.
+import { execSync } from 'node:child_process';
+
+const range = process.env.RULER_POSTMERGE_RANGE || 'ORIG_HEAD HEAD';
+
+function changedRulerFiles() {
+  try {
+    const out = execSync(`git diff --name-only ${range} -- .ruler`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.split('\n').filter(Boolean);
+  } catch {
+    // ORIG_HEAD may be unset (e.g. first commit); nothing to compare, stay silent.
+    return [];
+  }
+}
+
+const changed = changedRulerFiles();
+if (changed.length > 0) {
+  const yellow = (s) => `\x1b[33m${s}\x1b[0m`;
+  process.stdout.write(
+    yellow(`\n⚠ .ruler AI guidance changed in this pull (${changed.length} file(s)).`) +
+      '\n  Refresh your generated agent files so they are not stale:\n' +
+      '    ruler apply --agents <your-tool>\n\n'
+  );
+}


### PR DESCRIPTION
# What is it?
- Infra

# Description
Adds a notify-only `post-merge` git hook (via `simple-git-hooks`) that prints a reminder when a pull changes anything under `.ruler/`, so you remember to re-run `ruler apply` and your generated agent files don't go stale. It only prints — never writes files — so no surprise scaffolds, no CI noise (post-merge doesn't fire on fetch/checkout), and no install-script trust cost. Installs on `pnpm install` via the existing `prepare` script.