### PR TITLE
fix(qwik): surface container resume failures instead of hanging

### DIFF
--- a/.changeset/surface-resume-failures.md
+++ b/.changeset/surface-resume-failures.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: surface a failed container resume — report it and unblock `whenContainerDataReady` waiters — instead of swallowing the error into a silent hang.

--- a/packages/qwik/src/core/client/process-state-data.ts
+++ b/packages/qwik/src/core/client/process-state-data.ts
@@ -1,5 +1,6 @@
 import { type DomContainer } from './dom-container';
 import { onVNodeDataReady } from './process-vnode-data';
+import { logError } from '../shared/utils/log';
 import {
   createYieldingIteratorState,
   scheduleYieldingIterator,
@@ -91,9 +92,10 @@ function scheduleProcessContainerStateData(
       state.$active$ = null;
       scheduleProcessContainerStateData(container, state);
     },
-    () => {
+    (error) => {
       state.$active$ = null;
-      container.$containerDataProcessState$ = ContainerDataProcessState.ProcessingStateDone;
+      logError(error);
+      markContainerDataReady(container);
     }
   );
   scheduleYieldingIterator(state.$active$);

--- a/packages/qwik/src/core/client/process-state-data.unit.tsx
+++ b/packages/qwik/src/core/client/process-state-data.unit.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { domRender } from '@qwik.dev/core/testing';
+import type { DomContainer } from './dom-container';
+import { processContainerStateData, whenContainerDataReady } from './process-state-data';
+
+describe('container state-data resume errors', () => {
+  it('a resume error unblocks whenContainerDataReady instead of hanging silently', async () => {
+    const { container } = await domRender(<div id="ok">ok</div>);
+
+    // Drive the container-state pipeline with a throwing iterator
+    processContainerStateData(
+      container as unknown as DomContainer,
+      (function* () {
+        yield;
+        throw new Error('resume boom');
+      })()
+    );
+
+    await whenContainerDataReady(container as unknown as DomContainer, () => undefined);
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
# What is it?
- Bug

# Description
The container state-resume pipeline (`process-state-data.ts`) swallowed a thrown resume: `scheduleProcessContainerStateData`'s `onError` marked the container done but never called `markContainerDataReady`, so every `whenContainerDataReady` waiter hung forever — and it logged nothing, so the failure was invisible (a silent hang rather than a surfaced error).

Now it reports the error via `logError` and unblocks waiters so the rest of the page can still resume (graceful degradation). Includes a regression test that drives the pipeline with a throwing iterator and asserts it resolves instead of timing out (it times out without the fix).

Split out of the ErrorBoundary PR (#8745), where this was discovered — it's an independent core-resume robustness fix.