### PR TITLE
refactor(devtools): drive the sidebar from a configurable visible-tabs list

### DIFF
--- a/.changeset/sidebar-visible-tabs-model.md
+++ b/.changeset/sidebar-visible-tabs-model.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/devtools': patch
+---
+
+refactor: drive the devtools sidebar from a configurable visible-tabs list

--- a/packages/devtools/ui/src/devtools/DevtoolsSidebar.tsx
+++ b/packages/devtools/ui/src/devtools/DevtoolsSidebar.tsx
@@ -2,7 +2,7 @@ import { component$ } from '@qwik.dev/core';
 import { Tab } from '../components/Tab/Tab';
 import { QwikThemeToggle } from '../components/ThemeToggle/QwikThemeToggle';
 import type { DevtoolsState } from './state';
-import { devtoolsTabs } from './tabs';
+import { getVisibleTabs } from './sidebar-tabs';
 
 interface DevtoolsSidebarProps {
   state: DevtoolsState;
@@ -11,13 +11,11 @@ interface DevtoolsSidebarProps {
 export const DevtoolsSidebar = component$<DevtoolsSidebarProps>(({ state }) => {
   return (
     <div class="glass-bg border-glass-border shadow-r flex h-full w-16 flex-col items-center justify-start gap-3 border-r p-3 md:w-20">
-      {devtoolsTabs
-        .filter((tab) => !(state.isExtension && tab.viteOnly))
-        .map((tab) => (
-          <Tab key={tab.id} state={state} id={tab.id} title={tab.title}>
-            {tab.renderIcon()}
-          </Tab>
-        ))}
+      {getVisibleTabs(state.visibleTabIds, state.isExtension).map((tab) => (
+        <Tab key={tab.id} state={state} id={tab.id} title={tab.title}>
+          {tab.renderIcon()}
+        </Tab>
+      ))}
 
       <div class="mt-auto mb-2 opacity-80 transition-opacity hover:opacity-100">
         <QwikThemeToggle />

--- a/packages/devtools/ui/src/devtools/sidebar-tabs.ts
+++ b/packages/devtools/ui/src/devtools/sidebar-tabs.ts
@@ -1,0 +1,30 @@
+import type { DevtoolsTabId } from './state';
+import { devtoolsTabs, type DevtoolsTabConfig } from './tabs';
+
+/** Tab configs keyed by id, for resolving an ordered id list. */
+const tabsById = new Map<DevtoolsTabId, DevtoolsTabConfig>(
+  devtoolsTabs.map((tab): [DevtoolsTabId, DevtoolsTabConfig] => [tab.id, tab])
+);
+
+/** Default sidebar configuration: every tab visible, in registry order. */
+export function getDefaultVisibleTabIds(): DevtoolsTabId[] {
+  return devtoolsTabs.map((tab) => tab.id);
+}
+
+/**
+ * Resolves the ordered visible ids to their tab configs, dropping unknown ids and, in the
+ * extension, tabs that require the Vite plugin.
+ */
+export function getVisibleTabs(
+  visibleTabIds: DevtoolsTabId[],
+  isExtension: boolean
+): DevtoolsTabConfig[] {
+  const tabs: DevtoolsTabConfig[] = [];
+  for (const id of visibleTabIds) {
+    const tab = tabsById.get(id);
+    if (tab && !(isExtension && tab.viteOnly)) {
+      tabs.push(tab);
+    }
+  }
+  return tabs;
+}

--- a/packages/devtools/ui/src/devtools/sidebar-tabs.unit.ts
+++ b/packages/devtools/ui/src/devtools/sidebar-tabs.unit.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { getDefaultVisibleTabIds, getVisibleTabs } from './sidebar-tabs';
+import { devtoolsTabs } from './tabs';
+
+const registryIds = devtoolsTabs.map((tab) => tab.id);
+const firstViteOnly = devtoolsTabs.find((tab) => tab.viteOnly)!;
+
+describe('sidebar tabs model', () => {
+  test('default visible tabs are every registry tab in order', () => {
+    expect(getDefaultVisibleTabIds()).toEqual(registryIds);
+  });
+
+  test('getDefaultVisibleTabIds returns a fresh array each call', () => {
+    const first = getDefaultVisibleTabIds();
+    first.pop();
+    expect(getDefaultVisibleTabIds()).toHaveLength(registryIds.length);
+  });
+
+  test('getVisibleTabs resolves ids to configs, preserving the given order', () => {
+    const tabs = getVisibleTabs(['performance', 'overview'], false);
+    expect(tabs.map((tab) => tab.id)).toEqual(['performance', 'overview']);
+  });
+
+  test('getVisibleTabs keeps vite-only tabs in the overlay', () => {
+    const tabs = getVisibleTabs([firstViteOnly.id], false);
+    expect(tabs.map((tab) => tab.id)).toEqual([firstViteOnly.id]);
+  });
+
+  test('getVisibleTabs drops vite-only tabs in the extension', () => {
+    expect(getVisibleTabs([firstViteOnly.id], true)).toEqual([]);
+  });
+});

--- a/packages/devtools/ui/src/devtools/state.ts
+++ b/packages/devtools/ui/src/devtools/state.ts
@@ -6,6 +6,7 @@ import type {
   RoutesInfo,
 } from '@qwik.dev/devtools/kit';
 import type { NoSerialize } from '@qwik.dev/core';
+import { getDefaultVisibleTabIds } from './sidebar-tabs';
 
 export type DevtoolsTabId =
   | 'overview'
@@ -38,6 +39,8 @@ export interface DevtoolsState {
   isLoadingDependencies: boolean;
   panelBounds: DevtoolsPanelBounds;
   lastPanelBounds: DevtoolsPanelBounds | null;
+  /** Ordered ids of the tabs shown in the sidebar; the rest live in the More panel. */
+  visibleTabIds: DevtoolsTabId[];
   /** Whether the Vite devtools plugin overlay is also active on the page. */
   vitePluginDetected?: boolean;
   /** True when running inside the browser extension panel (no Vite server). */
@@ -62,6 +65,7 @@ export function createDevtoolsState(opts?: { isExtension?: boolean }): DevtoolsS
       height: 0,
     },
     lastPanelBounds: null,
+    visibleTabIds: getDefaultVisibleTabIds(),
     isExtension: opts?.isExtension ?? false,
   };
 }


### PR DESCRIPTION
## Context

Foundation (**PR 1 of ~4**) for the **Customizable Sidebar Tabs** feature. This PR is intentionally behavior-preserving: it introduces the data model the later PRs build on, with **no visible change yet**.

## Change

- Add an ordered `visibleTabIds: DevtoolsTabId[]` to `DevtoolsState`, defaulting to every tab in registry order.
- New `sidebar-tabs.ts` model: `getDefaultVisibleTabIds()` and `getVisibleTabs(visibleTabIds, isExtension)`, which resolves the ordered ids to their configs (via a private `tabsById` map) and applies the existing extension vite-only filter.
- `DevtoolsSidebar` renders `getVisibleTabs(state.visibleTabIds, state.isExtension)` instead of iterating the registry directly.

The default (all tabs, registry order) makes the rendered sidebar identical to today, including the extension's vite-only filtering.

## Follow-up PRs (this is an epic, split for reviewability)

This PR ships the model only. The rest of the feature lands in separate PRs on top of it:

- **PR 2** — More panel + "Customize" entry point + fixed bottom actions grouping.
- **PR 3** — Customize Tabs overlay modal (Visible / Available lists, checkbox toggle, Apply/Cancel), plus preference persistence.
- **PR 4** — drag-and-drop reordering + usability polish.

The customization UI in PRs 2 to 4 is gated to the Vite overlay (`!state.isExtension`); the extension keeps the default sidebar.

## Verification

- `tsc` on the devtools UI passes (0 errors); the model is fully typed with no casts.
- New `sidebar-tabs.unit.ts` covers the default list, order preservation, and vite-only filtering in overlay vs extension.
- eslint passes on the touched files.

## References

QwikDev project board, feature "Support Customizable Sidebar Tabs".