### PR TITLE
feat(cli): handle nub package manager commands

### DIFF
--- a/packages/qwik/src/cli/utils/install-deps.ts
+++ b/packages/qwik/src/cli/utils/install-deps.ts
@@ -10,7 +10,7 @@ export function installDeps(pkgManager: string, dir: string) {
 }
 
 export function runInPkg(pkgManager: string, args: string[], cwd: string) {
-  const cmd = pkgManager === 'npm' ? 'npx' : pkgManager;
+  const cmd = pkgManager === 'npm' ? 'npx' : pkgManager === 'nub' ? 'nubx' : pkgManager;
   return runCommand(cmd, args, cwd);
 }
 

--- a/packages/qwik/src/cli/utils/utils.ts
+++ b/packages/qwik/src/cli/utils/utils.ts
@@ -122,10 +122,11 @@ export function getPackageManager() {
 
 export function pmRunCmd() {
   const pm = getPackageManager();
-  if (pm !== 'npm') {
-    return pm;
+  // npm and nub have no implicit script shortcut, so scripts run via `<pm> run`.
+  if (pm === 'npm' || pm === 'nub') {
+    return `${pm} run`;
   }
-  return `${pm} run`;
+  return pm;
 }
 
 export function panic(msg: string) {


### PR DESCRIPTION
The Qwik CLI already detects nub — `getPackageManager()` passes through the `which-pm-runs` name — but two command builders assume every non-npm manager accepts a bare `<pm> <script>`. That doesn't hold for [nub](https://nubjs.com): it has no implicit script shortcut, so `nub dev` is not valid; scripts run via `nub run dev`. Its executor is `nubx`, not a bare `nub <bin>`.

This routes nub through the `run`-prefixed form in `pmRunCmd()` (alongside npm) and maps it to `nubx` in `runInPkg()`. Install is unaffected — `installDeps` already spawns `<pm> install`.
