### PR TITLE
chore: release v2 from main instead of build/v2

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   ],
   "linked": [],
   "access": "public",
-  "baseBranch": "origin/build/v2",
+  "baseBranch": "origin/main",
   "updateInternalDependencies": "minor",
   "ignore": [
     "@qwik.dev/qwik-vite",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,7 +16,7 @@
     "@devtools/browser-extension": "0.1.0",
     "@qwik.dev/devtools": "0.2.8"
   },
-  "branch": "build/v2",
+  "branch": "main",
   "changesets": [
     "afraid-bags-jam",
     "afraid-garlics-greet",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Set Dist Tag
         id: set_dist_tag
         if: |
-          github.ref == 'refs/heads/build/v2' && (
+          github.ref == 'refs/heads/main' && (
             github.event_name == 'push' ||
             github.event_name == 'workflow_dispatch'
           )
@@ -1455,7 +1455,7 @@ jobs:
       always() && 
       github.event_name != 'pull_request' &&
       github.repository == 'QwikDev/qwik' && (
-        github.ref == 'refs/heads/build/v2' ||
+        github.ref == 'refs/heads/main' ||
         needs.test-unit.result == 'success' || 
         needs.test-unit.result == 'skipped'
       )
@@ -1513,13 +1513,13 @@ jobs:
       # Do this before other release steps to avoid
       # publishing temporary files
       - name: Create Release Pull Request or Publish to npm
-        if: github.ref == 'refs/heads/build/v2'
+        if: github.ref == 'refs/heads/main'
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           publish: pnpm release
           title: V2 Version Packages
-          branch: build/v2
+          branch: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -34,7 +34,7 @@ the cursor system, and the Rust optimizer.
 
 ## Monorepo Map
 
-- Base branch and release branch for v2 PRs: `build/v2`.
+- Base branch and release branch for v2 PRs: `main`. V1 lives on the `v1` branch.
 
 | Package | Path | Notes |
 | --- | --- | --- |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ the cursor system, and the Rust optimizer.
 
 ## Monorepo Map
 
-- Base branch and release branch for v2 PRs: `build/v2`.
+- Base branch and release branch for v2 PRs: `main`. V1 lives on the `v1` branch.
 
 | Package | Path | Notes |
 | --- | --- | --- |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ the cursor system, and the Rust optimizer.
 
 ## Monorepo Map
 
-- Base branch and release branch for v2 PRs: `build/v2`.
+- Base branch and release branch for v2 PRs: `main`. V1 lives on the `v1` branch.
 
 | Package | Path | Notes |
 | --- | --- | --- |

--- a/packages/docs/test-urls.js
+++ b/packages/docs/test-urls.js
@@ -188,7 +188,7 @@ async function testAllPaths() {
 
   for (const testPath of testPaths) {
     const editPath = makeEditPageUrl(testPath);
-    const editUrl = `https://github.com/QwikDev/qwik/blob/build/v2/packages/docs/src/routes/${editPath}/index.mdx`;
+    const editUrl = `https://github.com/QwikDev/qwik/blob/main/packages/docs/src/routes/${editPath}/index.mdx`;
 
     try {
       const result = await checkUrl(editUrl);

--- a/packages/qwik/src/core/tests/README.md
+++ b/packages/qwik/src/core/tests/README.md
@@ -39,9 +39,9 @@ In the current directory, you will find files such as `projection.spec.tsx`, `us
 Here are ways to contribute in the order of time commitment:
 
 1. Review the existing code and point out what is not clear or needs more documentation.
-2. Create small fixes against the `build/v2` branch.
-3. Add missing tests to the `build/v2` branch showcasing the missing features.
-4. Attempt to implement the features in the `build/v2` branch.
+2. Create small fixes against the `main` branch.
+3. Add missing tests to the `main` branch showcasing the missing features.
+4. Attempt to implement the features in the `main` branch.
 
 **IMPORTANT START HERE:** We have created a special unit test: [`README.spec.tsx`](./README.spec.tsx). The purpose of this unit test is to:
 


### PR DESCRIPTION
Part of the main-becomes-v2 branch swap (phase A). Points release gating, changesets config, and branch references at `main`.

**Do not merge until the swap moment**: once this lands on `build/v2`, pushes to `build/v2` no longer publish — main must be fast-forwarded to `build/v2` immediately after.

Swap sequence when ready (phase B):
1. Mark this PR ready + merge (merge commit, no squash)
2. Fast-forward: `git push origin origin/build/v2:main` (needs ruleset bypass on Protected Main)
3. Retarget open `build/v2` PRs to `main`
4. Deactivate the "Protected v2" ruleset; keep `build/v2` frozen for a while

Already done (phase A):
- `v1` branch created from main tip (c59a430cb) + "Protected v1" ruleset
- All 25 open main-based PRs retargeted to `v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)