### PR TITLE
docs: restyle article links

### DIFF
--- a/packages/docs/src/routes/docs/docs.css
+++ b/packages/docs/src/routes/docs/docs.css
@@ -65,11 +65,7 @@
 /* ─── Links ─── */
 
 .docs article a {
-  @apply text-secondary-foreground-base underline;
-}
-
-.docs article a:hover {
-  @apply no-underline;
+  @apply text-primary-standalone-base underline;
 }
 
 /* ─── Blockquotes ─── */


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
Restyle docs article links: switch to the primary standalone color token and keep links underlined on hover (drops the `hover:no-underline` rule).
