### PR TITLE
fix(router): preserve route loader subscriptions during seq cleanup

### DIFF
--- a/.changeset/little-gifts-cross.md
+++ b/.changeset/little-gifts-cross.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: ensure SPA navigation correctly refreshes route loader data for catch-all routes, including when loader data is shared through context

--- a/e2e/qwik-e2e/apps/qwikrouter-ssg-snapshot/expected.state.txt
+++ b/e2e/qwik-e2e/apps/qwikrouter-ssg-snapshot/expected.state.txt
@@ -66,7 +66,7 @@
                   Array [
                     RootRef [omitted]
                   ]
-                  {number} 7
+                  {number} 3
                   VNode "14A"
                   EffectSubscription [
                     RootRef [omitted]
@@ -81,7 +81,7 @@
             Constant undefined
             Constant undefined
             Constant undefined
-            {number} 256
+            {number} 260
             Constant NEEDS_COMPUTATION
             {number} 120000
           ]
@@ -348,7 +348,7 @@
           Array [
             RootRef [omitted]
           ]
-          {number} 7
+          {number} 3
           VNode "8"
           EffectSubscription [
             RootRef [omitted]
@@ -386,7 +386,7 @@
   RootRef [omitted]
 ]
 32 {string} "q-xxxxxxxx.js"
