### PR TITLE
docs(ruler): prefer prescriptive skill notes

### DIFF
--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -115,6 +115,10 @@ Follow that bias:
   scope.
 - Keep new durable lessons in the most specific skill or reference that future agents are likely to
   load. Do not add package-specific details to these always-on rules unless they affect most tasks.
+- Write those notes **prescriptively** — the invariants to keep, the traps that cause false passes,
+  where things live, and how to verify — rather than describing how the code currently works (the
+  source already does that). Omit "don't do X" prohibitions for anything a test already enforces; the
+  suite is the guardrail, so reserve notes for what it can't self-enforce.
 - When updating guidance, load the `qwik-guidance-maintenance` skill.
 
 ### Code Style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,10 @@ Follow that bias:
   scope.
 - Keep new durable lessons in the most specific skill or reference that future agents are likely to
   load. Do not add package-specific details to these always-on rules unless they affect most tasks.
+- Write those notes **prescriptively** — the invariants to keep, the traps that cause false passes,
+  where things live, and how to verify — rather than describing how the code currently works (the
+  source already does that). Omit "don't do X" prohibitions for anything a test already enforces; the
+  suite is the guardrail, so reserve notes for what it can't self-enforce.
 - When updating guidance, load the `qwik-guidance-maintenance` skill.
 
 ### Code Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,10 @@ Follow that bias:
   scope.
 - Keep new durable lessons in the most specific skill or reference that future agents are likely to
   load. Do not add package-specific details to these always-on rules unless they affect most tasks.
+- Write those notes **prescriptively** — the invariants to keep, the traps that cause false passes,
+  where things live, and how to verify — rather than describing how the code currently works (the
+  source already does that). Omit "don't do X" prohibitions for anything a test already enforces; the
+  suite is the guardrail, so reserve notes for what it can't self-enforce.
 - When updating guidance, load the `qwik-guidance-maintenance` skill.
 
 ### Code Style


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
Adds a Guidance Freshness bullet so future agents write skill/reference notes prescriptively — the invariants to keep, false-pass traps, where things live, and how to verify — instead of re-describing the code, and skip "don't do X" notes for anything the test suite already enforces.

Source edit is in `.ruler/AGENTS.md`; `AGENTS.md`/`CLAUDE.md` regenerated via `ruler apply`.