### PR TITLE
feat(build): keep Qwik and Router .d.ts fresh in build.core.dev

### DIFF
--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -69,6 +69,8 @@ pnpm vitest run packages/qwik/src/core/tests/use-task.spec.tsx
 pnpm playwright test e2e/qwik-e2e/tests/events.e2e.ts --browser=chromium --config e2e/qwik-e2e/playwright.config.ts
 ```
 
+`build.core.dev` also re-emits fresh Qwik and Router `.d.ts` incrementally (via `tscDevDts` + re-export shims), so editing a public signature no longer leaves stale types — `build.watch` skips the type pass to stay instant.
+
 For Qwik e2e tests, use `--browser=chromium` with `e2e/qwik-e2e/playwright.config.ts`.
 
 Run `pnpm build.full` only when you are touching the optimizer rust code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ pnpm vitest run packages/qwik/src/core/tests/use-task.spec.tsx
 pnpm playwright test e2e/qwik-e2e/tests/events.e2e.ts --browser=chromium --config e2e/qwik-e2e/playwright.config.ts
 ```
 
+`build.core.dev` also re-emits fresh Qwik and Router `.d.ts` incrementally (via `tscDevDts` + re-export shims), so editing a public signature no longer leaves stale types — `build.watch` skips the type pass to stay instant.
+
 For Qwik e2e tests, use `--browser=chromium` with `e2e/qwik-e2e/playwright.config.ts`.
 
 Run `pnpm build.full` only when you are touching the optimizer rust code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ pnpm vitest run packages/qwik/src/core/tests/use-task.spec.tsx
 pnpm playwright test e2e/qwik-e2e/tests/events.e2e.ts --browser=chromium --config e2e/qwik-e2e/playwright.config.ts
 ```
 
+`build.core.dev` also re-emits fresh Qwik and Router `.d.ts` incrementally (via `tscDevDts` + re-export shims), so editing a public signature no longer leaves stale types — `build.watch` skips the type pass to stay instant.
+
 For Qwik e2e tests, use `--browser=chromium` with `e2e/qwik-e2e/playwright.config.ts`.
 
 Run `pnpm build.full` only when you are touching the optimizer rust code.

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -4,11 +4,7 @@ import { join } from 'node:path';
 import { generateQwikApiMarkdownDocs, generateQwikRouterApiMarkdownDocs } from './api-docs.ts';
 import { type BuildConfig, copyFile, ensureDir, panic } from './util.ts';
 
-/**
- * Jsx-runtime only re-exports JSX, so we don't run it through api-extractor — we just point its
- * `.d.ts` at the source re-export. Shared by the production api-extractor path and the dev shim
- * path.
- */
+// jsx-runtime just re-exports JSX, so skip api-extractor.
 export function writeJsxRuntimeDts(config: BuildConfig) {
   const jsxContent = readFileSync(join(config.srcQwikDir, 'jsx-runtime.ts'), 'utf-8');
   writeFileSync(
@@ -293,7 +289,7 @@ function createTypesApi(
   }
 }
 
-function generateQwikRouterReferenceModules(config: BuildConfig) {
+export function generateQwikRouterReferenceModules(config: BuildConfig) {
   const srcModulesPath = join(config.packagesDir, 'qwik-router', 'lib');
 
   const destModulesPath = join(srcModulesPath, 'modules.d.ts');

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -5,6 +5,24 @@ import { generateQwikApiMarkdownDocs, generateQwikRouterApiMarkdownDocs } from '
 import { type BuildConfig, copyFile, ensureDir, panic } from './util.ts';
 
 /**
+ * Jsx-runtime only re-exports JSX, so we don't run it through api-extractor — we just point its
+ * `.d.ts` at the source re-export. Shared by the production api-extractor path and the dev shim
+ * path.
+ */
+export function writeJsxRuntimeDts(config: BuildConfig) {
+  const jsxContent = readFileSync(join(config.srcQwikDir, 'jsx-runtime.ts'), 'utf-8');
+  writeFileSync(
+    join(config.distQwikPkgDir, 'jsx-runtime.d.ts'),
+    `// re-export to make TS happy when not using nodenext import resolution\n${jsxContent}`
+  );
+  ensureDir(join(config.distQwikPkgDir, 'jsx-runtime'));
+  writeFileSync(
+    join(config.distQwikPkgDir, 'jsx-runtime', 'index.d.ts'),
+    `// re-export to make TS happy when not using nodenext import resolution\nexport * from '../jsx-runtime';`
+  );
+}
+
+/**
  * Create each submodule's bundled dts file, and ensure the public API has not changed for a
  * production build.
  */
