### PR TITLE
fix(router): await server$ stream close so a client disconnect can't crash Bun

### DIFF
--- a/.changeset/server-fn-stream-close-bun.md
+++ b/.changeset/server-fn-stream-close-bun.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: streaming server$ no longer crashes the Bun server on client disconnect

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -554,20 +554,7 @@ function createResolveRequestHandlers() {
       }
       throwIfControlFlowSignal(result);
       if (isAsyncIterator(result)) {
-        ev.headers.set('Content-Type', 'text/qwik-json-stream');
-        const writable = ev.getWritableStream();
-        const stream = writable.getWriter();
-        for await (const item of result) {
-          if (isDev) {
-            verifySerializable(item, qrl);
-          }
-          const message = await _serialize(item);
-          if (ev.signal.aborted) {
-            break;
-          }
-          await stream.write(encoder.encode(`${message}\n`));
-        }
-        stream.close();
+        await streamServerFunctionResult(ev, result, qrl);
       } else {
         verifySerializable(result, qrl);
         ev.headers.set('Content-Type', 'application/qwik-json');
@@ -576,6 +563,31 @@ function createResolveRequestHandlers() {
       }
       return;
     }
+  }
+
+  // Streams an async-iterator server function result to the response writable. A mid-stream
+  // client disconnect errors the writable, so write/close reject; dropping those rejections
+  // makes them unhandled, which aborts the process on Bun (Node only warns).
+  async function streamServerFunctionResult(
+    ev: RequestEvent,
+    result: AsyncIterable<unknown>,
+    qrl: QRL
+  ) {
+    ev.headers.set('Content-Type', 'text/qwik-json-stream');
+    const writable = ev.getWritableStream();
+    const stream = writable.getWriter();
+    for await (const item of result) {
+      if (isDev) {
+        verifySerializable(item, qrl);
+      }
+      const message = await _serialize(item);
+      if (ev.signal.aborted) {
+        break;
+      }
+      // Swallow rejection: writable may be errored by a client disconnect.
+      await stream.write(encoder.encode(`${message}\n`)).catch(() => {});
+    }
+    await stream.close().catch(() => {});
   }
 
   function fixTrailingSlash(ev: RequestEvent) {
@@ -798,6 +810,7 @@ The request origin "${inputOrigin}" does not match the server origin "${origin}"
     measure,
     renderQwikMiddleware,
     resolveRequestHandlers,
+    streamServerFunctionResult,
     verifySerializable,
   };
 }
@@ -814,5 +827,6 @@ export const {
   measure,
   renderQwikMiddleware,
   resolveRequestHandlers,
+  streamServerFunctionResult,
   verifySerializable,
 } = createResolveRequestHandlers();

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -565,9 +565,6 @@ function createResolveRequestHandlers() {
     }
   }
 
-  // Streams an async-iterator server function result to the response writable. A mid-stream
-  // client disconnect errors the writable, so write/close reject; dropping those rejections
-  // makes them unhandled, which aborts the process on Bun (Node only warns).
   async function streamServerFunctionResult(
     ev: RequestEvent,
     result: AsyncIterable<unknown>,
@@ -585,9 +582,17 @@ function createResolveRequestHandlers() {
         break;
       }
       // Swallow rejection: writable may be errored by a client disconnect.
-      await stream.write(encoder.encode(`${message}\n`)).catch(() => {});
+      await stream.write(encoder.encode(`${message}\n`)).catch((err) => {
+        if (isDev) {
+          console.error(`Server function ${qrl.getSymbol()} stream write failed:`, err);
+        }
+      });
     }
