### PR TITLE
build(repo): raise TypeScript lib floor to es2022

### DIFF
--- a/.changeset/dev-eslint-es2022.md
+++ b/.changeset/dev-eslint-es2022.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: the built-in dev-time eslint linter now targets es2022

--- a/packages/qwik-router/src/ssg/orchestrator.ts
+++ b/packages/qwik-router/src/ssg/orchestrator.ts
@@ -331,6 +331,6 @@ function validateOptions(opts: SsgGenerateOptions) {
   try {
     new URL(siteOrigin);
   } catch (e) {
-    throw new Error(`Invalid "origin"`, { cause: e as Error });
+    throw new Error(`Invalid "origin"`, { cause: e });
   }
 }

--- a/packages/qwik-vite/src/plugins/eslint-plugin.ts
+++ b/packages/qwik-vite/src/plugins/eslint-plugin.ts
@@ -26,7 +26,7 @@ export async function createLinter(
           parserOptions: {
             tsconfigRootDir: rootDir,
             project: tsconfigFileNames,
-            ecmaVersion: 2021,
+            ecmaVersion: 2022,
             sourceType: 'module',
             ecmaFeatures: {
               jsx: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "incremental": true,
     "target": "ESNext",
     "module": "ESNext",
-    "lib": ["es2021", "DOM", "webworker", "DOM.Iterable"],
+    "lib": ["es2022", "DOM", "webworker", "DOM.Iterable"],
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "allowArbitraryExtensions": true,


### PR DESCRIPTION
# What is it?
- Infra

# Description
Bumps the TypeScript `lib` floor from es2021 to es2022 in the root tsconfig (core, router, optimizer, vite, react all inherit it). Safe against our support matrix — the lowest declared runtime is Node 18.17, and every es2022 API (Error.cause, Object.hasOwn, `.at()`, class static blocks) lands by ~Node 16.11. No public API change.

Also drops one now-redundant `as Error` cast the bump makes unnecessary, and points qwik-vite's built-in dev linter at es2022 (patch).