### PR TITLE
fix: avoid serializing computed signal values by default

### DIFF
--- a/.changeset/calm-computed-secrets.md
+++ b/.changeset/calm-computed-secrets.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: avoid serializing computed values by default.

--- a/packages/qwik/src/core/reactive-primitives/signal-api.ts
+++ b/packages/qwik/src/core/reactive-primitives/signal-api.ts
@@ -29,7 +29,7 @@ export const createComputedSignal = <T>(
   return new ComputedSignalImpl<T>(
     options?.container || null,
     qrl as ComputeQRL<T>,
-    getComputedSignalFlags(options?.serializationStrategy || 'always'),
+    getComputedSignalFlags(options?.serializationStrategy || 'never'),
     options
   );
 };

--- a/packages/qwik/src/core/shared/serdes/serdes.unit.ts
+++ b/packages/qwik/src/core/shared/serdes/serdes.unit.ts
@@ -607,35 +607,40 @@ describe('shared-serialization', () => {
       const clean = createComputed$(() => foo.value + 2, { serializationStrategy: 'always' });
       const never = createComputed$(() => foo.value + 3, { serializationStrategy: 'never' });
       const always = createComputed$(() => foo.value + 4, { serializationStrategy: 'always' });
+      const defaultStrategy = createComputed$(() => foo.value + 5);
       const noSer = createComputed$(() => noSerialize({ foo }));
       // note that this won't subscribe because we're not setting up the context
       // do not read `dirty` to keep it dirty
       expect(clean.value).toBe(2);
       expect(never.value).toBe(3);
       expect(always.value).toBe(4);
-      const objs = await serialize(dirty, clean, never, always, noSer);
+      expect(defaultStrategy.value).toBe(5);
+      const objs = await serialize(dirty, clean, never, always, defaultStrategy, noSer);
       expect(_dumpState(objs)).toMatchInlineSnapshot(`
         "
         0 ComputedSignal [
-          QRL "6#1#-2"
+          QRL "7#1#-2"
         ]
         1 ComputedSignal [
-          QRL "6#2#-3"
+          QRL "7#2#-3"
           Constant undefined
           {number} 2
         ]
         2 ComputedSignal [
-          QRL "6#3#-4"
+          QRL "7#3#-4"
         ]
         3 ComputedSignal [
-          QRL "6#4#-5"
+          QRL "7#4#-5"
           Constant undefined
           {number} 4
         ]
         4 ComputedSignal [
-          QRL "6#5#-6"
+          QRL "7#5#-6"
         ]
-        5 Signal [
+        5 ComputedSignal [
+          QRL "7#6#-7"
+        ]
+        6 Signal [
           {number} 0
           EffectSubscriptionNoData [
             RootRef 1
@@ -649,14 +654,19 @@ describe('shared-serialization', () => {
             RootRef 3
             Constant '.'
           ]
+          EffectSubscriptionNoData [
+            RootRef 4
+            Constant '.'
+          ]
         ]
-        6 {string} "mock-chunk"
-        7 {string} "describe_describe_it_dirty_createComputed_ahnh0V4rf6g"
-        8 {string} "describe_describe_it_clean_createComputed_0ZTfN4iJ0tg"
-        9 {string} "describe_describe_it_never_createComputed_1HbLed7JXyo"
-        10 {string} "describe_describe_it_always_createComputed_4nMmgHlUOog"
-        11 {string} "describe_describe_it_noSer_createComputed_pXwl00hYYQQ"
-        (454 chars)"
+        7 {string} "mock-chunk"
+        8 {string} "describe_describe_it_dirty_createComputed_ahnh0V4rf6g"
+        9 {string} "describe_describe_it_clean_createComputed_0ZTfN4iJ0tg"
+        10 {string} "describe_describe_it_never_createComputed_1HbLed7JXyo"
+        11 {string} "describe_describe_it_always_createComputed_4nMmgHlUOog"
+        12 {string} "describe_describe_it_defaultStrategy_createComputed_i9O7shypysA"
+        13 {string} "describe_describe_it_noSer_createComputed_pXwl00hYYQQ"
+        (552 chars)"
       `);
     });
     it(title(TypeIds.SerializerSignal), async () => {

--- a/packages/qwik/src/core/shared/types.ts
+++ b/packages/qwik/src/core/shared/types.ts
@@ -142,8 +142,8 @@ export interface QContainerElement extends Element {
  * value during SSR.
  *
  * - `never`: The value is never serialized. When the component is resumed, the value will be
- *   recalculated when it is first read.
- * - `always`: The value is always serialized. This is the default.
+ *   recalculated when it is first read. This is the default for computed signals.
+ * - `always`: The value is always serialized. This is the default for async signals.
  *
  * **IMPORTANT**: When you use `never`, your serialized HTML is smaller, but the recalculation will
  * trigger subscriptions, meaning that other signals using this signal will recalculate, even if


### PR DESCRIPTION
### Motivation
- A recent change made computed signals default to `serializationStrategy: 'always'`, which caused evaluated computed values to be written into the SSR-embedded `qwik/state` and risked leaking server-only or sensitive derived data.
- The intent of this PR is to restore the safer previous default (computed signals do not serialize their cached value) while preserving the existing `always` default for async signals.

### Description
- Changed the computed-signal construction to use `getComputedSignalFlags(options?.serializationStrategy || 'never')` so computed signals default to `never` when no explicit `serializationStrategy` is provided (`packages/qwik/src/core/reactive-primitives/signal-api.ts`).
- Left async-signal defaults unchanged so async signals still default to `always` (`packages/qwik/src/core/reactive-primitives/signal-api.ts`).
- Updated the public `SerializationStrategy` documentation to explicitly distinguish that computed signals default to `never` and async signals default to `always` (`packages/qwik/src/core/shared/types.ts`).
- Added/updated focused serialization coverage to assert that a default computed signal does not serialize its cached value while an explicit `always`-configured computed still does, and updated the inline snapshot accordingly (`packages/qwik/src/core/shared/serdes/serdes.unit.ts`).
- Added a patch changeset for `@qwik.dev/core` (`.changeset/calm-computed-secrets.md`).

### Testing
- `pnpm dlx @intellectronica/ruler@0.3.42 apply --no-gitignore --no-mcp` was attempted and failed in this environment due to a registry `403` (environmental artifact, not related to the code change).
- `pnpm build.core.dev` completed successfully and produced the development build artifacts.
- Focused unit tests were run with `pnpm vitest run packages/qwik/src/core/shared/serdes/serdes.unit.ts -t "ComputedSignal" --reporter=verbose` and the failing snapshot was updated to reflect the new default; the focused run passed after the update.
- The full serialization unit file was run with `pnpm vitest run packages/qwik/src/core/shared/serdes/serdes.unit.ts --reporter=verbose` and completed with all tests in that file passing.
- Repository checks (`git diff --check`) were run as part of the verification and reported no problems with the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a31599a088331b80d375677120d4c)