### PR TITLE
fix(qwik): unblock vnode-data resume waiters on failure instead of hanging

### DIFF
--- a/.changeset/surface-vnode-resume-failures.md
+++ b/.changeset/surface-vnode-resume-failures.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: surface a failed vnode-data resume — report it and unblock the `whenVNodeDataReady` waiters — instead of swallowing the error into a silent hang.

--- a/packages/qwik/src/core/client/process-vnode-data.ts
+++ b/packages/qwik/src/core/client/process-vnode-data.ts
@@ -6,6 +6,7 @@ import {
   getSegmentVNodeRefId,
 } from '../shared/vnode-data-types';
 import type { ElementVNode } from '../shared/vnode/element-vnode';
+import { logError } from '../shared/utils/log';
 import type { ContainerElement, QDocument } from './types';
 import {
   createYieldingIteratorState,
@@ -143,7 +144,7 @@ export const whenVNodeDataReady = <T>(
   });
 };
 
-function enqueueProcessVNodeDataJob(
+export function enqueueProcessVNodeDataJob(
   qDocument: QDocument,
   iterator: Generator<void, void, void>
 ): void {
@@ -177,9 +178,8 @@ function scheduleProcessVNodeData(qDocument: QDocument, state: ProcessVNodeDataS
     },
     (error) => {
       state.$active$ = null;
-      qDocument.qVNodeDataReady = qDocument.qVNodeDataStarted = false;
-      qDocument.qVNodeDataState = undefined;
-      throw error;
+      logError(error);
+      markVNodeDataReady(qDocument);
     }
   );
   scheduleYieldingIterator(state.$active$);

--- a/packages/qwik/src/core/client/process-vnode-data.unit.tsx
+++ b/packages/qwik/src/core/client/process-vnode-data.unit.tsx
@@ -4,6 +4,7 @@ import '../../testing/vdom-diff.unit-util';
 import { VNodeDataSeparator, getSegmentVNodeRefId } from '../shared/vnode-data-types';
 import { DomContainer, getDomContainer } from './dom-container';
 import {
+  enqueueProcessVNodeDataJob,
   findVDataSectionEnd,
   processOutOfOrderSegmentVNodeData,
   processVNodeData,
@@ -1064,6 +1065,24 @@ describe('processVnodeData', () => {
     const refId = getSegmentVNodeRefId('1', 1);
     expect(first.element.qVNodeRefs?.get(refId)).toBe(first.element.querySelector('section'));
     expect(second.element.qVNodeRefs?.get(refId)).toBe(second.element.querySelector('section'));
+  });
+});
+
+describe('vnode-data resume errors', () => {
+  it('a resume error unblocks whenVNodeDataReady instead of hanging silently', async () => {
+    const document = createDocument() as QDocument;
+
+    // Drive the vnode-data pipeline with a throwing iterator
+    enqueueProcessVNodeDataJob(
+      document,
+      (function* () {
+        yield;
+        throw new Error('resume boom');
+      })()
+    );
+
+    await whenVNodeDataReady(document, () => undefined);
+    expect(true).toBe(true);
   });
 });
 


### PR DESCRIPTION
# What is it?
- Bug

# Description
Sibling to #8772 (which fixed the container state-data side). The vnode-data resume pipeline had the same class of bug: a thrown resume left `onVNodeDataReady`/`whenVNodeDataReady`/`onContainerDataReady` waiters hanging on a bare `throw`. Now it logs the error and calls `markVNodeDataReady` so the waiters fire instead of hanging silently.