### PR TITLE
fix(devtools): disable package lifecycle scripts for RPC package operations

### DIFF
--- a/.changeset/devtools-ignore-package-scripts.md
+++ b/.changeset/devtools-ignore-package-scripts.md
@@ -1,0 +1,5 @@
+---
+"@qwik.dev/devtools": patch
+---
+
+fix: disable lifecycle scripts during package operations.

--- a/packages/devtools/plugin/src/npm/package-manager.ts
+++ b/packages/devtools/plugin/src/npm/package-manager.ts
@@ -139,8 +139,8 @@ export function buildInstallCommand(
       command: 'npm',
       args:
         dependencyType === 'devDependencies'
-          ? ['install', '--save-dev', packageName]
-          : ['install', packageName],
+          ? ['install', '--ignore-scripts', '--save-dev', packageName]
+          : ['install', '--ignore-scripts', packageName],
       cwd: context.projectRoot,
     };
   }
@@ -148,7 +148,9 @@ export function buildInstallCommand(
     return {
       command: 'yarn',
       args:
-        dependencyType === 'devDependencies' ? ['add', '-D', packageName] : ['add', packageName],
+        dependencyType === 'devDependencies'
+          ? ['add', '--ignore-scripts', '-D', packageName]
+          : ['add', '--ignore-scripts', packageName],
       cwd: context.projectRoot,
     };
   }
@@ -157,8 +159,15 @@ export function buildInstallCommand(
   return {
     command: 'pnpm',
     args: context.workspacePackageSelector
-      ? ['--filter', context.workspacePackageSelector, 'add', ...saveArgs, packageName]
-      : ['add', ...saveArgs, packageName],
+      ? [
+          '--filter',
+          context.workspacePackageSelector,
+          'add',
+          '--ignore-scripts',
+          ...saveArgs,
+          packageName,
+        ]
+      : ['add', '--ignore-scripts', ...saveArgs, packageName],
     cwd: context.workspacePackageSelector ? context.workspaceRoot : context.projectRoot,
   };
 }
@@ -174,32 +183,44 @@ export function buildUpdateCommand(
     if (dependencyType === 'devDependencies') {
       return {
         command: 'npm',
-        args: ['install', '--save-dev', packageAtLatest],
+        args: ['install', '--ignore-scripts', '--save-dev', packageAtLatest],
         cwd: context.projectRoot,
       };
     }
     if (dependencyType === 'peerDependencies') {
       return {
         command: 'npm',
-        args: ['install', '--save-peer', packageAtLatest],
+        args: ['install', '--ignore-scripts', '--save-peer', packageAtLatest],
         cwd: context.projectRoot,
       };
     }
-    return { command: 'npm', args: ['install', packageAtLatest], cwd: context.projectRoot };
+    return {
+      command: 'npm',
+      args: ['install', '--ignore-scripts', packageAtLatest],
+      cwd: context.projectRoot,
+    };
   }
 
   if (context.packageManager === 'yarn') {
     if (dependencyType === 'devDependencies') {
-      return { command: 'yarn', args: ['add', '-D', packageAtLatest], cwd: context.projectRoot };
+      return {
+        command: 'yarn',
+        args: ['add', '--ignore-scripts', '-D', packageAtLatest],
+        cwd: context.projectRoot,
+      };
     }
     if (dependencyType === 'peerDependencies') {
       return {
         command: 'yarn',
-        args: ['add', '--peer', packageAtLatest],
+        args: ['add', '--ignore-scripts', '--peer', packageAtLatest],
         cwd: context.projectRoot,
       };
     }
-    return { command: 'yarn', args: ['add', packageAtLatest], cwd: context.projectRoot };
+    return {
+      command: 'yarn',
+      args: ['add', '--ignore-scripts', packageAtLatest],
+      cwd: context.projectRoot,
+    };
   }
 
   const saveArgs =
@@ -212,8 +233,15 @@ export function buildUpdateCommand(
   return {
     command: 'pnpm',
     args: context.workspacePackageSelector
-      ? ['--filter', context.workspacePackageSelector, 'add', ...saveArgs, packageAtLatest]
-      : ['add', ...saveArgs, packageAtLatest],
+      ? [
+          '--filter',
+          context.workspacePackageSelector,
+          'add',
+          '--ignore-scripts',
+          ...saveArgs,
+          packageAtLatest,
+        ]
+      : ['add', '--ignore-scripts', ...saveArgs, packageAtLatest],
     cwd: context.workspacePackageSelector ? context.workspaceRoot : context.projectRoot,
   };
 }