@@ -19,16 +37,7 @@ export async function apiExtractorQwik(config: BuildConfig) {
   );
   // Special case for jsx-runtime:
   // It only re-exports JSX. Don't duplicate the types
-  const jsxContent = readFileSync(join(config.srcQwikDir, 'jsx-runtime.ts'), 'utf-8');
-  writeFileSync(
-    join(config.distQwikPkgDir, 'jsx-runtime.d.ts'),
-    `// re-export to make TS happy when not using nodenext import resolution\n${jsxContent}`
-  );
-  ensureDir(join(config.distQwikPkgDir, 'jsx-runtime'));
-  writeFileSync(
-    join(config.distQwikPkgDir, 'jsx-runtime', 'index.d.ts'),
-    `// re-export to make TS happy when not using nodenext import resolution\nexport * from '../jsx-runtime';`
-  );
+  writeJsxRuntimeDts(config);
   createTypesApi(config, config.qwikVitePkgDir, join(config.distQwikPkgDir, 'optimizer.d.ts'), '.');
   createTypesApi(
     config,
@@ -298,7 +307,7 @@ function generateQwikRouterReferenceModules(config: BuildConfig) {
   writeFileSync(distIndexPath, serverDts);
 }
 
-function generateServerReferenceModules(config: BuildConfig) {
+export function generateServerReferenceModules(config: BuildConfig) {
   // server-modules.d.ts
   const referenceDts = `/// <reference types="./server" />
 declare module '@qwik-client-manifest' {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -28,8 +28,9 @@ import { submoduleServer } from './submodule-server.ts';
 import { submoduleTesting } from './submodule-testing.ts';
 import { submoduleWorker } from './submodule-worker.ts';
 import { buildSupabaseAuthHelpers } from './supabase-auth-helpers.ts';
-import { tsc, tscQwik, tscQwikRouter } from './tsc.ts';
+import { tsc, tscQwik, tscDevDts, tscQwikRouter } from './tsc.ts';
 import { tscDocs } from './tsc-docs.ts';
+import { writeQwikDtsShims, writeQwikRouterDtsShims } from './dts-shim.ts';
 import { emptyDir, ensureDir, panic, type BuildConfig } from './util.ts';
 import { validateBuild } from './validate-build.ts';
 import { submodulePreloader } from './submodule-preloader.ts';
@@ -63,6 +64,9 @@ export async function build(config: BuildConfig) {
       rmSync(config.tscDir, { recursive: true, force: true });
       rmSync(config.dtsDir, { recursive: true, force: true });
       await tscQwik(config);
+    } else if (config.dev && (config.qwik || config.qwikrouter) && !config.watch) {
+      // Dev: incremental dts emit; don't wipe dtsDir (keeps tsbuildinfo).
+      await tscDevDts(config);
     }
     ensureDir(config.distQwikPkgDir);
     if (config.qwik && !config.dev) {
@@ -114,6 +118,9 @@ export async function build(config: BuildConfig) {
     }
     if (config.api || ((!config.dev || config.tsc) && config.qwik)) {
       await apiExtractorQwik(config);
+    } else if (config.dev && config.qwik && !config.watch) {
+      // Dev: re-export shims replace the api-extractor rollup.
+      writeQwikDtsShims(config);
     }
 
     if (config.tsc || (!config.dev && config.qwikrouter)) {
@@ -134,6 +141,9 @@ export async function build(config: BuildConfig) {
 
     if (config.api || ((!config.dev || config.tsc) && config.qwikrouter)) {
       await apiExtractorQwikRouter(config);
+    } else if (config.dev && config.qwikrouter && !config.watch) {
+      // Dev: router shims from the same combined emit.
+      writeQwikRouterDtsShims(config);
     }
 
     if (config.tsc) {

--- a/scripts/dts-shim.ts
+++ b/scripts/dts-shim.ts
@@ -1,0 +1,81 @@
+import { ExtractorConfig } from '@microsoft/api-extractor';
+import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import {
+  generateQwikRouterReferenceModules,
+  generateServerReferenceModules,
+  writeJsxRuntimeDts,
+} from './api.ts';
+import { type BuildConfig } from './util.ts';
+
+// Dev: re-export shims instead of the slow non-incremental api-extractor rollup.
+
+function specifierTo(fromFile: string, targetDts: string) {
+  const rel = relative(dirname(fromFile), targetDts)
+    .replace(/\\/g, '/')
+    .replace(/\.d\.ts$/, '');
+  return rel.startsWith('.') ? rel : `./${rel}`;
+}
+
+function writeShimFor(extractorConfigPath: string): boolean {
+  let cfg: ExtractorConfig;
+  try {
+    cfg = ExtractorConfig.loadFileAndPrepare(extractorConfigPath);
+  } catch {
+    return false;
+  }
+  const entry = cfg.mainEntryPointFilePath;
+  if (!entry || !existsSync(entry)) {
+    return false;
+  }
+  const outputs = [
+    cfg.untrimmedFilePath,
+    cfg.betaTrimmedFilePath,
+    cfg.publicTrimmedFilePath,
+  ].filter((p): p is string => !!p);
+  if (!outputs.length) {
+    return false;
+  }
+  for (const out of outputs) {
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(
+      out,
+      `// dev shim → dts-out (not the api-extractor rollup)\n` +
+        `export * from '${specifierTo(out, entry)}';\n`
+    );
+  }
+  return true;
+}
+
+function findApiExtractorConfigs(dir: string): string[] {
+  const found: string[] = [];
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist' || name === 'lib') {
+      continue;
+    }
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      found.push(...findApiExtractorConfigs(full));
+    } else if (name === 'api-extractor.json') {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+export function writeQwikDtsShims(config: BuildConfig) {
+  const configs = [
+    ...findApiExtractorConfigs(config.srcQwikDir),
+    ...findApiExtractorConfigs(config.qwikVitePkgDir),
+  ];
+  const written = configs.filter(writeShimFor).length;
+  writeJsxRuntimeDts(config);
+  generateServerReferenceModules(config);
+  console.log(`🩹 qwik d.ts shims (dev): ${written} entry points`);
+}
+
+export function writeQwikRouterDtsShims(config: BuildConfig) {
+  const written = findApiExtractorConfigs(config.srcQwikRouterDir).filter(writeShimFor).length;
+  generateQwikRouterReferenceModules(config);
+  console.log(`🩹 qwik-router d.ts shims (dev): ${written} entry points`);
+}

--- a/scripts/tsc.ts
+++ b/scripts/tsc.ts
@@ -18,3 +18,16 @@ export const tscQwikRouter = (config: BuildConfig) =>
   runTsc('qwik-router', join(config.srcQwikRouterDir, '..', 'tsconfig.json'));
 
 export const tsc = (_config: BuildConfig) => runTsc('all');
+
+// tsconfig.dts.json resolves core/router to source so router dts avoids TS5055.
+// Dev type errors only warn — esbuild already built the bundle.
+export const tscDevDts = async (config: BuildConfig) => {
+  console.log('tsc dev (dts)');
+  const result = await execa('tsc', ['-p', join(config.rootDir, 'tsconfig.dts.json')], {
+    stdout: 'inherit',
+    reject: false,
+  });
+  if (result.failed) {
+    console.warn('⚠️  tsc dev reported type errors — .d.ts emitted best-effort (dev)');
+  }
+};

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -1,0 +1,76 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist-dev/tsbuildinfo/dev-dts.tsbuildinfo",
+    "inlineSourceMap": false,
+    "inlineSources": false,
+    "sourceMap": false,
+    "sourceRoot": "",
+    "paths": {
+      "@qwik.dev/core": ["packages/qwik/src/core"],
+      "@qwik.dev/core/internal": ["packages/qwik/src/core"],
+      "@qwik.dev/core/jsx-runtime": ["packages/qwik/src/jsx-runtime"],
+      "@qwik.dev/core/jsx-dev-runtime": ["packages/qwik/src/jsx-runtime"],
+      "@qwik.dev/core/build": ["packages/qwik/src/build"],
+      "@qwik.dev/optimizer": ["packages/optimizer/src"],
+      "@qwik.dev/core/optimizer": ["packages/qwik-vite/src"],
+      "@qwik.dev/core/preloader": ["packages/qwik/src/preloader"],
+      "@qwik.dev/core/server": ["packages/qwik/src/server"],
+      "@qwik.dev/core/testing": ["packages/qwik/src/testing"],
+      "@qwik.dev/core/worker": ["packages/qwik/src/web-worker"],
+      "@qwik.dev/core/devtools": ["packages/qwik/src/devtools"],
+      "@qwik.dev/core/insights": ["packages/qwik/src/insights"],
+      "@qwik.dev/core/insights/vite": ["packages/qwik/src/insights/vite"],
+      "@qwik-client-manifest": ["packages/qwik/src/server/server-modules.d.ts"],
+      "@qwik.dev/router": ["packages/qwik-router/src/runtime/src/index.ts"],
+      "@qwik.dev/router/service-worker": [
+        "packages/qwik-router/src/runtime/src/service-worker/index.ts"
+      ],
+      "@qwik.dev/router/adapters/azure-swa/vite": [
+        "packages/qwik-router/src/adapters/azure-swa/vite/index.ts"
+      ],
+      "@qwik.dev/router/adapters/cloudflare-pages/vite": [
+        "packages/qwik-router/src/adapters/cloudflare-pages/vite/index.ts"
+      ],
+      "@qwik.dev/router/adapters/node-server/vite": [
+        "packages/qwik-router/src/adapters/node-server/vite/index.ts"
+      ],
+      "@qwik.dev/router/adapters/netlify-edge/vite": [
+        "packages/qwik-router/src/adapters/netlify-edge/vite/index.ts"
+      ],
+      "@qwik.dev/router/adapters/shared/vite": [
+        "packages/qwik-router/src/adapters/shared/vite/index.ts"
+      ],
+      "@qwik.dev/router/adapters/ssg/vite": ["packages/qwik-router/src/adapters/ssg/vite/index.ts"],
+      "@qwik.dev/router/middleware/azure-swa": ["packages/qwik-router/src/middleware/azure-swa"],
+      "@qwik.dev/router/middleware/aws-lambda": ["packages/qwik-router/src/middleware/aws-lambda"],
+      "@qwik.dev/router/middleware/cloudflare-pages": [
+        "packages/qwik-router/src/middleware/cloudflare-pages"
+      ],
+      "@qwik.dev/router/middleware/request-handler": [
+        "packages/qwik-router/src/middleware/request-handler"
+      ],
+      "@qwik.dev/router/middleware/node": ["packages/qwik-router/src/middleware/node"],
+      "@qwik.dev/router/middleware/netlify-edge": [
+        "packages/qwik-router/src/middleware/netlify-edge"
+      ],
+      "@qwik.dev/router/ssg": ["packages/qwik-router/src/ssg"],
+      "@qwik.dev/router/vite": ["packages/qwik-router/src/buildtime/vite"],
+      "@qwik-router-config": ["packages/qwik-router/src/runtime/src/qwik-router-config.ts"],
+      "@qwik-router-sw-register-build": [
+        "packages/qwik-router/src/buildtime/runtime-generation/sw-register-build.ts"
+      ],
+      "@qwik-router-sw-register": ["packages/qwik-router/src/runtime/src/sw-register-runtime.ts"]
+    }
+  },
+  "include": [
+    "packages/qwik/src",
+    "packages/qwik/global.d.ts",
+    "packages/qwik-vite/global.d.ts",
+    "packages/qwik-router/src",
+    "packages/qwik-router/global.d.ts"
+  ],
+  "exclude": ["**/dist", "**/lib", "node_modules"]
+}


### PR DESCRIPTION
# What is it?
- Infra

# Description


`build.core.dev` did zero declaration work, so editing a public signature left stale `.d.ts` until a full `build.core`, meaning slower iterations cycles.

<img width="2342" height="286" alt="image" src="https://github.com/user-attachments/assets/94953d18-58be-4abb-8873-c74f10b8ca1c" />

> For context, the alternative to get the same fresh types is build.core at ~77s — so the dev loop is ~15× faster and now correct.

It now re-emits fresh Qwik **and Router** types incrementally — a single `emitDeclarationOnly` tsc over both packages (with core/router resolved to source) — and writes one-line re-export shims pointing at the per-file `dts-out`, instead of the slow, non-incremental api-extractor rollup.

A few seconds warm (~5s, ~6.6s after a router edit) vs ~75s for a full `build.core`. `build.watch` is untouched (stays esbuild-only), and prod `build.core` is unchanged — it overwrites the shims with the real rollups.