### PR TITLE
fix: Vite ecosystem worker build failures

### DIFF
--- a/.changeset/calm-workers-build.md
+++ b/.changeset/calm-workers-build.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: build optimizer before Vite ecosystem worker bundles

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "build.qwik-router": "node --require ./scripts/runBefore.ts scripts/index.ts --tsc --qwikrouter",
     "build.router": "node --require ./scripts/runBefore.ts scripts/index.ts --tsc --qwikrouter --api",
     "build.validate": "node --require ./scripts/runBefore.ts scripts/index.ts --tsc --qwik --qwikworker --api --eslint --qwikrouter --platform-binding --wasm --validate",
-    "build.vite": "node --require ./scripts/runBefore.ts scripts/index.ts --tsc --qwik --qwikworker --insights --api --qwikrouter --eslint --platform-binding-wasm-copy",
+    "build.vite": "node --require ./scripts/runBefore.ts scripts/index.ts --tsc --qwik --qwikworker --optimizer --insights --api --qwikrouter --eslint --platform-binding-wasm-copy",
     "build.wasm": "node --require ./scripts/runBefore.ts scripts/index.ts --wasm",
     "build.watch": "node --require ./scripts/runBefore.ts scripts/index.ts --qwik --qwikworker --qwikrouter --watch --dev --platform-binding",
     "change": "changeset",

--- a/scripts/submodule-worker.ts
+++ b/scripts/submodule-worker.ts
@@ -31,11 +31,12 @@ export async function submoduleWorker(config: BuildConfig) {
         fileName: () => 'index.mjs',
       },
       rollupOptions: {
-        external: (id) =>
-          /^@qwik\.dev\/core(?:\/|$)/.test(id) ||
-          id === './worker.js?worker&url' ||
-          id === './worker.node.js?worker&url' ||
-          id === 'node:worker_threads',
+        external: [
+          /^@qwik\.dev\/core(?:\/|$)/,
+          './worker.js?worker&url',
+          './worker.node.js?worker&url',
+          'node:worker_threads',
+        ],
       },
     },
     plugins: [preserveWorkerImports(), qwikVite({ srcDir: 'src/web-worker' })],


### PR DESCRIPTION
Fixed linked [Vite ecosystem failure](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/30613907400/job/91102602121).

- build.vite now builds optimizer before worker bundles.
- Worker externals use Rolldown-compatible arrays.