-33 {string} "s_0vpftJHSMyo"
+33 {string} "s_QL05LKnhMSo"
 34 RootRef [omitted]
 35 QRL "[omitted]"
 36 Map [

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/layout-loader-catchall/[...slug]/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/layout-loader-catchall/[...slug]/index.tsx
@@ -1,0 +1,59 @@
+import { component$, createContextId, useContext, useContextProvider } from '@qwik.dev/core';
+import { Link, routeLoader$, type DocumentHead } from '@qwik.dev/router';
+
+type PageData = {
+  blockText: string;
+  pageId: string;
+  pathname: string;
+  title: string;
+};
+
+export const useLayoutLoaderCatchallPageData = routeLoader$(
+  ({ url }) => {
+    const isMockDetail = url.pathname.endsWith('/mock-detail/');
+    return {
+      blockText: isMockDetail ? 'Mock detail content from loader' : 'Mock home content from loader',
+      pageId: isMockDetail ? 'mock-detail' : 'mock-home',
+      pathname: url.pathname,
+      title: isMockDetail ? 'Mock Detail Loader Page' : 'Mock Home Loader Page',
+    } satisfies PageData;
+  },
+  { serializationStrategy: 'never' }
+);
+
+export const PageDataContext = createContextId<ReturnType<typeof useLayoutLoaderCatchallPageData>>(
+  'layout-loader-catchall-page-data'
+);
+
+const PageGenerator = component$(() => {
+  const pageLoaded = useContext(PageDataContext);
+  const page = pageLoaded.value;
+
+  return (
+    <section data-page-id={page.pageId} id="layout-loader-catchall-page">
+      <h1 id="layout-loader-catchall-content">{page.blockText}</h1>
+      <p id="layout-loader-catchall-pathname">{page.pathname}</p>
+      <Link
+        href="/qwikrouter-test/layout-loader-catchall/mock-detail/"
+        id="layout-loader-catchall-detail"
+      >
+        Mock Detail
+      </Link>
+    </section>
+  );
+});
+
+export default component$(() => {
+  const pageLoaded = useLayoutLoaderCatchallPageData();
+  useContextProvider(PageDataContext, pageLoaded);
+
+  return <PageGenerator key={pageLoaded.value.pageId} />;
+});
+
+export const head: DocumentHead = ({ resolveValue }) => {
+  const pageData = resolveValue(useLayoutLoaderCatchallPageData);
+
+  return {
+    title: pageData.title,
+  };
+};

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/layout-loader-catchall/layout.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/layout-loader-catchall/layout.tsx
@@ -1,0 +1,13 @@
+import { component$, Slot } from '@qwik.dev/core';
+import { Link } from '@qwik.dev/router';
+
+export default component$(() => {
+  return (
+    <>
+      <Link href="/qwikrouter-test/layout-loader-catchall/" id="layout-loader-catchall-logo">
+        Mock Logo
+      </Link>
+      <Slot />
+    </>
+  );
+});

--- a/e2e/qwik-e2e/tests/qwikrouter/catchall.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/catchall.e2e.ts
@@ -8,6 +8,42 @@ test.describe('Qwik Router Catchall', () => {
   test.describe('spa', () => {
     test.use({ javaScriptEnabled: true });
     tests();
+    test('SPA navigation rerenders content for layout catchall route loaders', async ({
+      context,
+    }) => {
+      const page = await context.newPage();
+      const response = (await page.goto('/qwikrouter-test/layout-loader-catchall/'))!;
+      const status = response.status();
+      expect(status).toBe(200);
+
+      await expect(page).toHaveTitle('Mock Home Loader Page - Qwik');
+      await expect(page.locator('#layout-loader-catchall-content')).toHaveText(
+        'Mock home content from loader'
+      );
+      await expect(page.locator('#layout-loader-catchall-pathname')).toHaveText(
+        '/qwikrouter-test/layout-loader-catchall/'
+      );
+
+      await page.locator('#layout-loader-catchall-detail').click();
+      await expect(page).toHaveURL('/qwikrouter-test/layout-loader-catchall/mock-detail/');
+      await expect(page).toHaveTitle('Mock Detail Loader Page - Qwik');
+      await expect(page.locator('#layout-loader-catchall-content')).toHaveText(
+        'Mock detail content from loader'
+      );
+      await expect(page.locator('#layout-loader-catchall-pathname')).toHaveText(
+        '/qwikrouter-test/layout-loader-catchall/mock-detail/'
+      );
+
+      await page.locator('#layout-loader-catchall-logo').click();
+      await expect(page).toHaveURL('/qwikrouter-test/layout-loader-catchall/');
+      await expect(page.locator('#layout-loader-catchall-content')).toHaveText(
+        'Mock home content from loader'
+      );
+      await expect(page.locator('#layout-loader-catchall-pathname')).toHaveText(
+        '/qwikrouter-test/layout-loader-catchall/'
+      );
+      await expect(page).toHaveTitle('Mock Home Loader Page - Qwik');
+    });
   });
 });
 

--- a/packages/qwik-router/src/buildtime/build-layout.unit.ts
+++ b/packages/qwik-router/src/buildtime/build-layout.unit.ts
@@ -4,7 +4,7 @@ const test = testAppSuite('Build Layout');
 
 test('total layouts', ({ ctx: { layouts } }) => {
   // $ find e2e/qwik-e2e/apps/qwikrouter-test/src/routes -name layout*tsx | wc -l
-  assert.equal(layouts.length, 13, JSON.stringify(layouts, null, 2));
+  assert.equal(layouts.length, 14, JSON.stringify(layouts, null, 2));
 });
 
 test('nested named layout', ({ assertLayout }) => {

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -5,6 +5,7 @@ import {
   _getContextEvent,
   _getContextContainer,
   _injectAsyncSignalValue,
+  _markSignalAsExternallyOwned,
   _resolveContextWithoutSequentialScope,
   _verifySerializable,
   _UNINITIALIZED,
@@ -293,18 +294,13 @@ const createRouteLoaderSignal = (
     filteredSearch?: string;
     routePath?: string;
   } = {};
-  return createAsync$(
+  const signal = createAsync$(
     async (ctx) => {
       const { track, info, previous, abortSignal } = ctx;
       const hasInjectedValue = !!info && typeof info === 'object' && '__v' in (info as object);
-      let trackedRoutePath: string | undefined;
-      let trackedPagePathname: string | undefined;
-      let trackedPageSearch: string | undefined;
-      if (!isServer || hasInjectedValue) {
-        trackedRoutePath = track(routeLoaderCtx.loaderPaths, id) as string | undefined;
-        trackedPagePathname = track(routeLoaderCtx, 'pagePathname') as string | undefined;
-        trackedPageSearch = track(routeLoaderCtx, 'pageSearch') as string | undefined;
-      }
+      const trackedRoutePath = track(routeLoaderCtx.loaderPaths, id) as string | undefined;
+      const trackedPagePathname = track(routeLoaderCtx, 'pagePathname') as string | undefined;
+      const trackedPageSearch = track(routeLoaderCtx, 'pageSearch') as string | undefined;
       // Pre-loaded value injection (from middleware via setLoaderSignalValue, or from
       // an action response). Client-side route dependencies must already be tracked
       // here so a resumed loader can re-fetch on the first SPA navigation.
@@ -403,6 +399,8 @@ const createRouteLoaderSignal = (
       allowStale: loader.__allowStale,
     }
   );
+  _markSignalAsExternallyOwned(signal);
+  return signal;
 };
 
 /** Build a sorted, stable search string from only the allowed param names. */

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -3,12 +3,10 @@ import { qTest } from '../shared/utils/qdev';
 import { _EFFECT_BACK_REF } from '../reactive-primitives/backref';
 import { clearAllEffects, clearEffectSubscription } from '../reactive-primitives/cleanup';
 import { AsyncSignalImpl } from '../reactive-primitives/impl/async-signal-impl';
-import { SignalImpl } from '../reactive-primitives/impl/signal-impl';
-import { isStore } from '../reactive-primitives/impl/store';
 import { WrappedSignalImpl } from '../reactive-primitives/impl/wrapped-signal-impl';
 import type { Signal } from '../reactive-primitives/signal.public';
 import { SubscriptionData } from '../reactive-primitives/subscription-data';
-import { EffectProperty, type Consumer } from '../reactive-primitives/types';
+import { ComputedSignalFlags, EffectProperty, type Consumer } from '../reactive-primitives/types';
 import { isSignal } from '../reactive-primitives/utils';
 import { SERIALIZABLE_STATE, type OnRenderFn } from '../shared/component.public';
 import { isCursor, type Cursor } from '../shared/cursor/cursor';
@@ -102,6 +100,7 @@ import {
 } from './vnode-utils';
 import { isObjectEmpty } from '../shared/utils/objects';
 import { setInlineComponentData } from '../shared/cursor/chore-execution';
+import { ComputedSignalImpl } from '../reactive-primitives/impl/computed-signal-impl';
 
 export interface DiffContext {
   $container$: ClientContainer;
@@ -1963,8 +1962,13 @@ export function cleanup(
 
                 // don't call cleanupDestroyable yet, do it by the scheduler
                 continue;
-              } else if (obj instanceof SignalImpl || isStore(obj)) {
-                clearAllEffects(container, obj as Consumer);
+              }
+              // Stores and plain signals are only producers; their subscriptions are removed
+              // when cleaning the consumers that read them. They don't own reactive backrefs.
+              else if (obj instanceof ComputedSignalImpl || obj instanceof WrappedSignalImpl) {
+                if (!(obj.$flags$ & ComputedSignalFlags.PRESERVE_ON_SEQ_CLEANUP)) {
+                  clearAllEffects(container, obj as Consumer);
+                }
               }
 
               if (objIsTask || obj instanceof AsyncSignalImpl) {

--- a/packages/qwik/src/core/internal.ts
+++ b/packages/qwik/src/core/internal.ts
@@ -50,7 +50,7 @@ export {
   createStore as _createStore,
   isStore as _isStore,
 } from './reactive-primitives/impl/store';
-export { isSignal } from './reactive-primitives/utils';
+export { _markSignalAsExternallyOwned, isSignal } from './reactive-primitives/utils';
 export { _wrapProp, _wrapSignal } from './reactive-primitives/internal-api';
 export { getSubscriber as _getSubscriber } from './reactive-primitives/subscriber';
 export { SubscriptionData as _SubscriptionData } from './reactive-primitives/subscription-data';

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -87,9 +87,9 @@ export class _AsyncSignalImpl<T> extends ComputedSignalImpl<T, AsyncQRL<T>> impl
     $untrackedLoading$: boolean;
     // (undocumented)
     [_EFFECT_BACK_REF]: Map<_EffectProperty | string, EffectSubscription> | undefined;
-    // Warning: (ae-forgotten-export) The symbol "SignalFlags" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ComputedSignalFlags" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "SerializationSignalFlags" needs to be exported by the entry point index.d.ts
-    constructor(container: _Container | null, fn: AsyncQRL<T>, flags?: SignalFlags | SerializationSignalFlags, options?: AsyncSignalOptions<T>);
+    constructor(container: _Container | null, fn: AsyncQRL<T>, flags?: ComputedSignalFlags | SerializationSignalFlags, options?: AsyncSignalOptions<T>);
     abort(reason?: any): void;
     get error(): Error | undefined;
     // (undocumented)
@@ -758,6 +758,9 @@ export const _mapArray_get: <T>(array: (T | null)[], key: string, start: number)
 
 // @internal (undocumented)
 export const _mapArray_set: <T>(array: (T | null)[], key: string, value: T | null, start: number, allowNullValue?: boolean) => void;
+
+// @internal
+export const _markSignalAsExternallyOwned: (signal: ComputedSignal<unknown>) => void;
 
 // @public @deprecated (undocumented)
 export type NativeAnimationEvent = AnimationEvent;

--- a/packages/qwik/src/core/reactive-primitives/impl/async-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/async-signal-impl.ts
@@ -18,7 +18,7 @@ import {
   EffectSubscription,
   NEEDS_COMPUTATION,
   SerializationSignalFlags,
-  SignalFlags,
+  ComputedSignalFlags,
   type AsyncCtx,
   type AsyncSignalOptions,
 } from '../types';
@@ -122,7 +122,7 @@ export class AsyncSignalImpl<T>
   constructor(
     container: Container | null,
     fn: AsyncQRL<T>,
-    flags: SignalFlags | SerializationSignalFlags = SignalFlags.INVALID |
+    flags: ComputedSignalFlags | SerializationSignalFlags = ComputedSignalFlags.INVALID |
       SerializationSignalFlags.SERIALIZATION_STRATEGY_ALWAYS,
     options?: AsyncSignalOptions<T>
   ) {
@@ -218,7 +218,7 @@ export class AsyncSignalImpl<T>
   }
 
   override set value(value: T) {
-    this.$flags$ &= ~SignalFlags.INVALID;
+    this.$flags$ &= ~ComputedSignalFlags.INVALID;
     this.untrackedLoading = false;
     this.untrackedError = undefined;
     this.$info$ = undefined;
@@ -365,7 +365,7 @@ export class AsyncSignalImpl<T>
   }
 
   $setInvalid$(allowRecalc: boolean, mustClear: boolean | number): void {
-    this.$flags$ |= SignalFlags.INVALID;
+    this.$flags$ |= ComputedSignalFlags.INVALID;
     this.$clearNextPoll$();
     if (mustClear) {
       this.$untrackedValue$ = NEEDS_COMPUTATION;
@@ -412,7 +412,7 @@ export class AsyncSignalImpl<T>
 
   /** Run the computation if needed */
   $computeIfNeeded$(): void {
-    if (!(this.$flags$ & SignalFlags.INVALID)) {
+    if (!(this.$flags$ & ComputedSignalFlags.INVALID)) {
       return;
     }
     // Skip computation on SSR for clientOnly signals
@@ -425,7 +425,7 @@ export class AsyncSignalImpl<T>
     this.$clearNextPoll$();
 
     // Clear flag here to make sure the cleanups don't start another compute
-    this.$flags$ &= ~SignalFlags.INVALID;
+    this.$flags$ &= ~ComputedSignalFlags.INVALID;
 
     const current = this.$current$;
     if (current) {
@@ -438,7 +438,7 @@ export class AsyncSignalImpl<T>
       DEBUG && log(`Concurrency limit ${limit} reached, not starting new computation`);
       // We requested cleanups for all the previous jobs, once one finishes it will be removed from the jobs array and trigger computeIfNeeded
       // Restore invalid state
-      this.$flags$ |= SignalFlags.INVALID;
+      this.$flags$ |= ComputedSignalFlags.INVALID;
       return;
     }
 
@@ -531,7 +531,7 @@ export class AsyncSignalImpl<T>
         this.$info$ = undefined;
       }
 
-      if (this.$flags$ & SignalFlags.INVALID) {
+      if (this.$flags$ & ComputedSignalFlags.INVALID) {
         DEBUG && log('Computation finished but signal is invalid, re-running');
         // we became invalid again while running, so we need to re-run the computation to get the new promise
         this.$computeIfNeeded$();

--- a/packages/qwik/src/core/reactive-primitives/impl/async-signal.unit.tsx
+++ b/packages/qwik/src/core/reactive-primitives/impl/async-signal.unit.tsx
@@ -14,7 +14,7 @@ import {
   AsyncSignalFlags,
   EffectProperty,
   NEEDS_COMPUTATION,
-  SignalFlags,
+  ComputedSignalFlags,
 } from '../types';
 import { clearAllEffects } from '../cleanup';
 import { createSignal, createAsync$, createAsyncQrl } from '../signal.public';
@@ -106,13 +106,13 @@ describe('async signal', () => {
         await signal.promise();
 
         expect(ref.computeCalls).toBe(1);
-        expect(signal.$flags$ & SignalFlags.INVALID).toBe(0);
+        expect(signal.$flags$ & ComputedSignalFlags.INVALID).toBe(0);
         expect(signal.$pollTimeoutId$).toBeDefined();
 
         await delay(20);
 
         expect(ref.computeCalls).toBe(1);
-        expect(signal.$flags$ & SignalFlags.INVALID).toBe(SignalFlags.INVALID);
+        expect(signal.$flags$ & ComputedSignalFlags.INVALID).toBe(ComputedSignalFlags.INVALID);
         expect(signal.$untrackedValue$).toBe(1);
         expect(signal.$pollTimeoutId$).toBeUndefined();
       });
@@ -159,13 +159,13 @@ describe('async signal', () => {
       await withContainer(async () => {
         const signal = createAsync$(async () => 1, { expires: 10 }) as AsyncSignalImpl<number>;
         signal.untrackedValue = 1;
-        signal.$flags$ &= ~SignalFlags.INVALID;
+        signal.$flags$ &= ~ComputedSignalFlags.INVALID;
         signal.poll = false;
         (signal as any).$scheduleNextPoll$();
 
         await delay(20);
 
-        expect(signal.$flags$ & SignalFlags.INVALID).toBe(SignalFlags.INVALID);
+        expect(signal.$flags$ & ComputedSignalFlags.INVALID).toBe(ComputedSignalFlags.INVALID);
         expect(signal.$untrackedValue$).toBe(1);
         expect(signal.$pollTimeoutId$).toBeUndefined();
       });
@@ -178,14 +178,14 @@ describe('async signal', () => {
           allowStale: false,
         }) as AsyncSignalImpl<number>;
         signal.untrackedValue = 42;
-        signal.$flags$ &= ~SignalFlags.INVALID;
+        signal.$flags$ &= ~ComputedSignalFlags.INVALID;
         (signal as any).$scheduleNextPoll$();
 
         expect(signal.$pollTimeoutId$).toBeDefined();
 
         await delay(20);
 
-        expect(signal.$flags$ & SignalFlags.INVALID).toBe(SignalFlags.INVALID);
+        expect(signal.$flags$ & ComputedSignalFlags.INVALID).toBe(ComputedSignalFlags.INVALID);
         expect(signal.$untrackedValue$).toBe(42);
         expect(signal.$pollTimeoutId$).toBeUndefined();
       });
@@ -199,14 +199,14 @@ describe('async signal', () => {
           allowStale: false,
         }) as AsyncSignalImpl<number>;
         signal.untrackedValue = 42;
-        signal.$flags$ &= ~SignalFlags.INVALID;
+        signal.$flags$ &= ~ComputedSignalFlags.INVALID;
         (signal as any).$scheduleNextPoll$();
 
         expect(signal.$pollTimeoutId$).toBeDefined();
 
         await delay(20);
 
-        expect(signal.$flags$ & SignalFlags.INVALID).toBe(SignalFlags.INVALID);
+        expect(signal.$flags$ & ComputedSignalFlags.INVALID).toBe(ComputedSignalFlags.INVALID);
         expect(signal.$untrackedValue$).toBe(NEEDS_COMPUTATION);
         expect(signal.$pollTimeoutId$).toBeUndefined();
       });
@@ -931,12 +931,12 @@ describe('async signal', () => {
         }) as AsyncSignalImpl<number>;
 
         // Signal starts INVALID
-        expect(signal.$flags$ & SignalFlags.INVALID).toBeTruthy();
+        expect(signal.$flags$ & ComputedSignalFlags.INVALID).toBeTruthy();
 
         signal.value = 99;
 
         // INVALID should be cleared
-        expect(signal.$flags$ & SignalFlags.INVALID).toBe(0);
+        expect(signal.$flags$ & ComputedSignalFlags.INVALID).toBe(0);
         expect(signal.value).toBe(99);
       });
     });

--- a/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
@@ -15,7 +15,7 @@ import {
   EffectSubscription,
   NEEDS_COMPUTATION,
   SerializationSignalFlags,
-  SignalFlags,
+  ComputedSignalFlags,
 } from '../types';
 import { throwIfQRLNotResolved } from '../utils';
 import { SignalImpl } from './signal-impl';
@@ -40,7 +40,7 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
    * resolve the QRL during the mark dirty phase so that any call to it will be synchronous). )
    */
   $computeQrl$: S;
-  $flags$: SignalFlags | SerializationSignalFlags;
+  $flags$: ComputedSignalFlags | SerializationSignalFlags;
   [_EFFECT_BACK_REF]: Map<EffectProperty | string, EffectSubscription> | undefined = undefined;
 
   constructor(
@@ -48,7 +48,7 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
     fn: S,
     // We need a separate flag to know when the computation needs running because
     // we need the old value to know if effects need running after computation
-    flags: SignalFlags | SerializationSignalFlags = SignalFlags.INVALID |
+    flags: ComputedSignalFlags | SerializationSignalFlags = ComputedSignalFlags.INVALID |
       SerializationSignalFlags.SERIALIZATION_STRATEGY_ALWAYS
   ) {
     // The value is used for comparison when signals trigger, which can only happen
@@ -59,7 +59,7 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
   }
 
   invalidate() {
-    this.$flags$ |= SignalFlags.INVALID;
+    this.$flags$ |= ComputedSignalFlags.INVALID;
     const ctx = newInvokeContext();
     ctx.$container$ = this.$container$ || undefined;
     // @ts-expect-error it's confused about args any[] vs []
@@ -85,7 +85,7 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
   }
 
   $computeIfNeeded$() {
-    if (!(this.$flags$ & SignalFlags.INVALID)) {
+    if (!(this.$flags$ & ComputedSignalFlags.INVALID)) {
       return;
     }
     const computeQrl = this.$computeQrl$;
@@ -108,7 +108,7 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
       }
       DEBUG && log('Signal.$compute$', untrackedValue);
 
-      this.$flags$ &= ~SignalFlags.INVALID;
+      this.$flags$ &= ~ComputedSignalFlags.INVALID;
       super.value = untrackedValue;
     } finally {
       if (ctx) {

--- a/packages/qwik/src/core/reactive-primitives/impl/serializer-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/serializer-signal-impl.ts
@@ -7,7 +7,7 @@ import {
   EffectProperty,
   NEEDS_COMPUTATION,
   SerializationSignalFlags,
-  SignalFlags,
+  ComputedSignalFlags,
   type ComputeQRL,
 } from '../types';
 import { scheduleEffects, throwIfQRLNotResolved } from '../utils';
@@ -28,13 +28,13 @@ export class SerializerSignalImpl<T, S> extends ComputedSignalImpl<T> {
     super(
       container,
       argQrl as unknown as ComputeQRL<T>,
-      SignalFlags.INVALID | SerializationSignalFlags.SERIALIZATION_STRATEGY_ALWAYS
+      ComputedSignalFlags.INVALID | SerializationSignalFlags.SERIALIZATION_STRATEGY_ALWAYS
     );
   }
   $didInitialize$: boolean = false;
 
   $computeIfNeeded$() {
-    if (!(this.$flags$ & SignalFlags.INVALID)) {
+    if (!(this.$flags$ & ComputedSignalFlags.INVALID)) {
       return;
     }
     throwIfQRLNotResolved(this.$computeQrl$);
@@ -58,7 +58,7 @@ export class SerializerSignalImpl<T, S> extends ComputedSignalImpl<T> {
     this.$didInitialize$ = true;
 
     // Needs to invalidate only after all possible Promise throws happened
-    this.$flags$ &= ~SignalFlags.INVALID;
+    this.$flags$ &= ~ComputedSignalFlags.INVALID;
 
     DEBUG && log('SerializerSignal.$compute$', untrackedValue);
     // We allow forcing the update of the signal without changing the value, for example when the deserialized value is the same reference as the old value but its internals have changed. In that case we want to trigger effects that depend on this signal, even though the value is the same.

--- a/packages/qwik/src/core/reactive-primitives/impl/signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/signal-impl.ts
@@ -14,7 +14,7 @@ import {
   scheduleEffects,
 } from '../utils';
 import type { Signal } from '../signal.public';
-import { SignalFlags, type EffectSubscription } from '../types';
+import { ComputedSignalFlags, type EffectSubscription } from '../types';
 import type { WrappedSignalImpl } from './wrapped-signal-impl';
 import { isServerPlatform } from '../../shared/platform/platform';
 import type { SSRSegmentContainer } from '../../ssr/ssr-types';
@@ -138,7 +138,7 @@ export class SignalImpl<T = any> implements Signal<T> {
     if (isDev) {
       try {
         return (
-          `[${this.constructor.name}${(this as any).$flags$ & SignalFlags.INVALID ? ' INVALID' : ''} ${this.$untrackedValue$}]` +
+          `[${this.constructor.name}${(this as any).$flags$ & ComputedSignalFlags.INVALID ? ' INVALID' : ''} ${this.$untrackedValue$}]` +
           (Array.from(this.$effects$ || [])
             .map((e) => '\n -> ' + pad(qwikDebugToString(e.consumer), '    '))
             .join('\n') || '')

--- a/packages/qwik/src/core/reactive-primitives/impl/signal.unit.tsx
+++ b/packages/qwik/src/core/reactive-primitives/impl/signal.unit.tsx
@@ -24,7 +24,7 @@ import {
   type Signal,
 } from '../signal.public';
 import { getSubscriber } from '../subscriber';
-import { EffectProperty, SignalFlags } from '../types';
+import { EffectProperty, ComputedSignalFlags } from '../types';
 import type { ComputedSignalImpl } from './computed-signal-impl';
 
 class Foo {
@@ -255,7 +255,7 @@ describe('signal', () => {
         expect(log).toEqual([1]);
         expect(obj.count).toBe(1);
         // mark dirty but value remains shallow same after calc
-        (computed as ComputedSignalImpl<typeof obj>).$flags$ |= SignalFlags.INVALID;
+        (computed as ComputedSignalImpl<typeof obj>).$flags$ |= ComputedSignalFlags.INVALID;
         computed.value.count;
         await flushSignals();
         expect(log).toEqual([1]);

--- a/packages/qwik/src/core/reactive-primitives/impl/wrapped-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/wrapped-signal-impl.ts
@@ -5,7 +5,7 @@ import { ChoreBits } from '../../shared/vnode/enums/chore-bits.enum';
 import { trackSignal } from '../../use/use-core';
 import { getValueProp } from '../internal-api';
 import type { AllSignalFlags, EffectSubscription } from '../types';
-import { EffectProperty, NEEDS_COMPUTATION, SignalFlags, WrappedSignalFlags } from '../types';
+import { EffectProperty, NEEDS_COMPUTATION, ComputedSignalFlags } from '../types';
 import { isSignal, scheduleEffects } from '../utils';
 import { SignalImpl } from './signal-impl';
 import { markVNodeDirty } from '../../shared/vnode/vnode-dirty';
@@ -31,7 +31,7 @@ export class WrappedSignalImpl<T> extends SignalImpl<T> {
     fnStr: string | null,
     // We need a separate flag to know when the computation needs running because
     // we need the old value to know if effects need running after computation
-    flags: SignalFlags = SignalFlags.INVALID | WrappedSignalFlags.UNWRAP
+    flags: AllSignalFlags = ComputedSignalFlags.INVALID
   ) {
     super(container, NEEDS_COMPUTATION);
     this.$args$ = args;
@@ -41,7 +41,7 @@ export class WrappedSignalImpl<T> extends SignalImpl<T> {
   }
 
   invalidate() {
-    this.$flags$ |= SignalFlags.INVALID;
+    this.$flags$ |= ComputedSignalFlags.INVALID;
     // we are trying to run computation without creating a chore, which can be expensive
     // for many signals. If it fails, we schedule a chore to run the computation.
     try {
@@ -53,8 +53,8 @@ export class WrappedSignalImpl<T> extends SignalImpl<T> {
       }
     }
     // if the computation not failed, we can run the effects directly
-    if (this.$flags$ & SignalFlags.RUN_EFFECTS) {
-      this.$flags$ &= ~SignalFlags.RUN_EFFECTS;
+    if (this.$flags$ & ComputedSignalFlags.RUN_EFFECTS) {
+      this.$flags$ &= ~ComputedSignalFlags.RUN_EFFECTS;
       scheduleEffects(this.$container$, this, this.$effects$);
     }
   }
@@ -66,7 +66,7 @@ export class WrappedSignalImpl<T> extends SignalImpl<T> {
   }
 
   $computeIfNeeded$() {
-    if (!(this.$flags$ & SignalFlags.INVALID)) {
+    if (!(this.$flags$ & ComputedSignalFlags.INVALID)) {
       return;
     }
     const untrackedValue = trackSignal(
@@ -83,10 +83,10 @@ export class WrappedSignalImpl<T> extends SignalImpl<T> {
 
     // reset flag in case we call computedIfNeeded twice and the value was changed only the first time
     // TODO: change to version number?
-    this.$flags$ &= ~SignalFlags.RUN_EFFECTS;
+    this.$flags$ &= ~ComputedSignalFlags.RUN_EFFECTS;
     const didChange = untrackedValue !== this.$untrackedValue$;
     if (didChange) {
-      this.$flags$ |= SignalFlags.RUN_EFFECTS;
+      this.$flags$ |= ComputedSignalFlags.RUN_EFFECTS;
       this.$untrackedValue$ = untrackedValue;
     }
   }

--- a/packages/qwik/src/core/reactive-primitives/internal-api.ts
+++ b/packages/qwik/src/core/reactive-primitives/internal-api.ts
@@ -8,7 +8,6 @@ import type { SignalImpl } from './impl/signal-impl';
 import { getStoreTarget, isStore } from './impl/store';
 import { WrappedSignalImpl } from './impl/wrapped-signal-impl';
 import { isSignal, type Signal } from './signal.public';
-import { WrappedSignalFlags } from './types';
 
 // Keep these properties named like this so they're the same as from wrapSignal
 export const getValueProp = <T>(p0: { value: T }) => p0.value;
@@ -65,7 +64,7 @@ export const _wrapProp = <T extends object, P extends keyof T>(
     if (!(obj instanceof AsyncSignalImpl)) {
       isDev && assertEqual(prop, 'value', 'Left side is a signal, prop must be value');
     }
-    if (obj instanceof WrappedSignalImpl && obj.$flags$ & WrappedSignalFlags.UNWRAP) {
+    if (obj instanceof WrappedSignalImpl) {
       return obj as WrappedProp<T, P>;
     }
     return getWrapped(args) as WrappedProp<T, P>;

--- a/packages/qwik/src/core/reactive-primitives/types.ts
+++ b/packages/qwik/src/core/reactive-primitives/types.ts
@@ -123,14 +123,10 @@ export interface AsyncSignalOptions<T> extends ComputedOptions {
   timeout?: number;
 }
 
-export const enum SignalFlags {
+export const enum ComputedSignalFlags {
   INVALID = 1,
   RUN_EFFECTS = 2,
-}
-
-export const enum WrappedSignalFlags {
-  // should subscribe to value and be unwrapped for PropsProxy
-  UNWRAP = 4,
+  PRESERVE_ON_SEQ_CLEANUP = 4,
 }
 
 export const enum SerializationSignalFlags {
@@ -148,11 +144,7 @@ export const enum AsyncSignalFlags {
   NO_POLL = 256,
 }
 
-export type AllSignalFlags =
-  | SignalFlags
-  | WrappedSignalFlags
-  | SerializationSignalFlags
-  | AsyncSignalFlags;
+export type AllSignalFlags = ComputedSignalFlags | SerializationSignalFlags | AsyncSignalFlags;
 
 /**
  * Effect is something which needs to happen (side-effect) due to signal value change.

--- a/packages/qwik/src/core/reactive-primitives/utils.ts
+++ b/packages/qwik/src/core/reactive-primitives/utils.ts
@@ -13,12 +13,12 @@ import { TaskFlags, isTask } from '../use/use-task';
 import { ComputedSignalImpl } from './impl/computed-signal-impl';
 import { SignalImpl } from './impl/signal-impl';
 import type { WrappedSignalImpl } from './impl/wrapped-signal-impl';
-import type { Signal } from './signal.public';
+import type { ComputedSignal, Signal } from './signal.public';
 import { SubscriptionData, type NodeProp } from './subscription-data';
 import {
   SerializationSignalFlags,
   EffectProperty,
-  SignalFlags,
+  ComputedSignalFlags,
   type CustomSerializable,
   type EffectSubscription,
   type StoreTarget,
@@ -166,8 +166,8 @@ export const isSerializerObj = <T extends { [SerializerSymbol]: (obj: any) => an
 
 export const getComputedSignalFlags = (
   serializationStrategy: SerializationStrategy
-): SerializationSignalFlags | SignalFlags => {
-  let flags = SignalFlags.INVALID;
+): SerializationSignalFlags | ComputedSignalFlags => {
+  let flags = ComputedSignalFlags.INVALID;
   switch (serializationStrategy) {
     // TODO: implement this in the future
     // case 'auto':
@@ -181,4 +181,17 @@ export const getComputedSignalFlags = (
       break;
   }
   return flags;
+};
+
+/**
+ * Mark this signal as owned outside of the component that read it.
+ *
+ * Externally owned signals are preserved when found in a component's sequential scope during
+ * component cleanup.
+ *
+ * @internal
+ */
+export const _markSignalAsExternallyOwned = (signal: ComputedSignal<unknown>) => {
+  (signal as ComputedSignalImpl<unknown> | WrappedSignalImpl<unknown>).$flags$ |=
+    ComputedSignalFlags.PRESERVE_ON_SEQ_CLEANUP;
 };

--- a/packages/qwik/src/core/shared/cursor/chore-execution.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.ts
@@ -35,7 +35,7 @@ import {
 } from './cursor-props';
 import { invoke, newInvokeContext, untrack } from '../../use/use-core';
 import type { WrappedSignalImpl } from '../../reactive-primitives/impl/wrapped-signal-impl';
-import { SignalFlags } from '../../reactive-primitives/types';
+import { ComputedSignalFlags } from '../../reactive-primitives/types';
 import { cleanupDestroyable } from '../../use/utils/destroyable';
 import type { ISsrNode } from '../../ssr/ssr-types';
 import type { Cursor } from './cursor';
@@ -473,8 +473,8 @@ export function executeCompute(
       invoke.call(target, ctx, (target as WrappedSignalImpl<unknown>).$computeIfNeeded$)
     ),
     () => {
-      if ((target as WrappedSignalImpl<unknown>).$flags$ & SignalFlags.RUN_EFFECTS) {
-        (target as WrappedSignalImpl<unknown>).$flags$ &= ~SignalFlags.RUN_EFFECTS;
+      if ((target as WrappedSignalImpl<unknown>).$flags$ & ComputedSignalFlags.RUN_EFFECTS) {
+        (target as WrappedSignalImpl<unknown>).$flags$ &= ~ComputedSignalFlags.RUN_EFFECTS;
         return scheduleEffects(container, target, effects);
       }
     }

--- a/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
@@ -20,7 +20,7 @@ import type { CursorData } from './cursor-props';
 import type { Cursor } from './cursor';
 import { ELEMENT_SEQ, ELEMENT_PROPS, OnRenderProp, QScopedStyle } from '../utils/markers';
 import type { Props } from '../jsx/jsx-runtime';
-import { SignalFlags } from '../../reactive-primitives/types';
+import { ComputedSignalFlags } from '../../reactive-primitives/types';
 import type { ElementVNode } from '../vnode/element-vnode';
 import { runTask } from '../../use/use-task';
 import { vnode_diff } from '../../client/vnode-diff';
@@ -862,7 +862,7 @@ describe('executeCompute', () => {
   it('should schedule effects if RUN_EFFECTS flag is set', async () => {
     const effects = [vi.fn()];
     const signal = {
-      $flags$: SignalFlags.RUN_EFFECTS,
+      $flags$: ComputedSignalFlags.RUN_EFFECTS,
       $effects$: effects,
       $computeIfNeeded$: vi.fn(),
     };
@@ -872,7 +872,7 @@ describe('executeCompute', () => {
     await executeCompute(vNode, container);
 
     expect(scheduleEffects).toHaveBeenCalledWith(container, signal, effects);
-    expect(signal.$flags$ & SignalFlags.RUN_EFFECTS).toBe(0);
+    expect(signal.$flags$ & ComputedSignalFlags.RUN_EFFECTS).toBe(0);
   });
 
   it('should not schedule effects if flag is not set', async () => {
@@ -909,7 +909,7 @@ describe('executeCompute', () => {
   it('should handle computation that returns a promise', async () => {
     const effects = [vi.fn()];
     const signal = {
-      $flags$: SignalFlags.RUN_EFFECTS,
+      $flags$: ComputedSignalFlags.RUN_EFFECTS,
       $effects$: effects,
       $computeIfNeeded$: vi.fn(),
     };

--- a/packages/qwik/src/core/shared/jsx/props-proxy.ts
+++ b/packages/qwik/src/core/shared/jsx/props-proxy.ts
@@ -1,6 +1,6 @@
 import { addStoreEffect } from '../../reactive-primitives/impl/store';
 import { WrappedSignalImpl } from '../../reactive-primitives/impl/wrapped-signal-impl';
-import { WrappedSignalFlags, type EffectSubscription } from '../../reactive-primitives/types';
+import { type EffectSubscription } from '../../reactive-primitives/types';
 import { tryGetInvokeContext } from '../../use/use-core';
 import { _CONST_PROPS, _VAR_PROPS, _OWNER, _PROPS_HANDLER } from '../utils/constants';
 import { jsxEventToHtmlAttribute } from '../utils/event-names';
@@ -49,9 +49,7 @@ export class PropsProxyHandler implements ProxyHandler<any> {
       }
     }
     // a proxied value that the optimizer made
-    return value instanceof WrappedSignalImpl && value.$flags$ & WrappedSignalFlags.UNWRAP
-      ? value.value
-      : value;
+    return value instanceof WrappedSignalImpl ? value.value : value;
   }
   set(_: any, prop: string | symbol, value: any) {
     if (prop === _OWNER) {

--- a/packages/qwik/src/core/shared/serdes/inflate.ts
+++ b/packages/qwik/src/core/shared/serdes/inflate.ts
@@ -19,7 +19,7 @@ import {
   AsyncSignalFlags,
   EffectProperty,
   NEEDS_COMPUTATION,
-  SignalFlags,
+  ComputedSignalFlags,
   type AllSignalFlags,
   type AsyncQRL,
   type Consumer,
@@ -144,7 +144,7 @@ export const inflate = (
       signal.$args$ = d[1];
       signal.$untrackedValue$ = NEEDS_COMPUTATION;
       signal.$flags$ = d[2];
-      signal.$flags$ |= SignalFlags.INVALID;
+      signal.$flags$ |= ComputedSignalFlags.INVALID;
       signal.$hostElement$ = d[3];
       signal.$effects$ = new Set(d.slice(4) as EffectSubscription[]);
       inflateWrappedSignalValue(signal);
@@ -192,7 +192,7 @@ export const inflate = (
       }
       // can happen when never serialize etc
       if (asyncSignal.$untrackedValue$ === NEEDS_COMPUTATION) {
-        asyncSignal.$flags$ |= SignalFlags.INVALID;
+        asyncSignal.$flags$ |= ComputedSignalFlags.INVALID;
       }
 
       // Handle old format (negative = no poll) and new format (always positive, flag in d[5])
@@ -237,7 +237,7 @@ export const inflate = (
       if (typeId !== TypeIds.SerializerSignal && computed.$untrackedValue$ !== NEEDS_COMPUTATION) {
         // If we have a value after SSR, it will always be mean the signal was not invalid
         // The serialized signal is always left invalid so it can recreate the custom object
-        computed.$flags$ &= ~SignalFlags.INVALID;
+        computed.$flags$ &= ~ComputedSignalFlags.INVALID;
       }
       restoreEffectBackRefForEffects(computed.$effects$, computed);
       break;

--- a/packages/qwik/src/core/shared/serdes/serdes.unit.ts
+++ b/packages/qwik/src/core/shared/serdes/serdes.unit.ts
@@ -24,7 +24,7 @@ import { SubscriptionData } from '../../reactive-primitives/subscription-data';
 import {
   EffectProperty,
   EffectSubscription,
-  SignalFlags,
+  ComputedSignalFlags,
   StoreFlags,
 } from '../../reactive-primitives/types';
 import { Task } from '../../use/use-task';
@@ -562,7 +562,7 @@ describe('shared-serialization', () => {
           Array [
             {number} 3
           ]
-          {number} 5
+          {number} 1
         ]
         1 WrappedSignal [
           {number} 1
@@ -577,7 +577,7 @@ describe('shared-serialization', () => {
             ]
             {string} "value"
           ]
-          {number} 7
+          {number} 3
         ]
         (77 chars)"
       `);
@@ -1179,14 +1179,18 @@ describe('shared-serialization', () => {
     it.todo(title(TypeIds.SerializerSignal));
     it(`${title(TypeIds.AsyncSignal)} valid`, async () => {
       const asyncSignal = createAsync$(async () => 123);
-      expect((asyncSignal as AsyncSignalImpl<number>).$flags$ & SignalFlags.INVALID).toBeTruthy();
+      expect(
+        (asyncSignal as AsyncSignalImpl<number>).$flags$ & ComputedSignalFlags.INVALID
+      ).toBeTruthy();
       await asyncSignal.promise();
       expect((asyncSignal as AsyncSignalImpl<number>).$untrackedValue$).toBe(123);
       const objs = await serialize(asyncSignal);
       const restored = deserialize(objs)[0] as AsyncSignal<number>;
       expect(isSignal(restored)).toBeTruthy();
       expect((restored as AsyncSignalImpl<number>).$untrackedValue$).toBe(123);
-      expect((restored as AsyncSignalImpl<number>).$flags$ & SignalFlags.INVALID).toBeFalsy();
+      expect(
+        (restored as AsyncSignalImpl<number>).$flags$ & ComputedSignalFlags.INVALID
+      ).toBeFalsy();
     });
     it(`${title(TypeIds.AsyncSignal)} invalid`, async () => {
       const asyncSignal = createAsync$(async () => 123, {
@@ -1198,7 +1202,9 @@ describe('shared-serialization', () => {
       const restored = deserialize(objs)[0] as AsyncSignal<number>;
       expect(isSignal(restored)).toBeTruthy();
       expect((restored as AsyncSignalImpl<number>).$expires$).toBe(50);
-      expect((restored as AsyncSignalImpl<number>).$flags$ & SignalFlags.INVALID).toBeTruthy();
+      expect(
+        (restored as AsyncSignalImpl<number>).$flags$ & ComputedSignalFlags.INVALID
+      ).toBeTruthy();
       await restored.promise();
       expect((restored as AsyncSignalImpl<number>).$untrackedValue$).toBe(123);
       expect((restored as AsyncSignalImpl<number>).$concurrency$).toBe(3);

--- a/packages/qwik/src/core/shared/serdes/serialize.ts
+++ b/packages/qwik/src/core/shared/serdes/serialize.ts
@@ -13,7 +13,7 @@ import {
   EffectSubscription,
   NEEDS_COMPUTATION,
   SerializationSignalFlags,
-  SignalFlags,
+  ComputedSignalFlags,
   STORE_ALL_PROPS,
   type SerializerArg,
 } from '../../reactive-primitives/types';
@@ -583,7 +583,7 @@ export class Serializer {
           value.$flags$ & SerializationSignalFlags.SERIALIZATION_STRATEGY_ALWAYS;
         const shouldNeverSerialize =
           value.$flags$ & SerializationSignalFlags.SERIALIZATION_STRATEGY_NEVER;
-        const isInvalid = value.$flags$ & SignalFlags.INVALID;
+        const isInvalid = value.$flags$ & ComputedSignalFlags.INVALID;
         const isSkippable = fastSkipSerialize(value.$untrackedValue$);
         const isAsync = value instanceof AsyncSignalImpl;
         const expires = isAsync && value.$expires$ !== 0 ? value.$expires$ : undefined;

--- a/packages/qwik/src/core/tests/container.spec.tsx
+++ b/packages/qwik/src/core/tests/container.spec.tsx
@@ -13,7 +13,7 @@ import {
   vnode_getText,
 } from '../client/vnode-utils';
 import { createComputed$, createSignal } from '../reactive-primitives/signal.public';
-import { SignalFlags } from '../reactive-primitives/types';
+import { ComputedSignalFlags } from '../reactive-primitives/types';
 import { SERIALIZABLE_STATE, component$ } from '../shared/component.public';
 import { JSXNodeImpl } from '../shared/jsx/jsx-node';
 import { Fragment } from '../shared/jsx/jsx-runtime';
@@ -478,7 +478,7 @@ describe('serializer v2', () => {
         });
         const got = container.$getObjectById$(0);
         expect(got.$untrackedValue$).toMatchInlineSnapshot(`Symbol(invalid)`);
-        expect(!!(got.$flags$ & SignalFlags.INVALID)).toBe(true);
+        expect(!!(got.$flags$ & ComputedSignalFlags.INVALID)).toBe(true);
         expect(await retryOnPromise(() => got.value)).toBe('test!');
       });
     });


### PR DESCRIPTION
Fixed SPA navigation in cases where route loader data could stop updating after navigating between catch-all routes. Pages now correctly re-render their content when returning through client-side navigation, including layouts that share loader data through context.