### PR TITLE
docs: auto-link first mention of core APIs in docs prose

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/core/context/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/core/context/index.mdx
@@ -68,7 +68,7 @@ const Child = component$(() => {
 </CodeSandbox>
 
 
-In the above example, a `ContextId` named `docs.theme-context` is created and used to provide a `useSignal` to the `default` component. The `Child` component uses the `useContext` method to get the `useSignal` and render its value.
+In the above example, a `ContextId` named `docs.theme-context` is created and used to provide a [`useSignal`](/docs/core/state/#usesignal) to the `default` component. The `Child` component uses the `useContext` method to get the `useSignal` and render its value.
 
 ## `createContextId()`
 
@@ -117,7 +117,7 @@ export const Parent = component$(() => {
 
 - `ContextId`: A previously created Context must be supplied, serving as an identifier for the data being provided as the second parameter.
 
-- `data`: You can provide any data type, such as Qwik's useSignal, useStore, arrays, or objects.
+- `data`: You can provide any data type, such as Qwik's useSignal, [useStore](/docs/core/state/#usestore), arrays, or objects.
 
 ### Caveats
 

--- a/packages/docs/src/routes/docs/(qwik)/core/events/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/core/events/index.mdx
@@ -392,7 +392,7 @@ The `window:on`/`document:` prefixes are used to register an event at the curren
 
 ## `useOn[window|document]` Hook
 
-- `useOn()`: listen to events on the current component's root element.
+- [`useOn()`](/docs/guides/best-practices/#useon): listen to events on the current component's root element.
 - `useOnWindow()`: listen to events on the `window` object.
 - `useOnDocument()`: listen to events on the `document` object.
 

--- a/packages/docs/src/routes/docs/(qwik)/core/overview/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/core/overview/index.mdx
@@ -475,7 +475,7 @@ You can think of inline components as being inlined into the component where the
 ### Limitations
 Inline components come with some limitations that the standard `component$()`
 does not have. Inline components:
-- Cannot use `use*` methods such as `useSignal` or `useStore`.
+- Cannot use `use*` methods such as [`useSignal`](/docs/core/state/#usesignal) or [`useStore`](/docs/core/state/#usestore).
 - Cannot project content with a `<Slot>`.
 
 As the name implies, inline components are best used sparingly for

--- a/packages/docs/src/routes/docs/(qwik)/core/rendering/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/core/rendering/index.mdx
@@ -38,8 +38,8 @@ Just like React, Qwik uses [JSX](https://facebook.github.io/jsx/) to express the
 
 Qwik presents a few differences from other JSX frameworks:
 
-- Components are always declared with the `component$` function.
-- Components can use the `useSignal` hook to create reactive state.
+- Components are always declared with the [`component$`](/docs/core/overview/#component) function.
+- Components can use the [`useSignal`](/docs/core/state/#usesignal) hook to create reactive state.
 - Event handlers are declared with the `$` suffix.
 - For `<input>`, the `onChange` event is called `onInput$` in Qwik.
 - HTML attributes are preferred. `class` instead of `className`. `for` instead of `htmlFor`.

--- a/packages/docs/src/routes/docs/(qwik)/core/state/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/core/state/index.mdx
@@ -284,7 +284,7 @@ You do not need to list dependencies for `useComputed$()`. Qwik automatically tr
 
 ### `useAsync$()`
 
-Create a signal for a value that comes from async work, such as fetching data, calling `server$()`, reading from a Web Worker, or running a long calculation.
+Create a signal for a value that comes from async work, such as fetching data, calling [`server$()`](/docs/server$/#server), reading from a Web Worker, or running a long calculation.
 
 Like `useComputed$()`, the function can run again when the state it tracks changes.
 

--- a/packages/docs/src/routes/docs/(qwik)/core/tasks/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/core/tasks/index.mdx
@@ -560,7 +560,7 @@ return (<>
 
 When using lifecycle hooks, you must adhere to the following rules:
 
-- They can only be called at the root level of `component$` (not inside conditional blocks)
+- They can only be called at the root level of [`component$`](/docs/core/overview/#component) (not inside conditional blocks)
 - They can only be called at the root of another `use*` method, allowing for composition.
 
 ```tsx

--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -183,7 +183,7 @@ export default component$(() => {
 
 Code explanation:
 
-- The function passed to `routeLoader$` is invoked on the server eagerly before any component is rendered and is responsible for loading data.
+- The function passed to [`routeLoader$`](/docs/route-loader/#routeloader) is invoked on the server eagerly before any component is rendered and is responsible for loading data.
 - The `routeLoader$` returns a use-hook, `useDadJoke()`, that can be used in the component to retrieve the server data.
 
 <LongNote title="routeLoader$ Behavior">
@@ -289,7 +289,7 @@ export default component$(() => {
 
 ### 4. Modifying State
 
-Keeping track of the state and updating the UI is core to what applications do. Qwik provides a `useSignal` hook to keep track of the application's state. To learn more, see [state management](/docs/core/state/).
+Keeping track of the state and updating the UI is core to what applications do. Qwik provides a [`useSignal`](/docs/core/state/#usesignal) hook to keep track of the application's state. To learn more, see [state management](/docs/core/state/).
 
 To declare state:
 
@@ -368,7 +368,7 @@ export default component$(() => {
 
 In Qwik, a [task](/docs/core/tasks/#usetask) is work that needs to happen when a state changes. (This is similar to an "effect" in other frameworks.) In this example, we use the task to invoke code on the server.
 
-1. Import `useTask$` from `qwik` and `server$` from `qwik-router`.
+1. Import [`useTask$`](/docs/core/tasks/#usetask) from `qwik` and [`server$`](/docs/server$/#server) from `qwik-router`.
    ```tsx /useTask\$/ /server\$/
    import { component$, useSignal, useTask$ } from "@qwik.dev/core";
    import {
@@ -497,7 +497,7 @@ To add styles:
     ```tsx
     import styles from "./index.css?inline";
     ```
-3. Import `useStylesScoped$` from `qwik`.
+3. Import [`useStylesScoped$`](/docs/core/styles/) from `qwik`.
    ```tsx /useStylesScoped$/
    import { component$, useSignal, useStylesScoped$, useTask$ } from "@qwik.dev/core";
 4. Tell the component to load the styles:

--- a/packages/docs/src/routes/docs/(qwikrouter)/guides/best-practices/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/guides/best-practices/index.mdx
@@ -75,7 +75,7 @@ the function that the "read" is happening at, will re-run again
 on every change to that signal.
 
 That’s why it’s better to "read" values (and track them)
-inside of `useTask$`, `useComputed$`, or `useAsync$` functions instead of inside component functions,
+inside of [`useTask$`](/docs/core/tasks/#usetask), [`useComputed$`](/docs/core/state/#usecomputed), or [`useAsync$`](/docs/core/state/#useasync) functions instead of inside component functions,
 whenever possible.
 
 Because otherwise, your component function will re-run
@@ -126,13 +126,13 @@ export default component$(() => {
 
 ## Use `useVisibleTask$()` as a last resort
 
-Although convenient, `useVisibleTask$()` runs code eagerly and blocks the main thread, preventing user interaction until the task is finished. You can think of it as an escape hatch.
+Although convenient, [`useVisibleTask$()`](/docs/core/tasks/#usevisibletask) runs code eagerly and blocks the main thread, preventing user interaction until the task is finished. You can think of it as an escape hatch.
 
 When in doubt, instead of "useVisibleTask$()" use:
 - `useTask$()` -> perform code execution in SSR mode.
 - `useOn()` -> listen to events on the root element of `the current component`.
-- `useOnWindow()` -> listen to events on the `window` object.
-- `useOnDocument()` -> listen to events on the `document` object.
+- [`useOnWindow()`](/docs/core/events/#useonwindowdocument-hook) -> listen to events on the `window` object.
+- [`useOnDocument()`](/docs/core/events/#useonwindowdocument-hook) -> listen to events on the `document` object.
 
 Sometimes though, it is the only way to achieve the result.
 
@@ -176,7 +176,7 @@ useOnDocument(
 
 ## Avoid accessing the location from the `window` object
 
-Don't access `window.location` directly, use `useLocation()` hook instead.
+Don't access `window.location` directly, use [`useLocation()`](/docs/api/#uselocation) hook instead.
 
 ```tsx title="Suboptimal implementation"
 // Don't do this!

--- a/packages/docs/src/routes/docs/(qwikrouter)/guides/bundle/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/guides/bundle/index.mdx
@@ -25,7 +25,7 @@ Bundle Optimization refers to the process of deciding which symbol goes to which
 
 Symbols are individual lazy-loadable pieces in Qwik. A symbol is created whenever you use the `__$(__)` in your source code.  
 
-For example, the code below creates two symbols from `component$` and `onClick$`.
+For example, the code below creates two symbols from [`component$`](/docs/core/overview/#component) and `onClick$`.
 
 <CodeSandbox src="/src/routes/demo/state/counter-signal/index.tsx">
 ```tsx /component$/ /onClick$/

--- a/packages/docs/src/routes/docs/(qwikrouter)/guides/env-variables/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/guides/env-variables/index.mdx
@@ -111,7 +111,7 @@ DB_PRIVATE_KEY=123456789
 
 ### Usage Examples
 
-Server-side variables can only be accessed in server-only APIs that expose the `RequestEvent` object, such as `routeLoader$()`, `routeAction$()`, `server$()` and endpoint handlers such as `onGet`, `onPost`, `onRequest` etc.
+Server-side variables can only be accessed in server-only APIs that expose the `RequestEvent` object, such as [`routeLoader$()`](/docs/route-loader/#routeloader), [`routeAction$()`](/docs/action/#routeaction), [`server$()`](/docs/server$/#server) and endpoint handlers such as `onGet`, `onPost`, `onRequest` etc.
 
 ```tsx /DB_PRIVATE_KEY/ title="src/routes/index.tsx"
 import {

--- a/packages/docs/src/routes/docs/(qwikrouter)/guides/mdx/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/guides/mdx/index.mdx
@@ -159,7 +159,7 @@ The above example will generate the following HTML code.
 ```
 
 ## Reading frontmatter data
-Frontmatter keys are accessible by leveraging the `useDocumentHead()` hook.
+Frontmatter keys are accessible by leveraging the [`useDocumentHead()`](/docs/api/#usedocumenthead) hook.
 
 ```markdown title="src/routes/some/path/index.mdx"
 ---
@@ -375,4 +375,4 @@ export const ReadingProgress = component$(() => {
 - This functionality only works with `.mdx` files, not with `.tsx` or other file types
 - Headings must have unique content to generate unique IDs
 - The heading data is available only on the client-side after hydration
-- Consider using `useVisibleTask$` if you need to interact with the heading elements in the DOM
+- Consider using [`useVisibleTask$`](/docs/core/tasks/#usevisibletask) if you need to interact with the heading elements in the DOM

--- a/packages/docs/src/routes/docs/(qwikrouter)/guides/qwik-nutshell/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/guides/qwik-nutshell/index.mdx
@@ -25,7 +25,7 @@ created_at: '2023-03-30T19:49:50Z'
 
 ## Components
 
-Qwik components are very similar to React components. They are functions that return JSX. However, `component$(...)` needs to be used, event handlers must have the `$` suffix, state is created using `useSignal()`, `class` is used instead of `className` and some other differences.
+Qwik components are very similar to React components. They are functions that return JSX. However, [`component$(...)`](/docs/core/overview/#component) needs to be used, event handlers must have the `$` suffix, state is created using [`useSignal()`](/docs/core/state/#usesignal), `class` is used instead of `className` and some other differences.
 
 
 ```tsx title="src/components/my-other-component/index.tsx"
@@ -168,14 +168,14 @@ export default component$(() => {
 
 ### Rules of use hooks
 
-Methods that start with `use` are special in Qwik, such as `useSignal()`, `useStore()`, `useOn()`, `useTask$()`, `useLocation()` and so on. Very similar to React hooks.
+Methods that start with `use` are special in Qwik, such as `useSignal()`, [`useStore()`](/docs/core/state/#usestore), [`useOn()`](/docs/guides/best-practices/#useon), [`useTask$()`](/docs/core/tasks/#usetask), [`useLocation()`](/docs/api/#uselocation) and so on. Very similar to React hooks.
 
 - They can only be called within a component$.
 - They can only be called from the top level of a component$, not inside a conditional, or a loop.
 
 ## Styling
 
-Qwik supports out of the box, CSS modules, or even Tailwind, global CSS imports and lazy loading scoped CSS using `useStylesScoped$()`. CSS Modules are the recommended way to style Qwik components.
+Qwik supports out of the box, CSS modules, or even Tailwind, global CSS imports and lazy loading scoped CSS using [`useStylesScoped$()`](/docs/core/styles/). CSS Modules are the recommended way to style Qwik components.
 
 ### CSS Modules
 
@@ -202,7 +202,7 @@ Remember that Qwik uses `class` instead of `className` for CSS classes.
 
 ## $(...) rules
 
-The `$(...)` function and any function that end with `$` are special in Qwik, such as: `$()`, `useTask$()`, `useVisibleTask$()`... The `$` at the end represents a lazy loading boundary. There are some rules that apply to the first argument of any `$` function. It is NOT related to jQuery at all.
+The `$(...)` function and any function that end with `$` are special in Qwik, such as: `$()`, `useTask$()`, [`useVisibleTask$()`](/docs/core/tasks/#usevisibletask)... The `$` at the end represents a lazy loading boundary. There are some rules that apply to the first argument of any `$` function. It is NOT related to jQuery at all.
 
 - The first argument must be an imported variable.
 - The first argument must be a declared variable at the top level of the same module.
@@ -509,7 +509,7 @@ export default component$(() => {
 
 ## Fetching / loading data
 
-The recommended way to load data from the server is to use the `routeLoader$()` function exported from `@qwik.dev/router`. The `routeLoader$()` function is used to create a data loader that will be executed on the server before the route is rendered. The return of `routeLoader$()` must be exported as a named export from the route file, ie, it can only be used in a `index.tsx`, inside of `src/routes/`.
+The recommended way to load data from the server is to use the [`routeLoader$()`](/docs/route-loader/#routeloader) function exported from `@qwik.dev/router`. The `routeLoader$()` function is used to create a data loader that will be executed on the server before the route is rendered. The return of `routeLoader$()` must be exported as a named export from the route file, ie, it can only be used in a `index.tsx`, inside of `src/routes/`.
 
 ```tsx title="src/routes/user/[userID]/index.tsx"
 
@@ -558,7 +558,7 @@ The `routeLoader$()` function takes a function that returns a promise. The promi
 
 ## Handle form submissions
 
-Qwik provides the `routeAction$()` API exported from `@qwik.dev/router` to handle form requests on the server. `routeAction$()` is only executed on the server when the form is submitted.
+Qwik provides the [`routeAction$()`](/docs/action/#routeaction) API exported from `@qwik.dev/router` to handle form requests on the server. `routeAction$()` is only executed on the server when the form is submitted.
 
 ```tsx title="src/routes/user/[userID]/index.tsx"
 
@@ -724,7 +724,7 @@ The `routeLoader$()` is a special component that is only executed on the server.
 
 ### `server$((...args) => { ... })`
 
-The `server$()` is a special way to declare functions that only run on the server. If called from the client, they will behave like an RPC call, and will be executed on the server. They can take any serializable arguments, and return any serializable value.
+The [`server$()`](/docs/server$/#server) is a special way to declare functions that only run on the server. If called from the client, they will behave like an RPC call, and will be executed on the server. They can take any serializable arguments, and return any serializable value.
 
 ### `isServer` & `isBrowser` conditionals
 


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
Auto-links the first prose mention of each core API/hook (`useSignal`, `component$`, `routeLoader$`, …) to its reference anchor, but only on the beginner learning path — getting-started, core/*, and the guides (incl. qwik-nutshell). Reference, cookbook, integration, and advanced pages are left alone: they're entered mid-page via search/deep links, so a single top-of-page link is missed anyway and the ubiquitous-term links there are just noise. First mention per page only; skips code, headings, tables, blockquotes, `<Note>`/JSX, existing links, and self-links. 38 links across 12 pages.
