### PR TITLE
fix(router): honor routeLoader$ id option to avoid wrapper id collisions

### DIFF
--- a/.changeset/fix-route-loader-id-collision.md
+++ b/.changeset/fix-route-loader-id-collision.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix(router): honor the `routeLoader$` `id` option so loaders created through a shared wrapper get distinct ids
+
+When several `routeLoader$`s are defined through a shared helper that passes an inline QRL (e.g. a `withErrorHandling(fn)` wrapper), the optimizer gives that inline QRL a single hash for every instance. The loader id was derived solely from that hash, so all wrapped loaders collided on the same `__id` and all but the first were silently deduped away in `getModuleRouteLoaders` — only one loader ran on SSR and SPA navigation. The previously-deprecated `id` option is now honored again (`loader.__id = id ?? loaderQrl.getHash()`), letting each loader pass a distinct id such as `fn.getHash()`. A dev-mode warning is also logged when two distinct loaders share the same id.

--- a/.changeset/fix-route-loader-id-collision.md
+++ b/.changeset/fix-route-loader-id-collision.md
@@ -2,6 +2,4 @@
 '@qwik.dev/router': patch
 ---
 
-fix(router): honor the `routeLoader$` `id` option so loaders created through a shared wrapper get distinct ids
-
-When several `routeLoader$`s are defined through a shared helper that passes an inline QRL (e.g. a `withErrorHandling(fn)` wrapper), the optimizer gives that inline QRL a single hash for every instance. The loader id was derived solely from that hash, so all wrapped loaders collided on the same `__id` and all but the first were silently deduped away in `getModuleRouteLoaders` — only one loader ran on SSR and SPA navigation. The previously-deprecated `id` option is now honored again (`loader.__id = id ?? loaderQrl.getHash()`), letting each loader pass a distinct id such as `fn.getHash()`. A dev-mode warning is also logged when two distinct loaders share the same id.
+fix(router): honor the `routeLoader$` `id` option so loaders created through a shared wrapper (which share one optimizer-assigned QRL hash) get distinct ids instead of all but the first being silently deduped in `getModuleRouteLoaders`. A dev-mode warning is now logged when two distinct loaders share an id.

--- a/e2e/qwik-e2e/apps/qwikrouter-ssg-snapshot/expected.state.txt
+++ b/e2e/qwik-e2e/apps/qwikrouter-ssg-snapshot/expected.state.txt
@@ -374,9 +374,9 @@
 23 RootRef [omitted]
 24 RootRef [omitted]
 25 RootRef [omitted]
-26 RootRef [omitted]
+26 {string} "ssg-snapshot-loader"
 27 Object 0