--- a/packages/devtools/plugin/src/npm/package-manager.unit.ts
+++ b/packages/devtools/plugin/src/npm/package-manager.unit.ts
@@ -113,27 +113,27 @@ describe('build package manager commands', () => {
   test('builds install commands for prod and dev dependencies', () => {
     expect(buildInstallCommand(npmContext, 'vite', 'dependencies')).toEqual({
       command: 'npm',
-      args: ['install', 'vite'],
+      args: ['install', '--ignore-scripts', 'vite'],
       cwd: '/repo',
     });
     expect(buildInstallCommand(npmContext, 'vite', 'devDependencies')).toEqual({
       command: 'npm',
-      args: ['install', '--save-dev', 'vite'],
+      args: ['install', '--ignore-scripts', '--save-dev', 'vite'],
       cwd: '/repo',
     });
     expect(buildInstallCommand(singlePackageContext, 'vite', 'devDependencies')).toEqual({
       command: 'pnpm',
-      args: ['add', '-D', 'vite'],
+      args: ['add', '--ignore-scripts', '-D', 'vite'],
       cwd: '/repo',
     });
     expect(buildInstallCommand(workspaceContext, 'vite', 'devDependencies')).toEqual({
       command: 'pnpm',
-      args: ['--filter', './packages/docs', 'add', '-D', 'vite'],
+      args: ['--filter', './packages/docs', 'add', '--ignore-scripts', '-D', 'vite'],
       cwd: '/repo',
     });
     expect(buildInstallCommand(yarnContext, 'vite', 'dependencies')).toEqual({
       command: 'yarn',
-      args: ['add', 'vite'],
+      args: ['add', '--ignore-scripts', 'vite'],
       cwd: '/repo',
     });
   });
@@ -141,17 +141,24 @@ describe('build package manager commands', () => {
   test('builds update commands that preserve dependency type', () => {
     expect(buildUpdateCommand(npmContext, 'vite', 'dependencies')).toEqual({
       command: 'npm',
-      args: ['install', 'vite@latest'],
+      args: ['install', '--ignore-scripts', 'vite@latest'],
       cwd: '/repo',
     });
     expect(buildUpdateCommand(workspaceContext, '@mui/x-data-grid', 'devDependencies')).toEqual({
       command: 'pnpm',
-      args: ['--filter', './packages/docs', 'add', '-D', '@mui/x-data-grid@latest'],
+      args: [
+        '--filter',
+        './packages/docs',
+        'add',
+        '--ignore-scripts',
+        '-D',
+        '@mui/x-data-grid@latest',
+      ],
       cwd: '/repo',
     });
     expect(buildUpdateCommand(yarnContext, 'vite', 'peerDependencies')).toEqual({
       command: 'yarn',
-      args: ['add', '--peer', 'vite@latest'],
+      args: ['add', '--ignore-scripts', '--peer', 'vite@latest'],
       cwd: '/repo',
     });
   });


### PR DESCRIPTION
### Motivation

- Prevent remote devtools RPC from causing arbitrary code execution on the dev server by stopping registry package lifecycle scripts from running during installs/updates.

### Description

- Add `--ignore-scripts` to generated npm, yarn, and pnpm install/add/update command arguments in `buildInstallCommand` and `buildUpdateCommand` in `packages/devtools/plugin/src/npm/package-manager.ts` to disable lifecycle scripts while preserving dependency-type behavior.
- Keep `spawn(..., shell: false)` and command construction logic unchanged so shell injection protections are preserved.
- Update focused unit tests in `packages/devtools/plugin/src/npm/package-manager.unit.ts` to assert the new `--ignore-scripts` arguments across npm, pnpm (including workspace selector), and yarn variants.
- Add a patch changeset for `@qwik.dev/devtools` at `.changeset/devtools-ignore-package-scripts.md`.

### Testing

- Ran `pnpm build.core.dev` and it completed successfully.
- Ran the focused unit suite `pnpm vitest run packages/devtools/plugin/src/npm/package-manager.unit.ts` and all tests passed.
- Ran `pnpm exec prettier --check` on the modified files and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58fc2e4e288331ba07eb3b4b2aeccb)