### PR TITLE
SSR: handle async JSX/component promise rejections during pending flushes

### DIFF
--- a/.changeset/fix-async-component-flush-rejection.md
+++ b/.changeset/fix-async-component-flush-rejection.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: handle async component rejections during SSR flushes.

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -43,7 +43,7 @@ import {
   isInternalServerComponent,
 } from './internal-server-component';
 import { applyInlineComponent, applyQwikComponentBody } from './ssr-render-component';
-import type { ISsrComponentFrame, SSRContainer, SSRRenderJSXOptions } from './ssr-types';
+import type { ISsrComponentFrame, ISsrNode, SSRContainer, SSRRenderJSXOptions } from './ssr-types';
 import { resolveSlotName } from '../shared/utils/prop';
 
 class MaybeAsyncSignal {}
@@ -57,6 +57,20 @@ export type StackValue = ValueOrPromise<
   | AsyncGenerator
   | typeof MaybeAsyncSignal
 >;
+
+const markPromiseHandled = (
+  ssr: SSRContainer,
+  promise: Promise<unknown>,
+  host: ISsrNode | null = null
+): void => {
+  promise.catch((reason) => {
+    try {
+      ssr.handleError(reason, host);
+    } catch {
+      // Original promise remains awaited later.
+    }
+  });
+};
 
 function setParentOptions(
   mutable: { currentStyleScoped: string | null; parentComponentFrame: ISsrComponentFrame | null },
@@ -77,6 +91,11 @@ export async function _walkJSX(
 ): Promise<void> {
   const stack: StackValue[] = [value];
   const enqueue = (value: StackValue) => stack.push(value);
+  const enqueuePromise = (promise: Promise<unknown>) => {
+    markPromiseHandled(ssr, promise);
+    stack.push(promise as StackValue);
+    stack.push(Promise);
+  };
   const drain = async (): Promise<void> => {
     while (stack.length) {
       try {
@@ -98,7 +117,7 @@ export async function _walkJSX(
           }
           continue;
         }
-        processJSXNode(ssr, enqueue, value as JSXOutput, options);
+        processJSXNode(ssr, enqueue, enqueuePromise, value as JSXOutput, options);
       } finally {
         const pendingFlush = ssr.streamHandler.waitForPendingFlush();
         if (isPromise(pendingFlush)) {
@@ -113,6 +132,7 @@ export async function _walkJSX(
 function processJSXNode(
   ssr: SSRContainer,
   enqueue: (value: StackValue) => void,
+  enqueuePromise: (promise: Promise<unknown>) => void,
   value: JSXOutput,
   options: SSRRenderJSXOptions
 ) {
@@ -143,8 +163,7 @@ function processJSXNode(
     } else if (isPromise(value)) {
       ssr.openFragment(isDev ? { [DEBUG_TYPE]: VirtualType.Awaited } : EMPTY_OBJ);
       enqueue(ssr.closeFragment);
-      enqueue(value);
-      enqueue(Promise);
+      enqueuePromise(value);
       enqueue(() => ssr.streamHandler.flush());
     } else if (isAsyncGenerator(value)) {
       enqueue(async () => {
@@ -283,8 +302,11 @@ function processJSXNode(
             value = generator;
           }
 
-          enqueue(value as StackValue);
-          isPromise(value) && enqueue(Promise);
+          if (isPromise(value)) {
+            enqueuePromise(value);
+          } else {
+            enqueue(value as StackValue);
+          }
         } else if (type === SSRRaw) {
           ssr.htmlNode(directGetPropsProxyProp(jsx, 'data'));
         } else if (type === SSRStreamBlock) {
@@ -312,6 +334,7 @@ function processJSXNode(
           );
           enqueue(() => ssr.closeComponent());
           if (isPromise(jsxOutput)) {
+            markPromiseHandled(ssr, jsxOutput, host);
             // Defer reading QScopedStyle until after the promise resolves
             enqueue(async () => {
               await ssr.streamHandler.flush();
@@ -340,8 +363,11 @@ function processJSXNode(
             type,
             jsx
           );
-          enqueue(jsxOutput);
-          isPromise(jsxOutput) && enqueue(Promise);
+          if (isPromise(jsxOutput)) {
+            enqueuePromise(jsxOutput);
+          } else {
+            enqueue(jsxOutput);
+          }
         }
       }
     }

--- a/packages/qwik/src/core/tests/render-api.spec.tsx
+++ b/packages/qwik/src/core/tests/render-api.spec.tsx
@@ -10,6 +10,7 @@ import {
   setPlatform,
   useLexicalScope,
   useOn,
+  useAsync$,
   useServerData,
   useSignal,
   useTask$,
@@ -897,6 +898,90 @@ describe('render api', () => {
           streaming,
         });
         expect(write.mock.calls.length).toBeGreaterThan(100);
+      });
+      it('should handle jsx promise rejection while a flush is pending', async () => {
+        const firstWrite = createDeferred();
+        let writeCount = 0;
+        const unhandledRejections: unknown[] = [];
+        const onUnhandledRejection = (reason: unknown) => {
+          unhandledRejections.push(reason);
+        };
+        const stream = createTestStream(() => {
+          writeCount++;
+          if (writeCount === 1) {
+            return firstWrite.promise;
+          }
+        });
+
+        process.on('unhandledRejection', onUnhandledRejection);
+        try {
+          const renderPromise = renderToStreamAndSetPlatform(
+            <div>
+              prefix
+              {Promise.reject(new Error('jsx promise failed'))}
+            </div>,
+            {
+              containerTagName: 'div',
+              stream,
+              streaming: {
+                inOrder: { strategy: 'disabled' },
+              },
+            }
+          );
+          await new Promise((resolve) => setImmediate(resolve));
+
+          expect(unhandledRejections).toEqual([]);
+
+          firstWrite.resolve();
+          await expect(renderPromise).rejects.toThrow('jsx promise failed');
+        } finally {
+          process.off('unhandledRejection', onUnhandledRejection);
+        }
+      });
+      it('should handle async component rejection while a flush is pending', async () => {
+        const firstWrite = createDeferred();
+        let writeCount = 0;
+        const unhandledRejections: unknown[] = [];
+        const onUnhandledRejection = (reason: unknown) => {
+          unhandledRejections.push(reason);
+        };
+        const AsyncReject = component$(() => {
+          const result = useAsync$<JSXOutput>(() =>
+            Promise.reject(new Error('async component failed'))
+          );
+          return result.value;
+        });
+        const stream = createTestStream(() => {
+          writeCount++;
+          if (writeCount === 1) {
+            return firstWrite.promise;
+          }
+        });
+
+        process.on('unhandledRejection', onUnhandledRejection);
+        try {
+          const renderPromise = renderToStreamAndSetPlatform(
+            <div>
+              prefix
+              <AsyncReject />
+            </div>,
+            {
+              containerTagName: 'div',
+              stream,
+              streaming: {
+                inOrder: { strategy: 'disabled' },
+              },
+            }
+          );
+          await new Promise((resolve) => setImmediate(resolve));
+
+          expect(unhandledRejections).toEqual([]);
+
+          firstWrite.resolve();
+          await expect(renderPromise).rejects.toThrow('async component failed');
+        } finally {
+          process.off('unhandledRejection', onUnhandledRejection);
+        }
       });
       it('should wait for an async direct write before emitting the next one', async () => {
         const firstWrite = createDeferred();


### PR DESCRIPTION
### Motivation
- Prevent unhandled promise rejections when a JSX promise or async component rejects while an SSR flush is pending. 

### Description
- Add `markPromiseHandled` to register `.catch` handlers that forward errors to `ssr.handleError` and avoid Node `unhandledRejection` events. 
- Introduce `enqueuePromise` to mark and enqueue promises consistently during JSX traversal. 
- Wire `enqueuePromise`/`markPromiseHandled` into promise branches in `_walkJSX`/`processJSXNode`, including awaited JSX promises, stream generators, inline components, and async component outputs. 
- Update types import to include `ISsrNode` and add a changeset file describing the patch. 

### Testing
- Added two unit tests in `render-api.spec.tsx`: `should handle jsx promise rejection while a flush is pending` and `should handle async component rejection while a flush is pending`. 
- Ran the core unit tests (Vitest) including the new tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d93427b083319948b9f02c89d3ce)