### PR TITLE
fix: flush journal after isNavigating true

### DIFF
--- a/.changeset/calm-loaders-render.md
+++ b/.changeset/calm-loaders-render.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: render navigation state before loading the next route

--- a/e2e/docs-e2e/package.json
+++ b/e2e/docs-e2e/package.json
@@ -3,7 +3,7 @@
   "description": "",
   "author": "",
   "devDependencies": {
-    "@playwright/test": "1.57.0",
+    "@playwright/test": "1.61.0",
     "@types/node": "24.10.0"
   },
   "keywords": [],

--- a/e2e/qwik-cli-e2e/package.json
+++ b/e2e/qwik-cli-e2e/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "kleur": "^4.1.5",
-    "playwright": "^1.57.0"
+    "playwright": "^1.61.1"
   },
   "private": true,
   "scripts": {

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/products/[id]/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/(common)/products/[id]/index.tsx
@@ -3,13 +3,17 @@ import { Link, routeLoader$, useLocation, type DocumentHead } from '@qwik.dev/ro
 import os from 'node:os';
 
 export default component$(() => {
-  const { params, url } = useLocation();
+  const location = useLocation();
+  const { params, url } = location;
   const store = useStore({ productFetchData: '' });
 
   const product = useProductLoader();
 
   return (
     <div>
+      <output id="navigation-status" hidden>
+        {location.isNavigating ? 'navigating' : 'idle'}
+      </output>
       <h1>Product: {params.id}</h1>
 
       {product.value == null && <p>Not Found</p>}

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/double-nav/a/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/double-nav/a/index.tsx
@@ -16,6 +16,15 @@ export default component$(() => {
       >
         Double Nav
       </button>
+      <button
+        id="double-nav-render-btn"
+        onClick$={() => {
+          nav('/qwikrouter-test/double-nav/b/');
+          queueMicrotask(() => nav('/qwikrouter-test/double-nav/c/'));
+        }}
+      >
+        Double Nav During Render
+      </button>
     </div>
   );
 });

--- a/e2e/qwik-e2e/tests/qwikrouter/nav.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/nav.e2e.ts
@@ -82,24 +82,39 @@ test.describe('nav', () => {
     });
 
     test('should update history and render immediately during SPA nav', async ({ page }) => {
+      let releaseRoute!: () => void;
+      let markRouteRequested!: () => void;
+      const routeRequested = new Promise<void>((resolve) => (markRouteRequested = resolve));
+      const routeReleased = new Promise<void>((resolve) => (releaseRoute = resolve));
       await page.route('**/products/jacket/q-loader-*.json', async (route) => {
-        await new Promise((resolve) => setTimeout(resolve, 600));
+        markRouteRequested();
+        await routeReleased;
         await route.continue();
       });
 
       await page.goto('/qwikrouter-test/products/hat/');
       const link = page.locator('[data-test-link="products-jacket"]');
       const heading = page.locator('h1');
+      const navigationStatus = page.locator('#navigation-status');
 
       await expect(heading).toHaveText('Product: hat');
-      await link.click();
+      await expect(navigationStatus).toHaveText('idle');
+      const click = link.click();
+      await routeRequested;
 
+      try {
+        await expect(navigationStatus).toHaveText('navigating');
+      } finally {
+        releaseRoute();
+      }
+      await click;
       // URL and params update immediately — the nav task does not wait for loaders.
       // The heading uses params.id directly so it switches right away.
       await expect
         .poll(() => new URL(page.url()).pathname)
         .toBe('/qwikrouter-test/products/jacket/');
       await expect(heading).toHaveText('Product: jacket');
+      await expect(navigationStatus).toHaveText('idle');
     });
 
     test.describe('scroll-restoration', () => {
@@ -370,6 +385,17 @@ test.describe('nav', () => {
       await btn.click();
 
       // Should end up at C (the second nav call), not B
+      await expect(page.locator('#double-nav-c')).toBeVisible();
+      expect(new URL(page.url()).pathname).toBe('/qwikrouter-test/double-nav/c/');
+      await expect(page.locator('#double-nav-c-data')).toHaveText('data-c');
+    });
+
+    test('second nav() call should win while the first waits for render', async ({ page }) => {
+      await page.goto('/qwikrouter-test/double-nav/a/');
+      await expect(page.locator('#double-nav-a')).toBeVisible();
+
+      await page.locator('#double-nav-render-btn').click();
+
       await expect(page.locator('#double-nav-c')).toBeVisible();
       expect(new URL(page.url()).pathname).toBe('/qwikrouter-test/double-nav/c/');
       await expect(page.locator('#double-nav-c-data')).toHaveText('data-c');

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
           "dependencyTypes": [
             "dev"
           ],
-          "pinVersion": "1.57.0"
+          "pinVersion": "1.61.0"
         }
       ],
       "semverGroups": [
@@ -114,7 +114,7 @@
     "@napi-rs/triples": "1.2.0",
     "@node-rs/helper": "1.6.0",
     "@octokit/action": "6.1.0",
-    "@playwright/test": "1.57.0",
+    "@playwright/test": "1.61.0",
     "@qwik.dev/core": "workspace:*",
     "@qwik.dev/optimizer": "workspace:*",
     "@qwik.dev/partytown": "0.13.2",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -41,7 +41,7 @@
     "gray-matter": "4.0.3",
     "leaflet": "1.9.4",
     "magic-string": "0.30.21",
-    "playwright": "1.57.0",
+    "playwright": "1.61.0",
     "pagefind": "1.4.0",
     "prettier": "3.7.4",
     "prism-themes": "1.9.0",

--- a/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
+++ b/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
@@ -384,7 +384,7 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
       return navResolver.p;
     }
 
-    internalState.navCount++;
+    const navCount = ++internalState.navCount;
     internalState.currentTransition?.skipTransition();
 
     if (
@@ -394,10 +394,9 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
         !isSamePath(dest, lastDest) ||
         !isSameOrigin(dest, lastDest))
     ) {
-      const ourNavId = internalState.navCount;
       const prevents = await Promise.all([...preventNav.$cbs$.values()].map((cb) => cb(dest)));
-      if (ourNavId !== internalState.navCount || prevents.some(Boolean)) {
-        if (ourNavId === internalState.navCount && type === 'popstate') {
+      if (navCount !== internalState.navCount || prevents.some(Boolean)) {
+        if (navCount === internalState.navCount && type === 'popstate') {
           // Popstate events are not cancellable, so we push to undo
           // TODO keep state?
           history.pushState(null, '', lastDest);
@@ -463,8 +462,17 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
       historyUpdated = true;
     }
 
-    actionState.value = undefined;
+    routeLocation.isNavigating = true;
+    const container = isBrowser ? _getContextContainer() : undefined;
+    if (container) {
+      // flush isNavigating to the DOM before awaiting the next task so that the router outlet can show a loading state
+      await _waitUntilRendered(container);
+      if (navCount !== internalState.navCount) {
+        return;
+      }
+    }
 
+    actionState.value = undefined;
     routeInternal.value = {
       type,
       dest,
@@ -478,8 +486,6 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
       // Prefetch: start loading route bundles and optionally loader data
       prefetchRoute(dest, true, 0.8, manifestHash);
     }
-
-    routeLocation.isNavigating = true;
 
     navResolver.p = new Promise<void>((resolve) => {
       navResolver.r = () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       '@playwright/test':
-        specifier: 1.57.0
-        version: 1.57.0
+        specifier: 1.61.0
+        version: 1.61.0
       '@qwik.dev/core':
         specifier: workspace:*
         version: link:packages/qwik
@@ -256,8 +256,8 @@ importers:
   e2e/docs-e2e:
     devDependencies:
       '@playwright/test':
-        specifier: 1.57.0
-        version: 1.57.0
+        specifier: 1.61.0
+        version: 1.61.0
       '@types/node':
         specifier: 24.10.0
         version: 24.10.0
@@ -268,8 +268,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       playwright:
-        specifier: ^1.57.0
-        version: 1.57.0
+        specifier: ^1.61.1
+        version: 1.61.1
 
   e2e/qwik-e2e: {}
 
@@ -576,8 +576,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       playwright:
-        specifier: 1.57.0
-        version: 1.57.0
+        specifier: 1.61.0
+        version: 1.61.0
       prettier:
         specifier: 3.7.4
         version: 3.7.4
@@ -3732,8 +3732,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.57.0':
-    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9314,13 +9314,23 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  playwright-core@1.57.0:
-    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.57.0:
-    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -14428,9 +14438,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.57.0':
+  '@playwright/test@1.61.0':
     dependencies:
-      playwright: 1.57.0
+      playwright: 1.61.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -20995,11 +21005,19 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.57.0: {}
+  playwright-core@1.61.0: {}
 
-  playwright@1.57.0:
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.0:
     dependencies:
-      playwright-core: 1.57.0
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
Ensures isNavigating is rendered before route-blocking work begins, allowing navigation loaders to appear reliably