### PR TITLE
fix(qwik-router): deprecate fail()/.value.failed in favor of error()/.error

### DIFF
--- a/.changeset/deprecate-fail-in-favor-of-error.md
+++ b/.changeset/deprecate-fail-in-favor-of-error.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: deprecate `fail()`/`.value.failed` in favor of `error()`/`.error` — annotation-only, non-breaking

--- a/packages/docs/src/routes/api/qwik-router/api.json
+++ b/packages/docs/src/routes/api/qwik-router/api.json
@@ -306,7 +306,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type FailReturn<T> = T & Failed;\n```",
+      "content": "> Warning: This API is now obsolete.\n> \n> Return `error(status, data)` instead and read the typed `ServerError` via the signal's `.error`<!-- -->. `fail()`<!-- -->/`.value.failed` will be removed in v3.\n> \n\n\n```typescript\nexport type FailReturn<T> = T & Failed;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.failreturn.md"
     },

--- a/packages/docs/src/routes/api/qwik-router/index.mdx
+++ b/packages/docs/src/routes/api/qwik-router/index.mdx
@@ -796,6 +796,10 @@ export type FailOfRest<REST extends readonly DataValidator[]> =
 
 <h2 id="failreturn">FailReturn</h2>
 
+> Warning: This API is now obsolete.
+>
+> Return `error(status, data)` instead and read the typed `ServerError` via the signal's `.error`. `fail()`/`.value.failed` will be removed in v3.
+
 ```typescript
 export type FailReturn<T> = T & Failed;
 ```

--- a/packages/qwik-router/src/middleware/request-handler/middleware.request-handler.api.md
+++ b/packages/qwik-router/src/middleware/request-handler/middleware.request-handler.api.md
@@ -120,7 +120,7 @@ export interface RequestEvent<PLATFORM = QwikRouterPlatform> extends RequestEven
 
 // @public (undocumented)
 export interface RequestEventAction<PLATFORM = QwikRouterPlatform> extends RequestEventCommon<PLATFORM> {
-    // (undocumented)
+    // @deprecated (undocumented)
     fail: <T extends Record<string, any>>(status: number, returnData: T) => FailReturn<T>;
 }
 

--- a/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
@@ -301,6 +301,10 @@ export function createRequestEventWithDeps(
       return typeof returnData === 'function' ? returnData : () => returnData;
     },
 
+    /**
+     * @deprecated Return `error(status, data)` instead and read the typed `ServerError` via the
+     *   signal's `.error`. `fail()`/`.value.failed` will be removed in v3.
+     */
     fail: <T extends Record<string, any>>(statusCode: number, data: T): FailReturn<T> => {
       check();
       status = statusCode;

--- a/packages/qwik-router/src/middleware/request-handler/types.ts
+++ b/packages/qwik-router/src/middleware/request-handler/types.ts
@@ -498,6 +498,10 @@ declare global {
 export interface RequestEventAction<
   PLATFORM = QwikRouterPlatform,
 > extends RequestEventCommon<PLATFORM> {
+  /**
+   * @deprecated Return `error(status, data)` instead and read the typed `ServerError` via the
+   *   signal's `.error`. `fail()`/`.value.failed` will be removed in v3.
+   */
   fail: <T extends Record<string, any>>(status: number, returnData: T) => FailReturn<T>;
 }
 

--- a/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
+++ b/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
@@ -198,7 +198,7 @@ export type FailOfRest<REST extends readonly DataValidator[]> = REST extends rea
 
 // Warning: (ae-forgotten-export) The symbol "Failed" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type FailReturn<T> = T & Failed;
 
 // @public (undocumented)

--- a/packages/qwik-router/src/runtime/src/types.ts
+++ b/packages/qwik-router/src/runtime/src/types.ts
@@ -982,10 +982,18 @@ export type ActionStore<RETURN, INPUT, OPTIONAL extends boolean = true> = {
 };
 
 type Failed = {
+  /**
+   * @deprecated Return `error(status, data)` instead and read the typed `ServerError` via the
+   *   signal's `.error`. `fail()`/`.value.failed` will be removed in v3.
+   */
   failed: true;
 };
 
-/** @public */
+/**
+ * @deprecated Return `error(status, data)` instead and read the typed `ServerError` via the
+ *   signal's `.error`. `fail()`/`.value.failed` will be removed in v3.
+ * @public
+ */
 export type FailReturn<T> = T & Failed;
 
 /** @public */


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
Deprecates `fail()`/`.value.failed`; use `error()` + `.error` instead. Annotation-only, non-breaking. Throw/`.error` rework for actions lands in a follow-up.