### PR TITLE
fix: preserve pending UI updates across frame yields

### DIFF
--- a/.changeset/wacky-cows-pull.md
+++ b/.changeset/wacky-cows-pull.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: prevent large updates that span multiple frames from restarting incorrectly and missing pending UI changes

--- a/packages/qwik/src/core/shared/cursor/cursor-props.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-props.ts
@@ -43,11 +43,18 @@ export function setCursorPosition(
   }
 }
 
-function mergeCursors(container: Container, newCursorData: CursorData, oldCursor: VNode): void {
+export function mergeCursors(
+  container: Container,
+  newCursorData: CursorData,
+  oldCursor: VNode
+): void {
+  const oldCursorData = getCursorData(oldCursor);
+  if (!oldCursorData || oldCursorData === newCursorData) {
+    return;
+  }
+
   // delete from global cursors queue
   removeCursorFromQueue(oldCursor, container);
-  const oldCursorData = getCursorData(oldCursor)!;
-
   mergeCursorData(newCursorData, oldCursorData);
 }
 

--- a/packages/qwik/src/core/shared/cursor/cursor-walker.spec.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor-walker.spec.ts
@@ -5,7 +5,7 @@ import { ChoreBits } from '../vnode/enums/chore-bits.enum';
 import type { VirtualVNode } from '../vnode/virtual-vnode';
 import { isCursor, type Cursor } from './cursor';
 import { getNextVNode, partitionDirtyChildren, tryDescendDirtyChildren } from './cursor-walker';
-import { getCursorData, setCursorData, type CursorData } from './cursor-props';
+import { getCursorData, setCursorData, setCursorPosition, type CursorData } from './cursor-props';
 import type { Container } from '../types';
 import { QCursorBoundary } from '../utils/markers';
 import {
@@ -652,6 +652,46 @@ describe('tryDescendDirtyChildren', () => {
 
     // Should return first dirty child after partitioning (skipping clean regular1)
     expect(result).toBe(regular2);
+  });
+});
+
+describe('setCursorPosition', () => {
+  const createMockContainer = () =>
+    ({
+      $pendingCount$: 0,
+      $renderPromise$: null,
+      $resolveRenderPromise$: null,
+      $checkPendingCount$: () => {},
+    }) as unknown as Container;
+
+  it('should keep the cursor flag when a cursor advances back to itself', () => {
+    const container = createMockContainer();
+    const cursor = vnode_newVirtual() as Cursor;
+    const cursorData: CursorData = {
+      container,
+      position: null,
+      promise: null,
+      journal: null,
+      extraPromises: null,
+      afterFlushTasks: null,
+      priority: 0,
+      boundaries: null,
+    };
+
+    setCursorData(cursor, cursorData);
+    cursor.flags |= VNodeFlags.Cursor;
+    addCursorToQueue(container, cursor);
+
+    try {
+      setCursorPosition(container, cursorData, cursor);
+
+      expect(isCursor(cursor)).toBe(true);
+      expect(getCursorData(cursor)).toBe(cursorData);
+      expect(getHighestPriorityCursor()).toBe(cursor);
+      expect(container.$pendingCount$).toBe(1);
+    } finally {
+      removeCursorFromQueue(cursor, container);
+    }
   });
 });
 

--- a/packages/qwik/src/core/shared/cursor/cursor.ts
+++ b/packages/qwik/src/core/shared/cursor/cursor.ts
@@ -22,6 +22,10 @@ export type Cursor = VNode;
  * @returns The vNode itself, now acting as a cursor
  */
 export function addCursor(container: Container, root: VNode, priority: number): Cursor {
+  if (isCursor(root)) {
+    triggerCursors();
+    return root;
+  }
   const cursorData: CursorData = {
     afterFlushTasks: null,
     extraPromises: null,


### PR DESCRIPTION
This fixes an issue where large UI updates spanning multiple frames could restart incorrectly and lose pending work. The update preserves in-progress render state when a cursor advances back to itself, preventing missed UI changes after yielding to the browser.