### PR TITLE
fix(router): handle action redirects that don't use RedirectMessage

### DIFF
--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/returned-control-flow/action-redirect-discarded/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/returned-control-flow/action-redirect-discarded/index.tsx
@@ -1,0 +1,16 @@
+import { component$ } from '@qwik.dev/core';
+import { Form, routeAction$ } from '@qwik.dev/router';
+
+// Calls redirect() but neither throws nor returns the signal.
+export const useRedirectAction = routeAction$((_data, { redirect }) => {
+  redirect(302, '/qwikrouter-test/returned-control-flow/target/');
+});
+
+export default component$(() => {
+  const action = useRedirectAction();
+  return (
+    <Form action={action}>
+      <button type="submit">Submit</button>
+    </Form>
+  );
+});

--- a/e2e/qwik-e2e/tests/qwikrouter/returned-control-flow.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/returned-control-flow.e2e.ts
@@ -46,4 +46,16 @@ test.describe('returned control-flow signals', () => {
     // The client then navigates to the redirect target.
     await expect(page.locator('#returned-control-flow-target')).toBeVisible();
   });
+
+  test('JSON action redirect works even when the signal is neither thrown nor returned', async ({
+    page,
+  }) => {
+    await page.goto(`${base}/action-redirect-discarded/`);
+    const [response] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('qaction=')),
+      page.locator('button[type="submit"]').click(),
+    ]);
+    expect(response.headers()['location']).toBeUndefined();
+    await expect(page.locator('#returned-control-flow-target')).toBeVisible();
+  });
 });

--- a/packages/qwik-router/src/middleware/request-handler/handlers/action-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/action-handler.ts
@@ -7,6 +7,7 @@ import type {
   RequestHandler,
   ValidatorReturn,
 } from '../../../runtime/src/types';
+import { RedirectMessage } from '../redirect-handler';
 import { RequestEvSharedActionId, type RequestEventInternal } from '../request-event-core';
 import { IsQAction, QActionId } from '../request-path';
 import { throwIfControlFlowSignal } from '../server-error';
@@ -98,6 +99,10 @@ export function actionHandler(routeActions: ActionInternal[]): RequestHandler {
         verifySerializable(actionResolved, action.__qrl);
       }
       actionResult = actionResolved;
+    }
+    // The action resulted in a redirect, throw a RedirectMessage to let the redirect handler handle it.
+    if (requestEv.headers.has('Location')) {
+      throw new RedirectMessage();
     }
     const responseData: Record<string, unknown> = {
       result: actionResult,


### PR DESCRIPTION
This fixes @auth/qwik which can redirect the response without using RedirectMessage
