### PR TITLE
fix(core): rewind cursor when attaching dirty descendants

### DIFF
--- a/.changeset/stale-ends-enter.md
+++ b/.changeset/stale-ends-enter.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: prevent signal-bound DOM from staying stale when a signal is updated while a render is already in progress

--- a/packages/qwik/src/core/shared/vnode/vnode-dirty.spec.ts
+++ b/packages/qwik/src/core/shared/vnode/vnode-dirty.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { VNodeFlags } from '../../client/types';
+import { vnode_newVirtual } from '../../client/vnode-utils';
+import type { Cursor } from '../cursor/cursor';
+import { setCursorData, type CursorData } from '../cursor/cursor-props';
+import type { Container } from '../types';
+import { ChoreBits } from './enums/chore-bits.enum';
+import type { VirtualVNode } from './virtual-vnode';
+import { markVNodeDirty } from './vnode-dirty';
+
+describe('markVNodeDirty', () => {
+  const createMockContainer = () =>
+    ({
+      $pendingCount$: 0,
+      $renderPromise$: null,
+      $resolveRenderPromise$: null,
+      $checkPendingCount$: () => {},
+      getHostProp: () => null,
+      handleError: () => {},
+    }) as unknown as Container;
+
+  const createCursorData = (
+    container: Container,
+    cursor: Cursor,
+    position: VirtualVNode
+  ): CursorData => {
+    const cursorData: CursorData = {
+      container,
+      position,
+      promise: null,
+      journal: null,
+      extraPromises: null,
+      afterFlushTasks: null,
+      priority: 0,
+      boundaries: null,
+    };
+    setCursorData(cursor, cursorData);
+    cursor.flags |= VNodeFlags.Cursor;
+    return cursorData;
+  };
+
+  it('should rewind an existing blocking cursor to the dirty branch', () => {
+    const container = createMockContainer();
+    const cursor = vnode_newVirtual() as Cursor;
+    const previousPosition = vnode_newVirtual() as VirtualVNode;
+    const parent = vnode_newVirtual() as VirtualVNode;
+    const child = vnode_newVirtual() as VirtualVNode;
+
+    previousPosition.parent = cursor;
+    parent.parent = cursor;
+    child.parent = parent;
+
+    const cursorData = createCursorData(container, cursor, previousPosition);
+
+    markVNodeDirty(container, child, ChoreBits.NODE_DIFF);
+
+    expect(cursorData.position).toBe(parent);
+    expect(cursor.dirty & ChoreBits.CHILDREN).toBeTruthy();
+    expect(cursor.dirtyChildren).toContain(parent);
+    expect(parent.dirty & ChoreBits.CHILDREN).toBeTruthy();
+    expect(parent.dirtyChildren).toContain(child);
+  });
+
+  it('should not rewind past dirty ancestors to the leaf vnode', () => {
+    const container = createMockContainer();
+    const cursor = vnode_newVirtual() as Cursor;
+    const previousPosition = vnode_newVirtual() as VirtualVNode;
+    const branch = vnode_newVirtual() as VirtualVNode;
+    const parent = vnode_newVirtual() as VirtualVNode;
+    const child = vnode_newVirtual() as VirtualVNode;
+
+    previousPosition.parent = cursor;
+    branch.parent = cursor;
+    parent.parent = branch;
+    child.parent = parent;
+
+    const cursorData = createCursorData(container, cursor, previousPosition);
+
+    markVNodeDirty(container, child, ChoreBits.NODE_DIFF);
+
+    expect(cursorData.position).toBe(branch);
+    expect(cursorData.position).not.toBe(parent);
+    expect(cursorData.position).not.toBe(child);
+    expect(cursor.dirtyChildren).toContain(branch);
+    expect(branch.dirty & ChoreBits.CHILDREN).toBeTruthy();
+    expect(branch.dirtyChildren).toContain(parent);
+    expect(parent.dirty & ChoreBits.CHILDREN).toBeTruthy();
+    expect(parent.dirtyChildren).toContain(child);
+  });
+});

--- a/packages/qwik/src/core/shared/vnode/vnode-dirty.ts
+++ b/packages/qwik/src/core/shared/vnode/vnode-dirty.ts
@@ -109,6 +109,10 @@ function findAndPropagateToBlockingCursor(container: Container, vNode: VNode): b
       // remember that cursor's nearest boundary for async/suspense bookkeeping.
       setNearestCursorBoundary(vNode, cursorBoundary);
       propagatePath(current);
+      const cursorData: CursorData = getCursorData(current)!;
+      if (cursorData.position !== current) {
+        cursorData.position = reusablePath[reusablePath.length - 1];
+      }
       reusablePath.length = 0;
       return true;
     }


### PR DESCRIPTION
Ensure signal-bound DOM updates are processed when a signal changes while an existing render cursor is already in progress.