### PR TITLE
fix(qwik-router): ErrorBoundary catches its own subtree (closest-parent)

### DIFF
--- a/.changeset/errorboundary-closest-parent.md
+++ b/.changeset/errorboundary-closest-parent.md
@@ -3,4 +3,4 @@
 '@qwik.dev/router': major
 ---
 
-`<ErrorBoundary>` now catches errors only from its own subtree: the **closest** boundary handles an error, instead of every boundary on the page reacting to the global `qerror` event. The container now routes both synchronous render throws and async errors (`qerror`) to the nearest `<ErrorBoundary>` via `handleError`. A single top-level boundary still catches everything; nested boundaries now scope correctly.
+`<ErrorBoundary>` now catches errors only from its own subtree: the **closest** boundary handles an error, instead of every boundary on the page reacting to the global `qerror` event. The container routes both synchronous render throws and async errors (`qerror`) to the nearest `<ErrorBoundary>` via `handleError`. `<ErrorBoundary>` also catches render throws during **SSR** now (rendering its `fallback$` in place instead of aborting to the error page). A single top-level boundary still catches everything; nested boundaries now scope correctly.

--- a/.changeset/errorboundary-closest-parent.md
+++ b/.changeset/errorboundary-closest-parent.md
@@ -1,0 +1,6 @@
+---
+'@qwik.dev/core': minor
+'@qwik.dev/router': major
+---
+
+`<ErrorBoundary>` now catches errors only from its own subtree: the **closest** boundary handles an error, instead of every boundary on the page reacting to the global `qerror` event. The container now routes both synchronous render throws and async errors (`qerror`) to the nearest `<ErrorBoundary>` via `handleError`. A single top-level boundary still catches everything; nested boundaries now scope correctly.

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -654,7 +654,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface ErrorBoundaryStore \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nerror\n\n\n</td><td>\n\n\n</td><td>\n\nany \\| undefined\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport interface ErrorBoundaryStore \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n$fallback$?\n\n\n</td><td>\n\n\n</td><td>\n\n(error: any) =&gt; unknown\n\n\n</td><td>\n\n_(Optional)_ The boundary's fallback renderer. Set by `<ErrorBoundary>` so SSR can render the fallback in place of a subtree that throws during server render (on the client the boundary re-renders instead). Internal — not meant to be set by application code.\n\n\n</td></tr>\n<tr><td>\n\nerror\n\n\n</td><td>\n\n\n</td><td>\n\nany \\| undefined\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/error/error-handling.ts",
       "mdFile": "core.errorboundarystore.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.mdx
+++ b/packages/docs/src/routes/api/qwik/index.mdx
@@ -1645,6 +1645,21 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+$fallback$?
+
+</td><td>
+
+</td><td>
+
+(error: any) =&gt; unknown
+
+</td><td>
+
+_(Optional)_ The boundary's fallback renderer. Set by `<ErrorBoundary>` so SSR can render the fallback in place of a subtree that throws during server render (on the client the boundary re-renders instead). Internal — not meant to be set by application code.
+
+</td></tr>
+<tr><td>
+
 error
 
 </td><td>