-28 {string} "__qwik_route_loader_value__qO14f4pG8tQ"
+28 {string} "__qwik_route_loader_value__ssg-snapshot-loader"
 29 RootRef [omitted]
 30 Array []
 31 Object [

--- a/packages/qwik-router/src/runtime/src/route-loaders.spec.tsx
+++ b/packages/qwik-router/src/runtime/src/route-loaders.spec.tsx
@@ -7,10 +7,11 @@
 // This file should be moved to packages/qwik/src/core/tests/ if it needs the rendering infra.
 // For now, test the mechanism at the unit level using the signal test infrastructure.
 
-import { createAsync$, implicit$FirstArg, type QRL } from '@qwik.dev/core';
+import { createAsync$, implicit$FirstArg, isDev, type QRL } from '@qwik.dev/core';
 import {
   _AsyncSignalImpl as AsyncSignalImpl,
   _Container as Container,
+  _createQRL as createQRL,
   _createStore as createStore,
   _delay as delay,
   _getDomContainer as getDomContainer,
@@ -26,8 +27,9 @@ import {
   _vnode_setProp as vnode_setProp,
 } from '@qwik.dev/core/internal';
 import { createDocument } from '@qwik.dev/core/testing';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { setLoaderSignalValue } from './route-loaders';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getModuleRouteLoaders, routeLoaderQrl, setLoaderSignalValue } from './route-loaders';
+import type { LoaderInternal, RouteModule } from './types';
 
 describe('route loader store + async signal tracking', () => {
   let container: Container = null!;
@@ -286,4 +288,69 @@ describe('route loader store + async signal tracking', () => {
   }
 
   const effect$ = /*#__PURE__*/ implicit$FirstArg(effectQrl);
+});
+
+describe('getModuleRouteLoaders', () => {
+  const mkLoader = (id: string): LoaderInternal =>
+    Object.assign(() => {}, { __brand: 'server_loader', __id: id }) as unknown as LoaderInternal;
+  const asModule = (mod: Record<string, unknown>): RouteModule => mod as unknown as RouteModule;
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('dedups two distinct loaders that share an id, keeping the first', () => {
+    const first = mkLoader('shared');
+    const second = mkLoader('shared');
+    const loaders = getModuleRouteLoaders([asModule({ useFirst: first, useSecond: second })]);
+    expect(loaders).toHaveLength(1);
+    expect(loaders[0]).toBe(first);
+  });
+
+  it('keeps loaders with distinct ids', () => {
+    const a = mkLoader('a');
+    const b = mkLoader('b');
+    const loaders = getModuleRouteLoaders([asModule({ useA: a, useB: b })]);
+    expect(loaders).toEqual([a, b]);
+  });
+
+  it('returns the same loader object once across modules, with no warning', () => {
+    const shared = mkLoader('shared');
+    const loaders = getModuleRouteLoaders([
+      asModule({ useShared: shared }),
+      asModule({ useShared: shared }),
+    ]);
+    expect(loaders).toHaveLength(1);
+    expect(loaders[0]).toBe(shared);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when two distinct loaders collide on an id', () => {
+    getModuleRouteLoaders([asModule({ useA: mkLoader('dup'), useB: mkLoader('dup') })]);
+    if (isDev) {
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('dup');
+    } else {
+      expect(warnSpy).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe('routeLoaderQrl id option', () => {
+  const mkQrl = () =>
+    createQRL(null, 'useLoader_hashAAA', () => 'data') as unknown as QRL<() => unknown>;
+
+  it('derives __id from the QRL hash by default', () => {
+    const loader = routeLoaderQrl(mkQrl() as any) as LoaderInternal;
+    expect(loader.__id).toBe('hashAAA');
+  });
+
+  it('honors an explicit id option, overriding the QRL hash', () => {
+    const loader = routeLoaderQrl(mkQrl() as any, { id: 'explicit-id' }) as LoaderInternal;
+    expect(loader.__id).toBe('explicit-id');
+  });
 });

--- a/packages/qwik-router/src/runtime/src/route-loaders.spec.tsx
+++ b/packages/qwik-router/src/runtime/src/route-loaders.spec.tsx
@@ -318,7 +318,7 @@ describe('getModuleRouteLoaders', () => {
     expect(loaders).toEqual([a, b]);
   });
 
-  it('returns the same loader object once across modules, with no warning', () => {
+  it('a loader shared across modules is deduped without a false-positive warning', () => {
     const shared = mkLoader('shared');
     const loaders = getModuleRouteLoaders([
       asModule({ useShared: shared }),

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -418,6 +418,7 @@ export const filterSearchParams = (params: URLSearchParams, allowed: string[]): 
 };
 
 const getLoaderOptions = (rest: (LoaderOptions | DataValidator)[]) => {
+  let id: string | undefined;
   let serializationStrategy: SerializationStrategy = DEFAULT_LOADERS_SERIALIZATION_STRATEGY;
   let expires: number | undefined;
   let poll: boolean | undefined;
@@ -433,6 +434,9 @@ const getLoaderOptions = (rest: (LoaderOptions | DataValidator)[]) => {
       if ('validate' in options) {
         validators.push(options);
       } else {
+        if (options.id) {
+          id = options.id;
+        }
         if (options.serializationStrategy) {
           serializationStrategy = options.serializationStrategy;
         }
@@ -466,6 +470,7 @@ const getLoaderOptions = (rest: (LoaderOptions | DataValidator)[]) => {
   }
 
   return {
+    id,
     validators: validators.reverse(),
     serializationStrategy,
     expires,
@@ -571,7 +576,7 @@ export const updateRouteLoaderPaths = (
 
 export const getModuleRouteLoaders = (mods: readonly (RouteModule | undefined)[]) => {
   const routeLoaders: LoaderInternal[] = [];
-  const seen = new Set<string>();
+  const seen = new Map<string, LoaderInternal>();
   for (let i = 0; i < mods.length; i++) {
     const mod = mods[i];
     if (!mod) {
@@ -579,8 +584,23 @@ export const getModuleRouteLoaders = (mods: readonly (RouteModule | undefined)[]
     }
     for (const key in mod) {
       const value = mod[key as keyof typeof mod];
-      if (isLoaderInternal(value) && !seen.has(value.__id)) {
-        seen.add(value.__id);
+      if (isLoaderInternal(value)) {
+        const existing = seen.get(value.__id);
+        if (existing) {
+          // Two distinct loaders sharing one __id collide here: the second is dropped and never
+          // runs. The usual cause is defining loaders through a shared wrapper that passes an
+          // inline QRL to routeLoader$ — the optimizer gives that inline QRL a single hash for all
+          // instances. Pass a distinct `id` option (e.g. the wrapped fn's getHash()) to fix it.
+          if (isDev && existing !== value) {
+            console.warn(
+              `Two route loaders share the same id "${value.__id}". Only the first will run; ` +
+                `the others are ignored. If they are created by a shared wrapper around ` +
+                `routeLoader$, give each loader a distinct \`id\` option.`
+            );
+          }
+          continue;
+        }
+        seen.set(value.__id, value);
         routeLoaders.push(value);
       }
     }
@@ -773,8 +793,17 @@ export const routeLoaderQrl = ((
   loaderQrl: QRL<(event: RequestEventLoader) => unknown>,
   ...rest: (LoaderOptions | DataValidator)[]
 ): LoaderInternal => {
-  const { validators, serializationStrategy, expires, poll, eTag, cacheKey, search, allowStale } =
-    getLoaderOptions(rest);
+  const {
+    id,
+    validators,
+    serializationStrategy,
+    expires,
+    poll,
+    eTag,
+    cacheKey,
+    search,
+    allowStale,
+  } = getLoaderOptions(rest);
 
   function loader() {
     const state = _resolveContextWithoutSequentialScope(RouteStateContext)!;
@@ -790,7 +819,12 @@ export const routeLoaderQrl = ((
   loader.__brand = 'server_loader' as const;
   loader.__qrl = loaderQrl;
   loader.__validators = validators;
-  loader.__id = loaderQrl.getHash();
+  // Allow an explicit `id` to override the QRL hash. This is essential when a loader
+  // is created through a shared wrapper (e.g. a helper that calls routeLoader$ with an
+  // inline QRL): the optimizer gives that inline QRL a single hash for all instances, so
+  // without an override every wrapped loader would collide on the same __id and all but
+  // one would be deduped away in getModuleRouteLoaders.
+  loader.__id = id ?? loaderQrl.getHash();
   loader.__serializationStrategy = serializationStrategy;
   loader.__expires = expires ?? 120_000; // 2 minutes
   loader.__poll = poll ?? false;

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -587,10 +587,6 @@ export const getModuleRouteLoaders = (mods: readonly (RouteModule | undefined)[]
       if (isLoaderInternal(value)) {
         const existing = seen.get(value.__id);
         if (existing) {
-          // Two distinct loaders sharing one __id collide here: the second is dropped and never
-          // runs. The usual cause is defining loaders through a shared wrapper that passes an
-          // inline QRL to routeLoader$ — the optimizer gives that inline QRL a single hash for all
-          // instances. Pass a distinct `id` option (e.g. the wrapped fn's getHash()) to fix it.
           if (isDev && existing !== value) {
             console.warn(
               `Two route loaders share the same id "${value.__id}". Only the first will run; ` +
@@ -819,11 +815,6 @@ export const routeLoaderQrl = ((
   loader.__brand = 'server_loader' as const;
   loader.__qrl = loaderQrl;
   loader.__validators = validators;
-  // Allow an explicit `id` to override the QRL hash. This is essential when a loader
-  // is created through a shared wrapper (e.g. a helper that calls routeLoader$ with an
-  // inline QRL): the optimizer gives that inline QRL a single hash for all instances, so
-  // without an override every wrapped loader would collide on the same __id and all but
-  // one would be deduped away in getModuleRouteLoaders.
   loader.__id = id ?? loaderQrl.getHash();
   loader.__serializationStrategy = serializationStrategy;
   loader.__expires = expires ?? 120_000; // 2 minutes

--- a/packages/qwik-router/src/runtime/src/types.ts
+++ b/packages/qwik-router/src/runtime/src/types.ts
@@ -789,13 +789,8 @@ export type ActionConstructorQRL = {
 /** @public */
 export type LoaderOptions = {
   /**
-   * Explicit loader id, overriding the default (the loader QRL's hash).
-   *
-   * Required when defining a loader through a shared wrapper that passes an inline QRL to
-   * `routeLoader$` (e.g. a `withErrorHandling(fn)` helper). The optimizer assigns that inline QRL a
-   * single hash shared by every instance, so without a distinct `id` all wrapped loaders collide on
-   * the same id and all but the first are deduped away. Pass a stable, unique value such as the
-   * wrapped function's `fn.getHash()`.
+   * Explicit loader id, overriding the QRL hash. Pass a distinct value (e.g. `fn.getHash()`) when
+   * loaders share a wrapper QRL.
    */
   readonly id?: string;
   readonly validation?: DataValidator[];

--- a/packages/qwik-router/src/runtime/src/types.ts
+++ b/packages/qwik-router/src/runtime/src/types.ts
@@ -788,7 +788,15 @@ export type ActionConstructorQRL = {
 
 /** @public */
 export type LoaderOptions = {
-  /** @deprecated Unused */
+  /**
+   * Explicit loader id, overriding the default (the loader QRL's hash).
+   *
+   * Required when defining a loader through a shared wrapper that passes an inline QRL to
+   * `routeLoader$` (e.g. a `withErrorHandling(fn)` helper). The optimizer assigns that inline QRL a
+   * single hash shared by every instance, so without a distinct `id` all wrapped loaders collide on
+   * the same id and all but the first are deduped away. Pass a stable, unique value such as the
+   * wrapped function's `fn.getHash()`.
+   */
   readonly id?: string;
   readonly validation?: DataValidator[];
   readonly serializationStrategy?: SerializationStrategy;


### PR DESCRIPTION
## Overview

Loaders defined through a shared wrapper that passes an **inline QRL** to `routeLoader$` — e.g. a `withErrorHandling(fn)` helper — all share a single optimizer-assigned QRL hash. Since the loader id was derived solely from that hash (`loader.__id = loaderQrl.getHash()`), every wrapped loader collided on the same `__id`, and all but the first were silently deduped away in `getModuleRouteLoaders`. The result: only one of the wrapped loaders ran during SSR and SPA navigation. Plain `routeLoader$` calls are unaffected because each is its own lexical QRL with a distinct hash.

## Changes

- **Honor the `id` option** (previously marked `@deprecated Unused`): `loader.__id = id ?? loaderQrl.getHash()`. Wrappers can now pass a stable, distinct id such as `fn.getHash()`.
- **Dev warning** in `getModuleRouteLoaders` when two distinct loaders share the same id, so this collision surfaces loudly instead of silently dropping loaders.
- Documented the `id` option and added a changeset.

## Notes

Surfaced while migrating a real app to Qwik v2: a `routeLoaderWithErrorHandling` helper wrapping `routeLoader$` caused only the first loader on each route to run. The app already passed `id: fn.getHash()`, but the router had stopped honoring it.

I couldn't run the router unit tests in my environment; happy to add a `getModuleRouteLoaders` dedup/id-override test if you'd like.