### PR TITLE
fix(core): require NoSerialize marker brand

### DIFF
--- a/.changeset/strong-noserialize-brand.md
+++ b/.changeset/strong-noserialize-brand.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: require noSerialize values to carry the marker brand

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -1212,7 +1212,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Returned type of the `noSerialize()` function. It will be TYPE or undefined.\n\n\n```typescript\nexport type NoSerialize<T> = (T & {\n    __no_serialize__?: true;\n}) | undefined;\n```",
+      "content": "Returned type of the `noSerialize()` function. It will be TYPE or undefined.\n\n\n```typescript\nexport type NoSerialize<T> = (T & {\n    __no_serialize__: true;\n}) | undefined;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/serdes/verify.ts",
       "mdFile": "core.noserialize.md"
     },
@@ -1226,7 +1226,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "Returned type of the `noSerialize()` function. It will be TYPE or undefined.\n\n\n```typescript\nexport type NoSerialize<T> = (T & {\n    __no_serialize__?: true;\n}) | undefined;\n```",
+      "content": "Returned type of the `noSerialize()` function. It will be TYPE or undefined.\n\n\n```typescript\nexport type NoSerialize<T> = (T & {\n    __no_serialize__: true;\n}) | undefined;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/serdes/verify.ts",
       "mdFile": "core.noserialize.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.mdx
+++ b/packages/docs/src/routes/api/qwik/index.mdx
@@ -2823,7 +2823,7 @@ Returned type of the `noSerialize()` function. It will be TYPE or undefined.
 ```typescript
 export type NoSerialize<T> =
   | (T & {
-      __no_serialize__?: true;
+      __no_serialize__: true;
     })
   | undefined;
 ```
@@ -2837,7 +2837,7 @@ Returned type of the `noSerialize()` function. It will be TYPE or undefined.
 ```typescript
 export type NoSerialize<T> =
   | (T & {
-      __no_serialize__?: true;
+      __no_serialize__: true;
     })
   | undefined;
 ```

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -758,7 +758,7 @@ export const _noopQrlDEV: <T>(symbolName: string, opts: QRLDev, lexicalScopeCapt
 
 // @public
 export type NoSerialize<T> = (T & {
-    __no_serialize__?: true;
+    __no_serialize__: true;
 }) | undefined;
 
 // @public

--- a/packages/qwik/src/core/shared/serdes/verify.ts
+++ b/packages/qwik/src/core/shared/serdes/verify.ts
@@ -127,7 +127,7 @@ export const fastSkipSerialize = (obj: unknown): boolean => {
  * @public
  * @see noSerialize
  */
-export type NoSerialize<T> = (T & { __no_serialize__?: true }) | undefined;
+export type NoSerialize<T> = (T & { __no_serialize__: true }) | undefined;
 
 // <docs markdown="../../readme.md#noSerialize">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!

--- a/packages/qwik/src/core/shared/serdes/verify.unit.ts
+++ b/packages/qwik/src/core/shared/serdes/verify.unit.ts
@@ -5,8 +5,22 @@ import {
   fastSkipSerialize,
   NoSerializeSymbol,
   SerializerSymbol,
+  type NoSerialize,
 } from './verify';
 import * as useCore from '../../use/use-core';
+
+describe('NoSerialize type', () => {
+  it('requires values to be branded by noSerialize()', () => {
+    const marked = noSerialize({ token: 'secret' });
+    const noSerializeValue: NoSerialize<{ token: string }> = marked;
+
+    // @ts-expect-error Plain objects must be wrapped with noSerialize().
+    const plainValue: NoSerialize<{ token: string }> = { token: 'secret' };
+
+    expect(noSerializeValue?.token).toBe('secret');
+    expect(plainValue).toEqual({ token: 'secret' });
+  });
+});
 
 describe('verifySerializable', () => {
   describe('serializable values', () => {


### PR DESCRIPTION
### Motivation
- A recent change made the `NoSerialize<T>` phantom brand optional, allowing plain objects to be structurally assignable to `NoSerialize<T>` and removing a useful static guard that prevents accidental serialization of intended server-only state.
- At runtime Qwik only skips serialization for values recorded via `noSerialize()` (WeakSet) or carrying `NoSerializeSymbol`, so the weakened type could cause sensitive data to be leaked in SSR/q-data.

### Description
- Restore the required brand by changing the type alias to `export type NoSerialize<T> = (T & { __no_serialize__: true }) | undefined;` in `packages/qwik/src/core/shared/serdes/verify.ts` so plain `T` is not assignable without an explicit branded value.
- Add a focused type/regression unit test in `packages/qwik/src/core/shared/serdes/verify.unit.ts` that accepts `noSerialize()` output but uses `// @ts-expect-error` to assert a plain object assignment is rejected.
- Regenerate and update the public API/docs outputs (`packages/qwik/src/core/qwik.core.api.md`, `packages/docs/src/routes/api/qwik/*`, `packages/docs/src/routes/api/qwik/api.json`) to reflect the restored required brand.
- Add a patch changeset `.changeset/strong-noserialize-brand.md` describing the fix for `@qwik.dev/core`.

### Testing
- Ran `pnpm build.core.dev` and the dev build completed successfully after fixing the temporary test type issue.
- Ran the focused unit suite `pnpm vitest run packages/qwik/src/core/shared/serdes/verify.unit.ts` and all tests in that file passed.
- Ran `pnpm tsc.check` and the TypeScript check completed with no errors.
- Ran `pnpm api.update` to regenerate API docs and the update completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a3570b37c83319d98352894266a30)