### PR TITLE
fix(router): scope loader request state

### DIFF
--- a/.changeset/quiet-ravens-fetch.md
+++ b/.changeset/quiet-ravens-fetch.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: scope cached loader request state to loader paths.

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
@@ -87,7 +87,7 @@ describe('loaderHandler', () => {
     const cacheKeyEv = cacheKey.mock.calls[0][0];
     expect(cacheKeyEv).not.toBe(requestEv);
     expect(cacheKeyEv.url.search).toBe('?page=2&q=shoes');
-    expect(cacheKeyEv.request.url).toBe(requestEv.request.url);
+    expect(cacheKeyEv.request.url).toBe('http://localhost/products/?page=2&q=shoes');
     expect(cacheKey).toHaveBeenCalledWith(cacheKeyEv, '');
     expect(requestEv.send).toHaveBeenCalledWith(200, expect.any(String));
   });
@@ -99,6 +99,8 @@ describe('loaderHandler', () => {
       __qrl: {
         call: vi.fn(async (_thisArg, ev) => ({
           requestUrl: ev.request.url,
+          originalUrl: ev.originalUrl.href,
+          params: ev.params,
           search: ev.url.search,
           q: ev.query.get('q'),
           ignored: ev.query.has('ignored'),
@@ -115,9 +117,11 @@ describe('loaderHandler', () => {
 
     const loaderEv = loader.__qrl.call.mock.calls[0][1];
     expect(loaderEv.url.search).toBe('?q=shoes');
+    expect(loaderEv.request.url).toBe('http://localhost/products/?q=shoes');
+    expect(loaderEv.originalUrl.href).toBe('http://localhost/products/?q=shoes');
+    expect(loaderEv.params).toEqual({});
     expect(loaderEv.query.get('q')).toBe('shoes');
     expect(loaderEv.query.has('ignored')).toBe(false);
-    expect(loaderEv.request.url).toBe(requestEv.request.url);
     expect(requestEv.send).toHaveBeenCalledWith(200, expect.any(String));
   });
 

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-request-event.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-request-event.unit.ts
@@ -17,12 +17,16 @@ describe('createLoaderRequestEventFactory', () => {
     expect(pageEv.url.search).toBe('?page=2');
     expect(pageEv.query.get('page')).toBe('2');
     expect(pageEv.query.has('q')).toBe(false);
-    expect(pageEv.request.url).toBe(requestEv.url.href);
+    expect(pageEv.request.url).toBe('http://localhost/products/?page=2');
+    expect(pageEv.originalUrl.href).toBe('http://localhost/products/?page=2');
+    expect(pageEv.params).toEqual({});
 
     expect(queryEv.url.search).toBe('?q=shoes');
     expect(queryEv.query.get('q')).toBe('shoes');
     expect(queryEv.query.has('page')).toBe(false);
-    expect(queryEv.request.url).toBe(requestEv.url.href);
+    expect(queryEv.request.url).toBe('http://localhost/products/?q=shoes');
+    expect(queryEv.originalUrl.href).toBe('http://localhost/products/?q=shoes');
+    expect(queryEv.params).toEqual({});
 
     pageEv.sharedMap.set('shared', 'value');
     expect(requestEv.sharedMap.get('shared')).toBe('value');
@@ -37,7 +41,8 @@ describe('createLoaderRequestEventFactory', () => {
     expect(missingEv).not.toBe(requestEv);
     expect(missingEv.url.search).toBe('');
     expect(missingEv.query.toString()).toBe('');
-    expect(missingEv.request.url).toBe(requestEv.url.href);
+    expect(missingEv.request.url).toBe('http://localhost/products/');
+    expect(missingEv.originalUrl.href).toBe('http://localhost/products/');
   });
 
   it('returns the original request event when there is no loader search filter', () => {
@@ -103,7 +108,9 @@ describe('createLoaderRequestEventFactory', () => {
       expect(productsEv.url.href).toBe('http://localhost/products/?page=2');
       expect(detailsEv.pathname).toBe('/products/123/');
       expect(detailsEv.url.href).toBe('http://localhost/products/123/?page=2');
-      expect(productsEv.request.url).toBe(requestEv.url.href);
+      expect(productsEv.request.url).toBe('http://localhost/products/?page=2');
+      expect(productsEv.originalUrl.href).toBe('http://localhost/products/?page=2');
+      expect(productsEv.params).toEqual({});
     } finally {
       globalThis.__STRICT_LOADERS__ = previousStrictLoaders;
     }

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -789,13 +789,26 @@ export const getLoaderRequestEvent = (
   if (!loaderRequestEv) {
     url.pathname = pathname;
     url.search = filteredSearch;
+    const request = new Request(url, rootRequestEv.request);
     loaderRequestEv = Object.create(rootRequestEv, {
+      originalUrl: {
+        value: new URL(url),
+        enumerable: true,
+      },
+      params: {
+        value: {},
+        enumerable: true,
+      },
       pathname: {
         get: () => url.pathname,
         enumerable: true,
       },
       query: {
         get: () => url.searchParams,
+        enumerable: true,
+      },
+      request: {
+        value: request,
         enumerable: true,
       },
       url: {


### PR DESCRIPTION
### Motivation
- Prevent cross-route loader cache poisoning by ensuring loader-scoped cache keys cannot be mismatched with full-route state that loaders can still read.
- The previous change used a loader-scoped `RequestEvent` for cache keys but left `request`, `originalUrl`, and `params` inherited from the root event, enabling an attacker to prime a cache for one full path and have it served for another.

### Description
- In `getLoaderRequestEvent()` create a new `Request` for the loader-scoped URL and override `request`, `originalUrl`, and `params` in the per-loader event in addition to the existing `pathname`, `query`, and `url` overrides so all URL-bearing fields are consistent with the scoped cache key.
- Update unit tests in `packages/qwik-router/src/middleware/request-handler/handlers/loader-request-event.unit.ts` and `packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts` to assert that `request.url`, `originalUrl`, and `params` are scoped to the loader view.
- Add a patch changeset for `@qwik.dev/router` documenting the fix.

### Testing
- `pnpm build.core.dev` completed successfully.
- `pnpm vitest run packages/qwik-router/src/middleware/request-handler/handlers/loader-request-event.unit.ts packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts` passed (all tests in those files passed).
- `pnpm vitest run packages/qwik-router/src/middleware/request-handler/etag.unit.ts packages/qwik-router/src/runtime/src/route-loaders.unit.ts` passed (all tests in those files passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591105e4688331a81629ff6b6f7138)