### PR TITLE
fix(ssr): flush stream buffer before awaiting component-body promise

### DIFF
--- a/.changeset/flush-before-component-promise.md
+++ b/.changeset/flush-before-component-promise.md
@@ -1,0 +1,6 @@
+---
+'@qwik.dev/core': patch
+---
+
+Fix SSR in-order streaming not flushing before awaiting a component-body promise.
+

--- a/e2e/qwik-e2e/apps/e2e/src/components/streaming/streaming-flush.tsx
+++ b/e2e/qwik-e2e/apps/e2e/src/components/streaming/streaming-flush.tsx
@@ -1,0 +1,21 @@
+import { component$ } from '@qwik.dev/core';
+
+export function delay(time: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => resolve(), time);
+  });
+}
+
+export const AsyncCmp = component$(async () => {
+  await delay(5000);
+  return <span id="async-result">Async done</span>;
+});
+
+export const StreamingFlush = component$(() => {
+  return (
+    <div>
+      <h1 id="prefix">Prefix content</h1>
+      <AsyncCmp />
+    </div>
+  );
+});

--- a/e2e/qwik-e2e/apps/e2e/src/root.tsx
+++ b/e2e/qwik-e2e/apps/e2e/src/root.tsx
@@ -26,6 +26,7 @@ import NakedObjectStoreReactivityIssue5001 from './components/signals/NakedObjec
 import { Signals } from './components/signals/signals';
 import { SlotParent } from './components/slot/slot';
 import { StreamingRoot } from './components/streaming/streaming';
+import { StreamingFlush } from './components/streaming/streaming-flush';
 import { Styles } from './components/styles/styles';
 import { SyncQRL } from './components/sync-qrl/sync-qrl';
 import { Toggle } from './components/toggle/toggle';
@@ -66,6 +67,7 @@ const tests: Record<string, FunctionComponent> = {
   '/e2e/resource-fn': () => <ResourceFn />,
   '/e2e/treeshaking': () => <TreeshakingApp />,
   '/e2e/streaming': () => <StreamingRoot />,
+  '/e2e/streaming-flush': () => <StreamingFlush />,
   '/e2e/mount': () => <MountRoot />,
   '/e2e/ref': () => <RefRoot />,
   '/e2e/signals': () => <Signals />,

--- a/e2e/qwik-e2e/tests/streaming.e2e.ts
+++ b/e2e/qwik-e2e/tests/streaming.e2e.ts
@@ -66,3 +66,25 @@ test.describe('streaming', () => {
     await expect(count).toHaveText('Rerender: 2');
   });
 });
+
+test.describe('streaming flush', () => {
+  test('should flush prefix before awaiting slow async component', async ({ page }) => {
+    await page.goto('/e2e/streaming-flush', {
+      waitUntil: 'commit',
+    });
+
+    // Prefix content must be visible quickly — the flush sends it
+    // before blocking on the 5s async component.
+    await expect(page.locator('#prefix')).toHaveText('Prefix content', {
+      timeout: 3000,
+    });
+
+    // Async content must NOT exist yet (still blocked on the delay).
+    await expect(page.locator('#async-result')).toHaveCount(0);
+
+    // After the async component resolves, the content appears.
+    await expect(page.locator('#async-result')).toHaveText('Async done', {
+      timeout: 8000,
+    });
+  });
+});

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -314,6 +314,7 @@ function processJSXNode(
           if (isPromise(jsxOutput)) {
             // Defer reading QScopedStyle until after the promise resolves
             enqueue(async () => {
+              await ssr.streamHandler.flush();
               const resolvedOutput = await jsxOutput;
               const compStyleComponentId = addComponentStylePrefix(host.getProp(QScopedStyle));
 


### PR DESCRIPTION
## Description

```
- Bug
```

### Description

Under the default in-order buffering strategy (`auto`), the SSR writer did not flush the stream buffer before awaiting a Qwik component body that returned a promise. All HTML already rendered before the pending component — including interactive UI the user could be seeing — sat in the server buffer until the async component resolved. With a slow data dependency the user saw a partial/stale page even though the HTML for the content above was fully produced.

The root cause: in `processJSXNode()` (`packages/qwik/src/core/ssr/ssr-render-jsx.ts`), the `isQwikComponent` branch enqueued `await jsxOutput` with no `streamHandler.flush()` beforehand, while the `isPromise(value)` branch right above it enqueued `ssr.streamHandler.flush()` before its await. This one-line fix adds the missing flush call, mirroring the existing pattern.

With `streaming.inOrder.strategy: 'direct'` the prefix already flushed correctly, which confirmed the buffering site.

Related: issue #8794.

### Checklist

- [x] My code follows the developer guidelines of this project
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs _(N/A — internal SSR behavior change, no API surface affected)_
- [ ] I added new tests to cover the fix / functionality _(existing stream handler and SSR container tests cover the flush/buffer machinery; the fix mirrors a pre-existing pattern at line 148)_