### PR TITLE
feat: insights speed and ux improvements

### DIFF
--- a/packages/insights/src/components/header/header-url.ts
+++ b/packages/insights/src/components/header/header-url.ts
@@ -1,0 +1,2 @@
+export const getSettingsHref = (publicApiKey: string | undefined): string | null =>
+  publicApiKey ? `/app/${encodeURIComponent(publicApiKey)}/edit/` : null;

--- a/packages/insights/src/components/header/header-url.unit.ts
+++ b/packages/insights/src/components/header/header-url.unit.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { getSettingsHref } from './header-url';
+
+describe('getSettingsHref', () => {
+  test('links to settings only when an application is selected', () => {
+    expect(getSettingsHref('221smyuj5gl')).toBe('/app/221smyuj5gl/edit/');
+    expect(getSettingsHref(undefined)).toBeNull();
+  });
+});

--- a/packages/insights/src/components/header/index.tsx
+++ b/packages/insights/src/components/header/index.tsx
@@ -1,12 +1,14 @@
 import { component$ } from '@qwik.dev/core';
-import { Link } from '@qwik.dev/router';
+import { Link, useLocation } from '@qwik.dev/router';
 import { useSession, useSignOut } from '~/routes/plugin@auth';
 import Avatar from '../avatar';
 import { QwikIcon } from '../icons/qwik';
