### PR TITLE
fix(ci): pin devtools artifact upload action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,7 +531,7 @@ jobs:
         run: tree -a packages/devtools/dist/
 
       - name: Upload devtools Build Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: artifact-devtools
           include-hidden-files: true


### PR DESCRIPTION
### Motivation
- Close a CI supply-chain integrity gap by removing a mutable `actions/upload-artifact@v7` reference that produced `artifact-devtools` which downstream release/publish jobs trust.

### Description
- Replace the devtools upload step's mutable `uses: actions/upload-artifact@v7` with the same immutable 40-character commit SHA used by the other artifact uploads, preserving the artifact name and upload settings.

### Testing
- Verified no `actions/upload-artifact` references in `.github/workflows/ci.yml` use a non-SHA ref with `rg -n 'actions/upload-artifact@(?![0-9a-f]{40}\b)' .github/workflows/ci.yml --pcre2` and the check passed.
- Verified workflow formatting with `pnpm exec prettier --check .github/workflows/ci.yml` and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59001e69508331a342cc066e11729e)