### PR TITLE
fix: encode vnode metadata keys

### DIFF
--- a/.changeset/secure-vnode-slot-names.md
+++ b/.changeset/secure-vnode-slot-names.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: encode vnode metadata keys in script output.

--- a/packages/qwik/src/core/client/vnode-utils.ts
+++ b/packages/qwik/src/core/client/vnode-utils.ts
@@ -2202,7 +2202,7 @@ function materializeFromVNodeData(
     } else if (peek() === VNodeDataChar.SEPARATOR) {
       // Custom attribute: |key|value
       const keyValue = consumeValue();
-      const key = decodeVNodeDataString(keyValue);
+      const key = decodeURIComponent(decodeVNodeDataString(keyValue));
       const valueSeparatorIdx = dataIdx + keyValue.length + 1;
       const isEscapedValue = getChar(valueSeparatorIdx + 1) === VNodeDataChar.SEPARATOR;
       let value;

--- a/packages/qwik/src/core/client/vnode.unit.tsx
+++ b/packages/qwik/src/core/client/vnode.unit.tsx
@@ -439,6 +439,16 @@ describe('vnode', () => {
         </test>
       );
     });
+    it('should decode encoded custom attribute names on Virtual', () => {
+      const attrName = '</script><script>globalThis.__qwik_xss=1</script>';
+      const encodedAttrName = encodeVNodeDataString(encodeVNodeDataKey(attrName));
+      parent.innerHTML = ``;
+      document.qVNodeData.set(parent, `{|${encodedAttrName}|value}`);
+
+      const virtual = vnode_getFirstChild(vParent)!;
+
+      expect(vnode_getProp(virtual, attrName, null)).toBe('value');
+    });
     it('should decode encoded slot names on Virtual', () => {
       const slotName = '</script>|~;=?@ zażółć';
       const encodedSlotName = encodeVNodeDataString(encodeVNodeDataKey(slotName));

--- a/packages/qwik/src/server/ssr-container.spec.ts
+++ b/packages/qwik/src/server/ssr-container.spec.ts
@@ -244,6 +244,32 @@ describe('SSR Container', () => {
     );
   });
 
+  it('should encode custom attribute names in emitVNodeData', () => {
+    const { container, writer } = createTestContainer();
+    container.openContainer();
+    container.serializationCtx.$roots$.push({});
+
+    const customKey = '</script><script>globalThis.__qwik_xss=1</script>';
+    (container as any).vNodeDatas = [
+      [
+        VNodeDataFlag.SERIALIZE | VNodeDataFlag.VIRTUAL_NODE,
+        { [customKey]: 'projection-ref' },
+        OPEN_FRAGMENT,
+        CLOSE_FRAGMENT,
+      ],
+    ];
+
+    (container as any).emitVNodeData();
+
+    const output = writer.toString();
+    const encodedKey = encodeVNodeDataString(encodeVNodeDataKey(customKey));
+
+    expect(output).not.toContain(customKey);
+    expect(output).toContain(
+      `${VNodeDataChar.SEPARATOR_CHAR}${encodedKey}${VNodeDataChar.SEPARATOR_CHAR}`
+    );
+  });
+
   it('should encode slot names in emitVNodeData', () => {
     const { container, writer } = createTestContainer();
     container.openContainer();

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -1304,7 +1304,7 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
         default: {
           encodeValue = encodeURI;
           this.write(VNodeDataChar.SEPARATOR_CHAR);
-          this.write(encodeVNodeDataString(key));
+          this.write(encodeVNodeDataString(encodeVNodeDataKey(key)));
           this.write(VNodeDataChar.SEPARATOR_CHAR);
         }
       }


### PR DESCRIPTION
### Motivation
- Prevent SSR XSS where attacker-controlled slot/property names can terminate `<script type="qwik/vnode">` blocks because keys were written without HTML/script-safe escaping. 
- The change restores a safe round-trip encoding/decoding for vnode metadata keys so Out-Of-Order Suspense streaming (OOOS) cannot emit raw `</script>` sequences from public slot names.

### Description
- Encode vnode metadata keys on the server by applying `encodeVNodeDataKey()` then `encodeVNodeDataString()` before writing into `qwik/vnode` script content (change in `packages/qwik/src/server/ssr-container.ts`).
- Decode encoded vnode metadata keys on the client by using `decodeURIComponent(decodeVNodeDataString(...))` during VNode materialization (change in `packages/qwik/src/core/client/vnode-utils.ts`).
- Add focused regression tests that assert a `</script><script>...` payload is not emitted raw and that encoded custom keys decode back on the client (changes in `packages/qwik/src/server/ssr-container.spec.ts` and `packages/qwik/src/core/client/vnode.unit.tsx`).
- Add a patch changeset for `@qwik.dev/core` describing the fix (`.changeset/secure-vnode-slot-names.md`).

### Testing
- Built local dev artifacts with `pnpm build.core.dev` which completed successfully.
- Ran focused unit tests with `pnpm vitest run packages/qwik/src/server/ssr-container.spec.ts packages/qwik/src/core/client/vnode.unit.tsx --config vitest.config.ts --reporter=dot` and the two modified test files passed (all tests in those files passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a3572560c8331beddc507d84838c2)