### PR TITLE
ci: trigger on v1 branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - v1
       - upcoming
       - next
       - qwik-labs

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,5 +1,7 @@
 # Qwik Docs Site ⚡️
 
+> The production docs at qwik.dev deploy from the `v1` branch.
+
 ## Development Builds
 
 ### Client only


### PR DESCRIPTION
`main` is now the v2 branch; `v1` continues v1 development.

- Pushes to `v1` need to run CI (the old `main` entry is dead config on this branch).
- Touches `packages/docs/README.md` so this push misses the docs build cache, rebuilding and redeploying the v1 docs to production (qwik.dev) via the fixed deploy-docs workflow (#8843).

🤖 Generated with [Claude Code](https://claude.com/claude-code)