-    await stream.close().catch(() => {});
+    await stream.close().catch((err) => {
+      if (isDev) {
+        console.error(`Server function ${qrl.getSymbol()} stream close failed:`, err);
+      }
+    });
   }
 
   function fixTrailingSlash(ev: RequestEvent) {

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
@@ -412,12 +412,13 @@ describe('resolve-request-handler', () => {
     }
 
     it('does not leak an unhandled rejection when close() rejects on a disconnected client', async () => {
+      const fakeQrl = { getHash: () => 'streamServerFn', getSymbol: () => 'streamServerFn' } as any;
       const rejections: unknown[] = [];
       const onUnhandled = (reason: unknown) => rejections.push(reason);
       process.on('unhandledRejection', onUnhandled);
       try {
         const ev = makeStreamingEvent(makeDisconnectedWritable());
-        await streamServerFunctionResult(ev, twoItems(), null as any);
+        await streamServerFunctionResult(ev, twoItems(), fakeQrl);
         // Let a macrotask elapse so a dropped rejection surfaces before we assert.
         await new Promise((resolve) => setTimeout(resolve, 10));
       } finally {

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
@@ -3,12 +3,13 @@ import {
   getPathname,
   fixTrailingSlash,
   resolveRequestHandlers,
+  streamServerFunctionResult,
 } from './resolve-request-handlers-core';
 import { RequestEvHttpStatusMessage, RequestEvSharedActionId } from './request-event-core';
 import { createRequestEvent } from './request-event-core';
 import { RedirectMessage } from './redirect-handler';
 import { isContentType } from './request-utils';
-import type { ServerRequestEvent } from './types';
+import type { RequestEvent, ServerRequestEvent } from './types';
 import { checkCSRF } from './resolve-request-handlers-core';
 import type { LoadedRoute, RouteModule } from '../../runtime/src/types';
 import { ServerError } from '@qwik.dev/router/middleware/request-handler';
@@ -383,6 +384,46 @@ describe('resolve-request-handler', () => {
 
       await expect(requestEv.resolveValue(actionA as any)).resolves.toBeUndefined();
       await expect(requestEv.resolveValue(actionB as any)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('streamServerFunctionResult', () => {
+    // A writable in the post-disconnect state: write/close reject (as Bun's does).
+    function makeDisconnectedWritable(): WritableStream<Uint8Array> {
+      return new WritableStream<Uint8Array>({
+        write() {},
+        close() {
+          throw new Error('Cannot close a writable stream that is closed or errored');
+        },
+      });
+    }
+
+    function makeStreamingEvent(writable: WritableStream<Uint8Array>): RequestEvent {
+      return {
+        headers: new Headers(),
+        getWritableStream: () => writable,
+        signal: new AbortController().signal,
+      } as unknown as RequestEvent;
+    }
+
+    async function* twoItems(): AsyncGenerator<{ n: number }> {
+      yield { n: 0 };
+      yield { n: 1 };
+    }
+
+    it('does not leak an unhandled rejection when close() rejects on a disconnected client', async () => {
+      const rejections: unknown[] = [];
+      const onUnhandled = (reason: unknown) => rejections.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        const ev = makeStreamingEvent(makeDisconnectedWritable());
+        await streamServerFunctionResult(ev, twoItems(), null as any);
+        // Let a macrotask elapse so a dropped rejection surfaces before we assert.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+      expect(rejections).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## What is it?

- Bug

## Description
A streaming `server$` (an `async function*` consumed as a stream) crashes the
**entire Bun process** when the client disconnects mid-stream (SPA navigation
away, tab close, refresh, network drop).

When the client goes away, the response writable is errored, so `write`/`close`
reject. The async-iterator branch of `runServerFunction` called `stream.close()`
**without awaiting or catching it**, so the rejection went unhandled. On Bun the
default `unhandledRejection` behavior is to abort the process (Node only logs a
warning, which is why this stayed hidden there). After the crash every following
request fails with `ECONNREFUSED` — the server is gone.

The fix extracts the streaming branch into `streamServerFunctionResult` and
`await`s + swallows both the per-item `write` and the final `close`, so a
disconnected writable tears down quietly instead of leaking a rejection.

**Reproduction:** a streaming `server$` on the Bun adapter — open the stream,
read one chunk, then abort the request while it is still producing; the process
exits.

**Related:** #5929 (fixed the `TextEncoderStream` polyfill, not this close),
#4381 (Node `ERR_STREAM_DESTROYED` on the same class of teardown),
oven-sh/bun#18228 (Bun's stance: the framework must catch the close).

Test drives `streamServerFunctionResult` with a writable whose `close()` rejects (the
post-disconnect state) and asserts no unhandled rejection escapes. It is red
without the fix (leaks `Cannot close a writable stream that is closed or
errored`) and green with it. The process-abort half is Bun-specific and can't be
reproduced under Node, but the leaked-rejection root cause is covered here.

## Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I added new tests to cover the fix / functionality
