### PR TITLE
docs: document mutating a module-level variable inside a $-extracted closure

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/advanced/dollar/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/dollar/index.mdx
@@ -192,6 +192,39 @@ component$(() => {
 });
 ```
 
+##### Module-level variables cannot be mutated after extraction
+
+Reading an exported module-level variable from an extracted closure works, since the Optimizer turns the reference into an `import`. Assigning to it does not: `import` bindings are read-only, so mutating one from inside the extracted closure fails at build time.
+
+```tsx
+// Invalid
+export let count = 0;
+component$(() => {
+  return <button onClick$={() => count++}>{count}</button>; // count becomes an import; count++ fails
+});
+```
+
+<Note>A non-exported module-level `let` doesn't hit this error, but it's not safe either: the Optimizer duplicates the declaration into each chunk that references it, so every chunk mutates its own independent copy instead of shared state.</Note>
+
+Wrap the read and the write in their own exported functions in a separate module instead of mutating the binding directly:
+
+```tsx title="counter.ts"
+let count = 0;
+export const getCount = () => count;
+export const incrementCount = () => count++;
+```
+
+```tsx
+// Valid
+import { getCount, incrementCount } from './counter';
+
+component$(() => {
+  return <button onClick$={() => incrementCount()}>{getCount()}</button>;
+});
+```
+
+If the state needs to be reactive or scoped per component instance, use a [signal](../../core/state/index.mdx) instead of a module-level variable.
+
 ## Deep dive
 
 Let's look at the hypothetical problem of acting on a scroll event. You may be tempted to write the code like so:

--- a/packages/docs/src/routes/docs/upgrade/index.mdx
+++ b/packages/docs/src/routes/docs/upgrade/index.mdx
@@ -243,6 +243,37 @@ export default component$(() => {
 
 <Note>If your root component is reactive (reads signals), use `<QwikRouterProvider>` instead. `useQwikRouter()` only runs once during SSR.</Note>
 
+### Module-level variable mutated inside a closure no longer builds
+
+The v2 Optimizer extracts closures more aggressively than v1. If an extracted closure mutates an exported module-level `let`, the Optimizer rewrites the reference as an `import`, and assigning to an import binding fails at build time — a path v1's less aggressive extraction didn't reach.
+
+```tsx
+// Fails to build in v2
+export let count = 0;
+component$(() => {
+  return <button onClick$={() => count++}>{count}</button>;
+});
+```
+
+Move the mutation into an exported accessor function in a separate module:
+
+```tsx
+// counter.ts
+let count = 0;
+export const getCount = () => count;
+export const incrementCount = () => count++;
+```
+
+```tsx
+import { getCount, incrementCount } from './counter';
+
+component$(() => {
+  return <button onClick$={() => incrementCount()}>{getCount()}</button>;
+});
+```
+
+See [Module-level variables cannot be mutated after extraction](../../advanced/dollar/index.mdx#module-level-variables-cannot-be-mutated-after-extraction).
+
 ### Serialization
 
 v1 serialized state into `<script type="qwik/json">` tags. v2 uses `<script type="qwik/vnode">` and `<script type="qwik/state">` at the end of the document. No code change needed, but tooling that parses the old tags will need updating.
@@ -427,6 +458,10 @@ Add `"type": "module"` to `package.json`. Run the CLI again if this wasn't set a
 ### Calling a 'use*()' method outside 'component$(...)'
 
 Move the hook inside `component$` (error Q10).
+
+### Cannot assign to import ... / Illegal reassignment of import ...
+
+A module-level `let` mutated inside a `$`-extracted closure. The exact wording depends on the bundler: esbuild says `Cannot assign to import "x"`, Rollup/Rolldown say `Illegal reassignment of import "x"`. See [Module-level variable mutated inside a closure no longer builds](#module-level-variable-mutated-inside-a-closure-no-longer-builds).
 
 ### Move qwik packages [...] to devDependencies
 


### PR DESCRIPTION
## Overview

Documents a v1 → v2 behavior change: mutating an exported module-level `let` from inside a `$`-extracted closure now fails at build time, with no diagnostic from the Optimizer.

## What is it?

- Docs / tests / types / typos

## Description

- v2's Optimizer extracts closures more aggressively than v1
- Mutating an exported module-level `let` inside a closure gets rewritten as an `import` reference — import bindings are read-only, so the assignment fails at build time
- Confirmed by reproducing against `createOptimizer().transformModules()` and checking the real error text in esbuild (`Cannot assign to import "x"`) and Rollup/Rolldown (`Illegal reassignment of import "x"`)
- Fix (also verified): move the read/write into exported accessor functions in a separate module

Adds:
- **`docs/advanced/dollar`** — new rule next to the existing "module-declared variables can be importable" section, plus a note on the quieter sibling case (non-exported variables get silently duplicated per chunk instead of erroring)
- **`docs/upgrade`** — Behavioral Changes entry + Troubleshooting entry keyed to both bundlers' error text

## Checklist

- My code follows the developer guidelines of the project
- I performed a self-review of my own code
- Prettier passes; MDX compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
