### PR TITLE
fix(router): clear error response route data

### DIFF
--- a/.changeset/fix-error-page-loader-leak.md
+++ b/.changeset/fix-error-page-loader-leak.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: prevent error pages from exposing route data

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -15,6 +15,7 @@ import type {
   ValidatorReturn,
 } from '../../runtime/src/types';
 import {
+  clearRouteLoaderData,
   getRouteLoaderCtx,
   getRouteLoaderValues,
   loadRouteLoader,
@@ -28,6 +29,7 @@ import {
   RequestEvETagCacheKey,
   RequestEvHttpStatusMessage,
   RequestEvShareServerTiming,
+  RequestEvSharedActionFormData,
   RequestEvSharedActionId,
   RequestRouteName,
   type RequestEventInternal,
@@ -499,10 +501,18 @@ function createResolveRequestHandlers() {
           RequestEvHttpStatusMessage,
           typeof e.data === 'string' ? e.data : 'Server Error'
         );
+        clearErrorResponseData(requestEv);
 
         await renderHandler(requestEv);
       }
     };
+  }
+
+  function clearErrorResponseData(requestEv: RequestEvent) {
+    clearRouteLoaderData(requestEv);
+    requestEv.sharedMap.delete(RequestEvSharedActionId);
+    requestEv.sharedMap.delete(RequestEvSharedActionFormData);
+    requestEv.sharedMap.delete('@actionResult');
   }
 
   async function runValidators(

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
@@ -14,6 +14,7 @@ import { checkCSRF } from './resolve-request-handlers-core';
 import type { LoadedRoute, RouteModule } from '../../runtime/src/types';
 import { ServerError } from '@qwik.dev/router/middleware/request-handler';
 import { IsQLoader, QLoaderId } from './request-path';
+import { getRouteLoaderValues } from '../../runtime/src/route-loaders';
 
 function createMockServerRequestEvent(url = 'http://localhost:3000/test'): ServerRequestEvent {
   const mockRequest = new Request(url);
@@ -457,6 +458,26 @@ describe('resolve-request-handler', () => {
 
       expect(requestEv.status()).toBe(401);
       expect(requestEv.sharedMap.get(RequestEvHttpStatusMessage)).toBe('boom');
+    });
+
+    it('clears resolved route loader data before rendering a ServerError page', async () => {
+      const route = pageRouteWithLoaders(
+        makeLoader('protected', () => ({ secret: 'hidden' })),
+        makeLoader('guard', () => {
+          throw new ServerError(401, 'login required');
+        })
+      );
+      const renderHandler = vi.fn((requestEv: RequestEvent) => {
+        expect(getRouteLoaderValues(requestEv)).toEqual({});
+        requestEv.exit();
+      });
+      const requestEv = runPage(route, renderHandler);
+
+      await requestEv.next();
+
+      expect(renderHandler).toHaveBeenCalledOnce();
+      expect(requestEv.status()).toBe(401);
+      expect(requestEv.sharedMap.get(RequestEvHttpStatusMessage)).toBe('login required');
     });
 
     it('reports the first blockSSR loader (in route order) that errors', async () => {

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -563,6 +563,16 @@ function getRouteLoaderPromises(requestEv: RequestEventBase): Record<string, Pro
   return promises;
 }
 
+/** Clear loader state before rendering a route-independent error boundary. */
+export function clearRouteLoaderData(requestEv: RequestEventBase) {
+  requestEv.sharedMap.delete(REQUEST_ROUTE_LOADER_STATE);
+  requestEv.sharedMap.delete(REQUEST_ROUTE_LOADER_VALUES);
+  requestEv.sharedMap.delete(REQUEST_ROUTE_LOADER_PROMISES);
+  requestEv.sharedMap.delete(REQUEST_ROUTE_LOADER_EVENTS);
+  requestEv.sharedMap.delete(REQUEST_ROUTE_LOADER_ROOT_EVENT);
+  requestEv.sharedMap.delete(REQUEST_ROUTE_LOADERS);
+}
+
 /** Store the route loader internals on the request for SSG to read. */
 export function setRouteLoaders(requestEv: RequestEventBase, loaders: LoaderInternal[]) {
   requestEv.sharedMap.set(REQUEST_ROUTE_LOADERS, loaders);


### PR DESCRIPTION
### Motivation
- Prevent a security-sensitive information leak where rendering a caught `ServerError` could reuse previously resolved route loader or action data and serialize confidential values into the error-page SSR response.
- Ensure error page rendering runs with a clean request-scoped environment so the error response cannot inherit protected route state.

### Description
- Add `clearRouteLoaderData()` in `packages/qwik-router/src/runtime/src/route-loaders.ts` to remove request-scoped loader state, promises, events, root event, and stored loader internals.
- Invoke a new `clearErrorResponseData()` in the server error path inside `packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts` which calls `clearRouteLoaderData()` and also deletes action-related shared keys (`RequestEvSharedActionId`, `RequestEvSharedActionFormData`, and `@actionResult`).
- Update unit coverage in `packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts` to assert that resolved loader values are cleared before the error page render handler runs.
- Add a patch changeset to `.changeset/fix-error-page-loader-leak.md` for `@qwik.dev/router` describing the behavior fix.

### Testing
- Ran `pnpm build.core.dev` and the build completed successfully.
- Ran the focused unit suite with `pnpm vitest run packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts` and all tests passed (33 tests passed).
- The focused regression test that verifies loader values are emptied before error rendering passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a594d732db883318696d0205f1470d6)