### PR TITLE
fix: report repeated qrl chunk load failures only once

### DIFF
--- a/.changeset/quiet-chunks-report.md
+++ b/.changeset/quiet-chunks-report.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: report repeated qrl chunk load failures only once

--- a/packages/qwik/src/core/shared/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/shared/qrl/qrl-class.ts
@@ -2,7 +2,7 @@
 import { getPlatform, isServerPlatform } from '../platform/platform';
 // ^^^ keep these imports above the rest to prevent circular dep issues
 
-import { isBrowser, isDev } from '@qwik.dev/core/build';
+import { isBrowser, isDev, isServer } from '@qwik.dev/core/build';
 import { invokeApply, tryGetInvokeContext, type InvokeContext } from '../../use/use-core';
 import { assertDefined } from '../error/assert';
 import { QError, qError } from '../error/error';
@@ -82,6 +82,8 @@ export type QRLInternalMethods<TYPE> = {
   readonly $lazy$: LazyRef<TYPE>;
 };
 
+let reportedChunkFailures: WeakMap<Container, Set<string>> | undefined;
+
 let getLazyRef: <TYPE>(
   chunk: string | null,
   symbol: string,
@@ -137,7 +139,27 @@ export class LazyRef<TYPE = unknown> {
       ref.then(
         (r) => (this.$ref$ = r),
         (err) => {
-          console.error(`qrl ${this.$symbol$} failed to load`, err);
+          const errorMessage = `qrl ${this.$symbol$} failed to load`;
+
+          if (qTest ? isServerPlatform() : isServer) {
+            console.error(errorMessage, err);
+          } else if (qTest ? !isServerPlatform() : isBrowser) {
+            const failureKey =
+              this.$chunk$ === null ? `symbol:${this.$symbol$}` : `chunk:${this.$chunk$}`;
+            const container = this.$container$;
+            let containerFailures = container && reportedChunkFailures?.get(container);
+            if (!containerFailures?.has(failureKey)) {
+              if (container) {
+                if (!containerFailures) {
+                  containerFailures = new Set();
+                  (reportedChunkFailures ||= new WeakMap()).set(container, containerFailures);
+                }
+                containerFailures.add(failureKey);
+              }
+              console.error(errorMessage, err);
+            }
+          }
+
           // We shouldn't cache rejections, we can try again later
           this.$ref$ = null;
         }

--- a/packages/qwik/src/core/shared/qrl/qrl.unit.ts
+++ b/packages/qwik/src/core/shared/qrl/qrl.unit.ts
@@ -1,6 +1,7 @@
 import { $ } from '@qwik.dev/core';
-import { assert, assertType, describe, expectTypeOf, test } from 'vitest';
+import { assert, assertType, describe, expectTypeOf, test, vi } from 'vitest';
 import { useLexicalScope } from '../../use/use-lexical-scope.public';
+import { getPlatform, setPlatform } from '../platform/platform';
 import { createSerializationContext, parseQRL, qrlToString } from '../serdes/index';
 import { _regSymbol, inlinedQrl, qrl } from './qrl';
 import { _captures, createQRL, deserializeCaptureDeltas } from './qrl-class';
@@ -175,6 +176,66 @@ describe('createQRL', () => {
     assert.equal(q.resolved, undefined);
     assert.equal(await q.resolve(), 'resolved');
     assert.equal(q.resolved, 'resolved');
+  });
+
+  test('should log a failed chunk only once per container', async () => {
+    const firstError = new Error('first failure');
+    const secondError = new Error('second failure');
+    const thirdError = new Error('third failure');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const previousPlatform = getPlatform();
+    const importSymbol = vi
+      .fn()
+      .mockRejectedValueOnce(firstError)
+      .mockRejectedValueOnce(secondError)
+      .mockRejectedValueOnce(thirdError);
+    setPlatform({ ...previousPlatform, isServer: false, importSymbol });
+
+    try {
+      const firstContainer = { element: {} } as any;
+      const secondContainer = { element: {} } as any;
+      const firstQrl = createQRL('chunk', 'first', null, null, null, firstContainer);
+      const secondQrl = createQRL('chunk', 'second', null, null, null, firstContainer);
+      const thirdQrl = createQRL('chunk', 'third', null, null, null, secondContainer);
+
+      const results = await Promise.allSettled([
+        firstQrl.resolve(),
+        secondQrl.resolve(),
+        thirdQrl.resolve(),
+      ]);
+
+      assert.deepEqual(results, [
+        { status: 'rejected', reason: firstError },
+        { status: 'rejected', reason: secondError },
+        { status: 'rejected', reason: thirdError },
+      ]);
+      assert.equal(consoleError.mock.calls.length, 2);
+      assert.deepEqual(consoleError.mock.calls[0], ['qrl first failed to load', firstError]);
+      assert.deepEqual(consoleError.mock.calls[1], ['qrl third failed to load', thirdError]);
+    } finally {
+      setPlatform(previousPlatform);
+      consoleError.mockRestore();
+    }
+  });
+
+  test('should not deduplicate failed chunks on the server', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const previousPlatform = getPlatform();
+    const importSymbol = vi.fn().mockRejectedValue(new Error('failure'));
+    setPlatform({ ...previousPlatform, isServer: true, importSymbol });
+
+    try {
+      const container = { element: {} } as any;
+      const firstQrl = createQRL('server-chunk', 'first', null, null, null, container);
+      const secondQrl = createQRL('server-chunk', 'second', null, null, null, container);
+
+      await Promise.allSettled([firstQrl.resolve(), secondQrl.resolve()]);
+
+      assert.equal(consoleError.mock.calls.length, 2);
+    } finally {
+      setPlatform(previousPlatform);
+      consoleError.mockRestore();
+    }
   });
 
   const fn = () => 'hi';


### PR DESCRIPTION
Deduplicate QRL chunk load errors per container to prevent repeated console logs when multiple QRLs reference the same failing chunk. Rejected promises remain retryable and continue propagating to callers.