### PR TITLE
fix: preserve transitive server$ modules in SSR builds

### DIFF
--- a/.changeset/silver-frogs-flash.md
+++ b/.changeset/silver-frogs-flash.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: register aliased server functions used only in client code like visible tasks

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/root.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/root.tsx
@@ -1,8 +1,9 @@
 import { RouterOutlet, useQwikRouter } from '@qwik.dev/router';
 import { RouterHead } from './components/router-head/router-head';
+import { component$ } from '@qwik.dev/core';
 import './global.css';
 
-export default function Root() {
+export default component$(function Root() {
   useQwikRouter();
   return (
     <>
@@ -15,4 +16,4 @@ export default function Root() {
       </body>
     </>
   );
-}
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/server-function/eager-transitive/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/server-function/eager-transitive/index.tsx
@@ -1,0 +1,10 @@
+import { component$ } from '@qwik.dev/core';
+import { EagerTransitiveGenerator } from '~/shared/eager-transitive-generator';
+
+export default component$(() => {
+  return (
+    <div>
+      <EagerTransitiveGenerator />
+    </div>
+  );
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/server-function/eager-transitive/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/server-function/eager-transitive/index.tsx
@@ -2,9 +2,5 @@ import { component$ } from '@qwik.dev/core';
 import { EagerTransitiveGenerator } from '~/shared/eager-transitive-generator';
 
 export default component$(() => {
-  return (
-    <div>
-      <EagerTransitiveGenerator />
-    </div>
-  );
+  return <EagerTransitiveGenerator />;
 });

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/eager-transitive-block.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/eager-transitive-block.tsx
@@ -1,0 +1,16 @@
+import { component$, useSignal, useVisibleTask$ } from '@qwik.dev/core';
+
+export const EagerTransitiveBlock = component$(() => {
+  const result = useSignal('pending');
+
+  useVisibleTask$(async () => {
+    try {
+      const { getEagerTransitiveStatus } = await import('./eager-transitive-server-fn');
+      result.value = await getEagerTransitiveStatus();
+    } catch {
+      result.value = 'failed';
+    }
+  });
+
+  return <p id="eager-transitive-result">{result.value}</p>;
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/eager-transitive-generator.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/eager-transitive-generator.tsx
@@ -1,0 +1,9 @@
+import { component$ } from '@qwik.dev/core';
+import { EAGER_TRANSITIVE_BLOCKS } from './eager-transitive-registry';
+
+export const EagerTransitiveGenerator = component$(() => {
+  const block = EAGER_TRANSITIVE_BLOCKS.product;
+  const Component = block.component;
+
+  return <Component />;
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/eager-transitive-registry.ts
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/eager-transitive-registry.ts
@@ -1,0 +1,7 @@
+import { EagerTransitiveBlock } from './eager-transitive-block';
+
+export const EAGER_TRANSITIVE_BLOCKS = {
+  product: {
+    component: EagerTransitiveBlock,
+  },
+};

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/eager-transitive-server-fn.ts
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/eager-transitive-server-fn.ts
@@ -1,0 +1,9 @@
+import { server$ } from '@qwik.dev/router';
+
+const getEagerTransitiveStatusServer = server$(async function () {
+  return 'registered';
+});
+
+export async function getEagerTransitiveStatus() {
+  return getEagerTransitiveStatusServer();
+}

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/package.json
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/shared/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/tsconfig.json
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/tsconfig.json
@@ -20,8 +20,7 @@
     "types": ["node", "vite/client"],
     "rootDir": ".",
     "paths": {
-      "~/*": ["./src/*"],
-      "@/*": ["./src/*"]
+      "~/*": ["./src/*"]
     }
   }
 }

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/server-func/visible-task-alias-only/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/server-func/visible-task-alias-only/index.tsx
@@ -1,0 +1,12 @@
+import { component$, useSignal, useVisibleTask$ } from '@qwik.dev/core';
+import { ping } from '~/shared/visible-task-server-fn';
+
+export default component$(() => {
+  const result = useSignal('pending');
+
+  useVisibleTask$(async () => {
+    result.value = await ping();
+  });
+
+  return <div id="visible-task-alias-server-fn">{result.value}</div>;
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/server-func/visible-task-at-alias-only/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/server-func/visible-task-at-alias-only/index.tsx
@@ -1,0 +1,12 @@
+import { component$, useSignal, useVisibleTask$ } from '@qwik.dev/core';
+import { ping } from '@/shared/visible-task-server-fn';
+
+export default component$(() => {
+  const result = useSignal('pending');
+
+  useVisibleTask$(async () => {
+    result.value = await ping();
+  });
+
+  return <div id="visible-task-at-alias-server-fn">{result.value}</div>;
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/shared/visible-task-server-fn.ts
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/shared/visible-task-server-fn.ts
@@ -1,0 +1,5 @@
+import { server$ } from '@qwik.dev/router';
+
+export const ping = server$(async function () {
+  return 'pong:no-args';
+});

--- a/e2e/qwik-e2e/dev-server.ts
+++ b/e2e/qwik-e2e/dev-server.ts
@@ -207,6 +207,10 @@ export { router }
     base: basePath,
     ...extra,
     resolve: {
+      alias: {
+        '~': appSrcDir,
+        '@': appSrcDir,
+      },
       conditions: [isProd ? 'production' : 'development'],
       mainFields: [],
     },

--- a/e2e/qwik-e2e/tests/qwikrouter/server.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/server.e2e.ts
@@ -197,6 +197,11 @@ test.describe('server$', () => {
     expect(data.loaded).toBe(false);
   });
 
+  test('registers server$ reached through a prod visible task import', async ({ page }) => {
+    await page.goto('/qwikrouter-test.prod/server-function/eager-transitive/');
+    await expect(page.locator('#eager-transitive-result')).toHaveText('registered');
+  });
+
   for (const [alias, route, id] of [
     ['~', 'visible-task-alias-only', 'visible-task-alias-server-fn'],
     ['@', 'visible-task-at-alias-only', 'visible-task-at-alias-server-fn'],

--- a/e2e/qwik-e2e/tests/qwikrouter/server.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/server.e2e.ts
@@ -196,4 +196,16 @@ test.describe('server$', () => {
     const data = await response.json();
     expect(data.loaded).toBe(false);
   });
+
+  for (const [alias, route, id] of [
+    ['~', 'visible-task-alias-only', 'visible-task-alias-server-fn'],
+    ['@', 'visible-task-at-alias-only', 'visible-task-at-alias-server-fn'],
+  ]) {
+    test(`registers visible-task server function imported through ${alias}/ alias`, async ({
+      page,
+    }) => {
+      await page.goto(`/qwikrouter-test/server-func/${route}/`);
+      await expect(page.locator(`#${id}`)).toHaveText('pong:no-args');
+    });
+  }
 });

--- a/packages/optimizer/core/src/collector.rs
+++ b/packages/optimizer/core/src/collector.rs
@@ -45,6 +45,7 @@ pub struct ExportInfo {
 pub struct GlobalCollect {
 	pub synthetic: Vec<(Id, Import)>,
 	pub imports: IndexMap<Id, Import>,
+	pub dynamic_imports: Vec<Atom>,
 	pub exports: IndexMap<Atom, ExportInfo>,
 	pub root: IndexMap<Id, Span>,
 
@@ -57,6 +58,7 @@ pub fn global_collect(program: &ast::Program) -> GlobalCollect {
 	let mut collect = GlobalCollect {
 		synthetic: vec![],
 		imports: IndexMap::with_capacity(16),
+		dynamic_imports: vec![],
 		exports: IndexMap::with_capacity(16),
 
 		root: IndexMap::with_capacity(16),
@@ -290,6 +292,17 @@ impl Visit for GlobalCollect {
 				}
 			}
 		}
+	}
+
+	fn visit_call_expr(&mut self, node: &ast::CallExpr) {
+		if matches!(&node.callee, ast::Callee::Import(_)) {
+			if let Some(arg) = node.args.first() {
+				if let ast::Expr::Lit(ast::Lit::Str(source)) = &*arg.expr {
+					self.dynamic_imports.push(source.value.clone());
+				}
+			}
+		}
+		node.visit_children_with(self);
 	}
 
 	fn visit_named_export(&mut self, node: &ast::NamedExport) {

--- a/packages/optimizer/core/src/parse.rs
+++ b/packages/optimizer/core/src/parse.rs
@@ -597,6 +597,8 @@ pub fn transform_code(config: TransformCodeOptions) -> Result<TransformOutput, a
 								.values()
 								.map(|import| import.source.clone())
 								.collect();
+							imports
+								.extend(q.options.global_collect.dynamic_imports.iter().cloned());
 							imports.sort();
 							imports.dedup();
 							imports

--- a/packages/optimizer/core/src/parse.rs
+++ b/packages/optimizer/core/src/parse.rs
@@ -184,6 +184,9 @@ pub struct TransformModule {
 	pub path: String,
 	pub code: String,
 
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub imports: Vec<Atom>,
+
 	pub map: Option<String>,
 
 	pub segment: Option<SegmentAnalysis>,
@@ -551,6 +554,7 @@ pub fn transform_code(config: TransformCodeOptions) -> Result<TransformOutput, a
 								map,
 								is_entry,
 								path: segment_path,
+								imports: vec![],
 								order: h.hash,
 								segment: Some(SegmentAnalysis {
 									origin: h.data.origin,
@@ -583,6 +587,22 @@ pub fn transform_code(config: TransformCodeOptions) -> Result<TransformOutput, a
 						}
 					}
 
+					let imports = qt
+						.as_ref()
+						.map(|q| {
+							let mut imports: Vec<_> = q
+								.options
+								.global_collect
+								.imports
+								.values()
+								.map(|import| import.source.clone())
+								.collect();
+							imports.sort();
+							imports.dedup();
+							imports
+						})
+						.unwrap_or_default();
+
 					let (code, map) = match program {
 						ast::Program::Module(ref mut modu) => {
 							add_section_separators(modu, &comments);
@@ -611,6 +631,7 @@ pub fn transform_code(config: TransformCodeOptions) -> Result<TransformOutput, a
 						is_entry: false,
 						path,
 						code,
+						imports,
 						map,
 						order: hasher.finish(),
 						segment: None,

--- a/packages/optimizer/core/src/test.rs
+++ b/packages/optimizer/core/src/test.rs
@@ -888,6 +888,46 @@ export const Works = component$((props) => {
 }
 
 #[test]
+fn reports_import_used_only_in_stripped_segment() {
+	let output = test_input!(TestInput {
+		code: r#"
+import { component$, useVisibleTask$ } from '@qwik.dev/core';
+import { ping } from '~/shared/visible-task-server-fn';
+
+export const App = component$(() => {
+	useVisibleTask$(async () => {
+		await ping();
+	});
+	return <div>hi</div>;
+});
+"#
+		.to_string(),
+		entry_strategy: EntryStrategy::Hoist,
+		strip_ctx_name: Some(vec!["useVisibleTask".into()]),
+		strip_event_handlers: true,
+		transpile_ts: true,
+		transpile_jsx: true,
+		is_server: Some(true),
+		snapshot: false,
+		..TestInput::default()
+	})
+	.unwrap();
+
+	let root_module = output
+		.modules
+		.iter()
+		.find(|module| !module.is_entry && module.segment.is_none())
+		.expect("root module should exist");
+	let visible_task_import: Atom = "~/shared/visible-task-server-fn".into();
+
+	assert!(
+		root_module.imports.contains(&visible_task_import),
+		"root module should report imports used before stripping, got {:?}",
+		root_module.imports
+	);
+}
+
+#[test]
 fn example_reg_ctx_name_segments_inlined() {
 	test_input!(TestInput {
 		code: r#"

--- a/packages/optimizer/core/src/test.rs
+++ b/packages/optimizer/core/src/test.rs
@@ -928,6 +928,46 @@ export const App = component$(() => {
 }
 
 #[test]
+fn reports_dynamic_import_used_only_in_stripped_segment() {
+	let output = test_input!(TestInput {
+		code: r#"
+import { component$, useVisibleTask$ } from '@qwik.dev/core';
+
+export const App = component$(() => {
+	useVisibleTask$(async () => {
+		const { ping } = await import('~/shared/visible-task-server-fn');
+		await ping();
+	});
+	return <div>hi</div>;
+});
+"#
+		.to_string(),
+		entry_strategy: EntryStrategy::Hoist,
+		strip_ctx_name: Some(vec!["useVisibleTask".into()]),
+		strip_event_handlers: true,
+		transpile_ts: true,
+		transpile_jsx: true,
+		is_server: Some(true),
+		snapshot: false,
+		..TestInput::default()
+	})
+	.unwrap();
+
+	let root_module = output
+		.modules
+		.iter()
+		.find(|module| !module.is_entry && module.segment.is_none())
+		.expect("root module should exist");
+	let visible_task_import: Atom = "~/shared/visible-task-server-fn".into();
+
+	assert!(
+		root_module.imports.contains(&visible_task_import),
+		"root module should report dynamic imports used before stripping, got {:?}",
+		root_module.imports
+	);
+}
+
+#[test]
 fn example_reg_ctx_name_segments_inlined() {
 	test_input!(TestInput {
 		code: r#"

--- a/packages/optimizer/src/types.ts
+++ b/packages/optimizer/src/types.ts
@@ -105,6 +105,7 @@ export interface TransformModule {
   path: string;
   isEntry: boolean;
   code: string;
+  imports?: string[];
   map: string | null;
   segment: SegmentAnalysis | null;
   origPath: string | null;

--- a/packages/qwik-router/src/buildtime/vite/plugin.ts
+++ b/packages/qwik-router/src/buildtime/vite/plugin.ts
@@ -654,7 +654,12 @@ function serverFnsPlugin(buildContextRef: BuildContextRef): Plugin {
           if (!isServerBuild || serverFnModules.size === 0) {
             return '// No server$ functions';
           }
-          return [...serverFnModules].map((mod) => `import ${JSON.stringify(mod)};`).join('\n');
+          return [...serverFnModules]
+            .map(
+              (mod, index) =>
+                `import * as serverFnModule${index} from ${JSON.stringify(mod)};\nObject.values(serverFnModule${index});`
+            )
+            .join('\n');
         }
         return null;
       },

--- a/packages/qwik-router/src/buildtime/vite/server-fns.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.ts
@@ -3,6 +3,7 @@ import type { RoutingContext } from '../types';
 
 export type ServerFnPluginContext = Pick<Rollup.PluginContext, 'resolve' | 'load'>;
 export type ServerFnRoutingContext = Pick<RoutingContext, 'layouts' | 'routes' | 'serverPlugins'>;
+
 export async function collectServerFnModuleIds(
   routingContext: ServerFnRoutingContext,
   resolvedVirtualId: string,
@@ -44,16 +45,20 @@ export async function collectServerFnModuleIds(
       continue;
     }
 
-    const moduleInfo = await pluginContext.load({ id: resolved.id });
+    const moduleInfo = await pluginContext.load({ id: resolved.id, resolveDependencies: true });
     if (moduleInfo.code == null) {
       continue;
     }
+
+    const qwikDeps = ((moduleInfo as any).meta?.qwikdeps ?? []) as string[];
 
     if (moduleInfo.code.includes('serverQrl(')) {
       serverFnModules.add(moduleInfo.id);
     }
 
-    const resolvedImports = moduleInfo.importedIds.concat(moduleInfo.dynamicallyImportedIds);
+    const resolvedImports = moduleInfo.importedIds
+      .concat(moduleInfo.dynamicallyImportedIds)
+      .concat(qwikDeps);
     for (let i = 0; i < resolvedImports.length; i++) {
       const resolvedImport = resolvedImports[i];
       if (resolvedImport && !seenModuleIds.has(resolvedImport)) {

--- a/packages/qwik-router/src/buildtime/vite/server-fns.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.ts
@@ -56,9 +56,11 @@ export async function collectServerFnModuleIds(
       serverFnModules.add(moduleInfo.id);
     }
 
-    const resolvedImports = moduleInfo.importedIds
-      .concat(moduleInfo.dynamicallyImportedIds)
-      .concat(qwikDeps);
+    const resolvedImports = [
+      ...moduleInfo.importedIds,
+      ...moduleInfo.dynamicallyImportedIds,
+      ...qwikDeps,
+    ];
     for (let i = 0; i < resolvedImports.length; i++) {
       const resolvedImport = resolvedImports[i];
       if (resolvedImport && !seenModuleIds.has(resolvedImport)) {

--- a/packages/qwik-router/src/buildtime/vite/server-fns.unit.ts
+++ b/packages/qwik-router/src/buildtime/vite/server-fns.unit.ts
@@ -6,13 +6,14 @@ describe('collectServerFnModuleIds', () => {
   it('walks the reachable module graph and collects modules containing serverQrl', async () => {
     const resolvedVirtualId = '\0virtual:qwik-router-server-fns';
     const loads: string[] = [];
+    const loadResolveDependencies: (boolean | undefined)[] = [];
     const modules = new Map([
       [
         '/app/routes/index.tsx',
         {
           id: '/app/routes/index.tsx',
           code: 'export default component$(() => null);',
-          importedIds: ['/app/shared.ts', '/node_modules/@qwik.dev/core/index.mjs'],
+          importedIds: ['/app/shared.ts', '/app/qrl.ts', '/node_modules/@qwik.dev/core/index.mjs'],
           dynamicallyImportedIds: ['/app/lazy.ts'],
         },
       ],
@@ -31,6 +32,25 @@ describe('collectServerFnModuleIds', () => {
           id: '/app/shared.ts',
           code: 'export const shared = true;',
           importedIds: [resolvedVirtualId],
+          dynamicallyImportedIds: [],
+        },
+      ],
+      [
+        '/app/qrl.ts',
+        {
+          id: '/app/qrl.ts',
+          code: 'export const qrl = true;',
+          importedIds: [],
+          dynamicallyImportedIds: [],
+          meta: { qwikdeps: ['/app/qrl-segment.ts'] },
+        },
+      ],
+      [
+        '/app/qrl-segment.ts',
+        {
+          id: '/app/qrl-segment.ts',
+          code: 'export const segmentFn = serverQrl(() => null);',
+          importedIds: [],
           dynamicallyImportedIds: [],
         },
       ],
@@ -94,8 +114,9 @@ describe('collectServerFnModuleIds', () => {
 
     const pluginContext = {
       resolve: async (id: string) => ({ id, external: false }) as any,
-      load: async ({ id }: { id: string }) => {
+      load: async ({ id, resolveDependencies }: { id: string; resolveDependencies?: boolean }) => {
         loads.push(id);
+        loadResolveDependencies.push(resolveDependencies);
         const moduleInfo = modules.get(id);
         if (!moduleInfo) {
           throw new Error(`Unexpected module load: ${id}`);
@@ -106,14 +127,21 @@ describe('collectServerFnModuleIds', () => {
 
     const serverFnModules = await collectServerFnModuleIds(ctx, resolvedVirtualId, pluginContext);
 
-    expect(serverFnModules.sort()).toEqual(['/app/lazy.ts', '/app/plugin.ts']);
+    expect(serverFnModules.sort()).toEqual([
+      '/app/lazy.ts',
+      '/app/plugin.ts',
+      '/app/qrl-segment.ts',
+    ]);
     expect(loads).toEqual([
       '/app/routes/index.tsx',
       '/app/layout.tsx',
       '/app/plugin.ts',
       '/app/shared.ts',
+      '/app/qrl.ts',
       '/node_modules/@qwik.dev/core/index.mjs',
       '/app/lazy.ts',
+      '/app/qrl-segment.ts',
     ]);
+    expect(loadResolveDependencies).toEqual([true, true, true, true, true, true, true, true]);
   });
 });

--- a/packages/qwik-vite/src/plugins/plugin.ts
+++ b/packages/qwik-vite/src/plugins/plugin.ts
@@ -601,9 +601,9 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
     inputImports: string[],
     outputCode: string,
     importerId: string
-  ) => {
+  ): Promise<string[]> => {
     if (inputImports.length === 0) {
-      return outputCode;
+      return [];
     }
 
     const outputResolvedIds = new Set<string>();
@@ -614,20 +614,17 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
       }
     }
 
-    const restoredImports: string[] = [];
+    const restoredDeps: string[] = [];
     for (const importId of inputImports) {
       const resolvedId = await resolveTransformableImport(ctx, importId, importerId);
       if (!resolvedId || outputResolvedIds.has(resolvedId)) {
         continue;
       }
-      restoredImports.push(`import ${JSON.stringify(importId)};`);
+      restoredDeps.push(resolvedId);
       outputResolvedIds.add(resolvedId);
     }
 
-    if (restoredImports.length === 0) {
-      return outputCode;
-    }
-    return `${restoredImports.join('\n')}\n${outputCode}`;
+    return restoredDeps;
   };
 
   let resolveIdCount = 0;
@@ -1094,8 +1091,14 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
       // debug({ isServer, strip }, transformOpts, newOutput);
       diagnosticsCallback(newOutput.diagnostics, optimizer, srcDir);
 
+      let restoredSsrImportDeps: string[] = [];
       if (isServer && strip) {
-        module.code = await restoreSsrImportGraphEdges(ctx, module.imports ?? [], module.code, id);
+        restoredSsrImportDeps = await restoreSsrImportGraphEdges(
+          ctx,
+          module.imports ?? [],
+          module.code,
+          id
+        );
       }
 
       if (isServer) {
@@ -1136,6 +1139,9 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
             }
           }
         }
+      }
+      for (const restoredDep of restoredSsrImportDeps) {
+        deps.add(restoredDep);
       }
 
       ctx.addWatchFile(id);

--- a/packages/qwik-vite/src/plugins/plugin.ts
+++ b/packages/qwik-vite/src/plugins/plugin.ts
@@ -599,29 +599,19 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
   const restoreSsrImportGraphEdges = async (
     ctx: Rollup.PluginContext,
     inputImports: string[],
-    outputCode: string,
     importerId: string
   ): Promise<string[]> => {
     if (inputImports.length === 0) {
       return [];
     }
 
-    const outputResolvedIds = new Set<string>();
-    for (const importId of getImportSpecifiers(ctx, outputCode)) {
-      const resolvedId = await resolveTransformableImport(ctx, importId, importerId);
-      if (resolvedId) {
-        outputResolvedIds.add(resolvedId);
-      }
-    }
-
     const restoredDeps: string[] = [];
     for (const importId of inputImports) {
       const resolvedId = await resolveTransformableImport(ctx, importId, importerId);
-      if (!resolvedId || outputResolvedIds.has(resolvedId)) {
+      if (!resolvedId) {
         continue;
       }
       restoredDeps.push(resolvedId);
-      outputResolvedIds.add(resolvedId);
     }
 
     return restoredDeps;
@@ -1093,12 +1083,7 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
 
       let restoredSsrImportDeps: string[] = [];
       if (isServer && strip) {
-        restoredSsrImportDeps = await restoreSsrImportGraphEdges(
-          ctx,
-          module.imports ?? [],
-          module.code,
-          id
-        );
+        restoredSsrImportDeps = await restoreSsrImportGraphEdges(ctx, module.imports ?? [], id);
       }
 
       if (isServer) {

--- a/packages/qwik-vite/src/plugins/plugin.ts
+++ b/packages/qwik-vite/src/plugins/plugin.ts
@@ -574,6 +574,62 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
     }
   };
 
+  const resolveTransformableImport = async (
+    ctx: Rollup.PluginContext,
+    importId: string,
+    importerId: string
+  ) => {
+    const resolved = await ctx.resolve(importId, importerId, { skipSelf: true });
+    if (!resolved || resolved.external || isVirtualId(resolved.id)) {
+      return;
+    }
+
+    const parsedId = parseId(resolved.id);
+    if (parsedId.query) {
+      return;
+    }
+
+    const resolvedPathId = normalizePath(parsedId.pathId);
+    const ext = getPath().extname(resolvedPathId).toLowerCase();
+    if (ext in TRANSFORM_EXTS || TRANSFORM_REGEX.test(resolvedPathId)) {
+      return resolvedPathId;
+    }
+  };
+
+  const restoreSsrImportGraphEdges = async (
+    ctx: Rollup.PluginContext,
+    inputImports: string[],
+    outputCode: string,
+    importerId: string
+  ) => {
+    if (inputImports.length === 0) {
+      return outputCode;
+    }
+
+    const outputResolvedIds = new Set<string>();
+    for (const importId of getImportSpecifiers(ctx, outputCode)) {
+      const resolvedId = await resolveTransformableImport(ctx, importId, importerId);
+      if (resolvedId) {
+        outputResolvedIds.add(resolvedId);
+      }
+    }
+
+    const restoredImports: string[] = [];
+    for (const importId of inputImports) {
+      const resolvedId = await resolveTransformableImport(ctx, importId, importerId);
+      if (!resolvedId || outputResolvedIds.has(resolvedId)) {
+        continue;
+      }
+      restoredImports.push(`import ${JSON.stringify(importId)};`);
+      outputResolvedIds.add(resolvedId);
+    }
+
+    if (restoredImports.length === 0) {
+      return outputCode;
+    }
+    return `${restoredImports.join('\n')}\n${outputCode}`;
+  };
+
   let resolveIdCount = 0;
   let doNotEdit = false;
   /**
@@ -1037,6 +1093,10 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
       // uncomment to show transform results
       // debug({ isServer, strip }, transformOpts, newOutput);
       diagnosticsCallback(newOutput.diagnostics, optimizer, srcDir);
+
+      if (isServer && strip) {
+        module.code = await restoreSsrImportGraphEdges(ctx, module.imports ?? [], module.code, id);
+      }
 
       if (isServer) {
         if (newOutput.diagnostics.length === 0 && linter) {

--- a/packages/qwik-vite/src/plugins/plugin.unit.ts
+++ b/packages/qwik-vite/src/plugins/plugin.unit.ts
@@ -524,6 +524,45 @@ describe('resolveId', () => {
   });
 });
 
+test('transform exposes SSR imports restored after client-only stripping as qwik deps', async () => {
+  const plugin = await mockPlugin(process.platform, true);
+  await plugin.normalizeOptions({
+    target: 'ssr',
+    rootDir: '/root',
+    srcDir: '/root/src',
+  });
+
+  const result = await plugin.transform(
+    {
+      addWatchFile: () => undefined,
+      emitFile: () => undefined,
+      parse: parseImportsOnly,
+      resolve: async (id: string) => {
+        if (id === '@qwik.dev/core' || id === '@qwik.dev/core/jsx-runtime') {
+          return { id: `/root/node_modules/${id}/index.mjs` };
+        }
+        if (id === '@example/server-fn') {
+          return { id: '/root/libs/server-fn.ts' };
+        }
+      },
+    } as any,
+    `import { component$, useVisibleTask$ } from '@qwik.dev/core';
+import { callServer } from '@example/server-fn';
+
+export default component$(() => {
+  useVisibleTask$(() => {
+    callServer();
+  });
+  return <span>ready</span>;
+});
+`,
+    '/root/src/routes/index.tsx'
+  );
+
+  expect(result?.code).not.toContain('import "@example/server-fn";');
+  expect(result?.meta?.qwikdeps).toContain('/root/libs/server-fn.ts');
+});
+
 test('load skips HMR wrapper for worker$ segments', async () => {
   const plugin = await mockPlugin(process.platform, true);
   await plugin.normalizeOptions({ rootDir: '/root' });
@@ -674,6 +713,17 @@ async function mockPlugin(os = process.platform, useRealOptimizer = false) {
   });
   await plugin.init();
   return plugin;
+}
+
+function parseImportsOnly(code: string) {
+  const body = Array.from(
+    code.matchAll(/(?:import|export)\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g)
+  ).map(([, value]) => ({
+    type: 'ImportDeclaration',
+    importKind: 'value',
+    source: { value },
+  }));
+  return { type: 'Program', body };
 }
 
 describe('transform: globalThis.__QWIK_MANIFEST__ replacement', () => {


### PR DESCRIPTION
Fixes SSR server function registration when server$ is only reachable through stripped client-side code or transitive imports. The router now preserves discovered server function modules through tree-shaking, including packages marked with sideEffects: false.

Examples:

1. Transitive server$ import
```ts
// route.tsx
import { ProductPage } from './product-page';
// product-page.tsx
import { emitViewContent } from './emit-view-content';

export const ProductPage = component$(() => {
  // ...
});
// emit-view-content.ts
const emitViewContentServer = server$(async function () {
  return 'ok';
});

export async function emitViewContent() {
  return emitViewContentServer();
}
```
Fixed path:

route -> product-page -> emit-view-content -> server$
2. server$ only used inside stripped client code
```ts
import { emitViewContent } from './emit-view-content';

useVisibleTask$(async () => {
  await emitViewContent();
});
```
Before, SSR stripping removed the visible task usage, so the import could disappear from the SSR graph.

3. Dynamic import inside stripped client code
```ts
useVisibleTask$(async () => {
  const { emitViewContent } = await import('./emit-view-content');
  await emitViewContent();
});
```
Before, the literal dynamic import was lost when useVisibleTask$ was stripped from SSR.

4. Modules inside packages with sideEffects: false
```ts
{
  "sideEffects": false
}
// emit-view-content.ts
const emitViewContentServer = server$(async function () {
  return 'ok';
});

export async function emitViewContent() {
  return emitViewContentServer();
}
```
Before, the router generated only:

import './emit-view-content';
Rollup could tree-shake that away. Now it keeps the module exports live.