### PR TITLE
fix(router): ignore route path header outside dev

### DIFF
--- a/.changeset/strict-loader-route-path.md
+++ b/.changeset/strict-loader-route-path.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: ignore strict loader route hints outside dev mode.

--- a/packages/qwik-router/src/middleware/request-handler/request-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-handler.ts
@@ -84,7 +84,8 @@ export async function requestHandler<T = unknown>(
 }
 
 export function getRequestHandlerPathname(
-  serverRequestEv: Pick<ServerRequestEvent, 'url' | 'request'>
+  serverRequestEv: Pick<ServerRequestEvent, 'url' | 'request'>,
+  isDevRequest = isDev
 ) {
   const recognized = recognizeRequest(serverRequestEv.url.pathname);
   if (!recognized) {
@@ -96,13 +97,11 @@ export function getRequestHandlerPathname(
     return loaderPathname;
   }
 
-  return (
-    resolveValidInternalFullPathname(
-      loaderPathname,
-      serverRequestEv.request.headers.get(FULLPATH_HEADER) ??
-        serverRequestEv.request.headers.get(ROUTE_PATH_HEADER)
-    ) ?? loaderPathname
-  );
+  const routePath =
+    serverRequestEv.request.headers.get(FULLPATH_HEADER) ??
+    (isDevRequest ? serverRequestEv.request.headers.get(ROUTE_PATH_HEADER) : null);
+
+  return resolveValidInternalFullPathname(loaderPathname, routePath) ?? loaderPathname;
 }
 
 async function loadRequestHandlers(

--- a/packages/qwik-router/src/middleware/request-handler/request-handler.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-handler.unit.ts
@@ -63,7 +63,7 @@ describe('getRequestHandlerPathname', () => {
     expect(getRequestHandlerPathname(ev)).toBe('/products/123/');
   });
 
-  it('uses the validated route pathname for strict dev loader requests', () => {
+  it('ignores the strict dev route pathname outside dev mode', () => {
     const ev = createMockServerRequestEvent(
       `http://localhost/products/${getLoaderName('loader-id', 'manifest')}`,
       {
@@ -73,7 +73,20 @@ describe('getRequestHandlerPathname', () => {
       }
     );
 
-    expect(getRequestHandlerPathname(ev)).toBe('/products/123/');
+    expect(getRequestHandlerPathname(ev, false)).toBe('/products/');
+  });
+
+  it('uses the validated route pathname for strict dev loader requests in dev mode', () => {
+    const ev = createMockServerRequestEvent(
+      `http://localhost/products/${getLoaderName('loader-id', 'manifest')}`,
+      {
+        headers: {
+          [ROUTE_PATH_HEADER]: '/products/123/',
+        },
+      }
+    );
+
+    expect(getRequestHandlerPathname(ev, true)).toBe('/products/123/');
   });
 
   it('ignores a strict dev route pathname outside the loader path', () => {


### PR DESCRIPTION
### Motivation
- A dev-only header, `X-Qwik-route-path`, was being honored in production request routing, allowing an attacker to craft q-loader requests that load protected route loaders while middleware still observed the original loader path.  
- This can bypass path-based global middleware that enforces authorization by `requestEv.url.pathname`.  
- Restricting the dev-only hint to dev environments preserves the intended safety boundary while keeping `X-Qwik-fullpath` behavior intact for legitimate fullpath overrides.

### Description
- Update `getRequestHandlerPathname` in `packages/qwik-router/src/middleware/request-handler/request-handler.ts` to accept an `isDevRequest` parameter (defaulting to `isDev`) and only honor `X-Qwik-route-path` when `isDevRequest` is true.  
- Compute `routePath` from `X-Qwik-fullpath` or, if and only if dev, from `X-Qwik-route-path`, and pass it to `resolveValidInternalFullPathname` to resolve q-loader paths.  
- Add focused unit coverage in `packages/qwik-router/src/middleware/request-handler/request-handler.unit.ts` asserting that `X-Qwik-route-path` is ignored outside dev mode and honored in dev mode, and add a changeset ` .changeset/strict-loader-route-path.md` for the router patch.

### Testing
- Built the dev artifacts with `pnpm build.core.dev` and the build completed successfully.  
- Ran the focused unit suite with `pnpm vitest run packages/qwik-router/src/middleware/request-handler/request-handler.unit.ts` and all tests passed after the build.  
- The new/updated unit tests specifically validate non-dev behavior (ignores `X-Qwik-route-path`) and dev behavior (honors `X-Qwik-route-path`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58f94f58688331b80bf787826366d3)