### PR TITLE
test(qwik-e2e): assert non-asserting e2e checks

### DIFF
--- a/e2e/qwik-e2e/tests/sync-qrl.e2e.ts
+++ b/e2e/qwik-e2e/tests/sync-qrl.e2e.ts
@@ -24,6 +24,6 @@ test.describe('resuming', () => {
     // clicking checkbox does not toggles the checked state, because default is prevented.
     await input.click();
     await expect(input).toBeChecked();
-    await expect(await input.getAttribute('prevented')).toBeDefined();
+    await expect(input).toHaveAttribute('prevented', 'true');
   });
 });

--- a/e2e/qwik-e2e/tests/use-id.e2e.ts
+++ b/e2e/qwik-e2e/tests/use-id.e2e.ts
@@ -15,7 +15,7 @@ test.describe('use-id', () => {
 
   test('Creates unique ids and ensure no collisions', async ({ page }) => {
     const totalIdsLocator = page.locator('#totalIds');
-    await totalIdsLocator.isVisible();
+    await expect(totalIdsLocator).toBeVisible();
     const totalIdsText = await totalIdsLocator.textContent();
     const totalIds = parseInt(totalIdsText || '-1');
     await expect(totalIds).toBeGreaterThan(0); // MAKE SURE WE HAVE SOME IDS


### PR DESCRIPTION
# What is it?

- Docs / tests / types / typos

# Description

Two e2e checks in the qwik-e2e suite silently always pass, so they cannot catch a regression:

- sync-qrl.e2e.ts asserted expect(await input.getAttribute('prevented')).toBeDefined().
  getAttribute returns string | null and both pass toBeDefined(), so the check never fails.
  The sync-qrl app sets the attribute to String(e.defaultPrevented), and the test intent is to
  confirm the default was prevented, so this now asserts toHaveAttribute('prevented', 'true').
- use-id.e2e.ts called await totalIdsLocator.isVisible() and discarded the boolean, asserting
  nothing. Replaced with the web-first await expect(totalIdsLocator).toBeVisible().

Both edits strengthen existing checks without changing test names or behavior. Test-only change,
no published package touched, so no changeset is needed.

This re-targets QwikDev/qwik#8727 onto build/v2 at wmertens' request: that PR was approved on main
but closed because development is focused on build/v2 and merging would conflict. The same
anti-patterns are present in the restructured v2 suite, so the fix is reproduced here.

# Testing

Verified statically: the new assertions use Playwright matchers valid for this suite, and the
sync-qrl change matches the app component that sets the attribute to String(e.defaultPrevented).
The e2e specs were not run locally, since the run needs pnpm install plus a core build and a
browser download. This is disclosed rather than claimed.

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