+import { getSettingsHref } from './header-url';
 
 export default component$(() => {
   const signOutSig = useSignOut();
   const userCtx = useSession();
+  const settingsHref = getSettingsHref(useLocation().params.publicApiKey);
 
   return (
     <header class="flex items-center gap-3 border border-b-slate-200 px-6 py-3">
@@ -17,7 +19,7 @@ export default component$(() => {
 
       {userCtx.value?.user?.email && (
         <div class="ml-auto flex items-center justify-center gap-8">
-          <Link href="/">Setting</Link>
+          {settingsHref && <Link href={settingsHref}>Settings</Link>}
           <Link
             class="cursor-pointer"
             onClick$={() => {

--- a/packages/insights/src/components/navigation-loader/index.tsx
+++ b/packages/insights/src/components/navigation-loader/index.tsx
@@ -1,0 +1,19 @@
+import { component$ } from '@qwik.dev/core';
+import { useLocation } from '@qwik.dev/router';
+
+export const NavigationLoader = component$(() => {
+  const location = useLocation();
+
+  return (
+    <div
+      role="status"
+      style={{ display: location.isNavigating ? 'flex' : 'none' }}
+      class="fixed inset-0 z-50 items-center justify-center bg-slate-950/20 backdrop-blur-[1px]"
+    >
+      <div class="flex items-center gap-3 rounded-lg border border-slate-200 bg-white px-5 py-4 text-sm font-semibold text-slate-700 shadow-lg">
+        <span class="h-5 w-5 animate-spin rounded-full border-2 border-slate-200 border-t-slate-700" />
+        Loading...
+      </div>
+    </div>
+  );
+});

--- a/packages/insights/src/components/symbol-tile/index.tsx
+++ b/packages/insights/src/components/symbol-tile/index.tsx
@@ -1,7 +1,9 @@
 import { Resource, component$, useResource$, useStore } from '@qwik.dev/core';
-import { server$, useLocation } from '@qwik.dev/router';
+import { getRequestEvent, server$, useLocation, type RequestEvent } from '@qwik.dev/router';
 import { and, eq } from 'drizzle-orm';
 import { getDB, symbolDetailTable } from '~/db';
+import type { InsightsUser } from '~/db/sql-user';
+import { getInsightUser } from '~/routes/app/layout';
 import { SymbolIcon } from '../icons/symbol';
 import { type PopupEvent } from '../popup-manager';
 
@@ -26,7 +28,7 @@ export const SymbolSource = component$<{ symbolHash: string }>(({ symbolHash }) 
     if (state.symbolHash) {
       state.fullName = '...';
       state.origin = '...';
-      const data = await serverGetSourceSnippet(location.params.publicApiKey, state.symbolHash);
+      const data = await serverGetSourceSnippet(state.symbolHash);
       state.fullName = data.fullName;
       state.origin = data.origin;
       state.originUrl = data.originUrl;
@@ -96,7 +98,23 @@ export const SymbolTile = component$<{ symbol: string }>(({ symbol }) => {
   );
 });
 
-const serverGetSourceSnippet = server$(async function (publicApiKey: string, symbolHash: string) {
+export function getAuthorizedPublicApiKey(
+  requestEvent: Pick<RequestEvent, 'params' | 'sharedMap' | 'error'>
+) {
+  const publicApiKey = requestEvent.params.publicApiKey;
+  const insightUser = getInsightUser(requestEvent.sharedMap) as InsightsUser | undefined;
+  if (!publicApiKey || !insightUser?.isAuthorizedForApp(publicApiKey)) {
+    throw requestEvent.error(403, 'Forbidden');
+  }
+  return publicApiKey;
+}
+
+const serverGetSourceSnippet = server$(async function (symbolHash: string) {
+  const requestEvent = getRequestEvent(this);
+  if (!requestEvent) {
+    throw new Error('Missing request context');
+  }
+  const publicApiKey = getAuthorizedPublicApiKey(requestEvent);
   const db = getDB();
   let [symbolDetail] = await Promise.all([
     db

--- a/packages/insights/src/components/symbol-tile/index.unit.ts
+++ b/packages/insights/src/components/symbol-tile/index.unit.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { RequestEvent } from '@qwik.dev/router';
+import { ServerError } from '@qwik.dev/router/middleware/request-handler';
+import { InsightsUser } from '~/db/sql-user';
+
+vi.mock('@qwik.dev/router', () => ({
+  getRequestEvent: vi.fn(),
+  server$: (serverFunction: unknown) => serverFunction,
+  serverQrl: vi.fn(),
+  useLocation: vi.fn(),
+}));
+
+describe('symbol source tenant authorization', () => {
+  test('rejects a request without an authenticated Insights user', async () => {
+    (globalThis as any).__EXPERIMENTAL__ = {};
+    const { getAuthorizedPublicApiKey } = await import('./index');
+    const forbidden = new ServerError(403, 'Forbidden');
+    const error = vi.fn(() => forbidden);
+
+    expect(() =>
+      getAuthorizedPublicApiKey({
+        params: { publicApiKey: 'app-a' },
+        sharedMap: new Map(),
+        error: error as RequestEvent['error'],
+      })
+    ).toThrow(forbidden);
+  });
+
+  test('rejects a tenant that the current user cannot access', async () => {
+    (globalThis as any).__EXPERIMENTAL__ = {};
+    const { getAuthorizedPublicApiKey } = await import('./index');
+    const forbidden = new ServerError(403, 'Forbidden');
+    const error = vi.fn(() => forbidden);
+
+    expect(() =>
+      getAuthorizedPublicApiKey({
+        params: { publicApiKey: 'app-b' },
+        sharedMap: new Map([
+          ['insightUser', new InsightsUser(1, 'john@example.com', false, ['app-a'])],
+        ]),
+        error: error as RequestEvent['error'],
+      })
+    ).toThrow(forbidden);
+    expect(error).toHaveBeenCalledWith(403, 'Forbidden');
+  });
+
+  test('uses the route tenant when the current user can access it', async () => {
+    (globalThis as any).__EXPERIMENTAL__ = {};
+    const { getAuthorizedPublicApiKey } = await import('./index');
+
+    expect(
+      getAuthorizedPublicApiKey({
+        params: { publicApiKey: 'app-a' },
+        sharedMap: new Map([
+          ['insightUser', new InsightsUser(1, 'john@example.com', false, ['app-a'])],
+        ]),
+        error: vi.fn() as RequestEvent['error'],
+      })
+    ).toBe('app-a');
+  });
+});

--- a/packages/insights/src/db/query.ts
+++ b/packages/insights/src/db/query.ts
@@ -5,6 +5,7 @@ import {
   createEdgeRow,
   createRouteRow,
   delayBucketField,
+  delayColumns,
   delayColumnSumList,
   edgeTableDelayCount,
   latencyBucketField,
@@ -23,6 +24,18 @@ import {
   type SymbolDetailRow,
 } from './schema';
 import { time } from './logging';
+import { BUCKETS } from '~/stats/vector';
+
+const delayColumnsByBucket = Object.values(delayColumns);
+const relationBoundary = BUCKETS.findIndex((bucket) => bucket.avg >= 250);
+const relatedCount = sql<number>`sum(${sql.join(
+  delayColumnsByBucket.slice(0, relationBoundary),
+  sql.raw(' + ')
+)})`;
+const unrelatedCount = sql<number>`sum(${sql.join(
+  delayColumnsByBucket.slice(relationBoundary),
+  sql.raw(' + ')
+)})`;
 
 export async function getEdges(
   db: AppDatabase,
@@ -58,6 +71,35 @@ export async function getEdges(
   });
 }
 
+export async function getSymbolGraphEdges(
+  db: AppDatabase,
+  publicApiKey: string,
+  { limit, manifestHashes }: { limit?: number; manifestHashes: string[] }
+) {
+  if (manifestHashes.length === 0) {
+    return [];
+  }
+  return time('edgeTable.getSymbolGraphEdges', async () => {
+    return db
+      .select({
+        from: edgeTable.from,
+        to: edgeTable.to,
+        relatedCount,
+        unrelatedCount,
+      })
+      .from(edgeTable)
+      .where(
+        and(
+          eq(edgeTable.publicApiKey, publicApiKey),
+          inArray(edgeTable.manifestHash, manifestHashes)
+        )
+      )
+      .groupBy(edgeTable.from, edgeTable.to)
+      .limit(limit || 5_000)
+      .all();
+  });
+}
+
 export interface SlowEdge {
   manifestHash: string;
   to: string;
@@ -69,26 +111,30 @@ export async function getSlowEdges(
   publicApiKey: string,
   manifests: string[]
 ): Promise<SlowEdge[]> {
-  let where = eq(edgeTable.publicApiKey, publicApiKey);
-  if (manifests.length) {
-    where = and(where, inArray(edgeTable.manifestHash, manifests))!;
+  if (manifests.length === 0) {
+    return [];
   }
-  const query = db
-    .select({
-      manifestHash: edgeTable.manifestHash,
-      to: edgeTable.to,
-      ...latencyColumnSums,
-    })
-    .from(edgeTable)
-    .where(where)
-    .groupBy(edgeTable.manifestHash, edgeTable.to)
-    .orderBy(sql`${computeLatency} DESC`)
-    .limit(400);
-  return (await query.all()).map((e) => ({
-    manifestHash: e.manifestHash,
-    to: e.to,
-    latency: toVector('sumLatencyCount' as const, e),
-  }));
+  return time('edgeTable.getSlowEdges', async () => {
+    const rows = await db
+      .select({
+        manifestHash: edgeTable.manifestHash,
+        to: edgeTable.to,
+        ...latencyColumnSums,
+      })
+      .from(edgeTable)
+      .where(
+        and(eq(edgeTable.publicApiKey, publicApiKey), inArray(edgeTable.manifestHash, manifests))
+      )
+      .groupBy(edgeTable.manifestHash, edgeTable.to)
+      .orderBy(sql`${computeLatency} DESC`)
+      .limit(400)
+      .all();
+    return rows.map((edge) => ({
+      manifestHash: edge.manifestHash,
+      to: edge.to,
+      latency: toVector('sumLatencyCount' as const, edge),
+    }));
+  });
 }
 
 export type SymbolDetailForApp = Pick<
@@ -101,23 +147,25 @@ export async function getSymbolDetails(
   publicApiKey: string,
   { manifestHashes }: { manifestHashes: string[] }
 ): Promise<SymbolDetailForApp[]> {
-  return db
-    .select({
-      hash: symbolDetailTable.hash,
-      fullName: symbolDetailTable.fullName,
-      origin: symbolDetailTable.origin,
-      lo: symbolDetailTable.lo,
-      hi: symbolDetailTable.hi,
-    })
-    .from(symbolDetailTable)
-    .where(
-      and(
-        eq(symbolDetailTable.publicApiKey, publicApiKey),
-        inArray(symbolDetailTable.manifestHash, manifestHashes)
+  return time('symbolDetailTable.getSymbolDetails', async () => {
+    return db
+      .select({
+        hash: symbolDetailTable.hash,
+        fullName: symbolDetailTable.fullName,
+        origin: symbolDetailTable.origin,
+        lo: symbolDetailTable.lo,
+        hi: symbolDetailTable.hi,
+      })
+      .from(symbolDetailTable)
+      .where(
+        and(
+          eq(symbolDetailTable.publicApiKey, publicApiKey),
+          inArray(symbolDetailTable.manifestHash, manifestHashes)
+        )
       )
-    )
-    .limit(1000)
-    .all();
+      .limit(1000)
+      .all();
+  });
 }
 
 export async function getAppInfo(

--- a/packages/insights/src/db/query.unit.ts
+++ b/packages/insights/src/db/query.unit.ts
@@ -1,0 +1,50 @@
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { assert, test } from 'vitest';
+import type { AppDatabase } from '.';
+
+test('returns aggregated symbol graph counts', async () => {
+  (globalThis as any).__EXPERIMENTAL__ = {};
+  const { getSlowEdges, getSymbolGraphEdges } = await import('./query');
+  const client = createClient({ url: 'file::memory:' });
+  const delayColumns = Array.from(
+    { length: 50 },
+    (_, index) => `delay_count_${String(index).padStart(2, '0')} INTEGER NOT NULL DEFAULT 0`
+  ).join(',');
+
+  try {
+    await client.execute(
+      `CREATE TABLE edges (public_api_key TEXT NOT NULL, manifest_hash TEXT NOT NULL, "from" TEXT, "to" TEXT NOT NULL, ${delayColumns})`
+    );
+    await client.batch([
+      {
+        sql: 'INSERT INTO edges (public_api_key, manifest_hash, "from", "to", delay_count_00, delay_count_25) VALUES (?, ?, ?, ?, ?, ?)',
+        args: ['app', 'hash-a', 'parent', 'child', 2, 3],
+      },
+      {
+        sql: 'INSERT INTO edges (public_api_key, manifest_hash, "from", "to", delay_count_00, delay_count_25) VALUES (?, ?, ?, ?, ?, ?)',
+        args: ['app', 'hash-b', 'parent', 'child', 5, 7],
+      },
+      {
+        sql: 'INSERT INTO edges (public_api_key, manifest_hash, "from", "to", delay_count_00, delay_count_25) VALUES (?, ?, ?, ?, ?, ?)',
+        args: ['other-app', 'hash-a', 'parent', 'child', 100, 100],
+      },
+    ]);
+
+    const db = drizzle(client) as AppDatabase;
+    assert.deepEqual(
+      await getSymbolGraphEdges(db, 'app', { manifestHashes: ['hash-a', 'hash-b'] }),
+      [
+        {
+          from: 'parent',
+          to: 'child',
+          relatedCount: 7,
+          unrelatedCount: 10,
+        },
+      ]
+    );
+    assert.deepEqual(await getSlowEdges(db, 'app', []), []);
+  } finally {
+    client.close();
+  }
+});

--- a/packages/insights/src/db/schema.ts
+++ b/packages/insights/src/db/schema.ts
@@ -99,9 +99,13 @@ export const symbolDetailTable = sqliteTable(
     hi: integer('hi').notNull(),
   },
   (symbolDetailTable) => ({
-    apiKeyManifestHashIndex: uniqueIndex('idx_symbolDetail_apiKey_manifestHash').on(
+    apiKeyManifestHashIndex: index('idx_symbolDetail_apiKey_manifestHash').on(
       symbolDetailTable.publicApiKey,
       symbolDetailTable.manifestHash
+    ),
+    apiKeyHashIndex: index('idx_symbolDetail_apiKey_hash').on(
+      symbolDetailTable.publicApiKey,
+      symbolDetailTable.hash
     ),
     publicApiKeyReference: foreignKey({
       columns: [symbolDetailTable.publicApiKey],

--- a/packages/insights/src/db/sql-manifest.ts
+++ b/packages/insights/src/db/sql-manifest.ts
@@ -1,7 +1,7 @@
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and, inArray, sql } from 'drizzle-orm';
 import { type AppDatabase } from './index';
 import { type ManifestRow, edgeTable, manifestTable } from './schema';
-import { latencyColumnSums, latencyCount, toVector } from './query-helpers';
+import { latencyColumnSums, toVector } from './query-helpers';
 
 export async function dbGetManifests(
   db: AppDatabase,
@@ -27,6 +27,10 @@ export async function dbGetManifestStats(
   db: AppDatabase,
   publicApiKey: string
 ): Promise<ManifestStatsRow[]> {
+  const manifestHashes = await dbGetManifestHashes(db, publicApiKey);
+  if (manifestHashes.length === 0) {
+    return [];
+  }
   const manifests = await db
     .select({
       hash: manifestTable.hash,
@@ -34,11 +38,19 @@ export async function dbGetManifestStats(
       ...latencyColumnSums,
     })
     .from(manifestTable)
-    .innerJoin(edgeTable, eq(edgeTable.manifestHash, manifestTable.hash))
-    .where(and(eq(manifestTable.publicApiKey, publicApiKey)))
+    .innerJoin(
+      edgeTable,
+      and(
+        eq(edgeTable.publicApiKey, manifestTable.publicApiKey),
+        eq(edgeTable.manifestHash, manifestTable.hash)
+      )
+    )
+    .where(
+      and(eq(manifestTable.publicApiKey, publicApiKey), inArray(manifestTable.hash, manifestHashes))
+    )
     .groupBy(manifestTable.hash)
     .orderBy(sql`${manifestTable.timestamp} DESC`)
-    .limit(1000)
+    .limit(100)
     .all();
   return manifests.map((manifest) => {
     return {
@@ -78,35 +90,15 @@ export async function dbGetManifestInfo(
 export async function dbGetManifestHashes(
   db: AppDatabase,
   publicApiKey: string,
-  { sampleSize }: { sampleSize?: number } = {}
+  { limit = 100, offset = 0 }: { limit?: number; offset?: number } = {}
 ): Promise<string[]> {
-  if (typeof sampleSize !== 'number') {
-    sampleSize = 100000;
-  }
   const manifests = await db
-    .select({ hash: manifestTable.hash, ...latencyCount })
+    .select({ hash: manifestTable.hash })
     .from(manifestTable)
-    .innerJoin(
-      edgeTable,
-      and(
-        eq(edgeTable.publicApiKey, manifestTable.publicApiKey),
-        eq(edgeTable.manifestHash, manifestTable.hash)
-      )
-    )
     .where(eq(manifestTable.publicApiKey, publicApiKey))
-    .groupBy(manifestTable.hash)
     .orderBy(sql`${manifestTable.timestamp} DESC`)
-    .limit(1000)
+    .limit(limit)
+    .offset(offset)
     .all();
-  const hashes: string[] = [];
-  let sum = 0;
-  for (let i = 0; i < manifests.length; i++) {
-    const row = manifests[i];
-    hashes.push(row.hash);
-    sum += row.latencyCount;
-    if (sum > sampleSize) {
-      break;
-    }
-  }
-  return hashes;
+  return manifests.map((manifest) => manifest.hash);
 }

--- a/packages/insights/src/db/sql-manifest.unit.ts
+++ b/packages/insights/src/db/sql-manifest.unit.ts
@@ -1,0 +1,56 @@
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { assert, test } from 'vitest';
+import type { AppDatabase } from '.';
+import { manifestTable } from './schema';
+import { dbGetManifestHashes, dbGetManifestStats } from './sql-manifest';
+
+test('returns the 100 newest manifest hashes', async () => {
+  const client = createClient({ url: 'file::memory:' });
+  const latencyColumns = Array.from(
+    { length: 50 },
+    (_, index) => `latency_count_${String(index).padStart(2, '0')} INTEGER NOT NULL DEFAULT 0`
+  ).join(',');
+
+  try {
+    await client.execute(
+      'CREATE TABLE manifests (id INTEGER PRIMARY KEY, public_api_key TEXT NOT NULL, hash TEXT NOT NULL, timestamp INTEGER NOT NULL)'
+    );
+    await client.execute(
+      `CREATE TABLE edges (public_api_key TEXT NOT NULL, manifest_hash TEXT NOT NULL, ${latencyColumns})`
+    );
+
+    const db = drizzle(client) as AppDatabase;
+    const manifests = Array.from({ length: 125 }, (_, index) => ({
+      publicApiKey: 'app',
+      hash: `hash-${index}`,
+      timestamp: new Date(index),
+    }));
+    await db.insert(manifestTable).values(manifests).run();
+    await client.batch(
+      manifests.map(({ publicApiKey, hash }) => ({
+        sql: 'INSERT INTO edges (public_api_key, manifest_hash) VALUES (?, ?)',
+        args: [publicApiKey, hash],
+      }))
+    );
+    await client.execute({
+      sql: 'INSERT INTO edges (public_api_key, manifest_hash, latency_count_00) VALUES (?, ?, ?)',
+      args: ['other-app', 'hash-24', 10],
+    });
+
+    const expectedHashes = Array.from({ length: 100 }, (_, index) => `hash-${124 - index}`);
+    assert.deepEqual(await dbGetManifestHashes(db, 'app'), expectedHashes);
+    assert.deepEqual(
+      await dbGetManifestHashes(db, 'app', { limit: 20, offset: 20 }),
+      expectedHashes.slice(20, 40)
+    );
+    const stats = await dbGetManifestStats(db, 'app');
+    assert.deepEqual(
+      stats.map((manifest) => manifest.hash),
+      expectedHashes
+    );
+    assert.equal(stats[0].latency[0], 0);
+  } finally {
+    client.close();
+  }
+});

--- a/packages/insights/src/routes/app/[publicApiKey]/index.tsx
+++ b/packages/insights/src/routes/app/[publicApiKey]/index.tsx
@@ -1,4 +1,4 @@
-import { getAppInfo, getEdgeCount } from '~/db/query';
+import { getAppInfo } from '~/db/query';
 import { routeLoader$, useLocation } from '@qwik.dev/router';
 
 import AppCard from '~/components/app-card';
@@ -9,11 +9,8 @@ import { getDB } from '~/db';
 export const useAppData = routeLoader$(async ({ params }) => {
   const db = getDB();
   const publicApiKey = params.publicApiKey;
-  const [app, symbolCount] = await Promise.all([
-    getAppInfo(db, publicApiKey),
-    getEdgeCount(db, publicApiKey),
-  ]);
-  return { app, symbolCount };
+  const app = await getAppInfo(db, publicApiKey);
+  return { app };
 });
 
 export default component$(() => {

--- a/packages/insights/src/routes/app/[publicApiKey]/routes/[route]/index.tsx
+++ b/packages/insights/src/routes/app/[publicApiKey]/routes/[route]/index.tsx
@@ -11,7 +11,7 @@ import { TIMELINE_BUCKETS, vectorAvg, vectorSum } from '~/stats/vector';
 export const useRouteData = routeLoader$(async ({ params }) => {
   const db = getDB();
   const publicApiKey = params.publicApiKey;
-  const route = decodeURIComponent(params.route);
+  const route = params.route;
   const manifestHashes = await dbGetManifestHashes(db, publicApiKey);
   const routes = await getRouteTimeline(db, publicApiKey, route, manifestHashes);
   return routeRowsToRouteTree(routes);
@@ -19,7 +19,7 @@ export const useRouteData = routeLoader$(async ({ params }) => {
 
 export default component$(() => {
   const symbolData = useRouteData();
-  const route = decodeURIComponent(useLocation().params.route);
+  const route = useLocation().params.route;
   return (
     <div>
       <h1 class="h3">

--- a/packages/insights/src/routes/app/[publicApiKey]/routes/index.tsx
+++ b/packages/insights/src/routes/app/[publicApiKey]/routes/index.tsx
@@ -4,6 +4,7 @@ import { RoutesIcon } from '~/components/icons/routes';
 import { getDB } from '~/db';
 import { dbGetManifestHashes } from '~/db/sql-manifest';
 import { getRouteNames } from '~/db/sql-routes';
+import { getRouteDetailsHref } from './route-url';
 
 export const useRouteData = routeLoader$(async ({ params }) => {
   const db = getDB();
@@ -16,7 +17,6 @@ export const useRouteData = routeLoader$(async ({ params }) => {
 export default component$(() => {
   const location = useLocation();
   const routesData = useRouteData();
-  const baseLink = `/app/${location.params.publicApiKey}/routes/`;
   return (
     <div>
       <h1 class="h3">
@@ -41,7 +41,9 @@ export default component$(() => {
                 <code>{route.route}</code>
               </th>
               <td scope="col" class="px-6 py-3 w-32">
-                <a href={baseLink + route.route + '/'}>View details</a>
+                <a href={getRouteDetailsHref(location.params.publicApiKey, route.route)}>
+                  View details
+                </a>
               </td>
             </tr>
           ))}

--- a/packages/insights/src/routes/app/[publicApiKey]/routes/route-url.ts
+++ b/packages/insights/src/routes/app/[publicApiKey]/routes/route-url.ts
@@ -1,0 +1,2 @@
+export const getRouteDetailsHref = (publicApiKey: string, route: string): string =>
+  `/app/${publicApiKey}/routes/${encodeURIComponent(route)}/`;

--- a/packages/insights/src/routes/app/[publicApiKey]/routes/route-url.unit.ts
+++ b/packages/insights/src/routes/app/[publicApiKey]/routes/route-url.unit.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+import { getRouteDetailsHref } from './route-url';
+
+describe('getRouteDetailsHref', () => {
+  test('keeps the complete route in one URL segment', () => {
+    const route = '/url/do/trasy/ktora/chcesz';
+    const href = getRouteDetailsHref('public-key', route);
+
+    expect(href).toBe('/app/public-key/routes/%2Furl%2Fdo%2Ftrasy%2Fktora%2Fchcesz/');
+    expect(decodeURIComponent(href.split('/').at(-2)!)).toBe(route);
+    expect(getRouteDetailsHref('public-key', '/')).toBe('/app/public-key/routes/%2F/');
+  });
+});

--- a/packages/insights/src/routes/app/[publicApiKey]/symbols/edge/index.tsx
+++ b/packages/insights/src/routes/app/[publicApiKey]/symbols/edge/index.tsx
@@ -1,22 +1,32 @@
 import { component$ } from '@qwik.dev/core';
-import { routeLoader$ } from '@qwik.dev/router';
+import { Link, routeLoader$ } from '@qwik.dev/router';
+import { SymbolTile } from '~/components/symbol-tile';
 import { getDB } from '~/db';
-import { computeSymbolGraph, type Symbol } from '~/stats/edges';
-import { getSymbolDetails, getEdges } from '~/db/query';
+import { computeSymbolGraph, computeSymbolTree, type SymbolTreeNode } from '~/stats/edges';
+import { getSymbolGraphEdges } from '~/db/query';
 import { dbGetManifestHashes } from '~/db/sql-manifest';
 import { SymbolIcon } from '~/components/icons/symbol';
 
 export const useRootSymbol = routeLoader$(async ({ params, url }) => {
   const db = getDB();
+  const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '', 10) || 1);
   const limit = url.searchParams.get('limit')
     ? parseInt(url.searchParams.get('limit')!)
     : undefined;
-  const manifestHashes = await dbGetManifestHashes(db, params.publicApiKey);
-  const [symbols, details] = await Promise.all([
-    getEdges(db, params.publicApiKey, { limit, manifestHashes }),
-    getSymbolDetails(db, params.publicApiKey, { manifestHashes }),
-  ]);
-  return computeSymbolGraph(symbols, details);
+  const manifestHashes = await dbGetManifestHashes(db, params.publicApiKey, {
+    limit: 101,
+    offset: (page - 1) * 100,
+  });
+  const hasNext = manifestHashes.length > 100;
+  const pageManifestHashes = manifestHashes.slice(0, 100);
+  if (pageManifestHashes.length === 0) {
+    return { rootSymbol: computeSymbolTree(computeSymbolGraph([])[0]), page, hasNext };
+  }
+  const symbols = await getSymbolGraphEdges(db, params.publicApiKey, {
+    limit,
+    manifestHashes: pageManifestHashes,
+  });
+  return { rootSymbol: computeSymbolTree(computeSymbolGraph(symbols)[0]), page, hasNext };
 });
 
 export default component$(() => {
@@ -27,12 +37,52 @@ export default component$(() => {
         <SymbolIcon />
         Symbols
       </h1>
-      <SymbolTree symbol={rootSymbol.value[0]} depth={0} />
+      <nav
+        aria-label="Pagination"
+        class="mb-6 flex items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm"
+      >
+        {rootSymbol.value.page > 1 && (
+          <Link
+            href={`?page=${rootSymbol.value.page - 1}`}
+            class="inline-flex min-w-28 items-center justify-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+          >
+            ← Previous
+          </Link>
+        )}
+        {rootSymbol.value.page === 1 && (
+          <span class="inline-flex min-w-28 cursor-not-allowed items-center justify-center rounded-md border border-slate-200 bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-400">
+            ← Previous
+          </span>
+        )}
+        <span class="text-sm font-semibold text-slate-600">Page {rootSymbol.value.page}</span>
+        {rootSymbol.value.hasNext && (
+          <Link
+            href={`?page=${rootSymbol.value.page + 1}`}
+            class="inline-flex min-w-28 items-center justify-center rounded-md border border-slate-300 bg-slate-200 px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-slate-300"
+          >
+            Next →
+          </Link>
+        )}
+        {!rootSymbol.value.hasNext && (
+          <span class="inline-flex min-w-28 cursor-not-allowed items-center justify-center rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-400">
+            Next →
+          </span>
+        )}
+      </nav>
+      <SymbolTree symbol={rootSymbol.value.rootSymbol} depth={0} />
     </div>
   );
 });
 
-function SymbolTree({ symbol, depth, count }: { symbol: Symbol; depth: number; count?: number }) {
+function SymbolTree({
+  symbol,
+  depth,
+  count,
+}: {
+  symbol: SymbolTreeNode;
+  depth: number;
+  count?: number;
+}) {
   const nextDepth = depth + 1;
   symbol.children.sort(
     (a, b) => (b.to.depth === nextDepth ? b.count : 0) - (a.to.depth === nextDepth ? a.count : 0)
@@ -53,18 +103,16 @@ function SymbolTree({ symbol, depth, count }: { symbol: Symbol; depth: number; c
           <span class="bg-white inline-block py-1 min-w-[120px] text-xs text-center rounded-full whitespace-nowrap">
             {count} / {symbol.count}
           </span>
-          <code class="text-xs ml-3 whitespace-nowrap">
-            <span class="font-bold">{(symbol.name as string | undefined) ?? 'n/A'}</span>
-            <span class="text-purple-500 mx-2">|</span>
-            {symbol.fullName ?? 'n/A'}
-            <span class="text-purple-500 mx-2">|</span>
-            {symbol.fileSrc || 'n/A'}
+          <span class="text-xs ml-3 whitespace-nowrap">
+            <span class="font-bold">
+              <SymbolTile symbol={symbol.name} />
+            </span>
             <span class="text-purple-500 mx-2">|</span>
             Depth:{' '}
             <span class="bg-slate-200 inline-block py-[2px] px-2 text-xs text-center rounded-full">
               {symbol.depth}
             </span>
-          </code>
+          </span>
         </div>
       )}
       {!terminal && (

--- a/packages/insights/src/routes/app/[publicApiKey]/symbols/index.tsx
+++ b/packages/insights/src/routes/app/[publicApiKey]/symbols/index.tsx
@@ -1,18 +1,16 @@
 import { component$ } from '@qwik.dev/core';
-import { routeLoader$ } from '@qwik.dev/router';
+import { Link, routeLoader$ } from '@qwik.dev/router';
 import Histogram, { delayColors, latencyColors } from '~/components/histogram';
 import { ManifestIcon } from '~/components/icons/manifest';
 import { SymbolIcon } from '~/components/icons/symbol';
 import { SymbolTile } from '~/components/symbol-tile';
 import { getDB } from '~/db';
-import { getEdges, getSymbolDetails } from '~/db/query';
+import { getEdges } from '~/db/query';
 import { dbGetManifestHashes } from '~/db/sql-manifest';
 import { BUCKETS, vectorAdd, vectorNew } from '~/stats/vector';
 
 interface Symbol {
   hash: string;
-  fullName: string;
-  origin: string;
   manifests: Record<string, Manifest>;
   delay: number[];
   latency: number[];
@@ -28,18 +26,25 @@ interface SymbolsInfo {
   symbols: Symbol[];
   manifests: Manifest[];
   buckets: typeof BUCKETS;
+  page: number;
+  hasNext: boolean;
 }
 
 export const useData = routeLoader$<SymbolsInfo>(async ({ params, url }) => {
   const db = getDB();
+  const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '', 10) || 1);
   const limit = url.searchParams.get('limit')
     ? parseInt(url.searchParams.get('limit')!)
     : undefined;
-  const manifestHashes = await dbGetManifestHashes(db, params.publicApiKey);
-  const [edges, details] = await Promise.all([
-    getEdges(db, params.publicApiKey, { limit, manifestHashes }),
-    getSymbolDetails(db, params.publicApiKey, { manifestHashes }),
-  ]);
+  const manifestHashes = await dbGetManifestHashes(db, params.publicApiKey, {
+    limit: 101,
+    offset: (page - 1) * 100,
+  });
+  const hasNext = manifestHashes.length > 100;
+  const pageManifestHashes = manifestHashes.slice(0, 100);
+  const edges = pageManifestHashes.length
+    ? await getEdges(db, params.publicApiKey, { limit, manifestHashes: pageManifestHashes })
+    : [];
 
   const symbolMap = new Map<string, Symbol>();
   const manifests = new Map<string, Manifest>();
@@ -54,17 +59,12 @@ export const useData = routeLoader$<SymbolsInfo>(async ({ params, url }) => {
     vectorAdd(symbol.delay, edge.delay);
     vectorAdd(symbol.latency, edge.latency);
   });
-  details.forEach((detail) => {
-    const symbol = symbolMap.get(detail.hash);
-    if (symbol) {
-      symbol.fullName = detail.fullName;
-      symbol.origin = detail.origin;
-    }
-  });
   return {
     symbols: Array.from(symbolMap.values()),
     manifests: Array.from(manifests.values()),
     buckets: BUCKETS,
+    page,
+    hasNext,
   };
   ////////////////////////////////////////////////////////
   function getSymbol(name: string) {
@@ -72,8 +72,6 @@ export const useData = routeLoader$<SymbolsInfo>(async ({ params, url }) => {
     if (!symbol) {
       symbol = {
         hash: name,
-        fullName: '',
-        origin: '',
         manifests: {} as Symbol['manifests'],
         delay: vectorNew(),
         latency: vectorNew(),
@@ -199,15 +197,15 @@ export default component$(() => {
               </td>
               <td scope="col" class="px-6 py-3 bg-slate-50">
                 <SymbolTile symbol={symbol.hash} />
-                <span class="block text-slate-500">
-                  {symbol.origin}
-                  {symbol.fullName}
-                </span>
               </td>
             </tr>
           ))}
         </tbody>
       </table>
+      <nav class="flex gap-4 mt-6">
+        {data.value.page > 1 && <Link href={`?page=${data.value.page - 1}`}>Previous</Link>}
+        {data.value.hasNext && <Link href={`?page=${data.value.page + 1}`}>Next</Link>}
+      </nav>
     </div>
   );
 });

--- a/packages/insights/src/routes/app/[publicApiKey]/symbols/slow/index.tsx
+++ b/packages/insights/src/routes/app/[publicApiKey]/symbols/slow/index.tsx
@@ -3,38 +3,23 @@ import { routeLoader$ } from '@qwik.dev/router';
 import Histogram, { latencyColors } from '~/components/histogram';
 import { SlowIcon } from '~/components/icons/slow';
 import { SymbolTile } from '~/components/symbol-tile';
-import { type ApplicationRow, getDB } from '~/db';
-import {
-  getAppInfo,
-  getSlowEdges,
-  getSymbolDetails,
-  type SlowEdge,
-  type SymbolDetailForApp,
-} from '~/db/query';
+import { getDB } from '~/db';
+import { getSlowEdges, type SlowEdge } from '~/db/query';
 import { dbGetManifestHashes } from '~/db/sql-manifest';
 import { BUCKETS, vectorAvg, vectorSum } from '~/stats/vector';
 
 interface SlowSymbol {
-  app: ApplicationRow;
   edges: SlowEdge[];
-  detailsMap: Record<string, SymbolDetailForApp | undefined>;
 }
 
 export const useData = routeLoader$<SlowSymbol>(async ({ params, query }) => {
   const manifest = query.get('manifest');
-  const manifests = manifest ? manifest.split(',') : [];
   const db = getDB();
-  const manifestHashes = await dbGetManifestHashes(db, params.publicApiKey);
-  const [app, edges, details] = await Promise.all([
-    getAppInfo(db, params.publicApiKey),
-    getSlowEdges(db, params.publicApiKey, manifests),
-    getSymbolDetails(db, params.publicApiKey, { manifestHashes }),
-  ]);
-  const detailsMap: Record<string, SymbolDetailForApp | undefined> = {};
-  details.forEach((detail) => {
-    detailsMap[detail.hash] = detail;
-  });
-  return { app, edges, detailsMap };
+  const manifestHashes = manifest
+    ? manifest.split(',').filter(Boolean).slice(0, 100)
+    : await dbGetManifestHashes(db, params.publicApiKey);
+  const edges = await getSlowEdges(db, params.publicApiKey, manifestHashes);
+  return { edges };
 });
 
 export default component$(() => {
@@ -67,7 +52,6 @@ export default component$(() => {
         </thead>
         <tbody>
           {data.value.edges.map((edge) => {
-            const detail = data.value.detailsMap[edge.to];
             return (
               <tr key={edge.to} class="border-b border-slate-200 text-xs">
                 <td class="px-6 py-3 bg-slate-50 font-bold">{edge.manifestHash}</td>
@@ -75,7 +59,6 @@ export default component$(() => {
                   <span class="font-bold">
                     <SymbolTile symbol={edge.to} />
                   </span>
-                  <span class="block text-slate-500">{detail?.fullName}</span>
                 </td>
                 <td class="px-6 py-3 bg-slate-50">{vectorSum(edge.latency)}</td>
                 <td class="px-6 py-2">{Math.round(vectorAvg(edge.latency))}ms</td>

--- a/packages/insights/src/routes/layout.tsx
+++ b/packages/insights/src/routes/layout.tsx
@@ -1,7 +1,8 @@
 import { Slot, component$ } from '@qwik.dev/core';
 
+import { NavigationLoader } from '~/components/navigation-loader';
 import { PopupManager } from '~/components/popup-manager';
-import { routeLoader$ } from '@qwik.dev/router';
+import { type RequestHandler } from '@qwik.dev/router';
 import type { GetSessionResult } from '@auth/qwik';
 
 export type SessionData = Awaited<GetSessionResult>['data'];
@@ -18,19 +19,19 @@ export type SessionData = Awaited<GetSessionResult>['data'];
 //   } as SessionData);
 // };
 
-export const useUserSession = routeLoader$(({ sharedMap, redirect, url }) => {
+export const onRequest: RequestHandler = async ({ sharedMap, redirect, url }) => {
   const session = sharedMap.get('session') as SessionData;
   if (session && url.pathname === '/') {
     // if authorized user try to access login page then redirect to app page
     throw redirect(307, '/app/');
   }
-  return session;
-});
+};
 
 export default component$(() => {
   return (
     <PopupManager>
       <Slot />
+      <NavigationLoader />
     </PopupManager>
   );
 });

--- a/packages/insights/src/stats/edges.ts
+++ b/packages/insights/src/stats/edges.ts
@@ -33,13 +33,23 @@ export interface SymbolPairs {
   latency: number[];
 }
 
+export interface SymbolPairCounts {
+  from: string | null;
+  to: string;
+  relatedCount: number;
+  unrelatedCount: number;
+}
+
 export interface SymbolDetail {
   hash: string;
   fullName: string;
   origin: string;
 }
 
-export function computeSymbolGraph(rows: SymbolPairs[], details?: SymbolDetail[]): Symbol[] {
+export function computeSymbolGraph(
+  rows: (SymbolPairs | SymbolPairCounts)[],
+  details?: SymbolDetail[]
+): Symbol[] {
   const detailMap = new Map<string, SymbolDetail>();
   const edgeMap = new Map<string, Edge>();
   const symbols: Symbol[] = [];
@@ -48,12 +58,15 @@ export function computeSymbolGraph(rows: SymbolPairs[], details?: SymbolDetail[]
   const rootSymbol = getSymbol('<synthetic.root.symbol>');
   for (const row of rows) {
     fixNames(row);
-    const [countRelated, countUnrelated] = vectorSum2(
-      row.delay,
-      // If previous symbol occurred less than x ms than assume that they are related.
-      // if more than x ms than assume that they are unrelated (parent is null).
-      250
-    );
+    const [countRelated, countUnrelated] =
+      'delay' in row
+        ? vectorSum2(
+            row.delay,
+            // If previous symbol occurred less than x ms than assume that they are related.
+            // if more than x ms than assume that they are unrelated (parent is null).
+            250
+          )
+        : [row.relatedCount, row.unrelatedCount];
     const self = getSymbol(row.to);
     self.count += countRelated + countUnrelated;
     if (countRelated) {
@@ -107,7 +120,7 @@ export function computeSymbolGraph(rows: SymbolPairs[], details?: SymbolDetail[]
     return edge;
   }
 
-  function fixNames(row: SymbolPairs) {
+  function fixNames(row: { from: string | null; to: string }) {
     row.to = row.to.split('_').pop()!;
     row.from = row.from == null ? null : row.from.split('_').pop()!;
     if (row.from === 'hW') {
@@ -134,6 +147,29 @@ export function computeSymbolGraph(rows: SymbolPairs[], details?: SymbolDetail[]
       symbols.push(symbol);
     }
     return symbol;
+  }
+}
+
+export type SymbolTreeNode = Omit<Symbol, 'children'> & {
+  children: { count: number; to: SymbolTreeNode }[];
+};
+
+export function computeSymbolTree(root: Symbol): SymbolTreeNode {
+  const expandedSymbols = new Set<Symbol>();
+  return visit(root, 0);
+
+  function visit(symbol: Symbol, depth: number): SymbolTreeNode {
+    const shouldExpand = symbol.depth === depth && !expandedSymbols.has(symbol);
+    if (shouldExpand) {
+      expandedSymbols.add(symbol);
+    }
+    const { children, ...node } = symbol;
+    return {
+      ...node,
+      children: shouldExpand
+        ? children.map((edge) => ({ count: edge.count, to: visit(edge.to, depth + 1) }))
+        : [],
+    };
   }
 }
 
@@ -192,7 +228,9 @@ export function computeSymbolVectors(symbols: Symbol[]): SymbolVectors {
       symbolVectorIdxMap.set(symbols[i], i);
       vector.push(0);
     }
-    vectors.push(vector);
+    if (vector.length > 0) {
+      vectors.push(vector);
+    }
     for (let i = 1; i < vector.length; i++) {
       vectors.push(vector.slice());
     }

--- a/packages/insights/src/stats/edges.unit.ts
+++ b/packages/insights/src/stats/edges.unit.ts
@@ -3,8 +3,51 @@ import {
   type SymbolPairs,
   type SymbolVectors,
   computeSymbolGraph,
+  computeSymbolTree,
   computeSymbolVectors,
 } from './edges';
+
+test('empty graph', () => {
+  assert.deepEqual(computeSymbolVectors(computeSymbolGraph([])), {
+    symbols: [],
+    vectors: [],
+  });
+});
+
+test('pre-aggregated graph counts', () => {
+  const graph = computeSymbolGraph([
+    { from: 'parent', to: 'child', relatedCount: 2, unrelatedCount: 3 },
+  ]);
+  const root = graph[0];
+  const child = graph.find((symbol) => symbol.name === 'child')!;
+  const parent = graph.find((symbol) => symbol.name === 'parent')!;
+
+  assert.equal(child.count, 5);
+  assert.equal(parent.children[0].count, 2);
+  assert.equal(root.children[0].count, 3);
+});
+
+test('expands a shared symbol only once', () => {
+  const graph = computeSymbolGraph([
+    edge('->a'),
+    edge('a->b'),
+    edge('a->c'),
+    edge('b->d'),
+    edge('c->d'),
+    edge('d->e'),
+  ]);
+  const tree = computeSymbolTree(graph[0]);
+  const names: string[] = [];
+  visit(tree);
+
+  assert.equal(names.filter((name) => name === 'd').length, 2);
+  assert.equal(names.filter((name) => name === 'e').length, 1);
+
+  function visit(symbol: typeof tree) {
+    names.push(symbol.name);
+    symbol.children.forEach((child) => visit(child.to));
+  }
+});
 
 test('simple paths', () => {
   const graph = computeSymbolGraph([edge('->a'), edge('a->b'), edge('b->c'), edge('c->d')]);


### PR DESCRIPTION
- Added a global navigation loader.
- Moved the authenticated root redirect from routeLoader$ to onRequest.
- Limited analytics queries to the latest 100 manifests with pagination.
- Optimized symbol, edge, and slow-symbol pages by removing eager detail queries and aggregating data in SQL.
- Added database indexes and fixed manifest joins for faster lookups.
- Added safer symbol-tree handling for shared nodes and empty graphs.
- Fixed route-detail URLs and the application-specific Settings link.