### PR TITLE
fix: loading route loaders for dev server

### DIFF
--- a/.changeset/tidy-candles-guess.md
+++ b/.changeset/tidy-candles-guess.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: ensure dev SPA navigation loads route loader data correctly for catch-all and base-prefixed routes

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/q-loader-shared-map/[...slug]/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/q-loader-shared-map/[...slug]/index.tsx
@@ -1,0 +1,36 @@
+import { component$ } from '@qwik.dev/core';
+import { Link, routeLoader$ } from '@qwik.dev/router';
+import { IMPORTED_LOADER_SHARED_KEY } from '../../../loaders-serialization/shared-map';
+
+export const useQLoaderSharedMap = routeLoader$(
+  ({ params, sharedMap, url }) => {
+    const shared = sharedMap.get(IMPORTED_LOADER_SHARED_KEY) as { value: string } | undefined;
+
+    return {
+      pathname: url.pathname,
+      slug: params.slug,
+      value: shared?.value ?? 'missing',
+    };
+  },
+  { serializationStrategy: 'always' }
+);
+
+export default component$(() => {
+  const data = useQLoaderSharedMap();
+
+  return (
+    <section>
+      <h1>Q Loader Shared Map</h1>
+      <p id="q-loader-shared-map-value">{data.value.value}</p>
+      <p id="q-loader-shared-map-pathname">{data.value.pathname}</p>
+      <p id="q-loader-shared-map-slug">{data.value.slug}</p>
+      <Link
+        href="/qwikrouter-test/q-loader-shared-map/two/nested/"
+        id="q-loader-shared-map-link-two"
+        prefetchData="off"
+      >
+        Two Nested
+      </Link>
+    </section>
+  );
+});

