### PR TITLE
fix: preserve camelcase html attributes after client resume

### DIFF
--- a/.changeset/calm-tables-span.md
+++ b/.changeset/calm-tables-span.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: preserve camelcase html attributes after client resume

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -1181,14 +1181,22 @@ function diffProps(
     vnode_ensureElementInflated(diffContext.$container$, vnode);
   }
   const oldAttrs = vnode.props;
+  const isHtml = (vnode.flags & VNodeFlags.NAMESPACE_MASK) === VNodeFlags.NS_html;
 
   // Actual diffing logic
   // Apply all new attributes
   for (const key in newAttrs) {
     const newValue = newAttrs[key];
+    // HTML parsers lowercase attribute names.
+    const oldKey =
+      oldAttrs && isHtml && !_hasOwnProperty.call(oldAttrs, key) ? key.toLowerCase() : key;
 
-    if (oldAttrs && _hasOwnProperty.call(oldAttrs, key)) {
-      const oldValue = oldAttrs[key];
+    if (oldAttrs && _hasOwnProperty.call(oldAttrs, oldKey)) {
+      const oldValue = oldAttrs[oldKey];
+      if (oldKey !== key) {
+        vnode_setProp(vnode, oldKey, null);
+        vnode_setProp(vnode, key, oldValue);
+      }
       if (!areDiffValuesEqual(newValue, oldValue)) {
         patchProperty(diffContext, vnode, key, newValue, currentFile);
       }

--- a/packages/qwik/src/core/tests/inline-component.spec.tsx
+++ b/packages/qwik/src/core/tests/inline-component.spec.tsx
@@ -40,6 +40,8 @@ const InlineWrapper = () => {
   return <MyComp />;
 };
 
+const ChildrenWrapper = (props: { children?: any }) => props.children;
+
 const Id = (props: any) => <div>Id: {props.id}</div>;
 
 const inlineProjectionContext = createContextId<{ value: string }>('inline-projection');
@@ -740,6 +742,56 @@ describe.each([
         </Fragment>
       </Component>
     );
+  });
+
+  it('should preserve table cell spans after inline component rerender', async () => {
+    const Cmp = component$(() => {
+      const sig = useSignal(true);
+      const valA = [3, 6, 12, 24];
+      const valB = [12, 24];
+      sig.value;
+
+      return (
+        <div>
+          <ChildrenWrapper>
+            <table>
+              <thead>
+                <tr>
+                  <th rowSpan={3}>ZZZ</th>
+                  <th colSpan={1 + valA.length + valB.length}>AAA</th>
+                </tr>
+                <tr>
+                  <th colSpan={valA.length + 1}>CCC</th>
+                  <th colSpan={valB.length}>DDD</th>
+                </tr>
+                <tr>
+                  <th>EEE</th>
+                  {valA.map((value, index) => (
+                    <th key={index}>{value}</th>
+                  ))}
+                  {valB.map((value, index) => (
+                    <th key={index}>{value}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+            <button onClick$={() => (sig.value = !sig.value)}>submit</button>
+          </ChildrenWrapper>
+        </div>
+      );
+    });
+
+    const { document } = await render(<Cmp />, { debug });
+    const getColSpans = () =>
+      Array.from(
+        document.querySelectorAll<HTMLTableCellElement>('th[colspan]'),
+        (cell) => cell.colSpan
+      );
+
+    expect(getColSpans()).toEqual([7, 5, 2]);
+    await trigger(document.body, 'button', 'click');
+    expect(getColSpans()).toEqual([7, 5, 2]);
   });
 
   it('should allow to modify children component props', async () => {


### PR DESCRIPTION
Preserve camel-cased HTML attributes such as colSpan during resume by reconciling DOM-normalized keys in the vnode diff