### PR TITLE
fix(router): respect vite build.assetsDir in static paths

### DIFF
--- a/.changeset/assets-dir-static-paths.md
+++ b/.changeset/assets-dir-static-paths.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: respect vite build.assetsDir in static paths and public files

--- a/.changeset/user-static-paths-raw.md
+++ b/.changeset/user-static-paths-raw.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: user-provided static file paths match without a trailing slash

--- a/e2e/adapters-e2e/adapters/deno/vite.config.ts
+++ b/e2e/adapters-e2e/adapters/deno/vite.config.ts
@@ -10,6 +10,13 @@ export default extendConfig(baseConfig, () => {
         input: ['src/entry.deno.tsx'],
       },
     },
-    plugins: [denoServerAdapter({ name: 'deno' })],
+    plugins: [
+      denoServerAdapter({
+        name: 'deno',
+        // Prerender routes with and without loaders to cover static serving of
+        // pages and loader sidecars.
+        ssg: { include: ['/profile/', '/loaders/*'] },
+      }),
+    ],
   };
 });

--- a/e2e/adapters-e2e/adapters/deno/vite.config.ts
+++ b/e2e/adapters-e2e/adapters/deno/vite.config.ts
@@ -13,8 +13,7 @@ export default extendConfig(baseConfig, () => {
     plugins: [
       denoServerAdapter({
         name: 'deno',
-        // Prerender routes with and without loaders to cover static serving of
-        // pages and loader sidecars.
+        // Prerender pages and a static loader sidecar for serving coverage.
         ssg: { include: ['/profile/', '/loaders/*'] },
       }),
     ],

--- a/e2e/adapters-e2e/playwright.deno.config.ts
+++ b/e2e/adapters-e2e/playwright.deno.config.ts
@@ -1,8 +1,7 @@
 import { defineConfig } from '@playwright/test';
 import { adapterPlaywrightConfig, createAdapterWebServerConfig } from './playwright.shared';
 
-// The deno variant builds with a custom assets dir to cover assetsDir-aware
-// static paths through the isStaticPath-gated staticFile middleware.
+// Build with a custom assets dir to cover assetsDir-aware static paths.
 process.env.ADAPTERS_E2E_ASSETS_DIR = 'q';
 
 export default defineConfig({

--- a/e2e/adapters-e2e/playwright.deno.config.ts
+++ b/e2e/adapters-e2e/playwright.deno.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from '@playwright/test';
 import { adapterPlaywrightConfig, createAdapterWebServerConfig } from './playwright.shared';
 
+// The deno variant builds with a custom assets dir to cover assetsDir-aware
+// static paths through the isStaticPath-gated staticFile middleware.
+process.env.ADAPTERS_E2E_ASSETS_DIR = 'q';
+
 export default defineConfig({
   ...adapterPlaywrightConfig,
   webServer: createAdapterWebServerConfig('npm run deno'),

--- a/e2e/adapters-e2e/public/robots.txt
+++ b/e2e/adapters-e2e/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/e2e/adapters-e2e/src/components/click-me/assets/circle.svg
+++ b/e2e/adapters-e2e/src/components/click-me/assets/circle.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="50" />
+</svg>

--- a/e2e/adapters-e2e/src/components/click-me/click-me.tsx
+++ b/e2e/adapters-e2e/src/components/click-me/click-me.tsx
@@ -1,10 +1,12 @@
 import { component$, useSignal } from '@qwik.dev/core';
+import circleSvg from './assets/circle.svg?url';
 
 // We need to extract the component to see the bug on 1.5.7
 export default component$(() => {
   const isOpenSig = useSignal(false);
   return (
     <>
+      <img alt="circle" width="20" height="20" src={circleSvg} />
       <button
         onClick$={() => {
           return (isOpenSig.value = !isOpenSig.value);

--- a/e2e/adapters-e2e/src/routes/loaders/subpage/index.tsx
+++ b/e2e/adapters-e2e/src/routes/loaders/subpage/index.tsx
@@ -1,9 +1,13 @@
 import { component$ } from '@qwik.dev/core';
 import { routeLoader$ } from '@qwik.dev/router';
 
-export const useTest = routeLoader$(async () => {
-  return 42;
-});
+export const useTest = routeLoader$(
+  async () => {
+    return 42;
+  },
+  // Static loader: SSG writes it as a q-loader sidecar file.
+  { expires: 0 }
+);
 
 export default component$(() => {
   const loaded = useTest();

--- a/e2e/adapters-e2e/tests/static-paths.spec.ts
+++ b/e2e/adapters-e2e/tests/static-paths.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appDir = fileURLToPath(new URL('..', import.meta.url));
+// Matches the assets dir the playwright config built the app with, if any.
+const assetsDir = process.env.ADAPTERS_E2E_ASSETS_DIR;
+const urlPrefix = assetsDir ? `/${assetsDir}` : '';
+
+test.describe('static paths', () => {
+  test('serves robots.txt from the site root', async ({ request }) => {
+    const response = await request.get('/robots.txt');
+    expect(response.ok()).toBeTruthy();
+    expect((await response.text()).trim()).toBe('User-agent: *\nAllow: /');
+  });
+
+  test('references and serves the imported svg from the assets dir', async ({ page, request }) => {
+    await page.goto('/');
+    const src = await page.getByAltText('circle').getAttribute('src');
+    expect(src).toMatch(new RegExp(`^${urlPrefix}/assets/.+\\.svg$`));
+    const response = await request.get(src!);
+    expect(response.ok()).toBeTruthy();
+    expect(await response.text()).toContain('<circle');
+  });
+
+  test('serves js bundles from the build dir', async ({ request }) => {
+    const buildDir = join(appDir, 'dist', ...(assetsDir ? [assetsDir] : []), 'build');
+    const chunk = (await readdir(buildDir)).find((fileName) => fileName.endsWith('.js'));
+    expect(chunk).toBeTruthy();
+    const response = await request.get(`${urlPrefix}/build/${chunk}`);
+    expect(response.ok()).toBeTruthy();
+  });
+
+  test('resumes interactivity with served bundles', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'click me' }).click();
+    await expect(page.getByTestId('hi')).toBeVisible();
+  });
+
+  test('injects root-relative static paths into the server bundle', async () => {
+    const serverDir = join(appDir, 'server');
+    const files = (await readdir(serverDir)).filter((fileName) => fileName.endsWith('.js'));
+    const code = (
+      await Promise.all(files.map((fileName) => readFile(join(serverDir, fileName), 'utf-8')))
+    ).join('\n');
+    expect(code).toContain('"/robots.txt"');
+    if (assetsDir) {
+      expect(code).toContain(`"${urlPrefix}/build/"`);
+      expect(code).not.toContain(`${urlPrefix}${urlPrefix}/`);
+    }
+  });
+
+  test('keeps prerendered pages on disk and serves them', async ({ page }) => {
+    test.skip(!assetsDir, 'prerendering is configured on the assetsDir variant only');
+    expect(existsSync(join(appDir, 'dist', 'profile', 'index.html'))).toBe(true);
+    expect(existsSync(join(appDir, 'dist', 'loaders', 'index.html'))).toBe(true);
+    await page.goto('/profile/');
+    await expect(page.getByRole('heading', { name: 'Profile page' })).toBeVisible();
+  });
+});

--- a/e2e/adapters-e2e/tests/static-paths.spec.ts
+++ b/e2e/adapters-e2e/tests/static-paths.spec.ts
@@ -59,4 +59,16 @@ test.describe('static paths', () => {
     await page.goto('/profile/');
     await expect(page.getByRole('heading', { name: 'Profile page' })).toBeVisible();
   });
+
+  test('serves the prerendered loader sidecar', async ({ request }) => {
+    test.skip(!assetsDir, 'prerendering is configured on the assetsDir variant only');
+    const subpageDir = join(appDir, 'dist', 'loaders', 'subpage');
+    const sidecar = (await readdir(subpageDir)).find((fileName) =>
+      /^q-loader-.+\.json$/.test(fileName)
+    );
+    expect(sidecar).toBeTruthy();
+    const response = await request.get(`/loaders/subpage/${sidecar}`);
+    expect(response.ok()).toBeTruthy();
+    expect(await response.text()).toContain('42');
+  });
 });

--- a/e2e/adapters-e2e/vite-env.d.ts
+++ b/e2e/adapters-e2e/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*.svg?url' {
+  const src: string;
+  export default src;
+}

--- a/e2e/adapters-e2e/vite.config.ts
+++ b/e2e/adapters-e2e/vite.config.ts
@@ -23,6 +23,13 @@ errorOnDuplicatesPkgDeps(devDependencies, dependencies);
 export default defineConfig((): UserConfig => {
   return {
     plugins: [qwikRouter(), qwikVite(), tsconfigPaths({ root: '.' })],
+    build: {
+      // Emit imported assets as files so the e2e can assert their URLs.
+      assetsInlineLimit: 0,
+      // Set by playwright configs that cover a custom assets dir; must apply
+      // to the client and the adapter builds alike.
+      assetsDir: process.env.ADAPTERS_E2E_ASSETS_DIR || undefined,
+    },
     // This tells Vite which dependencies to pre-build in dev mode.
     optimizeDeps: {
       // Put problematic deps that break bundling here, mostly those with binaries.

--- a/e2e/adapters-e2e/vite.config.ts
+++ b/e2e/adapters-e2e/vite.config.ts
@@ -26,8 +26,7 @@ export default defineConfig((): UserConfig => {
     build: {
       // Emit imported assets as files so the e2e can assert their URLs.
       assetsInlineLimit: 0,
-      // Set by playwright configs that cover a custom assets dir; must apply
-      // to the client and the adapter builds alike.
+      // Set by playwright configs; must apply to client and adapter builds.
       assetsDir: process.env.ADAPTERS_E2E_ASSETS_DIR || undefined,
     },
     // This tells Vite which dependencies to pre-build in dev mode.

--- a/packages/qwik-router/src/adapters/shared/vite/index.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/index.ts
@@ -302,7 +302,8 @@ export function viteAdapter(opts: ViteAdapterPluginOptions) {
       await postBuild(
         clientPublicOutDir,
         serverOutDir,
-        assetsDir ? join(basePathname, assetsDir) : basePathname,
+        basePathname,
+        assetsDir,
         staticPaths,
         !!opts.cleanStaticGenerated
       );

--- a/packages/qwik-router/src/adapters/shared/vite/post-build.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/post-build.ts
@@ -7,20 +7,23 @@ import { ensureSlash } from '../../../utils/pathname';
 export async function postBuild(
   clientOutDir: string,
   serverOutDir: string,
-  pathName: string,
+  basePathname: string,
+  assetsDir: string | undefined,
   userStaticPaths: string[],
   cleanStatic: boolean
 ) {
-  if (pathName && !pathName.endsWith('/')) {
-    pathName = ensureSlash(pathName);
-  }
-  const pathNameBase = pathName || '/';
+  const pathNameBase = ensureSlash(basePathname || '/');
+  const normalizedAssetsDir = assetsDir ? assetsDir.replace(/^\/+|\/+$/g, '') : '';
+  const nestedDirBase = normalizedAssetsDir
+    ? pathNameBase + normalizedAssetsDir + '/'
+    : pathNameBase;
   const ignorePathnames = new Set([
-    pathNameBase + (globalThis.__QWIK_BUILD_DIR__ || 'build') + '/',
-    pathNameBase + (globalThis.__QWIK_ASSETS_DIR__ || 'assets') + '/',
+    nestedDirBase + (globalThis.__QWIK_BUILD_DIR__ || 'build') + '/',
+    nestedDirBase + (globalThis.__QWIK_ASSETS_DIR__ || 'assets') + '/',
   ]);
 
-  const staticPaths = new Set(userStaticPaths.map(ensureSlash));
+  // Keep the raw form too: user-listed file paths must match without a trailing slash.
+  const staticPaths = new Set(userStaticPaths.flatMap((p) => [p, ensureSlash(p)]));
 
   const loadItem = async (fsDir: string, fsName: string, pathname: string) => {
     pathname = ensureSlash(pathname);
@@ -62,7 +65,7 @@ export async function postBuild(
   };
 
   if (fs.existsSync(clientOutDir)) {
-    await loadDir(clientOutDir, pathName);
+    await loadDir(clientOutDir, pathNameBase);
   }
 
   const staticPathsCode = createStaticPathsCode(staticPaths);

--- a/packages/qwik-router/src/adapters/shared/vite/post-build.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/post-build.ts
@@ -17,10 +17,12 @@ export async function postBuild(
   const nestedDirBase = normalizedAssetsDir
     ? pathNameBase + normalizedAssetsDir + '/'
     : pathNameBase;
-  const ignorePathnames = new Set([
+  // Also injected for the runtime isStaticPath prefix checks.
+  const staticPathPrefixes = [
     nestedDirBase + (globalThis.__QWIK_BUILD_DIR__ || 'build') + '/',
     nestedDirBase + (globalThis.__QWIK_ASSETS_DIR__ || 'assets') + '/',
-  ]);
+  ];
+  const ignorePathnames = new Set(staticPathPrefixes);
 
   // Keep the raw form too: user-listed file paths must match without a trailing slash.
   const staticPaths = new Set(userStaticPaths.flatMap((p) => [p, ensureSlash(p)]));
@@ -68,28 +70,28 @@ export async function postBuild(
     await loadDir(clientOutDir, pathNameBase);
   }
 
-  const staticPathsCode = createStaticPathsCode(staticPaths);
-
-  await injectStatics(staticPathsCode, serverOutDir);
+  const staticPathsCode = toArrayBody([...staticPaths].sort());
+  const staticPathPrefixesCode = toArrayBody(staticPathPrefixes);
+  await injectStatics(staticPathsCode, staticPathPrefixesCode, serverOutDir);
 }
 
-function createStaticPathsCode(staticPaths: Set<string>) {
-  // This is the body of the static paths array
-  return JSON.stringify(Array.from(new Set<string>(staticPaths)).sort()).slice(1, -1);
+function toArrayBody(values: string[]) {
+  // An array literal's body, without the surrounding brackets.
+  return JSON.stringify(values).slice(1, -1);
 }
 
-const injectStatics = async (staticPathsCode: string, outDir: string) => {
+const injectStatics = async (
+  staticPathsCode: string,
+  staticPathPrefixesCode: string,
+  outDir: string
+) => {
   const promises = new Set<Promise<void>>();
-  // replace the static-paths placeholder in the build output with the actual values
   const doReplace = async (path: string) => {
     const code = await fs.promises.readFile(path, 'utf-8');
-
-    let replaced = false;
-    const newCode = code.replace(/(['"])__QWIK_ROUTER_STATIC_PATHS_ARRAY__\1/g, () => {
-      replaced = true;
-      return staticPathsCode;
-    });
-    if (replaced) {
+    const newCode = code
+      .replace(/(['"])__QWIK_ROUTER_STATIC_PATHS_ARRAY__\1/g, () => staticPathsCode)
+      .replace(/(['"])__QWIK_ROUTER_STATIC_PATHS_PREFIXES__\1/g, () => staticPathPrefixesCode);
+    if (newCode !== code) {
       await fs.promises.writeFile(path, newCode);
     }
   };

--- a/packages/qwik-router/src/adapters/shared/vite/post-build.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/post-build.ts
@@ -24,8 +24,10 @@ export async function postBuild(
   ];
   const ignorePathnames = new Set(staticPathPrefixes);
 
-  // Keep the raw form too: user-listed file paths must match without a trailing slash.
-  const staticPaths = new Set(userStaticPaths.flatMap((p) => [p, ensureSlash(p)]));
+  // Only file-like paths keep the raw unslashed form.
+  const staticPaths = new Set(
+    userStaticPaths.flatMap((p) => (/\.[^/]*$/.test(p) ? [p, ensureSlash(p)] : [ensureSlash(p)]))
+  );
 
   const loadItem = async (fsDir: string, fsName: string, pathname: string) => {
     pathname = ensureSlash(pathname);

--- a/packages/qwik-router/src/adapters/shared/vite/post-build.unit.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/post-build.unit.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
+import { matchesStaticPath } from '../../../middleware/request-handler/static-paths';
 import { postBuild } from './post-build';
 
 const dirs: string[] = [];
@@ -99,6 +100,11 @@ describe.each(matrix)('$label', ({ base, assetsDir }) => {
     }
   });
 
+  test('injects base/assetsDir-aware static path prefixes', async () => {
+    const { prefixes } = await run(distTree(assetsDir), routes, { base, assetsDir });
+    expect(prefixes).toEqual([`${nestedPrefix}build/`, `${nestedPrefix}assets/`]);
+  });
+
   test('cleanStatic keeps prerendered pages of static routes and deletes stale ones', async () => {
     const { paths, clientOutDir } = await run(distTree(assetsDir), routes, {
       base,
@@ -162,6 +168,20 @@ test('keeps user static file paths unmangled and preserves dotted directory rout
   // Platform-provided file path, absent from dist: must survive un-slashed.
   expect(paths).toContain('/sitemap.xml');
   expect(fs.existsSync(join(clientOutDir, 'docs/v1.2/index.html'))).toBe(true);
+});
+
+test('injected arrays drive the runtime matcher end to end', async () => {
+  const base = '/base/';
+  const { paths, prefixes } = await run(distTree('q'), [base, `${base}profile/`], {
+    base,
+    assetsDir: 'q',
+  });
+  const set = new Set(paths);
+  expect(matchesStaticPath('GET', '/base/robots.txt', set, prefixes!)).toBe(true);
+  expect(matchesStaticPath('GET', '/base/q/build/q-chunk.js', set, prefixes!)).toBe(true);
+  expect(matchesStaticPath('GET', '/base/q/assets/hero-abc123.svg', set, prefixes!)).toBe(true);
+  expect(matchesStaticPath('GET', '/base/unknown/', set, prefixes!)).toBe(false);
+  expect(matchesStaticPath('POST', '/base/robots.txt', set, prefixes!)).toBe(false);
 });
 
 test('lists a written loader sidecar of a static route, but not its index.html', async () => {

--- a/packages/qwik-router/src/adapters/shared/vite/post-build.unit.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/post-build.unit.ts
@@ -1,7 +1,8 @@
+import fs from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, expect, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { postBuild } from './post-build';
 
 const dirs: string[] = [];
@@ -15,9 +16,21 @@ async function tmp() {
   return d;
 }
 
-/** Run postBuild against a temp client/server tree and return the injected STATIC_PATHS array. */
-async function run(files: Record<string, string>, userStaticPaths: string[], cleanStatic = false) {
-  const clientOutDir = await tmp();
+interface RunOptions {
+  base?: string;
+  assetsDir?: string;
+  cleanStatic?: boolean;
+  missingClientDir?: boolean;
+}
+
+/** Run postBuild as viteAdapter invokes it; return the injected arrays and the client dir. */
+async function run(
+  files: Record<string, string>,
+  userStaticPaths: string[],
+  opts: RunOptions = {}
+) {
+  const { base = '/', assetsDir, cleanStatic = false } = opts;
+  const clientOutDir = opts.missingClientDir ? join(await tmp(), 'missing') : await tmp();
   const serverOutDir = await tmp();
   for (const [rel, content] of Object.entries(files)) {
     const full = join(clientOutDir, rel);
@@ -26,15 +39,133 @@ async function run(files: Record<string, string>, userStaticPaths: string[], cle
   }
   await writeFile(
     join(serverOutDir, 'server.js'),
-    `export const staticPaths = new Set(['__QWIK_ROUTER_STATIC_PATHS_ARRAY__']);`
+    `export const staticPaths = new Set(['__QWIK_ROUTER_STATIC_PATHS_ARRAY__']);\n` +
+      `export const staticPathPrefixes = ['__QWIK_ROUTER_STATIC_PATHS_PREFIXES__'];`
   );
-  await postBuild(clientOutDir, serverOutDir, '/', userStaticPaths, cleanStatic);
+  await postBuild(clientOutDir, serverOutDir, base, assetsDir, userStaticPaths, cleanStatic);
   const code = await readFile(join(serverOutDir, 'server.js'), 'utf-8');
-  return JSON.parse(code.match(/new Set\((\[[^\]]*\])\)/)![1]) as string[];
+  const paths = JSON.parse(code.match(/new Set\((\[[^\]]*\])\)/)![1]) as string[];
+  // Unreplaced placeholder stays single-quoted JS; parse only injected JSON.
+  const prefixesSource = code.match(/staticPathPrefixes = (\[[^\]]*\])/)![1];
+  const prefixes = prefixesSource.includes("'") ? null : (JSON.parse(prefixesSource) as string[]);
+  return { paths, prefixes, clientOutDir };
 }
 
+/** Vite client output layout: chunks nest under assetsDir, public files stay at the dist root. */
+function distTree(assetsDir?: string) {
+  const nested = assetsDir ? `${assetsDir}/` : '';
+  return {
+    'robots.txt': 'robots',
+    '404.html': '<html/>',
+    'icons/logo.svg': '<svg/>',
+    [`${nested}build/q-chunk.js`]: '// chunk',
+    [`${nested}build/sub/q-nested.js`]: '// nested chunk',
+    [`${nested}assets/hero-abc123.svg`]: '<svg/>',
+    'index.html': '<html/>',
+    'profile/index.html': '<html/>',
+    'profile/q-loader-WaXl02RHfZE.abc.json': '{}',
+    'stale/index.html': '<html/>',
+    'stale/q-loader-XyZ.def.json': '{}',
+  };
+}
+
+const matrix: { label: string; base: string; assetsDir?: string }[] = [
+  { label: 'default', base: '/' },
+  { label: 'base', base: '/base/' },
+  { label: 'assetsDir', base: '/', assetsDir: 'assets-dir' },
+  { label: 'base + assetsDir', base: '/base/', assetsDir: 'assets-dir' },
+];
+
+describe.each(matrix)('$label', ({ base, assetsDir }) => {
+  const nestedPrefix = `${base}${assetsDir ? `${assetsDir}/` : ''}`;
+  const routes = [base, `${base}profile/`];
+
+  test('lists root public files at the base, never under assetsDir', async () => {
+    const { paths } = await run(distTree(assetsDir), routes, { base, assetsDir });
+    expect(paths).toContain(`${base}robots.txt`);
+    expect(paths).toContain(`${base}404.html`);
+    expect(paths).toContain(`${base}icons/logo.svg`);
+    if (assetsDir) {
+      expect(paths).not.toContain(`${nestedPrefix}robots.txt`);
+    }
+  });
+
+  test('excludes qwik build and assets output, with no doubled segments', async () => {
+    const { paths } = await run(distTree(assetsDir), routes, { base, assetsDir });
+    expect(paths.filter((p) => p.startsWith(`${nestedPrefix}build/`))).toEqual([]);
+    expect(paths.filter((p) => p.startsWith(`${nestedPrefix}assets/`))).toEqual([]);
+    if (assetsDir) {
+      expect(paths.filter((p) => p.includes(`${assetsDir}/${assetsDir}/`))).toEqual([]);
+    }
+  });
+
+  test('cleanStatic keeps prerendered pages of static routes and deletes stale ones', async () => {
+    const { paths, clientOutDir } = await run(distTree(assetsDir), routes, {
+      base,
+      assetsDir,
+      cleanStatic: true,
+    });
+    expect(fs.existsSync(join(clientOutDir, 'index.html'))).toBe(true);
+    expect(fs.existsSync(join(clientOutDir, 'profile/index.html'))).toBe(true);
+    expect(fs.existsSync(join(clientOutDir, 'stale/index.html'))).toBe(false);
+    expect(paths).toContain(`${base}profile/q-loader-WaXl02RHfZE.abc.json`);
+    expect(fs.existsSync(join(clientOutDir, 'stale/q-loader-XyZ.def.json'))).toBe(false);
+  });
+});
+
+test('multi-segment assetsDir prunes nested output without doubling', async () => {
+  const { paths } = await run(distTree('foo/bar'), ['/'], { assetsDir: 'foo/bar' });
+  expect(paths).toContain('/robots.txt');
+  expect(paths.filter((p) => p.includes('build/'))).toEqual([]);
+  expect(paths.filter((p) => p.includes('foo/bar/foo/'))).toEqual([]);
+});
+
+test('assetsDir named like a qwik dir prunes only the nested output', async () => {
+  for (const dir of ['build', 'assets']) {
+    const files = { ...distTree(dir), [`${dir}/readme.txt`]: 'public file' };
+    const { paths } = await run(files, ['/'], { assetsDir: dir });
+    expect(paths).toContain(`/${dir}/readme.txt`);
+    expect(
+      paths.filter((p) => p.startsWith(`/${dir}/build/`) || p.startsWith(`/${dir}/assets/`))
+    ).toEqual([]);
+  }
+});
+
+test('trailing-slash assetsDir is normalized', async () => {
+  const { paths } = await run(distTree('q'), ['/'], { assetsDir: 'q/' });
+  expect(paths).toContain('/robots.txt');
+  expect(paths.filter((p) => p.includes('//') || p.includes('q/build/'))).toEqual([]);
+});
+
+test('lists public files copied directly under the assets dir', async () => {
+  const files = { ...distTree('assets-dir'), 'assets-dir/legal.txt': 'terms' };
+  const { paths } = await run(files, ['/'], { assetsDir: 'assets-dir' });
+  expect(paths).toContain('/assets-dir/legal.txt');
+});
+
+test('does not collapse a public dir named like the base segment', async () => {
+  const files = { ...distTree(), 'base/logo.png': 'png' };
+  const { paths } = await run(files, ['/base/'], { base: '/base/' });
+  expect(paths).toContain('/base/base/logo.png');
+});
+
+test('missing client dir leaves only the user static paths', async () => {
+  const { paths } = await run({}, ['/docs/'], { missingClientDir: true });
+  expect(paths).toEqual(['/docs/']);
+});
+
+test('keeps user static file paths unmangled and preserves dotted directory routes', async () => {
+  const files = { '404.html': '<html/>', 'docs/v1.2/index.html': '<html/>' };
+  const { paths, clientOutDir } = await run(files, ['/sitemap.xml', '/docs/v1.2'], {
+    cleanStatic: true,
+  });
+  // Platform-provided file path, absent from dist: must survive un-slashed.
+  expect(paths).toContain('/sitemap.xml');
+  expect(fs.existsSync(join(clientOutDir, 'docs/v1.2/index.html'))).toBe(true);
+});
+
 test('lists a written loader sidecar of a static route, but not its index.html', async () => {
-  const paths = await run(
+  const { paths } = await run(
     {
       'blog/index.html': '<html></html>',
       'blog/q-loader-WaXl02RHfZE.abc.json': '{"d":{}}',
@@ -47,6 +178,6 @@ test('lists a written loader sidecar of a static route, but not its index.html',
 });
 
 test('does not list a loader sidecar whose route is not static', async () => {
-  const paths = await run({ 'other/q-loader-X.abc.json': '{"d":{}}' }, []);
+  const { paths } = await run({ 'other/q-loader-X.abc.json': '{"d":{}}' }, []);
   expect(paths).not.toContain('/other/q-loader-X.abc.json');
 });

--- a/packages/qwik-router/src/adapters/shared/vite/post-build.unit.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/post-build.unit.ts
@@ -161,13 +161,21 @@ test('missing client dir leaves only the user static paths', async () => {
 });
 
 test('keeps user static file paths unmangled and preserves dotted directory routes', async () => {
-  const files = { '404.html': '<html/>', 'docs/v1.2/index.html': '<html/>' };
-  const { paths, clientOutDir } = await run(files, ['/sitemap.xml', '/docs/v1.2'], {
+  const files = {
+    '404.html': '<html/>',
+    'docs/v1.2/index.html': '<html/>',
+    'team/index.html': '<html/>',
+  };
+  const { paths, clientOutDir } = await run(files, ['/sitemap.xml', '/docs/v1.2', '/team'], {
     cleanStatic: true,
   });
   // Platform-provided file path, absent from dist: must survive un-slashed.
   expect(paths).toContain('/sitemap.xml');
+  // Extensionless route paths stay slash-normalized so fs middlewares skip them.
+  expect(paths).toContain('/team/');
+  expect(paths).not.toContain('/team');
   expect(fs.existsSync(join(clientOutDir, 'docs/v1.2/index.html'))).toBe(true);
+  expect(fs.existsSync(join(clientOutDir, 'team/index.html'))).toBe(true);
 });
 
 test('injected arrays drive the runtime matcher end to end', async () => {

--- a/packages/qwik-router/src/middleware/request-handler/static-paths.ts
+++ b/packages/qwik-router/src/middleware/request-handler/static-paths.ts
@@ -2,22 +2,38 @@
 // TODO calculate this at build time from the SSG configuration
 const staticPaths = new Set(['__QWIK_ROUTER_STATIC_PATHS_ARRAY__']);
 
+// Will be replaced in post-build with the base/assetsDir-aware build and assets prefixes
+const staticPathPrefixes = ['__QWIK_ROUTER_STATIC_PATHS_PREFIXES__'];
+
+/** Decide whether a request path is static, given the injected paths and prefixes. @internal */
+export function matchesStaticPath(
+  method: string,
+  pathname: string,
+  paths: Set<string>,
+  prefixes: string[]
+) {
+  if (method.toUpperCase() !== 'GET') {
+    return false;
+  }
+  if (prefixes.some((prefix) => pathname.startsWith(prefix))) {
+    return true;
+  }
+  // Loader sidecars are listed by post-build only when SSG wrote them, so a missing one falls to SSR.
+  return paths.has(pathname);
+}
+
 /**
  * Decide whether a given request path is a static path, for optimizing file access.
  *
  * @internal
  */
 export function isStaticPath(method: string, url: URL) {
-  if (method.toUpperCase() !== 'GET') {
-    return false;
-  }
-  const p = url.pathname;
-  if (p.startsWith('/' + (globalThis.__QWIK_BUILD_DIR__ || 'build') + '/')) {
-    return true;
-  }
-  if (p.startsWith('/' + (globalThis.__QWIK_ASSETS_DIR__ || 'assets') + '/')) {
-    return true;
-  }
-  // Loader sidecars are listed by post-build only when SSG wrote them, so a missing one falls to SSR.
-  return staticPaths.has(p);
+  // Non-adapter builds keep the placeholder unreplaced; fall back to the default layout.
+  const prefixes = staticPathPrefixes[0]?.startsWith('__QWIK_ROUTER_')
+    ? [
+        '/' + (globalThis.__QWIK_BUILD_DIR__ || 'build') + '/',
+        '/' + (globalThis.__QWIK_ASSETS_DIR__ || 'assets') + '/',
+      ]
+    : staticPathPrefixes;
+  return matchesStaticPath(method, url.pathname, staticPaths, prefixes);
 }

--- a/packages/qwik-router/src/middleware/request-handler/static-paths.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/static-paths.unit.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest';
+import { isStaticPath, matchesStaticPath } from './static-paths';
+
+test('matches exact entries for GET only', () => {
+  const paths = new Set(['/robots.txt', '/profile/']);
+  expect(matchesStaticPath('GET', '/robots.txt', paths, [])).toBe(true);
+  expect(matchesStaticPath('get', '/profile/', paths, [])).toBe(true);
+  expect(matchesStaticPath('POST', '/robots.txt', paths, [])).toBe(false);
+  expect(matchesStaticPath('GET', '/unknown/', paths, [])).toBe(false);
+});
+
+test('matches injected build and assets prefixes', () => {
+  const prefixes = ['/base/q/build/', '/base/q/assets/'];
+  expect(matchesStaticPath('GET', '/base/q/build/x.js', new Set<string>(), prefixes)).toBe(true);
+  expect(matchesStaticPath('GET', '/base/q/assets/a.svg', new Set<string>(), prefixes)).toBe(true);
+  expect(matchesStaticPath('GET', '/build/x.js', new Set<string>(), prefixes)).toBe(false);
+});
+
+test('falls back to default prefixes when placeholders are unreplaced', () => {
+  // The source module still holds the placeholders, as in non-adapter builds.
+  expect(isStaticPath('GET', new URL('https://qwik.dev/build/q.js'))).toBe(true);
+  expect(isStaticPath('GET', new URL('https://qwik.dev/assets/a.svg'))).toBe(true);
+  expect(isStaticPath('GET', new URL('https://qwik.dev/robots.txt'))).toBe(false);
+});


### PR DESCRIPTION
# What is it?

- Bug

# Description

Fixes #8151. Supersedes #8726 — thanks @intellix for the analysis and the test fixtures reused here.

`postBuild` walked the client output labeled with `join(basePathname, assetsDir)` while public files live at the dist root. With `build.assetsDir` set this doubled the assets segment in static paths, mis-prefixed root public files like robots.txt, and let `cleanStaticGenerated` delete prerendered pages. The walk now starts at `basePathname` with the ignore prefixes derived from `assetsDir`, and the computed prefixes are injected into `isStaticPath` so staticFile-based adapters serve bundles under a custom assetsDir too.

The deno e2e variant now builds with `assetsDir: 'q'` and prerenders a few routes (including a static loader sidecar) to cover this end-to-end.