### PR TITLE
fix: prefix dev CSS and HMR URLs with Vite base

### DIFF
--- a/.changeset/quiet-bases-resolve.md
+++ b/.changeset/quiet-bases-resolve.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: prefix dev CSS and HMR URLs with Vite base

--- a/packages/qwik-router/src/buildtime/vite/dev-middleware.spec.ts
+++ b/packages/qwik-router/src/buildtime/vite/dev-middleware.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ViteDevServer } from 'vite';
-import { getDevMiddlewareRequestPath, sendRouterCssHotUpdate } from './dev-middleware';
+import {
+  getDevMiddlewareRequestPath,
+  getRouterIndexTags,
+  sendRouterCssHotUpdate,
+} from './dev-middleware';
 
 const file = '/app/src/routes/docs/docs.css';
 
@@ -62,5 +66,31 @@ describe('sendRouterCssHotUpdate', () => {
     });
     expect(sendRouterCssHotUpdate(server, file, 1)).toBe(false);
     expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe('getRouterIndexTags', () => {
+  it('prefixes CSS URLs with the Vite base', () => {
+    const cssModule = {
+      url: '/@fs/app/src/routes/admin.css',
+      file: '/app/src/routes/admin.css',
+      importers: new Set(),
+    };
+    const moduleGraph = { idToModuleMap: new Map([[cssModule.url, cssModule]]) };
+    const server = {
+      config: { base: '/admin/' },
+      environments: {
+        client: { moduleGraph: { idToModuleMap: new Map() } },
+        ssr: { moduleGraph },
+      },
+      watcher: { add: vi.fn() },
+    } as unknown as ViteDevServer;
+
+    expect(getRouterIndexTags(server)).toEqual([
+      {
+        tag: 'link',
+        attrs: { rel: 'stylesheet', href: '/admin/@fs/app/src/routes/admin.css' },
+      },
+    ]);
   });
 });

--- a/packages/qwik-router/src/buildtime/vite/dev-middleware.ts
+++ b/packages/qwik-router/src/buildtime/vite/dev-middleware.ts
@@ -246,7 +246,7 @@ export const getRouterIndexTags = (server: ViteDevServer) => {
   const cssUrls = getCssUrls(server);
   return cssUrls.map((url) => ({
     tag: 'link',
-    attrs: { rel: 'stylesheet', href: url },
+    attrs: { rel: 'stylesheet', href: server.config.base + url.slice(1) },
   }));
 };
 

--- a/packages/qwik-router/src/buildtime/vite/html-transform-wrapper.spec.ts
+++ b/packages/qwik-router/src/buildtime/vite/html-transform-wrapper.spec.ts
@@ -210,4 +210,17 @@ describe('wrapResponseForHtmlTransform', () => {
       await viteServer.close();
     }
   });
+
+  it('should prefix the Qwik HMR bridge with the Vite base', async () => {
+    server.config = { base: '/admin/' } as ViteDevServer['config'];
+    server.hot = {} as ViteDevServer['hot'];
+    wrapResponseForHtmlTransform(req, res as any, server);
+
+    res.setHeader('Content-Type', 'text/html');
+    res.end('<html><head></head><body></body></html>');
+
+    await new Promise((resolve) => res.on('finish', resolve));
+
+    expect(res.output).toContain('src="/admin/@id/@qwik-hmr-bridge"');
+  });
 });

--- a/packages/qwik-router/src/buildtime/vite/html-transform-wrapper.ts
+++ b/packages/qwik-router/src/buildtime/vite/html-transform-wrapper.ts
@@ -163,7 +163,7 @@ class HtmlTransformPatcher {
 
       // The HMR bridge which is served by qwikVite
       const hmrBridge = this.server.hot
-        ? `<script type="module" src="/@id/@qwik-hmr-bridge"></script>`
+        ? `<script type="module" src="${this.server.config.base}@id/@qwik-hmr-bridge"></script>`
         : '';
 
       // Extract the pre and post head and body content. For now, ignore attributes added to the tags


### PR DESCRIPTION
Fixed Vite base handling for CSS URLs and the Qwik HMR bridge in dev mode