### PR TITLE
fix: preserve search params when submitting route actions

### DIFF
--- a/.changeset/action-search-params.md
+++ b/.changeset/action-search-params.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: preserve search params when submitting route actions

--- a/e2e/qwik-e2e/tests/qwikrouter/returned-control-flow.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/returned-control-flow.e2e.ts
@@ -30,6 +30,17 @@ test.describe('returned control-flow signals', () => {
     expect(response.status()).toEqual(403);
   });
 
+  test('action submission preserves current search params', async ({ page }) => {
+    await page.goto(`${base}/action-error/?foo=bar&tag=a&tag=b`);
+    const [response] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('qaction=')),
+      page.locator('button[type="submit"]').click(),
+    ]);
+    const actionUrl = new URL(response.url());
+    expect(actionUrl.searchParams.get('foo')).toEqual('bar');
+    expect(actionUrl.searchParams.getAll('tag')).toEqual(['a', 'b']);
+  });
+
   test('JSON action redirect responds with an envelope and navigates the page', async ({
     page,
   }) => {

--- a/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
+++ b/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
@@ -567,7 +567,7 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
 
         // Submit action if one was triggered
         if (action) {
-          const result = await submitAction(action, trackUrl.pathname);
+          const result = await submitAction(action, trackUrl);
           if (!result) {
             // HTTP redirect happened — bail
             routeInternal.untrackedValue = { type: navType, dest: trackUrl };

--- a/packages/qwik-router/src/runtime/src/use-endpoint.ts
+++ b/packages/qwik-router/src/runtime/src/use-endpoint.ts
@@ -6,13 +6,13 @@ import { QACTION_KEY } from './constants';
 /**
  * Submit an action to the server and get the result.
  *
- * POSTs to `/routePath/?qaction={actionId}` with `Accept: application/json`. The server runs the
- * action and returns the action result, optionally with the loader hashes that should be
- * invalidated.
+ * POSTs to the route URL with `qaction={actionId}` appended and `Accept: application/json`. The
+ * server runs the action and returns the action result, optionally with the loader hashes that
+ * should be invalidated.
  */
 export async function submitAction(
   action: NonNullable<RouteActionValue>,
-  routePath: string
+  routeUrl: URL
 ): Promise<
   | {
       status: number;
@@ -22,8 +22,9 @@ export async function submitAction(
     }
   | undefined
 > {
-  const pathBase = ensureSlash(routePath);
-  const url = `${pathBase}?${QACTION_KEY}=${encodeURIComponent(action.id)}`;
+  const pathBase = ensureSlash(routeUrl.pathname);
+  const querySeparator = routeUrl.search ? '&' : '?';
+  const url = `${pathBase}${routeUrl.search}${querySeparator}${QACTION_KEY}=${encodeURIComponent(action.id)}`;
 
   const actionData = action.data;
   // Clear immediately so a task rerun can't re-submit the same payload

--- a/packages/qwik-router/src/runtime/src/use-endpoint.unit.ts
+++ b/packages/qwik-router/src/runtime/src/use-endpoint.unit.ts
@@ -26,7 +26,7 @@ describe('submitAction', () => {
     );
 
     const action = { id: 'act-a', data: { name: 'Ada' } };
-    await submitAction(action as any, '/test/');
+    await submitAction(action as any, new URL('https://qwik.dev/test/'));
 
     expect(action.data).toBeUndefined();
   });
@@ -35,9 +35,26 @@ describe('submitAction', () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
 
     const action = { id: 'act-a', data: { field: 'value' } };
-    await expect(submitAction(action as any, '/test/')).rejects.toThrow('network error');
+    await expect(submitAction(action as any, new URL('https://qwik.dev/test/'))).rejects.toThrow(
+      'network error'
+    );
 
     expect(action.data).toBeUndefined();
+  });
+
+  it('preserves route search params when appending the action id', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(await makeJsonResponse({ result: { ok: true } }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await submitAction(
+      { id: 'act-a', data: {} } as any,
+      new URL('https://qwik.dev/test/?foo=bar&tag=a&tag=b')
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/test/?foo=bar&tag=a&tag=b&qaction=act-a',
+      expect.any(Object)
+    );
   });
 
   it('returns result and status from JSON action response', async () => {
@@ -50,7 +67,10 @@ describe('submitAction', () => {
         )
     );
 
-    const result = await submitAction({ id: 'act-a', data: {} } as any, '/test/');
+    const result = await submitAction(
+      { id: 'act-a', data: {} } as any,
+      new URL('https://qwik.dev/test/')
+    );
 
     expect(result).toEqual({
       status: 200,
@@ -70,7 +90,10 @@ describe('submitAction', () => {
         )
     );
 
-    const result = await submitAction({ id: 'act-a', data: {} } as any, '/test/');
+    const result = await submitAction(
+      { id: 'act-a', data: {} } as any,
+      new URL('https://qwik.dev/test/')
+    );
 
     expect(result?.status).toBe(422);
     expect(result?.result).toMatchObject({ failed: true });


### PR DESCRIPTION
Fix route action submissions to preserve existing URL search parameters when appending qaction