### PR TITLE
fix(qwik): dedupe already-streamed-chore SSR warning to once per host

### DIFF
--- a/.changeset/dedup-streamed-chore-warning.md
+++ b/.changeset/dedup-streamed-chore-warning.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: dedupe the ssr already-streamed-chore dev warning to once per host

--- a/packages/qwik/src/core/shared/cursor/ssr-chore-execution.ts
+++ b/packages/qwik/src/core/shared/cursor/ssr-chore-execution.ts
@@ -32,7 +32,13 @@ export function _executeSsrChores(
     if (ssrNode.dirty & ChoreBits.COMPUTE) {
       executeCompute(ssrNode, container);
     }
-    if (isDev && ssrNode.dirty & ChoreBits.DIRTY_MASK) {
+    if (
+      isDev &&
+      ssrNode.dirty & ChoreBits.DIRTY_MASK &&
+      !(ssrNode.flags & SsrNodeFlags.WarnedStreamedChore)
+    ) {
+      // Warn once per host; a re-dirtied streamed host would otherwise spam every tick.
+      ssrNode.flags |= SsrNodeFlags.WarnedStreamedChore;
       // We are running on the server.
       // On server we can't schedule task for a different host!
       // Server is SSR, and therefore scheduling for anything but the current host

--- a/packages/qwik/src/core/shared/types.ts
+++ b/packages/qwik/src/core/shared/types.ts
@@ -159,4 +159,5 @@ export type SerializationStrategy =
 
 export const enum SsrNodeFlags {
   Updatable = 1,
+  WarnedStreamedChore = 2,
 }

--- a/packages/qwik/src/core/tests/ssr-chore-warning.spec.tsx
+++ b/packages/qwik/src/core/tests/ssr-chore-warning.spec.tsx
@@ -1,0 +1,56 @@
+import '@qwik.dev/core';
+import { describe, expect, it, vi } from 'vitest';
+import { _executeSsrChores } from '../shared/cursor/ssr-chore-execution';
+import * as logUtils from '../shared/utils/log';
+import { SsrNodeFlags } from '../shared/types';
+import { ChoreBits } from '../shared/vnode/enums/chore-bits.enum';
+import type { ISsrNode, SSRContainer } from '../ssr/ssr-types';
+
+const STREAMED_CHORE_MESSAGE = 'A chore was scheduled on a host element';
+
+function createStreamedNode(id: string): ISsrNode {
+  // Streamed host: no Updatable flag, dirty bit that skips prop/compute and lands on the warn.
+  return {
+    id,
+    flags: 0 as SsrNodeFlags,
+    dirty: ChoreBits.TASKS,
+    currentFile: `file-${id}.tsx`,
+    toString: () => `<node ${id}>`,
+  } as unknown as ISsrNode;
+}
+
+describe('_executeSsrChores streamed-host warning', () => {
+  const container = {} as SSRContainer;
+
+  it('warns once per host even when the same host is re-dirtied', () => {
+    const warnSpy = vi.spyOn(logUtils, 'logWarn').mockImplementation(() => {});
+    try {
+      const node = createStreamedNode('a');
+      _executeSsrChores(container, node);
+      node.dirty = ChoreBits.TASKS;
+      _executeSsrChores(container, node);
+
+      const warnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes(STREAMED_CHORE_MESSAGE)
+      );
+      expect(warnings).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns once per distinct host', () => {
+    const warnSpy = vi.spyOn(logUtils, 'logWarn').mockImplementation(() => {});
+    try {
+      _executeSsrChores(container, createStreamedNode('a'));
+      _executeSsrChores(container, createStreamedNode('b'));
+
+      const warnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes(STREAMED_CHORE_MESSAGE)
+      );
+      expect(warnings).toHaveLength(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
# What is it?
- Bug

# Description
The SSR dev warning "A chore was scheduled on a host element that has already been streamed" fired once per chore, so a re-dirtied streamed host (e.g. a server-side `setInterval` bumping a signal) spammed N identical copies. Now deduped to once per host, so distinct problematic hosts still each warn once. Pre-existing dev-only warning, unrelated to any feature work.
