### PR TITLE
feat(devtools): add the Customize Tabs overlay to the sidebar

### DIFF
--- a/.changeset/customize-sidebar-tabs-modal.md
+++ b/.changeset/customize-sidebar-tabs-modal.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/devtools': minor
+---
+
+feat: customize which tabs appear in the devtools sidebar

--- a/.changeset/sidebar-visible-tabs-model.md
+++ b/.changeset/sidebar-visible-tabs-model.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/devtools': patch
+---
+
+refactor: drive the devtools sidebar from a configurable visible-tabs list

--- a/packages/devtools/ui/src/components/Icons/Icons.tsx
+++ b/packages/devtools/ui/src/components/Icons/Icons.tsx
@@ -380,3 +380,16 @@ export const QwikLogo = component$((props: IconProps) => {
     </svg>
   );
 });
+
+export const IconAdjustmentsHorizontal = component$((props: IconProps) => {
+  return (
+    <svg {...baseSvgProps({ ...props, viewBox: '0 0 24 24' })}>
+      {props.title ? <title>{props.title}</title> : null}
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75"
+      />
+    </svg>
+  );
+});

--- a/packages/devtools/ui/src/devtools/CustomizeTabsPanel.tsx
+++ b/packages/devtools/ui/src/devtools/CustomizeTabsPanel.tsx
@@ -1,0 +1,124 @@
+import { $, component$, Slot, useSignal, type QRL } from '@qwik.dev/core';
+import { IconXMark } from '../components/Icons/Icons';
+import { IconButton } from '../components/IconButton/IconButton';
+import type { DevtoolsState, DevtoolsTabId } from './state';
+import { getAvailableTabIds, resolveTabs, saveVisibleTabIds, setTabVisible } from './sidebar-tabs';
+
+interface TabRowProps {
+  id: DevtoolsTabId;
+  title: string;
+  checked: boolean;
+  onToggle$: QRL<(id: DevtoolsTabId, checked: boolean) => void>;
+}
+
+/** One selectable tab. The icon is passed as children so no non-serializable config crosses props. */
+const TabRow = component$<TabRowProps>(({ id, title, checked, onToggle$ }) => (
+  <li>
+    <label class="hover:bg-card-item-hover-bg flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5">
+      <input
+        type="checkbox"
+        class="h-3.5 w-3.5 rounded"
+        style={{ accentColor: 'var(--color-primary-active)' }}
+        checked={checked}
+        onChange$={(_, el) => onToggle$(id, el.checked)}
+      />
+      <span class="text-muted-foreground">
+        <Slot />
+      </span>
+      <span class="text-foreground text-sm">{title}</span>
+    </label>
+  </li>
+));
+
+interface CustomizeTabsPanelProps {
+  state: DevtoolsState;
+}
+
+/**
+ * Overlay for choosing which tools appear in the sidebar. Edits stay pending until "Apply", so
+ * closing or cancelling discards them. Relies on remounting when reopened to reset the pending
+ * list.
+ */
+export const CustomizeTabsPanel = component$<CustomizeTabsPanelProps>(({ state }) => {
+  const pendingVisibleIds = useSignal<DevtoolsTabId[]>([...state.visibleTabIds]);
+
+  const visibleTabs = resolveTabs(pendingVisibleIds.value);
+  const availableTabs = resolveTabs(getAvailableTabIds(pendingVisibleIds.value));
+
+  const toggle$ = $((id: DevtoolsTabId, checked: boolean) => {
+    pendingVisibleIds.value = setTabVisible(pendingVisibleIds.value, id, checked);
+  });
+
+  return (
+    <div class="absolute inset-0 z-30 flex items-start justify-start p-4">
+      <div
+        class="absolute inset-0 bg-black/40 backdrop-blur-sm transition-opacity"
+        onClick$={() => (state.isCustomizeOpen = false)}
+      />
+
+      <div class="glass-bg border-glass-border relative z-10 flex max-h-full w-80 flex-col overflow-hidden rounded-2xl border shadow-xl">
+        <div class="flex items-start justify-between p-4 pb-3">
+          <div>
+            <h2 class="text-foreground text-base font-semibold">Customize Tabs</h2>
+            <p class="text-muted-foreground text-xs">Choose which tools appear in the sidebar.</p>
+          </div>
+          <IconButton title="Close" onClick$={() => (state.isCustomizeOpen = false)}>
+            <IconXMark class="h-5 w-5" />
+          </IconButton>
+        </div>
+
+        <div class="custom-scrollbar flex flex-1 flex-col gap-4 overflow-y-auto px-4 pb-3">
+          <section>
+            <h3 class="text-foreground text-sm font-medium">Visible in Sidebar</h3>
+            <ul class="mt-2 flex flex-col gap-1">
+              {visibleTabs.map((tab) => (
+                <TabRow key={tab.id} id={tab.id} title={tab.title} checked onToggle$={toggle$}>
+                  {tab.renderIcon()}
+                </TabRow>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h3 class="text-foreground text-sm font-medium">Available in More Panel</h3>
+            <p class="text-muted-foreground text-xs">
+              Add tools to access them from the More panel.
+            </p>
+            <ul class="mt-2 flex flex-col gap-1">
+              {availableTabs.map((tab) => (
+                <TabRow
+                  key={tab.id}
+                  id={tab.id}
+                  title={tab.title}
+                  checked={false}
+                  onToggle$={toggle$}
+                >
+                  {tab.renderIcon()}
+                </TabRow>
+              ))}
+            </ul>
+          </section>
+        </div>
+
+        <div class="border-glass-border flex justify-end gap-2 border-t p-4">
+          <button
+            class="text-muted-foreground hover:text-foreground rounded-lg px-4 py-1.5 text-sm font-medium transition-colors"
+            onClick$={() => (state.isCustomizeOpen = false)}
+          >
+            Cancel
+          </button>
+          <button
+            class="bg-primary rounded-lg px-4 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+            onClick$={() => {
+              state.visibleTabIds = [...pendingVisibleIds.value];
+              saveVisibleTabIds(pendingVisibleIds.value);
+              state.isCustomizeOpen = false;
+            }}
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/packages/devtools/ui/src/devtools/DevtoolsSidebar.tsx
+++ b/packages/devtools/ui/src/devtools/DevtoolsSidebar.tsx
@@ -1,6 +1,7 @@
 import { component$ } from '@qwik.dev/core';
 import { Tab } from '../components/Tab/Tab';
 import { QwikThemeToggle } from '../components/ThemeToggle/QwikThemeToggle';
+import { IconAdjustmentsHorizontal } from '../components/Icons/Icons';
 import type { DevtoolsState } from './state';
 import { getVisibleTabs } from './sidebar-tabs';
 
@@ -17,8 +18,20 @@ export const DevtoolsSidebar = component$<DevtoolsSidebarProps>(({ state }) => {
         </Tab>
       ))}
 
-      <div class="mt-auto mb-2 opacity-80 transition-opacity hover:opacity-100">
-        <QwikThemeToggle />
+      <div class="mt-auto flex flex-col items-center gap-2">
+        {!state.isExtension && (
+          <button
+            class="text-muted-foreground hover:bg-foreground/5 hover:text-foreground flex h-11 w-11 items-center justify-center rounded-xl transition-all"
+            title="Customize Tabs"
+            aria-label="Customize Tabs"
+            onClick$={() => (state.isCustomizeOpen = true)}
+          >
+            <IconAdjustmentsHorizontal class="h-6 w-6" />
+          </button>
+        )}
+        <div class="mb-2 opacity-80 transition-opacity hover:opacity-100">
+          <QwikThemeToggle />
+        </div>
       </div>
     </div>
   );

--- a/packages/devtools/ui/src/devtools/DevtoolsSidebar.tsx
+++ b/packages/devtools/ui/src/devtools/DevtoolsSidebar.tsx
@@ -2,7 +2,7 @@ import { component$ } from '@qwik.dev/core';
 import { Tab } from '../components/Tab/Tab';
 import { QwikThemeToggle } from '../components/ThemeToggle/QwikThemeToggle';
 import type { DevtoolsState } from './state';
-import { devtoolsTabs } from './tabs';
+import { getVisibleTabs } from './sidebar-tabs';
 
 interface DevtoolsSidebarProps {
   state: DevtoolsState;
@@ -11,13 +11,11 @@ interface DevtoolsSidebarProps {
 export const DevtoolsSidebar = component$<DevtoolsSidebarProps>(({ state }) => {
   return (
     <div class="glass-bg border-glass-border shadow-r flex h-full w-16 flex-col items-center justify-start gap-3 border-r p-3 md:w-20">
-      {devtoolsTabs
-        .filter((tab) => !(state.isExtension && tab.viteOnly))
-        .map((tab) => (
-          <Tab key={tab.id} state={state} id={tab.id} title={tab.title}>
-            {tab.renderIcon()}
-          </Tab>
-        ))}
+      {getVisibleTabs(state.visibleTabIds, state.isExtension).map((tab) => (
+        <Tab key={tab.id} state={state} id={tab.id} title={tab.title}>
+          {tab.renderIcon()}
+        </Tab>
+      ))}
 
       <div class="mt-auto mb-2 opacity-80 transition-opacity hover:opacity-100">
         <QwikThemeToggle />

--- a/packages/devtools/ui/src/devtools/QwikDevtools.tsx
+++ b/packages/devtools/ui/src/devtools/QwikDevtools.tsx
@@ -9,6 +9,8 @@ import { DevtoolsContent } from './DevtoolsContent';
 import { loadDevtoolsData } from './rpc';
 import { createDevtoolsState, type DevtoolsState } from './state';
 import { DevtoolsSidebar } from './DevtoolsSidebar';
+import { CustomizeTabsPanel } from './CustomizeTabsPanel';
+import { loadVisibleTabIds } from './sidebar-tabs';
 import { ensurePreloadRuntime } from '../runtime/preloads';
 import { isExcludedPathname, normalizeExcludePathnames } from '../../../kit/src/overlay-paths';
 
@@ -29,6 +31,14 @@ export const QwikDevtools = component$<QwikDevtoolsProps>((props) => {
       }
 
       shouldRender.value = true;
+
+      // Restore the customized sidebar order/visibility (Vite overlay only).
+      if (!state.isExtension) {
+        const storedVisibleTabIds = loadVisibleTabIds();
+        if (storedVisibleTabIds) {
+          state.visibleTabIds = storedVisibleTabIds;
+        }
+      }
 
       if (!getQwikDevtoolsGlobal(window)?.[QWIK_DEVTOOLS_GLOBAL.props.dataProvider]) {
         ensurePreloadRuntime();
@@ -51,8 +61,11 @@ export const QwikDevtools = component$<QwikDevtoolsProps>((props) => {
         {state.isOpen && (
           <DevtoolsPanel state={state}>
             <DevtoolsSidebar state={state} />
-            <div class="custom-scrollbar min-h-0 flex-1 overflow-y-auto p-4">
-              <DevtoolsContent state={state} />
+            <div class="relative min-h-0 flex-1">
+              <div class="custom-scrollbar h-full overflow-y-auto p-4">
+                <DevtoolsContent state={state} />
+              </div>
+              {!state.isExtension && state.isCustomizeOpen && <CustomizeTabsPanel state={state} />}
             </div>
           </DevtoolsPanel>
         )}

--- a/packages/devtools/ui/src/devtools/sidebar-tabs.ts
+++ b/packages/devtools/ui/src/devtools/sidebar-tabs.ts
@@ -1,30 +1,106 @@
 import type { DevtoolsTabId } from './state';
 import { devtoolsTabs, type DevtoolsTabConfig } from './tabs';
 
+const STORAGE_KEY = 'qwik-devtools:visible-tabs';
+
 /** Tab configs keyed by id, for resolving an ordered id list. */
 const tabsById = new Map<DevtoolsTabId, DevtoolsTabConfig>(
   devtoolsTabs.map((tab): [DevtoolsTabId, DevtoolsTabConfig] => [tab.id, tab])
 );
+
+const KNOWN_TAB_IDS: ReadonlySet<string> = new Set(devtoolsTabs.map((tab) => tab.id));
+
+function isDevtoolsTabId(id: string): id is DevtoolsTabId {
+  return KNOWN_TAB_IDS.has(id);
+}
 
 /** Default sidebar configuration: every tab visible, in registry order. */
 export function getDefaultVisibleTabIds(): DevtoolsTabId[] {
   return devtoolsTabs.map((tab) => tab.id);
 }
 
+/** Tabs not currently visible (reachable via the More panel), in registry order. */
+export function getAvailableTabIds(visibleTabIds: DevtoolsTabId[]): DevtoolsTabId[] {
+  const visible = new Set(visibleTabIds);
+  return devtoolsTabs.map((tab) => tab.id).filter((id) => !visible.has(id));
+}
+
+/** Adds (appends) or removes a tab from the ordered visible list, returning a new list. */
+export function setTabVisible(
+  visibleTabIds: DevtoolsTabId[],
+  id: DevtoolsTabId,
+  visible: boolean
+): DevtoolsTabId[] {
+  if (visible) {
+    return visibleTabIds.includes(id) ? visibleTabIds : [...visibleTabIds, id];
+  }
+  return visibleTabIds.filter((tabId) => tabId !== id);
+}
+
+/** Drops ids no longer in the registry and de-dupes, preserving the stored order. */
+function normalizeVisibleTabIds(ids: readonly string[]): DevtoolsTabId[] {
+  const seen = new Set<DevtoolsTabId>();
+  const result: DevtoolsTabId[] = [];
+  for (const id of ids) {
+    if (isDevtoolsTabId(id) && !seen.has(id)) {
+      seen.add(id);
+      result.push(id);
+    }
+  }
+  return result;
+}
+
 /**
- * Resolves the ordered visible ids to their tab configs, dropping unknown ids and, in the
- * extension, tabs that require the Vite plugin.
+ * Reads the persisted visible-tabs list, or null when nothing valid is stored so the caller falls
+ * back to the default. An empty list is honored (the user hid every tab). Tabs added to the
+ * registry since the last save stay hidden (reachable via the More panel) until opted in.
+ */
+export function loadVisibleTabIds(): DevtoolsTabId[] | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    return normalizeVisibleTabIds(
+      parsed.filter((value): value is string => typeof value === 'string')
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Persists the visible-tabs list. Storage failures (private mode, quota) are ignored. */
+export function saveVisibleTabIds(visibleTabIds: DevtoolsTabId[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(visibleTabIds));
+  } catch {
+    // ignore storage failures
+  }
+}
+
+/** Resolves an ordered id list to its tab configs, dropping unknown ids. */
+export function resolveTabs(ids: DevtoolsTabId[]): DevtoolsTabConfig[] {
+  const tabs: DevtoolsTabConfig[] = [];
+  for (const id of ids) {
+    const tab = tabsById.get(id);
+    if (tab) {
+      tabs.push(tab);
+    }
+  }
+  return tabs;
+}
+
+/**
+ * Resolves the ordered visible ids to their tab configs, dropping, in the extension, tabs that
+ * require the Vite plugin.
  */
 export function getVisibleTabs(
   visibleTabIds: DevtoolsTabId[],
   isExtension: boolean
 ): DevtoolsTabConfig[] {
-  const tabs: DevtoolsTabConfig[] = [];
-  for (const id of visibleTabIds) {
-    const tab = tabsById.get(id);
-    if (tab && !(isExtension && tab.viteOnly)) {
-      tabs.push(tab);
-    }
-  }
-  return tabs;
+  return resolveTabs(visibleTabIds).filter((tab) => !(isExtension && tab.viteOnly));
 }

--- a/packages/devtools/ui/src/devtools/sidebar-tabs.ts
+++ b/packages/devtools/ui/src/devtools/sidebar-tabs.ts
@@ -1,0 +1,30 @@
+import type { DevtoolsTabId } from './state';
+import { devtoolsTabs, type DevtoolsTabConfig } from './tabs';
+
+/** Tab configs keyed by id, for resolving an ordered id list. */
+const tabsById = new Map<DevtoolsTabId, DevtoolsTabConfig>(
+  devtoolsTabs.map((tab): [DevtoolsTabId, DevtoolsTabConfig] => [tab.id, tab])
+);
+
+/** Default sidebar configuration: every tab visible, in registry order. */
+export function getDefaultVisibleTabIds(): DevtoolsTabId[] {
+  return devtoolsTabs.map((tab) => tab.id);
+}
+
+/**
+ * Resolves the ordered visible ids to their tab configs, dropping unknown ids and, in the
+ * extension, tabs that require the Vite plugin.
+ */
+export function getVisibleTabs(
+  visibleTabIds: DevtoolsTabId[],
+  isExtension: boolean
+): DevtoolsTabConfig[] {
+  const tabs: DevtoolsTabConfig[] = [];
+  for (const id of visibleTabIds) {
+    const tab = tabsById.get(id);
+    if (tab && !(isExtension && tab.viteOnly)) {
+      tabs.push(tab);
+    }
+  }
+  return tabs;
+}

--- a/packages/devtools/ui/src/devtools/sidebar-tabs.unit.ts
+++ b/packages/devtools/ui/src/devtools/sidebar-tabs.unit.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { getDefaultVisibleTabIds, getVisibleTabs } from './sidebar-tabs';
+import { devtoolsTabs } from './tabs';
+
+const registryIds = devtoolsTabs.map((tab) => tab.id);
+const firstViteOnly = devtoolsTabs.find((tab) => tab.viteOnly)!;
+
+describe('sidebar tabs model', () => {
+  test('default visible tabs are every registry tab in order', () => {
+    expect(getDefaultVisibleTabIds()).toEqual(registryIds);
+  });
+
+  test('getDefaultVisibleTabIds returns a fresh array each call', () => {
+    const first = getDefaultVisibleTabIds();
+    first.pop();
+    expect(getDefaultVisibleTabIds()).toHaveLength(registryIds.length);
+  });
+
+  test('getVisibleTabs resolves ids to configs, preserving the given order', () => {
+    const tabs = getVisibleTabs(['performance', 'overview'], false);
+    expect(tabs.map((tab) => tab.id)).toEqual(['performance', 'overview']);
+  });
+
+  test('getVisibleTabs keeps vite-only tabs in the overlay', () => {
+    const tabs = getVisibleTabs([firstViteOnly.id], false);
+    expect(tabs.map((tab) => tab.id)).toEqual([firstViteOnly.id]);
+  });
+
+  test('getVisibleTabs drops vite-only tabs in the extension', () => {
+    expect(getVisibleTabs([firstViteOnly.id], true)).toEqual([]);
+  });
+});

--- a/packages/devtools/ui/src/devtools/sidebar-tabs.unit.ts
+++ b/packages/devtools/ui/src/devtools/sidebar-tabs.unit.ts
@@ -1,5 +1,12 @@
-import { describe, expect, test } from 'vitest';
-import { getDefaultVisibleTabIds, getVisibleTabs } from './sidebar-tabs';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+  getAvailableTabIds,
+  getDefaultVisibleTabIds,
+  getVisibleTabs,
+  loadVisibleTabIds,
+  saveVisibleTabIds,
+  setTabVisible,
+} from './sidebar-tabs';
 import { devtoolsTabs } from './tabs';
 
 const registryIds = devtoolsTabs.map((tab) => tab.id);
@@ -21,12 +28,68 @@ describe('sidebar tabs model', () => {
     expect(tabs.map((tab) => tab.id)).toEqual(['performance', 'overview']);
   });
 
-  test('getVisibleTabs keeps vite-only tabs in the overlay', () => {
-    const tabs = getVisibleTabs([firstViteOnly.id], false);
-    expect(tabs.map((tab) => tab.id)).toEqual([firstViteOnly.id]);
+  test('getVisibleTabs keeps vite-only tabs in the overlay but drops them in the extension', () => {
+    expect(getVisibleTabs([firstViteOnly.id], false).map((tab) => tab.id)).toEqual([
+      firstViteOnly.id,
+    ]);
+    expect(getVisibleTabs([firstViteOnly.id], true)).toEqual([]);
   });
 
-  test('getVisibleTabs drops vite-only tabs in the extension', () => {
-    expect(getVisibleTabs([firstViteOnly.id], true)).toEqual([]);
+  test('available tabs are the registry minus the visible ones, in registry order', () => {
+    expect(getAvailableTabIds(['performance', 'overview'])).toEqual(
+      registryIds.filter((id) => id !== 'performance' && id !== 'overview')
+    );
+    expect(getAvailableTabIds(getDefaultVisibleTabIds())).toEqual([]);
+  });
+
+  test('setTabVisible removes, appends, and is a no-op for an already-visible tab', () => {
+    expect(setTabVisible(['overview', 'performance'], 'overview', false)).toEqual(['performance']);
+    expect(setTabVisible(['overview'], 'performance', true)).toEqual(['overview', 'performance']);
+    expect(setTabVisible(['overview'], 'overview', true)).toEqual(['overview']);
+  });
+});
+
+describe('visible tabs persistence', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    (globalThis as { localStorage?: Storage }).localStorage = {
+      getItem: (key) => store.get(key) ?? null,
+      setItem: (key, value) => void store.set(key, value),
+      removeItem: (key) => void store.delete(key),
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+  });
+
+  test('save then load round-trips the visible list', () => {
+    saveVisibleTabIds(['performance', 'overview']);
+    expect(loadVisibleTabIds()).toEqual(['performance', 'overview']);
+  });
+
+  test('load returns null when nothing is stored', () => {
+    expect(loadVisibleTabIds()).toBeNull();
+  });
+
+  test('load honors a persisted empty list (user hid every tab)', () => {
+    saveVisibleTabIds([]);
+    expect(loadVisibleTabIds()).toEqual([]);
+  });
+
+  test('load returns null for malformed json', () => {
+    localStorage.setItem('qwik-devtools:visible-tabs', '{not json');
+    expect(loadVisibleTabIds()).toBeNull();
+  });
+
+  test('load normalizes stored ids, dropping unknown and duplicate entries', () => {
+    localStorage.setItem(
+      'qwik-devtools:visible-tabs',
+      JSON.stringify(['overview', 'ghost', 7, 'performance', 'overview'])
+    );
+    expect(loadVisibleTabIds()).toEqual(['overview', 'performance']);
   });
 });

--- a/packages/devtools/ui/src/devtools/state.ts
+++ b/packages/devtools/ui/src/devtools/state.ts
@@ -41,6 +41,8 @@ export interface DevtoolsState {
   lastPanelBounds: DevtoolsPanelBounds | null;
   /** Ordered ids of the tabs shown in the sidebar; the rest live in the More panel. */
   visibleTabIds: DevtoolsTabId[];
+  /** Whether the Customize Tabs overlay is open (Vite overlay only). */
+  isCustomizeOpen: boolean;
   /** Whether the Vite devtools plugin overlay is also active on the page. */
   vitePluginDetected?: boolean;
   /** True when running inside the browser extension panel (no Vite server). */
@@ -66,6 +68,7 @@ export function createDevtoolsState(opts?: { isExtension?: boolean }): DevtoolsS
     },
     lastPanelBounds: null,
     visibleTabIds: getDefaultVisibleTabIds(),
+    isCustomizeOpen: false,
     isExtension: opts?.isExtension ?? false,
   };
 }

--- a/packages/devtools/ui/src/devtools/state.ts
+++ b/packages/devtools/ui/src/devtools/state.ts
@@ -6,6 +6,7 @@ import type {
   RoutesInfo,
 } from '@qwik.dev/devtools/kit';
 import type { NoSerialize } from '@qwik.dev/core';
+import { getDefaultVisibleTabIds } from './sidebar-tabs';
 
 export type DevtoolsTabId =
   | 'overview'
@@ -38,6 +39,8 @@ export interface DevtoolsState {
   isLoadingDependencies: boolean;
   panelBounds: DevtoolsPanelBounds;
   lastPanelBounds: DevtoolsPanelBounds | null;
+  /** Ordered ids of the tabs shown in the sidebar; the rest live in the More panel. */
+  visibleTabIds: DevtoolsTabId[];
   /** Whether the Vite devtools plugin overlay is also active on the page. */
   vitePluginDetected?: boolean;
   /** True when running inside the browser extension panel (no Vite server). */
@@ -62,6 +65,7 @@ export function createDevtoolsState(opts?: { isExtension?: boolean }): DevtoolsS
       height: 0,
     },
     lastPanelBounds: null,
+    visibleTabIds: getDefaultVisibleTabIds(),
     isExtension: opts?.isExtension ?? false,
   };
 }


### PR DESCRIPTION
## Context

PR 2 of the **Customizable Sidebar Tabs** feature, **stacked on #8826** (the visible-tabs model). Because it is a fork branch, this PR currently also contains #8826's commit; review/merge #8826 first and GitHub will reduce this diff to just the overlay commit. Review the top commit `feat(devtools): add the Customize Tabs overlay to the sidebar`. The customization UI is gated to the Vite overlay (`!state.isExtension`); the extension is unaffected.

<img width="800" height="534" alt="CleanShot 2026-07-14 at 12  16 16" src="https://github.com/user-attachments/assets/ccde50ca-2f7e-43c5-9c13-e908f3a07e66" />

## Change

- A "Customize" entry (adjustments icon) in the sidebar bottom actions opens a `CustomizeTabsPanel` overlay above the content (backdrop, no layout shift).
- The overlay shows a **Visible in Sidebar** list and an **Available in More Panel** list; checkboxes move tabs between them. Edits are pending until **Apply**, which commits `state.visibleTabIds` and persists it to `localStorage`; **Cancel** or closing discards them.
- Persistence is restored on load (overlay only); an empty list (all tabs hidden) is honored.
- Adds `IconAdjustmentsHorizontal`; extends `sidebar-tabs.ts` with `getAvailableTabIds`, `setTabVisible`, `resolveTabs`, and load/save helpers.

## Not in this PR (later stacked PRs)

- Drag-and-drop reordering of visible tabs.
- The sidebar **More panel** to actually open hidden tabs (today a hidden tab is reachable only by re-showing it in Customize).
- Usability polish (drag handles, refined states).

## Verification

- `tsc` on the devtools UI passes (0 errors); no `as` casts.
- `sidebar-tabs.unit.ts` covers available/toggle derivation and load/save/normalize (including honored empty and dropped unknown/duplicate ids).
- The devtools package builds through the Qwik optimizer, and the overlay was exercised in the docs host: toggling moves tabs between the two lists, Apply updates the sidebar, and the choice survives reload.
- eslint (incl. `eslint-plugin-qwik`) passes on the touched files.

## References

QwikDev project board, feature "Support Customizable Sidebar Tabs".