### PR TITLE
refactor(devtools): share the page data source contract between ui and extension

### DIFF
--- a/.changeset/shared-page-data-source.md
+++ b/.changeset/shared-page-data-source.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/devtools': patch
+---
+
+refactor: share the page data source contract between the ui and extension

--- a/packages/browser-extension/src/shared/extension-data-provider.ts
+++ b/packages/browser-extension/src/shared/extension-data-provider.ts
@@ -1,5 +1,6 @@
 import type {
   Component,
+  PageDataSource,
   QwikDevtoolsComponentSnapshot,
   QwikDevtoolsSignalsSnapshot,
   QwikPerfStoreRemembered,
@@ -172,7 +173,7 @@ export function createExtensionDataProvider() {
   };
 }
 
-export function createRemotePageDataSource() {
+export function createRemotePageDataSource(): PageDataSource {
   return {
     async readPerfData(): Promise<QwikPerfStoreRemembered | null> {
       return readJsonFromPage<QwikPerfStoreRemembered>(`${PAGE_DEVTOOLS_PERF} ?? null`);

--- a/packages/devtools/kit/src/client-bridge.ts
+++ b/packages/devtools/kit/src/client-bridge.ts
@@ -38,6 +38,38 @@ export interface InPageBridge {
   subscribeRenderEvents(cb: (event: DevtoolsRenderEvent) => void): (() => void) | null;
 }
 
+/**
+ * Page-level data access contract shared by the in-app overlay (same window) and the browser
+ * extension panel (reads the inspected page via chrome.devtools eval). Both implementations depend
+ * on this shape so a change to one side is type-checked against the other.
+ */
+export interface PageDataSource {
+  readPerfData(): Promise<QwikPerfStoreRemembered | null>;
+  readPreloadStore(): Promise<QwikPreloadStoreRemembered | null>;
+  clearPreloadStore(): Promise<void>;
+  /** Returns an unsubscribe fn, or null when live subscriptions are unsupported (extension polls). */
+  subscribePreloadUpdates(cb: () => void): (() => void) | null;
+  readComponentTree(): Promise<QwikDevtoolsComponentSnapshot[] | null>;
+  readSignals(): Promise<QwikDevtoolsSignalsSnapshot | null>;
+  readVNodeTree(): Promise<DevtoolsVNodeTreeNode[] | null>;
+  subscribeTreeUpdates(cb: (tree: DevtoolsVNodeTreeNode[]) => void): (() => void) | null;
+  readComponentDetail(
+    componentName: string,
+    qrlChunk?: string
+  ): Promise<DevtoolsComponentDetailEntry[] | null>;
+  readNodeProps(nodeId: string): Promise<Record<string, unknown> | null>;
+  setSignalValue(
+    componentName: string,
+    qrlChunk: string | undefined,
+    variableName: string,
+    newValue: unknown
+  ): Promise<boolean>;
+  /** Highlight a component's DOM element on the page by its VNode tree node id. */
+  highlightElement(nodeId: string, componentName: string): Promise<void>;
+  unhighlightElement(): Promise<void>;
+  subscribeRenderEvents(cb: (event: DevtoolsRenderEvent) => void): (() => void) | null;
+}
+
 interface QwikDevtoolsHookExtended extends QwikDevtoolsHook {
   getVNodeTree?(): DevtoolsVNodeTreeNode[] | null;
   getNodeProps?(nodeId: string): Record<string, unknown> | null;

--- a/packages/devtools/ui/src/devtools/page-data-source.ts
+++ b/packages/devtools/ui/src/devtools/page-data-source.ts
@@ -2,6 +2,7 @@ import {
   createInPageBridge,
   getQwikDevtoolsGlobal,
   QWIK_DEVTOOLS_GLOBAL,
+  type PageDataSource,
   type QwikPerfStoreRemembered,
   type QwikPreloadStoreRemembered,
   type QwikDevtoolsComponentSnapshot,
@@ -12,78 +13,10 @@ import {
 } from '@qwik.dev/devtools/kit';
 import { isBrowser } from '@qwik.dev/core';
 
-// The VNode/detail/render shapes are the shared data contract, owned by @qwik.dev/devtools/kit.
-// Re-export under the local names so feature components keep one import source and cannot drift.
-export type { VNodeTreeNode, ComponentDetailEntry, RenderEvent };
-
-/**
- * Abstraction for accessing page-level data from different contexts.
- *
- * - In the overlay, data lives on the same `window` (direct access).
- * - In the browser extension panel, data must be read from the inspected page via
- *   `chrome.devtools.inspectedWindow.eval()`.
- *
- * Components use {@link getPageDataSource} to obtain the active source, which returns
- * {@link InPageDataSource} by default (overlay mode). The extension entry point replaces it via
- * `window.__QWIK_DEVTOOLS__.pageDataSource`.
- */
-export interface PageDataSource {
-  /** Read the performance store snapshot. */
-  readPerfData(): Promise<QwikPerfStoreRemembered | null>;
-
-  /** Read the preload store snapshot. */
-  readPreloadStore(): Promise<QwikPreloadStoreRemembered | null>;
-
-  /** Clear the preload store on the page. */
-  clearPreloadStore(): Promise<void>;
-
-  /**
-   * Subscribe to preload store updates. Returns an unsubscribe function, or `null` if live
-   * subscriptions are not supported (e.g. extension mode uses polling instead).
-   */
-  subscribePreloadUpdates(cb: () => void): (() => void) | null;
-
-  /** Read the component tree from the devtools hook. */
-  readComponentTree(): Promise<QwikDevtoolsComponentSnapshot[] | null>;
-
-  /** Read signal values from the devtools hook. */
-  readSignals(): Promise<QwikDevtoolsSignalsSnapshot | null>;
-
-  /** Read the VNode component tree from the devtools hook. */
-  readVNodeTree(): Promise<VNodeTreeNode[] | null>;
-
-  /**
-   * Subscribe to real-time VNode tree updates pushed by the page. Returns an unsubscribe function,
-   * or `null` if not supported.
-   */
-  subscribeTreeUpdates(cb: (tree: VNodeTreeNode[]) => void): (() => void) | null;
-
-  /** Read detailed hook data for a specific component (deeply serialized). */
-  readComponentDetail(
-    componentName: string,
-    qrlChunk?: string
-  ): Promise<ComponentDetailEntry[] | null>;
-
-  /** Read VNode props for a specific tree node by ID. */
-  readNodeProps(nodeId: string): Promise<Record<string, unknown> | null>;
-
-  /** Set a signal value on a component. Returns true on success. */
-  setSignalValue(
-    componentName: string,
-    qrlChunk: string | undefined,
-    variableName: string,
-    newValue: unknown
-  ): Promise<boolean>;
-
-  /** Highlight a component's DOM element on the page using its VNode tree node ID. */
-  highlightElement(nodeId: string, componentName: string): Promise<void>;
-
-  /** Remove the highlight overlay from the page. */
-  unhighlightElement(): Promise<void>;
-
-  /** Subscribe to live render events (CSR component renders with timing). */
-  subscribeRenderEvents(cb: (event: RenderEvent) => void): (() => void) | null;
-}
+// The VNode/detail/render shapes and the PageDataSource contract are owned by
+// @qwik.dev/devtools/kit. Re-export under the local names so feature components keep one import
+// source and cannot drift.
+export type { PageDataSource, VNodeTreeNode, ComponentDetailEntry, RenderEvent };
 
 /**
  * Default implementation that reads directly from `window` globals. Used when the devtools UI runs


### PR DESCRIPTION
## Problem

The browser extension's `createRemotePageDataSource()` in `extension-data-provider.ts` structurally mirrored the `PageDataSource` interface declared in `packages/devtools/ui/src/devtools/page-data-source.ts`, without depending on it. A change to the UI data-source contract would not be caught against the extension implementation.

## Solution

Make `PageDataSource` a single shared contract.

- Move the `PageDataSource` interface into `@qwik.dev/devtools/kit` (next to the related `InPageBridge`). All of its member types already live in kit, so no new imports are needed.
- The UI overlay source imports `PageDataSource` from kit (and re-exports it under the same name), and `InPageDataSource` keeps implementing it.
- The extension annotates `createRemotePageDataSource(): PageDataSource`, so TypeScript now checks the remote implementation against the shared contract.

## Verification

- kit builds and exports `PageDataSource`.
- `tsc` on the browser extension passes (only two pre-existing wxt `TS2742` errors remain, unrelated to this change), confirming the remote data source satisfies the contract.
- `tsc` on the devtools UI passes with zero errors.
- eslint passes on the touched files.

## References

QwikDev project board, card "p2 Page Data Source Shape Duplication": https://github.com/orgs/QwikDev/projects/6/views/1