### PR TITLE
chore(ruler): apply ruler in fresh worktrees

### DIFF
--- a/.ruler/README.md
+++ b/.ruler/README.md
@@ -119,6 +119,18 @@ writes files — so generated assistant outputs are never scaffolded behind your
 it, re-run `ruler apply --agents <your-tool>` to refresh your local files. The hook installs on
 `pnpm install` via the `prepare` script.
 
+## Fresh Worktrees
+
+Because the generated files are gitignored, a new git worktree starts without them, so AI assistants
+working in it miss the shared `.ruler/` guidance. A `post-checkout` git hook
+(`scripts/ruler-apply-if-missing.mjs`, wired through `simple-git-hooks`) runs
+`pnpm dlx @intellectronica/ruler apply` once when a worktree has none — covering both
+`pnpm worktree add` and an editor/agent's built-in worktree feature.
+
+Unlike the post-merge reminder, this hook does write files, but only when they are entirely absent,
+so it never overwrites an existing checkout: it is a no-op on ordinary branch switches and in CI. If
+it cannot run it skips silently rather than blocking the checkout — run `ruler apply` by hand then.
+
 ## Generate Local Assistant Files
 
 Install Ruler if you do not already have it:

--- a/package.json
+++ b/package.json
@@ -290,7 +290,8 @@
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm pretty-quick --staged",
-    "post-merge": "node ./scripts/ruler-postmerge-check.mjs"
+    "post-merge": "node ./scripts/ruler-postmerge-check.mjs",
+    "post-checkout": "node ./scripts/ruler-apply-if-missing.mjs"
   },
   "type": "module"
 }

--- a/scripts/ruler-apply-if-missing.mjs
+++ b/scripts/ruler-apply-if-missing.mjs
@@ -1,0 +1,24 @@
+// post-checkout git hook: generate Ruler's assistant files when a fresh worktree lacks them.
+//
+// Generated assistant files (CLAUDE.md, AGENTS.md, .claude/, ...) are local, gitignored Ruler
+// outputs, so a newly created worktree starts without them and AI assistants miss the shared
+// `.ruler/` guidance. Unlike the post-merge reminder, this hook *applies* Ruler — but only when
+// the outputs are entirely absent, i.e. a new `git worktree add`. It overwrites nothing in an
+// existing checkout (no-op once CLAUDE.md exists), is silent on ordinary branch switches, and
+// skips CI, where the files are not expected and a network fetch would only add noise.
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+if (process.env.CI || !existsSync('.ruler/ruler.toml') || existsSync('CLAUDE.md')) {
+  process.exit(0);
+}
+
+try {
+  process.stdout.write('[ruler] new worktree detected — generating assistant guidance...\n');
+  const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  const args = ['dlx', '@intellectronica/ruler', 'apply', '--no-gitignore', '--no-mcp'];
+  execFileSync(pnpm, args, { stdio: 'inherit' });
+} catch (err) {
+  // Never block a checkout on guidance generation.
+  process.stderr.write(`[ruler] skipped: ${err?.message ?? err}\n`);
+}


### PR DESCRIPTION
# What is it?
- Infra

# Description
Generated Ruler files (`CLAUDE.md`, `AGENTS.md`, `.claude/`…) are gitignored, so a fresh worktree starts without them and AI assistants working in it miss the shared `.ruler/` guidance. This adds a `post-checkout` git hook that runs `pnpm dlx @intellectronica/ruler apply` once when a worktree has none — covering both `pnpm worktree add` and an editor/agent's built-in worktree feature.

It only writes when the files are entirely absent, so it's a no-op on ordinary branch switches and in CI, and skips silently if it can't run. Sits alongside the existing post-merge reminder hook.