### PR TITLE
fix(optimizer): strip preprocessed server QRLs

### DIFF
--- a/.changeset/fuzzy-aardvarks-strip.md
+++ b/.changeset/fuzzy-aardvarks-strip.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/optimizer': patch
+---
+
+fix: strip preprocessed library server qrls from client output.

--- a/packages/optimizer/core/src/test.rs
+++ b/packages/optimizer/core/src/test.rs
@@ -7180,6 +7180,63 @@ export const App = component$(() => {
 }
 
 #[test]
+fn preprocessed_lib_server_qrl_is_stripped_from_client_output() {
+	let lib_res = test_input!(TestInput {
+		code: r#"
+import { server$ } from '@qwik.dev/core';
+
+export const serverAction = server$(() => {
+	const token = 'VALIDATION_SECRET_SERVER_ONLY_9f1ad6';
+	return token;
+});
+"#
+		.to_string(),
+		mode: EmitMode::Lib,
+		entry_strategy: EntryStrategy::Hoist,
+		transpile_ts: true,
+		snapshot: false,
+		..TestInput::default()
+	});
+
+	let lib_output = lib_res.unwrap();
+	let lib_code = lib_output
+		.modules
+		.iter()
+		.map(|module| module.code.as_str())
+		.collect::<Vec<_>>()
+		.join("\n");
+
+	assert!(
+		lib_code.contains("VALIDATION_SECRET_SERVER_ONLY_9f1ad6"),
+		"expected lib preprocessing to inline the server body:\n{}",
+		lib_code
+	);
+
+	let client_res = test_input!(TestInput {
+		code: lib_code,
+		mode: EmitMode::Prod,
+		entry_strategy: EntryStrategy::Hoist,
+		strip_ctx_name: Some(vec!["server".into()]),
+		snapshot: false,
+		..TestInput::default()
+	});
+
+	let client_output = client_res.unwrap();
+	let client_code = client_output
+		.modules
+		.iter()
+		.map(|module| module.code.as_str())
+		.collect::<Vec<_>>()
+		.join("\n");
+
+	assert!(
+		!client_code.contains("VALIDATION_SECRET_SERVER_ONLY_9f1ad6"),
+		"expected client transform to strip preprocessed server QRL body:\n{}",
+		client_code
+	);
+}
+
+#[test]
 fn inlined_qrl_preserves_captures() {
 	// Simulates lib-preprocessed code being processed by the app optimizer.
 	// The inner inlinedQrl has 5 captures, including variables defined via

--- a/packages/optimizer/core/src/transform.rs
+++ b/packages/optimizer/core/src/transform.rs
@@ -659,8 +659,10 @@ impl<'a> QwikTransform<'a> {
 			hash,
 			migrated_root_vars: Vec::new(),
 		};
-		// Preprocessed inlinedQrl from libs are always emitted — stripping is meant for user code without the user having to write guards; libs can put guards themselves.
-		// App-level $() calls go through _create_synthetic_qsegment which has its own strip check.
+		if !self.should_emit_segment(&segment_data) {
+			return self.create_noop_qrl(&symbol_name, segment_data);
+		}
+
 		for id in &segment_data.local_idents {
 			if let Some(root_id) = self.options.global_collect.root_id_for_symbol(&id.0) {
 				self.ensure_export(&root_id);


### PR DESCRIPTION
### Motivation
- Library preprocessing inlined QRL bodies into `inlinedQrl` calls, and later app/client transforms reconstructed context names (e.g. `serverQrl` → `server$`) but then unconditionally emitted those segments, bypassing the existing `strip_ctx_name` policy and exposing server-only code in client assets.
- The change restores the intended confidentiality invariant so preprocessed library server contexts do not leak into client bundles.

### Description
- Apply the existing emission policy by calling `should_emit_segment` for preprocessed `inlinedQrl` segments and return a noop QRL when the segment should be stripped, implemented in `packages/optimizer/core/src/transform.rs` inside `handle_inlined_qsegment`.
- Add a regression test `preprocessed_lib_server_qrl_is_stripped_from_client_output` to `packages/optimizer/core/src/test.rs` that asserts a `server$` body in lib output is removed by a subsequent client transform with `strip_ctx_name: Some(vec!["server".into()])`.
- Add a patch changeset `.changeset/fuzzy-aardvarks-strip.md` for `@qwik.dev/optimizer` describing the fix.

### Testing
- Ran `cargo test --manifest-path packages/optimizer/core/Cargo.toml preprocessed_lib_server_qrl_is_stripped_from_client_output -- --nocapture`, and the new regression test passed.
- `cargo fmt` could not be executed in this environment because `rustfmt` is not installed for the configured nightly toolchain, so formatting was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a594e104dfc8331950475680842b0bd)