### PR TITLE
docs: document ErrorBoundary caching behavior

### DIFF
--- a/packages/docs/src/routes/docs/labs/error-boundary/index.mdx
+++ b/packages/docs/src/routes/docs/labs/error-boundary/index.mdx
@@ -134,6 +134,17 @@ fallback$={$((error) => (
 The same throw during SSR is server-origin and redacts, so keep display throws client-side — or
 render the message conditionally instead of throwing.
 
+## Caching
+
+An error caught during SSR still responds 200. To keep that response out of caches, the router
+sends `Cache-Control: no-store` when the error precedes the first chunk, and it always skips its
+own SSR cache. A route is therefore not cached while it errors — watch `onError$` for recurring
+errors.
+
+If a failure should be an error response instead of an inline fallback, throw it from a blocking
+loader or middleware with `requestEvent.error(status, data)`: the error document keeps its real
+status and your CDN's error-caching rules apply.
+
 ## `transformError`
 
 A server render option that projects a thrown error into the `Error` the fallback displays during


### PR DESCRIPTION
# What is it?

- Docs / tests / types / typos

# Description

An SSR-caught boundary error still responds 200, so the router sends `Cache-Control: no-store` and skips its SSR cache — a route is not cached while it errors. Documents that cost and the way out: throw the failure as an error response (`requestEvent.error(status, data)`) when you want real error semantics instead of an inline fallback.

Follow-up to #8745; retarget to main after it merges.