### PR TITLE
test(qwik): fix stop-propagation in the events e2e fixture and pin deferred-handler loader behavior

### DIFF
--- a/e2e/qwik-e2e/apps/e2e/src/components/events/events.tsx
+++ b/e2e/qwik-e2e/apps/e2e/src/components/events/events.tsx
@@ -73,9 +73,9 @@ const EventsParent = component$(() => {
           <a
             href="/"
             preventdefault:click
+            stoppropagation:click
             id="prevent-default-2"
-            onClick$={(ev) => {
-              ev.stopPropagation();
+            onClick$={() => {
               store.countAnchor++;
             }}
           >

--- a/packages/qwik/src/qwikloader.behavior.unit.ts
+++ b/packages/qwik/src/qwikloader.behavior.unit.ts
@@ -303,6 +303,54 @@ describe('qwikloader behavior', () => {
     expect(logs).toEqual(['child bubble']);
   });
 
+  const stopLogHandlerQrl = (label: string) =>
+    `data:text/javascript;charset=utf-8,${encodeURIComponent(
+      `export const handler = () => globalThis.__qwikLoaderStopLogs.push(${JSON.stringify(label)});`
+    )}#handler#`;
+
+  test('a deferred (importing) handler that does not stop still runs the deferred ancestor', async () => {
+    const { doc } = createLoaderEnvironment(['e:click']);
+    const logs: string[] = [];
+    const previousLogs = (globalThis as any).__qwikLoaderStopLogs;
+    const container = createMockElement(null, { 'q:container': 'resumed', 'q:base': './' });
+    const parent = createMockElement(container, {
+      'q-e:click': stopLogHandlerQrl('parent bubble'),
+    });
+    const child = createMockElement(parent, { 'q-e:click': stopLogHandlerQrl('child run') });
+
+    (globalThis as any).__qwikLoaderStopLogs = logs;
+    try {
+      getSingleListener(doc, 'click').handler(createMockEvent(child));
+      await vi.waitFor(() => {
+        expect(logs).toEqual(['child run', 'parent bubble']);
+      });
+    } finally {
+      (globalThis as any).__qwikLoaderStopLogs = previousLogs;
+    }
+  });
+
+  test('a deferred (importing) capture handler that does not stop still runs the later deferred bubble handler', async () => {
+    const { doc } = createLoaderEnvironment(['e:click']);
+    const logs: string[] = [];
+    const previousLogs = (globalThis as any).__qwikLoaderStopLogs;
+    const container = createMockElement(null, { 'q:container': 'resumed', 'q:base': './' });
+    const capturer = createMockElement(container, {
+      'capture:click': true,
+      'q-e:click': stopLogHandlerQrl('capturer capture'),
+    });
+    const target = createMockElement(capturer, { 'q-e:click': stopLogHandlerQrl('target bubble') });
+
+    (globalThis as any).__qwikLoaderStopLogs = logs;
+    try {
+      getSingleListener(doc, 'click').handler(createMockEvent(target));
+      await vi.waitFor(() => {
+        expect(logs).toEqual(['capturer capture', 'target bubble']);
+      });
+    } finally {
+      (globalThis as any).__qwikLoaderStopLogs = previousLogs;
+    }
+  });
+
   test('applies parent preventdefault synchronously before async child bubbling completes', async () => {
     const { doc } = createLoaderEnvironment(['e:click']);
     const logs: string[] = [];


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
The events e2e fixture used `ev.stopPropagation()` inside an async `onClick$`, which Qwik doesn't support (it lands after the synchronous event-path walk) — it now uses the `stoppropagation:click` attribute. Also pins the stock loader behavior for deferred handlers with two regression tests. Found while working on #8745.