### PR TITLE
fix(qwik-vite): bootstrap QRL segment parents missing from the dev graph

### DIFF
--- a/.changeset/dev-qrl-parent-bootstrap.md
+++ b/.changeset/dev-qrl-parent-bootstrap.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+Dev-mode QRL segments now resolve even when their parent module was never loaded in the requesting Vite server (e.g. Vitest browser mode or SSR rendered in a separate server). The dev server transforms the parent on demand instead of erroring with "module does not exist in the build graph".

--- a/packages/qwik-vite/src/plugins/plugin.ts
+++ b/packages/qwik-vite/src/plugins/plugin.ts
@@ -836,18 +836,27 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
       // in dev mode, it could be that the id is a QRL segment that wasn't transformed yet
       const parentId = parentIds.get(id);
       if (parentId) {
+        // building here via ctx.load doesn't seem to work (no transform), instead we use the devserver directly
+        debug(`load(${count})`, 'transforming QRL parent', parentId);
         const parentModule = devServer.moduleGraph.getModuleById(parentId);
         if (parentModule) {
-          // building here via ctx.load doesn't seem to work (no transform), instead we use the devserver directly
-          debug(`load(${count})`, 'transforming QRL parent', parentId);
           await devServer.transformRequest(parentModule.url);
-          // The QRL segment should exist now
-          if (!outputs.has(id)) {
-            debug(`load(${count})`, `QRL segment ${id} not found in ${parentId}`);
-            return null;
-          }
         } else {
-          console.error(`load(${count})`, `module ${parentId} does not exist in the build graph!`);
+          // The parent isn't in THIS server's graph — e.g. SSR was rendered in a
+          // different vite server (test tooling, split server/browser SSR). Bootstrap
+          // it by id so its QRL segments populate `outputs`. If it genuinely can't be
+          // transformed, fall through to the graceful "not found" below rather than
+          // throwing (id-vs-url resolution can differ on Windows / with a non-root base).
+          try {
+            await devServer.transformRequest(parentId);
+          } catch (err) {
+            console.error(`load(${count})`, `could not transform QRL parent ${parentId}:`, err);
+          }
+        }
+        // The QRL segment should exist now
+        if (!outputs.has(id)) {
+          debug(`load(${count})`, `QRL segment ${id} not found in ${parentId}`);
+          return null;
         }
       }
     }

--- a/packages/qwik-vite/src/plugins/plugin.unit.ts
+++ b/packages/qwik-vite/src/plugins/plugin.unit.ts
@@ -660,6 +660,61 @@ test('transform omits sourcemaps for public virtual modules', async () => {
   expect(result!.map).toBeNull();
 });
 
+test('load bootstraps a cold QRL segment whose parent is not in the module graph', async () => {
+  // Absolute, pre-normalized paths so parentId matches the optimizer's segment
+  // keys on every platform (including Windows drive letters).
+  const root = normalizePath(resolve(cwd, 'cold-test'));
+  const parentId = `${root}/src/cold.tsx`;
+  const code = `import { component$ } from '@qwik.dev/core';
+export const Cold = component$(() => <div>hi</div>);
+`;
+  const transformCtx = {
+    addWatchFile: () => undefined,
+    emitFile: () => undefined,
+  } as any;
+
+  // Discover the real segment id the optimizer produces for this parent.
+  const discovery = await mockPlugin(process.platform, true);
+  await discovery.normalizeOptions({ rootDir: root });
+  discovery.configureServer({
+    hot: {},
+    moduleGraph: { getModuleById: () => undefined, invalidateModule: () => undefined },
+  } as any);
+  const discovered = await discovery.transform(transformCtx, code, parentId);
+  const segmentId: string = discovered!.meta!.qwikdeps![0];
+  expect(segmentId).toContain('cold.tsx_');
+
+  // Fresh plugin whose module graph never loaded the parent — the split
+  // server/browser SSR case (SSR rendered in a different vite server).
+  const plugin = await mockPlugin(process.platform, true);
+  await plugin.normalizeOptions({ rootDir: root });
+  const transformRequested: string[] = [];
+  plugin.configureServer({
+    hot: {},
+    moduleGraph: { getModuleById: () => undefined, invalidateModule: () => undefined },
+    // vite would transform the requested parent, populating the plugin's outputs
+    transformRequest: async (reqId: string) => {
+      transformRequested.push(reqId);
+      await plugin.transform(transformCtx, code, parentId);
+      return null;
+    },
+  } as any);
+
+  // A browser fetch of the segment: resolveId records segment -> parent, no transform.
+  await plugin.resolveId(
+    { resolve: async () => ({ id: parentId }) } as any,
+    segmentId,
+    `${root}/index.html`
+  );
+
+  // Cold load must bootstrap the never-loaded parent by id and resolve the segment,
+  // instead of erroring with "module does not exist in the build graph".
+  const loaded = await plugin.load({} as any, segmentId);
+
+  expect(transformRequested).toContain(parentId);
+  expect((loaded as { code: string })?.code).toBeTypeOf('string');
+});
+
 async function mockPlugin(os = process.platform, useRealOptimizer = false) {
   const plugin = createQwikPlugin({
     sys: {


### PR DESCRIPTION
# What is it?

- Bug

# Description

Needed for Vitest browser mode in the monorepo.

In dev, `load()` serves a QRL segment by lazily transforming its parent module — but only when the parent is already in the requesting server's module graph. If it isn't, it logs `module … does not exist in the build graph!` and the segment 404s.

That happens whenever SSR runs in a _different_ Vite server than the one resolving QRLs at runtime — e.g. Vitest browser mode, or any split server/browser SSR setup. The browser's Vite server never imported the component modules, so their segments can't be served.

`resolveId` already records the segment → parent link (it derives the parent from the segment URL). This PR uses it: when the parent isn't in the graph, transform it by id to bootstrap it instead of erroring. If it genuinely can't be transformed, it falls through to the existing graceful "not found" rather than throwing.

Dev-only — the branch is gated behind `devServer`, so production builds are unaffected.

Surfaced by [vitest-browser-qwik](https://github.com/QwikDev/vitest-browser-qwik), which currently works around this by pre-crawling the browser module graph before every SSR render; with this fix that workaround can go away.

# Checklist

- [x] My code follows the developer guidelines of this project
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I added new tests to cover the fix / functionality