--- a/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
@@ -10,6 +10,31 @@ test.describe('loaders', () => {
     test.use({ javaScriptEnabled: true });
     tests();
 
+    test('catch-all q-loader requests run server plugins before route loaders', async ({
+      page,
+    }) => {
+      await page.goto('/qwikrouter-test/q-loader-shared-map/one/');
+
+      await expect(page.locator('#q-loader-shared-map-value')).toHaveText('shared loader value');
+      await expect(page.locator('#q-loader-shared-map-slug')).toHaveText('one');
+
+      const qLoaderResponse = page.waitForResponse((response) => {
+        const url = response.url();
+        return (
+          url.includes('/qwikrouter-test/q-loader-shared-map/') &&
+          url.includes('/q-loader-') &&
+          url.endsWith('.json')
+        );
+      });
+
+      await page.locator('#q-loader-shared-map-link-two').click();
+      expect((await qLoaderResponse).ok()).toBe(true);
+
+      await expect(page).toHaveURL('/qwikrouter-test/q-loader-shared-map/two/nested/');
+      await expect(page.locator('#q-loader-shared-map-value')).toHaveText('shared loader value');
+      await expect(page.locator('#q-loader-shared-map-slug')).toHaveText('two/nested');
+    });
+
     test('should reuse filtered search loaders only for the same SPA route path', async ({
       page,
     }) => {

--- a/packages/qwik-router/src/buildtime/vite/dev-middleware.spec.ts
+++ b/packages/qwik-router/src/buildtime/vite/dev-middleware.spec.ts
@@ -1,8 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ViteDevServer } from 'vite';
-import { sendRouterCssHotUpdate } from './dev-middleware';
+import { getDevMiddlewareRequestPath, sendRouterCssHotUpdate } from './dev-middleware';
 
 const file = '/app/src/routes/docs/docs.css';
+
+describe('getDevMiddlewareRequestPath', () => {
+  it('keeps the base prefix from originalUrl', () => {
+    expect(
+      getDevMiddlewareRequestPath({
+        originalUrl: '/admin/blog/q-loader-abc.dev.json',
+        url: '/blog/q-loader-abc.dev.json',
+      } as any)
+    ).toBe('/admin/blog/q-loader-abc.dev.json');
+  });
+});
 
 /** Minimal ViteDevServer stand-in with controllable client/SSR graphs and a spy on the HMR channel. */
 function makeServer(opts: { client?: { url: string }[]; ssr?: { url: string }[] }) {

--- a/packages/qwik-router/src/buildtime/vite/dev-middleware.ts
+++ b/packages/qwik-router/src/buildtime/vite/dev-middleware.ts
@@ -1,10 +1,28 @@
 import type { Render } from '@qwik.dev/core/server';
 import type { RendererOptions } from '@qwik.dev/router';
 import type { Connect, ViteDevServer } from 'vite';
+import type { LoaderInternal } from '../../runtime/src/types';
+import { isPageExt, normalizePath } from '../../utils/fs';
+import {
+  IsQLoader,
+  recognizeRequest,
+  resolveValidInternalFullPathname,
+  trimRecognizedInternalPathname,
+} from '../../middleware/request-handler/request-path';
+import { devPreloadedRouteLoaders } from '../../middleware/request-handler/dev-preloaded-route-loader';
 import { updateRoutingContext } from '../build';
+import { routeSortCompare } from '../routing/sort-routes';
 import type { RoutingContext } from '../types';
 import { formatError } from './format-error';
 import { wrapResponseForHtmlTransform } from './html-transform-wrapper';
+import { getImportPath } from '../runtime-generation/utils';
+
+const FULLPATH_HEADER = 'X-Qwik-fullpath';
+type DevServerRequest = Parameters<Connect.NextHandleFunction>[0];
+
+export function getDevMiddlewareRequestPath(req: DevServerRequest) {
+  return (req as any).originalUrl || req.url;
+}
 
 export const makeRouterDevMiddleware =
   (server: ViteDevServer, ctx: RoutingContext): Connect.NextHandleFunction =>
@@ -32,6 +50,11 @@ export const makeRouterDevMiddleware =
     if (ctx!.isDirty) {
       await updateRoutingContext(ctx!);
       ctx!.isDirty = false;
+    }
+    const preloadedRouteLoader = await preloadQLoaderRouteLoader(server, ctx!, req);
+    if (preloadedRouteLoader) {
+      await server.ssrLoadModule('@qwik-router-config');
+      devPreloadedRouteLoaders.set(req, preloadedRouteLoader);
     }
 
     // entry.ts files
@@ -94,6 +117,76 @@ export const makeRouterDevMiddleware =
       return;
     }
   };
+
+async function preloadQLoaderRouteLoader(
+  server: ViteDevServer,
+  ctx: RoutingContext,
+  req: DevServerRequest
+) {
+  const requestPath = getDevMiddlewareRequestPath(req);
+  if (!requestPath) {
+    return undefined;
+  }
+  let requestUrl: URL;
+  try {
+    requestUrl = new URL(requestPath, 'http://qwik.dev');
+  } catch {
+    return undefined;
+  }
+  const recognized = recognizeRequest(requestUrl.pathname);
+  if (recognized?.type !== IsQLoader || !recognized.data?.loaderId) {
+    return undefined;
+  }
+
+  const loaderId = recognized.data.loaderId;
+  const headerValue = req.headers[FULLPATH_HEADER.toLowerCase()];
+  const fullPathHeader = Array.isArray(headerValue) ? headerValue[0] : (headerValue ?? null);
+  const loaderPathname = trimRecognizedInternalPathname(requestUrl.pathname, recognized);
+  const pathname =
+    resolveValidInternalFullPathname(loaderPathname, fullPathHeader) ?? loaderPathname;
+  const route = ctx.routes
+    .filter((route) => isPageExt(route.ext))
+    .slice()
+    .sort(routeSortCompare)
+    .find((route) => route.pattern.test(pathname));
+  if (!route) {
+    return undefined;
+  }
+
+  const routeRootFiles = [...route.layouts.map((layout) => layout.filePath), route.filePath];
+  const modules = await Promise.all([
+    ...ctx.serverPlugins.map((plugin) => loadSsrModule(server, plugin.filePath)),
+    ...routeRootFiles.map((filePath) => loadSsrModule(server, filePath)),
+  ]);
+  for (const mod of modules) {
+    const loader = findMatchingLoader(mod, loaderId);
+    if (loader) {
+      return loader;
+    }
+  }
+}
+
+async function loadSsrModule(server: ViteDevServer, filePath: string) {
+  return server.ssrLoadModule(getImportPath(normalizePath(filePath))) as Promise<
+    Record<string, unknown>
+  >;
+}
+
+function findMatchingLoader(mod: Record<string, unknown>, loaderId: string) {
+  for (const value of Object.values(mod)) {
+    if (isLoaderInternal(value) && matchesLoaderId(value, loaderId)) {
+      return value;
+    }
+  }
+}
+
+function matchesLoaderId(loader: LoaderInternal, loaderId: string) {
+  return loader.__id === loaderId || loader.__qrl.getHash() === loaderId;
+}
+
+function isLoaderInternal(value: unknown): value is LoaderInternal {
+  return typeof value === 'function' && (value as LoaderInternal).__brand === 'server_loader';
+}
 
 const CSS_EXTENSIONS = ['.css', '.scss', '.sass', '.less', '.styl', '.stylus'];
 const JS_EXTENSIONS = /\.[mc]?[tj]sx?$/;

--- a/packages/qwik-router/src/middleware/node/index.ts
+++ b/packages/qwik-router/src/middleware/node/index.ts
@@ -8,6 +8,7 @@ import type { Http2ServerRequest } from 'node:http2';
 import { basename, extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MIME_TYPES } from '../request-handler/mime-types';
+import { devPreloadedRouteLoaders } from '../request-handler/dev-preloaded-route-loader';
 import { computeOrigin, fromNodeHttp, getUrl } from './http';
 
 // @qwik.dev/router/middleware/node
@@ -59,6 +60,13 @@ export function createQwikRouter(
       // In dev mode, inject platform from options via secret property
       if (isDev && (opts as any).platform) {
         Object.assign(serverRequestEv.platform, (opts as any).platform);
+      }
+      if (isDev) {
+        const loader = devPreloadedRouteLoaders.get(req);
+        if (loader) {
+          devPreloadedRouteLoaders.set(serverRequestEv.request, loader);
+          devPreloadedRouteLoaders.delete(req);
+        }
       }
       const handled = await requestHandler(serverRequestEv, opts);
       if (handled) {

--- a/packages/qwik-router/src/middleware/request-handler/dev-preloaded-route-loader.ts
+++ b/packages/qwik-router/src/middleware/request-handler/dev-preloaded-route-loader.ts
@@ -1,0 +1,5 @@
+import type { LoaderInternal } from '../../runtime/src/types';
+
+export const devPreloadedRouteLoaders = ((globalThis as any)[
+  Symbol.for('devPreloadedRouteLoaders')
+] ??= new WeakMap<object, LoaderInternal>());

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts
@@ -1,4 +1,3 @@
-import { isDev } from '@qwik.dev/core';
 import { _serialize } from '@qwik.dev/core/internal';
 import {
   FULLPATH_HEADER,
@@ -43,9 +42,7 @@ export function loaderHandler(
       return;
     }
 
-    const activeRouteLoaders =
-      isDev && !routeLoaders.includes(loader) ? [...routeLoaders, loader] : routeLoaders;
-    setLoaderData(requestEv, activeRouteLoaders, loaderPaths);
+    setLoaderData(requestEv, routeLoaders, loaderPaths);
 
     const loaderRequestEv = createLoaderRequestEventFactory(requestEv)(loader);
 

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { FULLPATH_HEADER, routeLoaderQrl } from '../../../runtime/src/route-loaders';
+import { FULLPATH_HEADER } from '../../../runtime/src/route-loaders';
 import { getLoaderName, IsQLoader, QLoaderId } from '../request-path';
 import { loaderHandler } from './loader-handler';
 
@@ -16,6 +16,7 @@ describe('loaderHandler', () => {
       headersSent: false,
       exited: false,
       cacheControl: vi.fn(),
+      json: vi.fn(),
       send: vi.fn(),
       status: vi.fn(() => 200),
     };
@@ -120,19 +121,13 @@ describe('loaderHandler', () => {
     expect(requestEv.send).toHaveBeenCalledWith(200, expect.any(String));
   });
 
-  it('runs a dev registered loader that was not exported by the route module', async () => {
+  it('returns 404 when the requested loader is not available on the matched route', async () => {
     const requestEv = createRequestEv();
-    const qrl = {
-      call: vi.fn(async () => 'registered-loader-value'),
-      getHash: () => 'loader-id',
-      getSymbol: () => 'loader-id',
-    };
-    routeLoaderQrl(qrl as any);
 
     await loaderHandler([])(requestEv as any);
 
-    expect(qrl.call).toHaveBeenCalledOnce();
-    expect(requestEv.send).toHaveBeenCalledWith(200, expect.any(String));
+    expect(requestEv.json).toHaveBeenCalledWith(404, { error: 'Loader not found' });
+    expect(requestEv.send).not.toHaveBeenCalled();
   });
 
   it('treats empty normalized eTags as absent', async () => {

--- a/packages/qwik-router/src/middleware/request-handler/request-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-handler.ts
@@ -1,8 +1,10 @@
+import { isDev } from '@qwik.dev/core';
 import type { Render } from '@qwik.dev/core/server';
 import { loadRoute } from '../../runtime/src/routing';
 import { FULLPATH_HEADER } from '../../runtime/src/route-loaders';
 import type { QwikRouterConfig, RebuildRouteInfoInternal } from '../../runtime/src/types';
 import { _asyncRequestStore } from './async-request-store';
+import { devPreloadedRouteLoaders } from './dev-preloaded-route-loader';
 import {
   IsQLoader,
   recognizeRequest,
@@ -17,6 +19,9 @@ import { runQwikRouter, type QwikRouterRun } from './user-response';
 let qwikRouterConfig: QwikRouterConfig;
 
 async function getConfig(): Promise<QwikRouterConfig> {
+  if (isDev) {
+    return (await import('@qwik-router-config')) as any as QwikRouterConfig;
+  }
   if (!qwikRouterConfig) {
     // The production server build prunes this plan (drops prerendered server-free routes); full
     // when nothing is excluded. See the router config `load`.
@@ -48,7 +53,8 @@ export async function requestHandler<T = unknown>(
     pathname,
     serverRequestEv.request.method,
     checkOrigin ?? true,
-    render
+    render,
+    serverRequestEv
   );
 
   // When fallthrough is enabled and no route matched, let the adapter handle it
@@ -63,7 +69,8 @@ export async function requestHandler<T = unknown>(
       cleanPathname,
       serverRequestEv.request.method,
       checkOrigin ?? true,
-      render
+      render,
+      serverRequestEv
     );
   };
 
@@ -102,10 +109,18 @@ async function loadRequestHandlers(
   pathname: string,
   method: string,
   checkOrigin: boolean | 'lax-proto',
-  renderFn: Render
+  renderFn: Render,
+  serverRequestEv: ServerRequestEvent
 ) {
   const { routes, serverPlugins, cacheModules } = qwikRouterConfig;
   const loadedRoute = await loadRoute(routes, cacheModules, pathname);
+  const loader = isDev ? devPreloadedRouteLoaders.get(serverRequestEv.request) : undefined;
+  const lastModule = loadedRoute.$mods$[loadedRoute.$mods$.length - 1];
+  if (loader && lastModule) {
+    loadedRoute.$mods$[loadedRoute.$mods$.length - 1] = Object.assign({}, lastModule, {
+      __preloadedRouteLoader: loader,
+    });
+  }
   const requestHandlers = resolveRequestHandlers(
     serverPlugins,
     loadedRoute,

--- a/packages/qwik-router/src/middleware/request-handler/request-path.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-path.ts
@@ -6,8 +6,8 @@ export const IsQAction = '@isQAction';
 export const QLoaderId = '@loaderId';
 export const QActionId = '@actionId';
 
-/** Matches `/q-loader-{loaderId}.{manifestHash}.json` */
-export const LOADER_REGEX = /\/(q-loader-([^.]+)\.([^.]+)\.json)$/;
+/** Matches the final `/q-loader-{loaderId}.{manifestHash}.json` path segment. */
+export const LOADER_REGEX = /\/(q-loader-([^/.]+)\.([^/.]+)\.json)$/;
 
 export const getLoaderName = (loaderId: string, manifestHash: string) =>
   `q-loader-${loaderId}.${manifestHash}.json`;

--- a/packages/qwik-router/src/middleware/request-handler/request-path.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-path.unit.ts
@@ -36,6 +36,19 @@ describe('request path helpers', () => {
     expect(trimRecognizedInternalPathname(loaderPathname, recognized!)).toBe('/');
   });
 
+  it('recognizes only the final q-loader path segment', () => {
+    const loaderPathname = `/q-loader-shared-map/two/nested/${getLoaderName(
+      'loader-id',
+      'manifest'
+    )}`;
+    const recognized = recognizeRequest(loaderPathname);
+
+    expect(recognized?.data?.loaderId).toBe('loader-id');
+    expect(trimRecognizedInternalPathname(loaderPathname, recognized!)).toBe(
+      '/q-loader-shared-map/two/nested/'
+    );
+  });
+
   it('accepts internal full pathnames below the loader pathname', () => {
     expect(resolveValidInternalFullPathname('/products/123/', '/products/123/view/')).toBe(
       '/products/123/view/'

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -18,6 +18,7 @@ import {
   getRouteLoaderCtx,
   getRouteLoaderValues,
   loadRouteLoader,
+  matchesRouteLoaderId,
   setRouteLoaders,
 } from '../../runtime/src/route-loaders';
 import { ensureSlash } from '../../utils/pathname';
@@ -243,7 +244,10 @@ function createResolveRequestHandlers() {
       return false;
     }
     for (const value of Object.values(routeModule)) {
-      if (checkBrand(value, 'server_loader') && (value as LoaderInternal).__id === loaderId) {
+      if (
+        checkBrand(value, 'server_loader') &&
+        matchesRouteLoaderId(value as LoaderInternal, loaderId)
+      ) {
         return true;
       }
     }

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
@@ -122,7 +122,7 @@ describe('resolve-request-handler', () => {
       expect(pageOnRequest).not.toHaveBeenCalled();
     });
 
-    it('runs page middleware for a loader exported by that page module', async () => {
+    it('runs page middleware for a synthetic preloaded loader export on that page module', async () => {
       const pageLoader = vi.fn() as any;
       pageLoader.__brand = 'server_loader';
       pageLoader.__id = 'page-loader';
@@ -132,7 +132,7 @@ describe('resolve-request-handler', () => {
         $params$: {},
         $mods$: [
           {},
-          { default: vi.fn(), onRequest: pageOnRequest, usePageData: pageLoader },
+          { default: vi.fn(), onRequest: pageOnRequest, __preloadedRouteLoader: pageLoader },
         ] as any,
       };
 

--- a/packages/qwik-router/src/runtime/src/qwik-router-config.ts
+++ b/packages/qwik-router/src/runtime/src/qwik-router-config.ts
@@ -10,6 +10,7 @@ export const fallthrough = false;
 
 export default {
   routes,
+  serverPlugins,
   trailingSlash,
   basePathname,
   cacheModules,

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -130,6 +130,8 @@ export type RouteLoaderCtx = {
   manifestHash?: string;
 };
 
+type DevRouteLoaderCtx = RouteLoaderCtx & { devRouteLoaderPaths?: Record<string, true> };
+
 export type RouteLoaderState = Record<string, AsyncSignal<unknown>>;
 
 const getRouteLoaderValueStateKey = (loaderId: string) => `${ROUTE_LOADER_VALUE_PREFIX}${loaderId}`;
@@ -168,24 +170,6 @@ const isRequestEvent = (value: unknown): value is RequestEvent =>
 
 const isLoaderInternal = (value: unknown): value is LoaderInternal =>
   typeof value === 'function' && (value as LoaderInternal).__brand === 'server_loader';
-
-const getDevRouteLoaderRegistry = () => {
-  if (!isDev || !isServer) {
-    return undefined;
-  }
-  const registryKey = Symbol.for('qwik.dev.router.route-loaders');
-  return ((globalThis as any)[registryKey] ||= new Map<string, LoaderInternal>()) as Map<
-    string,
-    LoaderInternal
-  >;
-};
-
-const registerDevRouteLoader = (loader: LoaderInternal) => {
-  if (!isDev) {
-    return;
-  }
-  getDevRouteLoaderRegistry()?.set(loader.__id, loader);
-};
 
 /**
  * Fetch a single loader's data from the server.
@@ -581,10 +565,16 @@ export const updateRouteLoaderPaths = (
   if (!isServer) {
     ctx.pagePathname = pageUrl.pathname;
     ctx.pageSearch = pageUrl.search;
+    if (isDev) {
+      (ctx as DevRouteLoaderCtx).devRouteLoaderPaths = {};
+    }
   }
   if (loaderPaths) {
     for (const key in loaderPaths) {
       ctx.loaderPaths[key] = loaderPaths[key];
+      if (!isServer && isDev) {
+        (ctx as DevRouteLoaderCtx).devRouteLoaderPaths![key] = true;
+      }
     }
   }
 };
@@ -641,8 +631,9 @@ export const ensureRouteLoaderSignals = (
     // Dev-only safety net for the first SPA nav: the route module isn't transformed yet, so the
     // client trie has no _R loader hash and the loader would resolve to undefined.
     if (isDev && !isServer) {
-      if (routeLoaderCtx.pagePathname && routeLoaderCtx.loaderPaths[loader.__id] === undefined) {
-        routeLoaderCtx.loaderPaths[loader.__id] = routeLoaderCtx.pagePathname;
+      const devCtx = routeLoaderCtx as DevRouteLoaderCtx;
+      if (devCtx.pagePathname && !devCtx.devRouteLoaderPaths?.[loader.__id]) {
+        devCtx.loaderPaths[loader.__id] = devCtx.pagePathname;
       }
     }
     ensureRouteLoaderSignal(loader, state, routeLoaderCtx);
@@ -665,10 +656,13 @@ export const resolveRouteLoaderByHash = (
   routeLoaders: readonly LoaderInternal[],
   loaderId: string
 ) => {
-  // Cold dev q-loader requests can know an id before route-local scans see the loader object.
+  return routeLoaders.find((loader) => matchesRouteLoaderId(loader, loaderId));
+};
+
+export const matchesRouteLoaderId = (loader: LoaderInternal, loaderId: unknown): boolean => {
   return (
-    routeLoaders.find((loader) => loader.__id === loaderId) ??
-    (isDev ? getDevRouteLoaderRegistry()?.get(loaderId) : undefined)
+    typeof loaderId === 'string' &&
+    (loader.__id === loaderId || (isDev && loader.__qrl.getHash() === loaderId))
   );
 };
 
@@ -849,9 +843,6 @@ export const routeLoaderQrl = ((
   loader.__search = search;
   loader.__allowStale = allowStale;
   Object.freeze(loader);
-  if (isDev) {
-    registerDevRouteLoader(loader);
-  }
   return loader;
 }) as LoaderConstructorQRL;
 


### PR DESCRIPTION
This PR removes the dev-only global route loader registry and replaces it with route-scoped preparation for q-loader requests.

The registry allowed loaders to be resolved from global state, even when they were not available through the currently matched route. That made dev behavior less deterministic and different from production. Instead, the dev middleware now prepares the matched route before handing the request to the router: it refreshes routing state, loads server plugins and route modules, and makes the requested loader available only for that request.