--- a/packages/qwik-router/src/runtime/src/error-boundary.tsx
+++ b/packages/qwik-router/src/runtime/src/error-boundary.tsx
@@ -1,4 +1,4 @@
-import { component$, useErrorBoundary, Slot, type QRL, useOnWindow, $ } from '@qwik.dev/core';
+import { component$, useErrorBoundary, Slot, type QRL } from '@qwik.dev/core';
 
 /** @public */
 export interface ErrorBoundaryProps {
@@ -7,14 +7,10 @@ export interface ErrorBoundaryProps {
 
 /** @public */
 export const ErrorBoundary = component$((props: ErrorBoundaryProps) => {
+  // The store is provided as ERROR_CONTEXT by useErrorBoundary. Both synchronous render throws and
+  // async errors (`qerror`) are routed by the container's handleError() to the CLOSEST boundary,
+  // which sets this store — so this component only has to read it and render the fallback.
   const store = useErrorBoundary();
-
-  useOnWindow(
-    'qerror',
-    $((e: CustomEvent) => {
-      store.error = e.detail.error;
-    })
-  );
 
   if (store.error && props.fallback$) {
     return <>{props.fallback$(store.error)}</>;

--- a/packages/qwik-router/src/runtime/src/error-boundary.tsx
+++ b/packages/qwik-router/src/runtime/src/error-boundary.tsx
@@ -1,4 +1,4 @@
-import { component$, useErrorBoundary, Slot, type QRL } from '@qwik.dev/core';
+import { component$, useErrorBoundary, Slot, noSerialize, type QRL } from '@qwik.dev/core';
 
 /** @public */
 export interface ErrorBoundaryProps {
@@ -11,6 +11,10 @@ export const ErrorBoundary = component$((props: ErrorBoundaryProps) => {
   // async errors (`qerror`) are routed by the container's handleError() to the CLOSEST boundary,
   // which sets this store — so this component only has to read it and render the fallback.
   const store = useErrorBoundary();
+  // Expose the fallback so SSR can render it in place when a child throws during server render
+  // (on the client the boundary simply re-renders and takes the branch below). Server-render-only,
+  // so noSerialize — it must not end up in the serialized state.
+  store.$fallback$ = noSerialize(props.fallback$);
 
   if (store.error && props.fallback$) {
     return <>{props.fallback$(store.error)}</>;

--- a/packages/qwik/src/core/client/dom-container.ts
+++ b/packages/qwik/src/core/client/dom-container.ts
@@ -114,6 +114,7 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
   private $stateData$: unknown[];
   private $rootForwardRefs$: Array<number | string> | null = null;
   private $styleIds$: Set<string> | null = null;
+  private $qErrorHandler$: ((e: Event) => void) | null = null;
 
   constructor(element: ContainerElement) {
     super({}, element.getAttribute(QLocaleAttr)!);
@@ -146,6 +147,20 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
       processSegmentStateScripts(this);
     }
     this.$hoistStyles$();
+    // Route async errors (a failed QRL import/handler emits a `qerror` event) to the CLOSEST
+    // ErrorBoundary, matching the synchronous render-throw path. Previously each ErrorBoundary
+    // listened to the global event and every one of them caught every error regardless of source.
+    this.$qErrorHandler$ = (e: Event) => {
+      const detail = (e as CustomEvent<{ error: unknown; element?: Element }>).detail;
+      const source = detail?.element;
+      if (source && this.element.contains(source)) {
+        const host = this.vNodeLocate(source);
+        if (host) {
+          this.handleError(detail.error, host);
+        }
+      }
+    };
+    document.addEventListener?.('qerror', this.$qErrorHandler$);
     if (!qTest && element.isConnected) {
       element.dispatchEvent(new CustomEvent('qresume', { bubbles: true }));
     }
@@ -153,6 +168,10 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
 
   /** Tear down this container so stale references fail gracefully. */
   $destroy$(): void {
+    if (this.$qErrorHandler$) {
+      this.document.removeEventListener?.('qerror', this.$qErrorHandler$);
+      this.$qErrorHandler$ = null;
+    }
     this.vNodeLocate = () => null as any;
     this.$rawStateData$.length = 0;
     this.$stateData$.length = 0;

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -495,6 +495,7 @@ export const _EMPTY_OBJ: Record<string, any>;
 
 // @public (undocumented)
 export interface ErrorBoundaryStore {
+    $fallback$?: (error: any) => unknown;
     // (undocumented)
     error: any | undefined;
 }

--- a/packages/qwik/src/core/shared/error/error-handling.ts
+++ b/packages/qwik/src/core/shared/error/error-handling.ts
@@ -3,6 +3,12 @@ import { createContextId } from '../../use/use-context';
 /** @public */
 export interface ErrorBoundaryStore {
   error: any | undefined;
+  /**
+   * The boundary's fallback renderer. Set by `<ErrorBoundary>` so SSR can render the fallback in
+   * place of a subtree that throws during server render (on the client the boundary re-renders
+   * instead). Internal — not meant to be set by application code.
+   */
+  $fallback$?: (error: any) => unknown;
 }
 
 export const ERROR_CONTEXT = /*#__PURE__*/ createContextId<ErrorBoundaryStore>('qk-error');

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -43,6 +43,7 @@ import {
   isInternalServerComponent,
 } from './internal-server-component';
 import { applyInlineComponent, applyQwikComponentBody } from './ssr-render-component';
+import { ERROR_CONTEXT } from '../shared/error/error-handling';
 import type { ISsrComponentFrame, SSRContainer, SSRRenderJSXOptions } from './ssr-types';
 import { resolveSlotName } from '../shared/utils/prop';
 
@@ -108,6 +109,27 @@ export async function _walkJSX(
     }
   };
   await drain();
+}
+
+/**
+ * A component threw during SSR render. Route it to the CLOSEST ErrorBoundary (matching the client's
+ * handleError): set the boundary's error and render its fallback in place of the failed subtree.
+ * With no boundary above, rethrow so the request aborts to the error page.
+ */
+function renderErrorBoundaryFallback(
+  ssr: SSRContainer,
+  host: ReturnType<SSRContainer['getOrCreateLastNode']>,
+  err: unknown
+): ValueOrPromise<JSXOutput> {
+  const errorStore = ssr.resolveContext(host, ERROR_CONTEXT);
+  // Only catch when the closest boundary exposes a fallback to render in place (SSR can't re-render
+  // the boundary). Boundaries without one — or no boundary at all — propagate, aborting to the error
+  // page, exactly as before.
+  if (!errorStore || !errorStore.$fallback$) {
+    throw err;
+  }
+  errorStore.error = err;
+  return errorStore.$fallback$(err) as ValueOrPromise<JSXOutput>;
 }
 
 function processJSXNode(
@@ -306,7 +328,12 @@ function processJSXNode(
             options.parentComponentFrame
           );
 
-          const jsxOutput = applyQwikComponentBody(ssr, jsx, type);
+          let jsxOutput: ValueOrPromise<JSXOutput>;
+          try {
+            jsxOutput = applyQwikComponentBody(ssr, jsx, type);
+          } catch (err) {
+            jsxOutput = renderErrorBoundaryFallback(ssr, host, err);
+          }
           enqueue(
             setParentOptions(options, options.currentStyleScoped, options.parentComponentFrame)
           );
@@ -333,12 +360,12 @@ function processJSXNode(
           ssr.openFragment(inlineComponentProps);
           enqueue(ssr.closeFragment);
           const component = ssr.getParentComponentFrame();
-          const jsxOutput = applyInlineComponent(
-            ssr,
-            component && component.componentNode,
-            type,
-            jsx
-          );
+          let jsxOutput: ValueOrPromise<JSXOutput>;
+          try {
+            jsxOutput = applyInlineComponent(ssr, component && component.componentNode, type, jsx);
+          } catch (err) {
+            jsxOutput = renderErrorBoundaryFallback(ssr, ssr.getOrCreateLastNode(), err);
+          }
           enqueue(jsxOutput);
           isPromise(jsxOutput) && enqueue(Promise);
         }

--- a/packages/qwik/src/core/tests/error-boundary.spec.tsx
+++ b/packages/qwik/src/core/tests/error-boundary.spec.tsx
@@ -1,0 +1,76 @@
+import { component$, Slot, useErrorBoundary } from '@qwik.dev/core';
+import { domRender, waitForDrain } from '@qwik.dev/core/testing';
+import { describe, expect, it } from 'vitest';
+
+const debug = false;
+
+/** Minimal boundary: provides ERROR_CONTEXT and renders a marker when its store gets an error. */
+const Boundary = component$<{ name: string }>((props) => {
+  const store = useErrorBoundary();
+  if (store.error) {
+    return <div id={`caught-${props.name}`}>caught</div>;
+  }
+  return <Slot />;
+});
+
+const Thrower = component$(() => {
+  throw new Error('boom');
+});
+
+describe('ErrorBoundary closest-parent resolution', () => {
+  it('a synchronous render throw is caught by the NEAREST boundary, not the outer one', async () => {
+    const { container } = await domRender(
+      <Boundary name="outer">
+        <div id="outer-content">ok</div>
+        <Boundary name="inner">
+          <Thrower />
+        </Boundary>
+      </Boundary>,
+      { debug }
+    );
+    const el = container.element;
+    expect(el.querySelector('#caught-inner')).toBeTruthy();
+    expect(el.querySelector('#caught-outer')).toBeFalsy();
+    // the outer subtree outside the inner boundary keeps rendering
+    expect(el.querySelector('#outer-content')).toBeTruthy();
+  });
+
+  it('an async qerror is routed to the NEAREST boundary by the container', async () => {
+    const { container } = await domRender(
+      <Boundary name="outer">
+        <Boundary name="inner">
+          <button id="target">x</button>
+        </Boundary>
+      </Boundary>,
+      { debug }
+    );
+    const el = container.element;
+    const target = el.querySelector('#target')!;
+    const ev = el.ownerDocument.createEvent('Event');
+    ev.initEvent('qerror', false, false);
+    (ev as any).detail = { error: new Error('async boom'), element: target };
+    el.ownerDocument.dispatchEvent(ev);
+    await waitForDrain(container);
+
+    expect(el.querySelector('#caught-inner')).toBeTruthy();
+    expect(el.querySelector('#caught-outer')).toBeFalsy();
+  });
+
+  it('an async qerror walks up to the outer boundary when there is no inner one', async () => {
+    const { container } = await domRender(
+      <Boundary name="outer">
+        <button id="target">x</button>
+      </Boundary>,
+      { debug }
+    );
+    const el = container.element;
+    const target = el.querySelector('#target')!;
+    const ev = el.ownerDocument.createEvent('Event');
+    ev.initEvent('qerror', false, false);
+    (ev as any).detail = { error: new Error('async boom'), element: target };
+    el.ownerDocument.dispatchEvent(ev);
+    await waitForDrain(container);
+
+    expect(el.querySelector('#caught-outer')).toBeTruthy();
+  });
+});

--- a/packages/qwik/src/core/tests/error-boundary.spec.tsx
+++ b/packages/qwik/src/core/tests/error-boundary.spec.tsx
@@ -1,5 +1,5 @@
-import { component$, Slot, useErrorBoundary } from '@qwik.dev/core';
-import { domRender, waitForDrain } from '@qwik.dev/core/testing';
+import { component$, noSerialize, Slot, useErrorBoundary } from '@qwik.dev/core';
+import { domRender, ssrRenderToDom, waitForDrain } from '@qwik.dev/core/testing';
 import { describe, expect, it } from 'vitest';
 
 const debug = false;
@@ -7,6 +7,8 @@ const debug = false;
 /** Minimal boundary: provides ERROR_CONTEXT and renders a marker when its store gets an error. */
 const Boundary = component$<{ name: string }>((props) => {
   const store = useErrorBoundary();
+  // Expose the fallback so SSR can render it in place when a child throws (mirrors <ErrorBoundary>).
+  store.$fallback$ = noSerialize(() => <div id={`caught-${props.name}`}>caught</div>);
   if (store.error) {
     return <div id={`caught-${props.name}`}>caught</div>;
   }
@@ -54,6 +56,40 @@ describe('ErrorBoundary closest-parent resolution', () => {
 
     expect(el.querySelector('#caught-inner')).toBeTruthy();
     expect(el.querySelector('#caught-outer')).toBeFalsy();
+  });
+
+  it('SSR: a child throw inside the inner boundary renders the inner fallback, not a 500', async () => {
+    const Page = component$(() => (
+      <Boundary name="outer">
+        <h1>Hi 👋</h1>
+        <Boundary name="inner">
+          <Thrower />
+        </Boundary>
+      </Boundary>
+    ));
+    const { container } = await ssrRenderToDom(<Page />, { debug });
+    expect(container.element.querySelector('#caught-inner')).toBeTruthy();
+    expect(container.element.querySelector('#caught-outer')).toBeFalsy();
+  });
+
+  it('repro shape: a child component (Thrower) inside the inner boundary is caught by the inner one', async () => {
+    const Page = component$(() => (
+      <>
+        <Boundary name="outer">
+          <h1>Hi 👋</h1>
+          <div>
+            text
+            <br />
+            <Boundary name="inner">
+              <Thrower />
+            </Boundary>
+          </div>
+        </Boundary>
+      </>
+    ));
+    const { container } = await domRender(<Page />, { debug });
+    expect(container.element.querySelector('#caught-inner')).toBeTruthy();
+    expect(container.element.querySelector('#caught-outer')).toBeFalsy();
   });
 
   it('an async qerror walks up to the outer boundary when there is no inner one', async () => {


### PR DESCRIPTION
The container now routes async errors (qerror) to the nearest ErrorBoundary via handleError, like synchronous render throws already do. Drops the global qerror broadcast where every boundary caught every error.

BREAKING CHANGE: <ErrorBoundary> no longer reacts to every error on the page.

<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
