### PR TITLE
fix: prevent action query parameter pollution

### DIFF
--- a/.changeset/clean-action-qaction.md
+++ b/.changeset/clean-action-qaction.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: prevent action query parameter pollution

--- a/packages/qwik-router/src/runtime/src/use-endpoint.ts
+++ b/packages/qwik-router/src/runtime/src/use-endpoint.ts
@@ -23,8 +23,10 @@ export async function submitAction(
   | undefined
 > {
   const pathBase = ensureSlash(routeUrl.pathname);
-  const querySeparator = routeUrl.search ? '&' : '?';
-  const url = `${pathBase}${routeUrl.search}${querySeparator}${QACTION_KEY}=${encodeURIComponent(action.id)}`;
+  const searchParams = new URLSearchParams(routeUrl.search);
+  searchParams.set(QACTION_KEY, action.id);
+  const search = searchParams.toString();
+  const url = `${pathBase}?${search}`;
 
   const actionData = action.data;
   // Clear immediately so a task rerun can't re-submit the same payload

--- a/packages/qwik-router/src/runtime/src/use-endpoint.unit.ts
+++ b/packages/qwik-router/src/runtime/src/use-endpoint.unit.ts
@@ -57,6 +57,18 @@ describe('submitAction', () => {
     );
   });
 
+  it('replaces any existing action id in route search params', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(await makeJsonResponse({ result: { ok: true } }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await submitAction(
+      { id: 'act-a', data: {} } as any,
+      new URL('https://qwik.dev/test/?qaction=act-b&foo=bar&qaction=act-c')
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith('/test/?qaction=act-a&foo=bar', expect.any(Object));
+  });
+
   it('returns result and status from JSON action response', async () => {
     vi.stubGlobal(
       'fetch',


### PR DESCRIPTION
### Motivation

- The client previously constructed the action POST URL by appending the intended `qaction` after the current `routeUrl.search`, which allowed an attacker-controlled `qaction` earlier in the query string to win due to server-side `URLSearchParams.get('qaction')` selecting the first value.
- The change's intent is to preserve other legitimate search params while ensuring the submitted `qaction` is the intended action id, preventing HTTP parameter pollution and action confusion.

### Description

- Replace manual string concatenation with `new URLSearchParams(routeUrl.search)` and `searchParams.set(QACTION_KEY, action.id)` in `submitAction` so any existing `qaction` is replaced before serializing the URL. (modified `packages/qwik-router/src/runtime/src/use-endpoint.ts`)
- Add a focused unit that proves a polluted URL with duplicate `qaction` values results in the fetch URL containing only the intended `qaction` while preserving other params. (modified `packages/qwik-router/src/runtime/src/use-endpoint.unit.ts`)
- Add a patch changeset for the router package to record the security fix. (added `.changeset/clean-action-qaction.md`)

### Testing

- Attempted `ruler apply` via `pnpm dlx @intellectronica/ruler@0.3.42 apply --no-gitignore --no-mcp` failed in this environment due to an npm registry `403` and is therefore not shown here. 
- Running `pnpm vitest run packages/qwik-router/src/runtime/src/use-endpoint.unit.ts` initially failed pre-build because the optimizer artifact was not present, so `pnpm build.core.dev` was run to produce build artifacts. 
- After `pnpm build.core.dev`, the focused unit suite `pnpm vitest run packages/qwik-router/src/runtime/src/use-endpoint.unit.ts` passed with all tests green (15/15 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59c7bd92488331834c3e4d365724ad)