### PR TITLE
fix: resume multiple SSR containers on the same page

### DIFF
--- a/.changeset/multi-container-vnode-resume.md
+++ b/.changeset/multi-container-vnode-resume.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: resume multiple SSR containers on the same page

--- a/packages/qwik/src/core/client/dom-container.ts
+++ b/packages/qwik/src/core/client/dom-container.ts
@@ -157,7 +157,7 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
     element.qContainer = this;
     element.qDestroy = () => this.$destroy$();
     this.$containerDataProcessState$ = ContainerDataProcessState.ProcessingVNode;
-    processVNodeData(document);
+    processVNodeData(document, element);
     onVNodeDataReady(document, () => {
       if (this.$containerDataProcessState$ === ContainerDataProcessState.ProcessingVNode) {
         processContainerStateData(this, this.$processContainerData$());

--- a/packages/qwik/src/core/client/process-vnode-data.ts
+++ b/packages/qwik/src/core/client/process-vnode-data.ts
@@ -75,9 +75,14 @@ interface ProcessVNodeDataState {
  * - Attach all `qwik/vnode` scripts (not the data contain within them) to the `q:container` element.
  * - Walk the tree and process each `q:container` element.
  */
-export function processVNodeData(document: Document): void {
+export function processVNodeData(document: Document, containerElement?: ContainerElement): void {
   const qDocument = document as QDocument;
-  if (qDocument.qVNodeDataStarted || qDocument.qVNodeDataProcessed) {
+  // Per-container gate: a walk already populated this container's refs → done.
+  if (containerElement?.qVNodeRefs) {
+    return;
+  }
+  // A document-wide walk is in flight; it will pick up this newly-added container too.
+  if (qDocument.qVNodeDataStarted && !qDocument.qVNodeDataProcessed) {
     return;
   }
   qDocument.qVNodeDataStarted = true;
@@ -215,7 +220,10 @@ function markVNodeDataReady(document: QDocument): void {
 
 function* processRootVNodeData(document: Document): Generator<void, void, void> {
   yield* processVNodeDataImpl(document);
-  (document as QDocument).qVNodeDataProcessed = true;
+  const qDocument = document as QDocument;
+  qDocument.qVNodeDataProcessed = true;
+  // Re-open the gate so a container added after this drain re-runs a walk.
+  qDocument.qVNodeDataStarted = false;
 }
 
 function* processOutOfOrderSegmentVNodeDataIterator(

--- a/packages/qwik/src/core/tests/multi-container-resume.spec.tsx
+++ b/packages/qwik/src/core/tests/multi-container-resume.spec.tsx
@@ -1,0 +1,73 @@
+import {
+  component$,
+  getDomContainer,
+  getPlatform,
+  setPlatform,
+  useSignal,
+  type JSXOutput,
+} from '@qwik.dev/core';
+import { renderToString } from '@qwik.dev/core/server';
+import {
+  createDocument,
+  emulateExecutionOfQwikFuncs,
+  getTestPlatform,
+  trigger,
+} from '@qwik.dev/core/testing';
+import { describe, expect, it } from 'vitest';
+import { whenContainerDataReady } from '../client/dom-container';
+import type { _ContainerElement } from '../internal';
+import { QContainerSelector } from '../shared/utils/markers';
+
+const renderToStringAndSetPlatform = async (jsx: JSXOutput) => {
+  const platform = getPlatform();
+  try {
+    return await renderToString(jsx, { qwikLoader: 'never', containerTagName: 'div' });
+  } finally {
+    setPlatform(platform);
+  }
+};
+
+describe('multiple SSR containers resumed on one page', () => {
+  it('resumes container B after A is already resumed', async () => {
+    setPlatform(getTestPlatform());
+
+    const Counter = component$((props: { testId: string }) => {
+      const count = useSignal(0);
+      return (
+        <button data-testid={props.testId} onClick$={() => count.value++}>
+          Count: {count.value}!
+        </button>
+      );
+    });
+
+    // 1. Render + resume container A in its own document.
+    const aResult = await renderToStringAndSetPlatform(<Counter testId="a" />);
+    const document = createDocument({ html: aResult.html });
+    emulateExecutionOfQwikFuncs(document);
+    const aElement = document.querySelector(QContainerSelector) as _ContainerElement;
+    const aContainer = getDomContainer(aElement);
+    await whenContainerDataReady(aContainer, () => undefined);
+
+    // 2. Render container B separately, then inject it into the SAME document AFTER A resumed.
+    const bResult = await renderToStringAndSetPlatform(<Counter testId="b" />);
+    const bDocument = createDocument({ html: bResult.html });
+    const bElement = bDocument.querySelector(QContainerSelector) as _ContainerElement;
+    document.body.appendChild(document.importNode(bElement, true));
+
+    // 3. Resume container B (its qfuncs + real DomContainer + processVNodeData).
+    emulateExecutionOfQwikFuncs(document);
+    const bElementInDoc = document.body
+      .querySelector(`${QContainerSelector} [data-testid="b"]`)!
+      .parentElement!.closest(QContainerSelector) as _ContainerElement;
+    const bContainer = getDomContainer(bElementInDoc);
+    await whenContainerDataReady(bContainer, () => undefined);
+
+    // 4. Interact with B — forces vnode_locate into B (throws "Missing qVNodeRefs" on the bug).
+    await trigger(bContainer.element, '[data-testid="b"]', 'click');
+    expect(document.querySelector('[data-testid="b"]')!.textContent).toBe('Count: 1!');
+
+    // A must still be live.
+    await trigger(aContainer.element, '[data-testid="a"]', 'click');
+    expect(document.querySelector('[data-testid="a"]')!.textContent).toBe('Count: 1!');
+  });
+});


### PR DESCRIPTION
# What is it?
- Bug

# Description

Needed for vitest-browser-qwik to work in the monorepo.

A second SSR container resumed on the same page threw "Missing qVNodeRefs" on first interaction. The perf "yield startup DOM processing during resume" change made `processVNodeData` a document-global one-shot (`qVNodeDataStarted`), so a container added after the first one resumed never had its vnode data walked. Gated the walk per-container instead and reopen it after each drain. Includes a pure-node regression test.
