### PR TITLE
fix(router): enforce blocking loader guards for q-loader requests

### DIFF
--- a/.changeset/block-q-loader-guards.md
+++ b/.changeset/block-q-loader-guards.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: enforce blocking loader guards for q-loader requests.

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts
@@ -3,6 +3,7 @@ import {
   FULLPATH_HEADER,
   getRouteLoaderCtx,
   getRouteLoaderResponse,
+  loadRouteLoader,
   resolveRouteLoaderByHash,
   setRouteLoaders,
 } from '../../../runtime/src/route-loaders';
@@ -43,6 +44,7 @@ export function loaderHandler(
     }
 
     setLoaderData(requestEv, routeLoaders, loaderPaths);
+    await runBlockingLoadersBeforeTarget(routeLoaders, loader, requestEv);
 
     const loaderRequestEv = createLoaderRequestEventFactory(requestEv)(loader);
 
@@ -113,6 +115,21 @@ export function loaderHandler(
 
     await sendLoaderResponse(requestEv, data, loader);
   };
+}
+
+async function runBlockingLoadersBeforeTarget(
+  routeLoaders: LoaderInternal[],
+  targetLoader: LoaderInternal,
+  requestEv: RequestEventInternal
+) {
+  for (const loader of routeLoaders) {
+    if (loader === targetLoader) {
+      return;
+    }
+    if (loader.__blockSSR) {
+      await loadRouteLoader(loader, requestEv);
+    }
+  }
 }
 
 function setLoaderData(

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import { FULLPATH_HEADER } from '../../../runtime/src/route-loaders';
 import { getLoaderName, IsQLoader, QLoaderId } from '../request-path';
+import { RedirectMessage } from '../redirect-handler';
 import { loaderHandler } from './loader-handler';
 
 describe('loaderHandler', () => {
   function createRequestEv() {
+    const headers = new Headers();
     return {
       sharedMap: new Map<string, unknown>([
         [IsQLoader, true],
         [QLoaderId, 'loader-id'],
       ]),
-      headers: new Headers(),
+      headers,
       request: new Request(`http://localhost/products/${getLoaderName('loader-id', 'manifest')}`),
       url: new URL('http://localhost/products/?q=shoes&page=2&ignored=true'),
       headersSent: false,
@@ -19,6 +21,10 @@ describe('loaderHandler', () => {
       json: vi.fn(),
       send: vi.fn(),
       status: vi.fn(() => 200),
+      redirect: vi.fn((_status: number, url: string) => {
+        headers.set('Location', url);
+        return new RedirectMessage();
+      }),
     };
   }
 
@@ -119,6 +125,45 @@ describe('loaderHandler', () => {
     expect(loaderEv.query.has('ignored')).toBe(false);
     expect(loaderEv.request.url).toBe(requestEv.request.url);
     expect(requestEv.send).toHaveBeenCalledWith(200, expect.any(String));
+  });
+
+  it('runs earlier blocking loaders before the requested q-loader', async () => {
+    const requestEv = createRequestEv();
+    const guardLoader = {
+      __id: 'guard-loader',
+      __qrl: {
+        call: vi.fn(async (_thisArg, ev) => ev.redirect(302, '/login')),
+        getHash: vi.fn(() => 'guard-loader'),
+      },
+      __validators: undefined,
+      __expires: undefined,
+      __eTag: undefined,
+      __cacheKey: undefined,
+      __search: undefined,
+      __blockSSR: true,
+    };
+    const secretLoader = {
+      __id: 'loader-id',
+      __qrl: {
+        call: vi.fn(async () => 'secret'),
+        getHash: vi.fn(() => 'loader-id'),
+      },
+      __validators: undefined,
+      __expires: undefined,
+      __eTag: undefined,
+      __cacheKey: undefined,
+      __search: undefined,
+      __blockSSR: true,
+    };
+
+    await expect(
+      loaderHandler([guardLoader as any, secretLoader as any])(requestEv as any)
+    ).rejects.toBeInstanceOf(RedirectMessage);
+
+    expect(guardLoader.__qrl.call).toHaveBeenCalledTimes(1);
+    expect(secretLoader.__qrl.call).not.toHaveBeenCalled();
+    expect(requestEv.headers.get('Location')).toBe('/login');
+    expect(requestEv.send).not.toHaveBeenCalled();
   });
 
   it('returns 404 when the requested loader is not available on the matched route', async () => {


### PR DESCRIPTION
### Motivation
- Direct q-loader JSON endpoints executed only the requested loader and bypassed parent `blockSSR` loaders used as guard/authorization logic, allowing protected loader data disclosure.
- The change makes `routeLoader$` default to `blockSSR=true`, so q-loader requests must run earlier blocking loaders in route order before executing the target loader.

### Description
- Run earlier `__blockSSR` route loaders before executing the requested q-loader by adding `runBlockingLoadersBeforeTarget` and invoking it from `loaderHandler` prior to the target loader execution (`packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts`).
- Import and use `loadRouteLoader` so blocking loaders are executed with the same loader machinery and response semantics as page SSR.
- Add a regression unit test asserting a blocking parent loader that redirects prevents the child q-loader from running and sending protected data (`packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts`).
- Add a patch changeset for `@qwik.dev/router` describing the fix (`.changeset/block-q-loader-guards.md`).

### Testing
- Ran `pnpm build.core.dev` to produce required build artifacts, which completed successfully.
- Ran the focused unit tests with `pnpm vitest run packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts`, which initially failed until the dev build was available and then passed (all tests green).
- Ran type-checks with `pnpm tsc.check`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58fff1ac6c83319470b2fbd8dfb9df)