### PR TITLE
fix: fix Vite Rolldown Type Compatibility

### DIFF
--- a/.changeset/fix-vite-rolldown-types.md
+++ b/.changeset/fix-vite-rolldown-types.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: support Vite's Rolldown type definitions in the optimizer plugin

--- a/packages/qwik-vite/src/plugins/plugin.ts
+++ b/packages/qwik-vite/src/plugins/plugin.ts
@@ -1355,7 +1355,10 @@ export const isDev = ${JSON.stringify(isDev)};
     }
   }
 
-  const manualChunks: Rollup.ManualChunksOption = (id: string, { getModuleInfo }) => {
+  const manualChunks: NonNullable<Rollup.OutputOptions['manualChunks']> = (
+    id: string,
+    { getModuleInfo }
+  ) => {
     if (opts.target === 'client') {
       if (
         // The preloader has to stay in a separate chunk if it's a client build

--- a/packages/qwik-vite/src/plugins/worker-core.ts
+++ b/packages/qwik-vite/src/plugins/worker-core.ts
@@ -1,5 +1,4 @@
-import type { OutputBundle, PluginContext } from 'rollup';
-import type { Plugin as VitePlugin, UserConfig } from 'vite';
+import type { Plugin as VitePlugin, Rollup, UserConfig } from 'vite';
 import type { QwikManifest } from '../types';
 import { QWIK_CORE_ID, QWIK_CORE_INTERNAL_ID, type QwikBuildTarget } from './plugin';
 import {
@@ -28,7 +27,7 @@ export const loadQwikWorkerCore = () => {
   };
 };
 
-export const emitQwikWorkerCoreChunk = (ctx: PluginContext) => {
+export const emitQwikWorkerCoreChunk = (ctx: Rollup.PluginContext) => {
   ctx.emitFile({
     id: QWIK_WORKER_CORE_ID,
     name: 'qwik-worker-core',
@@ -53,7 +52,7 @@ export const getQwikWorkerConfig = (
   };
 };
 
-export const rewriteClientWorkerCorePlaceholders = (rollupBundle: OutputBundle) => {
+export const rewriteClientWorkerCorePlaceholders = (rollupBundle: Rollup.OutputBundle) => {
   const workerCoreChunk = Object.values(rollupBundle).find(
     (output) => output.type === 'chunk' && output.facadeModuleId === QWIK_WORKER_CORE_ID
   );
@@ -66,7 +65,7 @@ export const rewriteClientWorkerCorePlaceholders = (rollupBundle: OutputBundle) 
 };
 
 export const rewriteSsrWorkerCorePlaceholders = (
-  rollupBundle: OutputBundle,
+  rollupBundle: Rollup.OutputBundle,
   manifest: QwikManifest | null
 ) => {
   const workerCoreChunkFileName = getWorkerCoreChunkFileNameFromManifest(manifest);
@@ -107,7 +106,7 @@ const createQwikWorkerPlugins = (userWorkerPlugins: WorkerConfig['plugins']) => 
 };
 
 const rewriteWorkerCorePlaceholdersInBundle = (
-  rollupBundle: OutputBundle,
+  rollupBundle: Rollup.OutputBundle,
   resolveWorkerCorePath: (fileName: string) => string | undefined
 ) => {
   for (const output of Object.values(rollupBundle)) {


### PR DESCRIPTION
Fixes the Vite ecosystem CI failure reported in this [job](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/30075415605/job/89424962844) by aligning Qwik’s Vite plugin types with Rolldown.